### PR TITLE
Added a hack to detect when ffigen generates broken bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.3
+
+* Warn when `ffigen` emits any `[SEVERE]` log messages,
+
 ## 1.2.2
 
 * Add Linux and Windows out-of-the-box support for the `with_flutter` example.


### PR DESCRIPTION
When LLVM is unable to resolve a particular type (e.g. due to a missing header) it will report the type as `int`, leading to broken/UB bindings. The `ffigen` binary will emit a `[SEVERE]` log message when this happens, but it'll still keep going and finish with a `0` exit code.

This adds a hacky `stdout.contains("[SEVERE]")` to check for these sorts of situations so we error out instead of letting the user think their generated code is okay.

See the comments from https://github.com/dart-lang/native/issues/338 for more.