### PR TITLE
Support more types of the form`Vec<primitive_type>` and `ZeroCopyBuffer<Vec<primitive_type>>`, such as `Vec<f32>` and `ZeroCopyBuffer<Vec<f32>>` to be transformed into `Float32List` in Dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.0
+
+* Support more types of the form`Vec<primitive_type>` and `ZeroCopyBuffer<Vec<primitive_type>>`, such as `Vec<f32>` and `ZeroCopyBuffer<Vec<f32>>` to be transformed into `Float32List` in Dart.
+
 ## 1.2.3
 
 * Warn when `ffigen` emits any `[SEVERE]` log messages.

--- a/frb_codegen/src/api_types.rs
+++ b/frb_codegen/src/api_types.rs
@@ -369,7 +369,7 @@ impl ApiTypeChild for ApiTypeDelegate {
     fn rust_api_type(&self) -> String {
         match self {
             ApiTypeDelegate::String => "String".to_owned(),
-            ApiTypeDelegate::ZeroCopyBufferVecPrimitive(primitive) => {
+            ApiTypeDelegate::ZeroCopyBufferVecPrimitive(_) => {
                 format!("ZeroCopyBuffer<{}>", self.get_delegate().rust_api_type())
             }
         }

--- a/frb_codegen/src/api_types.rs
+++ b/frb_codegen/src/api_types.rs
@@ -228,8 +228,13 @@ pub trait ApiTypeChild {
 pub enum ApiTypePrimitive {
     U8,
     I8,
+    U16,
+    I16,
+    U32,
     I32,
+    U64,
     I64,
+    F32,
     F64,
     Bool,
 }
@@ -241,12 +246,17 @@ impl ApiTypeChild for ApiTypePrimitive {
 
     fn dart_api_type(&self) -> String {
         match self {
-            ApiTypePrimitive::U8 => "int",
-            ApiTypePrimitive::I8 => "int",
-            ApiTypePrimitive::I32 => "int",
-            ApiTypePrimitive::I64 => "int",
-            ApiTypePrimitive::F64 => "double",
+            ApiTypePrimitive::U8
+            | ApiTypePrimitive::I8
+            | ApiTypePrimitive::U16
+            | ApiTypePrimitive::I16
+            | ApiTypePrimitive::U32
+            | ApiTypePrimitive::I32
+            // NOTE: does NOT support `u64`, since a u64 cannot be fit into a Dart int(i64)
+            | ApiTypePrimitive::I64 => "int",
+            ApiTypePrimitive::F32 | ApiTypePrimitive::F64 => "double",
             ApiTypePrimitive::Bool => "bool",
+            _ => panic!("dart_api_type does not support {:?}", &self),
         }
         .to_string()
     }
@@ -263,8 +273,13 @@ impl ApiTypeChild for ApiTypePrimitive {
         match self {
             ApiTypePrimitive::U8 => "u8",
             ApiTypePrimitive::I8 => "i8",
+            ApiTypePrimitive::U16 => "u16",
+            ApiTypePrimitive::I16 => "i16",
+            ApiTypePrimitive::U32 => "u32",
             ApiTypePrimitive::I32 => "i32",
+            ApiTypePrimitive::U64 => "u64",
             ApiTypePrimitive::I64 => "i64",
+            ApiTypePrimitive::F32 => "f32",
             ApiTypePrimitive::F64 => "f64",
             ApiTypePrimitive::Bool => "bool",
         }
@@ -280,8 +295,13 @@ impl ApiTypePrimitive {
         match self {
             ApiTypePrimitive::U8 | ApiTypePrimitive::Bool => "ffi.Uint8",
             ApiTypePrimitive::I8 => "ffi.Int8",
+            ApiTypePrimitive::U16 => "ffi.Uint16",
+            ApiTypePrimitive::I16 => "ffi.Int16",
+            ApiTypePrimitive::U32 => "ffi.Uint32",
             ApiTypePrimitive::I32 => "ffi.Int32",
+            ApiTypePrimitive::U64 => "ffi.Uint64",
             ApiTypePrimitive::I64 => "ffi.Int64",
+            ApiTypePrimitive::F32 => "ffi.Float",
             ApiTypePrimitive::F64 => "ffi.Double",
         }
     }
@@ -289,8 +309,13 @@ impl ApiTypePrimitive {
         match s {
             "u8" => Some(ApiTypePrimitive::U8),
             "i8" => Some(ApiTypePrimitive::I8),
+            "u16" => Some(ApiTypePrimitive::U16),
+            "i16" => Some(ApiTypePrimitive::I16),
+            "u32" => Some(ApiTypePrimitive::U32),
             "i32" => Some(ApiTypePrimitive::I32),
+            "u64" => Some(ApiTypePrimitive::U64),
             "i64" => Some(ApiTypePrimitive::I64),
+            "f32" => Some(ApiTypePrimitive::F32),
             "f64" => Some(ApiTypePrimitive::F64),
             "bool" => Some(ApiTypePrimitive::Bool),
             _ => None,
@@ -380,7 +405,13 @@ impl ApiTypeChild for ApiTypePrimitiveList {
         match &self.primitive {
             ApiTypePrimitive::U8 => "Uint8List",
             ApiTypePrimitive::I8 => "Int8List",
+            ApiTypePrimitive::U16 => "Uint16List",
+            ApiTypePrimitive::I16 => "Int16List",
+            ApiTypePrimitive::U32 => "Uint32List",
+            ApiTypePrimitive::I32 => "Int32List",
+            ApiTypePrimitive::U64 => "Uint64List",
             ApiTypePrimitive::I64 => "Int64List",
+            ApiTypePrimitive::F32 => "Float32List",
             ApiTypePrimitive::F64 => "Float64List",
             _ => panic!("does not support {:?} yet", &self.primitive),
         }

--- a/frb_codegen/src/generator_dart.rs
+++ b/frb_codegen/src/generator_dart.rs
@@ -201,7 +201,7 @@ fn generate_api2wire_func(ty: &ApiType) -> String {
             ApiTypeDelegate::String => {
                 "return _api2wire_uint_8_list(utf8.encoder.convert(raw));".to_string()
             }
-            ApiTypeDelegate::ZeroCopyBufferVecU8 => {
+            ApiTypeDelegate::ZeroCopyBufferVecPrimitive => {
                 "return _api2wire_uint_8_list(raw);".to_string()
             } // ApiTypeDelegate::Optional(_) => {
               // format!(
@@ -326,7 +326,7 @@ fn generate_wire2api_func(ty: &ApiType, api_file: &ApiFile) -> String {
         Primitive(p) => gen_simple_type_cast(&p.dart_api_type()),
         Delegate(d) => match d {
             ApiTypeDelegate::String => gen_simple_type_cast(&d.dart_api_type()),
-            ApiTypeDelegate::ZeroCopyBufferVecU8 => gen_simple_type_cast(&d.dart_api_type()),
+            ApiTypeDelegate::ZeroCopyBufferVecPrimitive => gen_simple_type_cast(&d.dart_api_type()),
         },
         Optional(opt) => format!(
             "return raw == null ? null : _wire2api_{}(raw);",

--- a/frb_codegen/src/generator_dart.rs
+++ b/frb_codegen/src/generator_dart.rs
@@ -201,14 +201,9 @@ fn generate_api2wire_func(ty: &ApiType) -> String {
             ApiTypeDelegate::String => {
                 "return _api2wire_uint_8_list(utf8.encoder.convert(raw));".to_string()
             }
-            ApiTypeDelegate::ZeroCopyBufferVecPrimitive => {
-                "return _api2wire_uint_8_list(raw);".to_string()
-            } // ApiTypeDelegate::Optional(_) => {
-              // format!(
-              // "return raw != null ? _api2wire_{}(raw) : ffi.nullptr;",
-              // d.get_delegate().safe_ident()
-              // )
-              // }
+            ApiTypeDelegate::ZeroCopyBufferVecPrimitive(_) => {
+                format!("return _api2wire_{}(raw);", d.get_delegate().safe_ident())
+            }
         },
         Optional(opt) => format!(
             "return raw == null ? ffi.nullptr : _api2wire_{}(raw);",
@@ -326,7 +321,9 @@ fn generate_wire2api_func(ty: &ApiType, api_file: &ApiFile) -> String {
         Primitive(p) => gen_simple_type_cast(&p.dart_api_type()),
         Delegate(d) => match d {
             ApiTypeDelegate::String => gen_simple_type_cast(&d.dart_api_type()),
-            ApiTypeDelegate::ZeroCopyBufferVecPrimitive => gen_simple_type_cast(&d.dart_api_type()),
+            ApiTypeDelegate::ZeroCopyBufferVecPrimitive(_) => {
+                gen_simple_type_cast(&d.dart_api_type())
+            }
         },
         Optional(opt) => format!(
             "return raw == null ? null : _wire2api_{}(raw);",

--- a/frb_codegen/src/generator_rust.rs
+++ b/frb_codegen/src/generator_rust.rs
@@ -308,7 +308,7 @@ impl Generator {
                 ApiTypeDelegate::String => "let vec: Vec<u8> = self.wire2api();
                 String::from_utf8_lossy(&vec).into_owned()"
                     .into(),
-                ApiTypeDelegate::ZeroCopyBufferVecPrimitive => {
+                ApiTypeDelegate::ZeroCopyBufferVecPrimitive(_) => {
                     "ZeroCopyBuffer(self.wire2api())".into()
                 }
             },

--- a/frb_codegen/src/generator_rust.rs
+++ b/frb_codegen/src/generator_rust.rs
@@ -308,7 +308,9 @@ impl Generator {
                 ApiTypeDelegate::String => "let vec: Vec<u8> = self.wire2api();
                 String::from_utf8_lossy(&vec).into_owned()"
                     .into(),
-                ApiTypeDelegate::ZeroCopyBufferVecU8 => "ZeroCopyBuffer(self.wire2api())".into(),
+                ApiTypeDelegate::ZeroCopyBufferVecPrimitive => {
+                    "ZeroCopyBuffer(self.wire2api())".into()
+                }
             },
             PrimitiveList(_) => "unsafe {
                 let wrap = support::box_from_leak_ptr(self);

--- a/frb_codegen/src/parser.rs
+++ b/frb_codegen/src/parser.rs
@@ -133,7 +133,7 @@ impl<'a> Parser<'a> {
 
                 if let Some(inner_type_str) = CAPTURE_ZERO_COPY_BUFFER.captures(ty) {
                     if let Some(ApiType::PrimitiveList(ApiTypePrimitiveList { primitive })) =
-                        self.try_parse_list(inner_type_str)
+                        self.try_parse_list(&inner_type_str)
                     {
                         return Some(ApiType::Delegate(
                             ApiTypeDelegate::ZeroCopyBufferVecPrimitive(primitive),

--- a/frb_codegen/src/parser.rs
+++ b/frb_codegen/src/parser.rs
@@ -104,7 +104,7 @@ impl<'a> Parser<'a> {
     fn parse_type(&mut self, ty: &str) -> ApiType {
         debug!("parse_type: {}", ty);
         None.or_else(|| ApiTypePrimitive::try_from_rust_str(ty).map(Primitive))
-            .or_else(|| ApiTypeDelegate::try_from_rust_str(ty).map(Delegate))
+            .or_else(|| self.try_parse_api_type_delegate(ty))
             .or_else(|| self.try_parse_list(ty))
             .or_else(|| self.try_parse_box(ty))
             .or_else(|| self.try_parse_option(ty))
@@ -120,6 +120,30 @@ impl<'a> Parser<'a> {
         CAPTURE_STREAM_SINK
             .captures(ty)
             .map(|inner| self.parse_type(&inner))
+    }
+
+    fn try_parse_api_type_delegate(&mut self, ty: &str) -> Option<ApiType> {
+        match ty {
+            "String" => Some(ApiType::Delegate(ApiTypeDelegate::String)),
+            _ => {
+                lazy_static! {
+                    static ref CAPTURE_ZERO_COPY_BUFFER: GenericCapture =
+                        GenericCapture::new("ZeroCopyBuffer");
+                }
+
+                if let Some(inner_type_str) = CAPTURE_ZERO_COPY_BUFFER.captures(ty) {
+                    if let Some(ApiType::PrimitiveList(ApiTypePrimitiveList { primitive })) =
+                        self.try_parse_list(inner_type_str)
+                    {
+                        return Some(ApiType::Delegate(
+                            ApiTypeDelegate::ZeroCopyBufferVecPrimitive(primitive),
+                        ));
+                    }
+                }
+
+                None
+            }
+        }
     }
 
     fn try_parse_list(&mut self, ty: &str) -> Option<ApiType> {

--- a/frb_example/pure_dart/dart/lib/bridge_generated.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.dart
@@ -23,7 +23,9 @@ abstract class FlutterRustBridgeExample extends FlutterRustBridgeBase<FlutterRus
 
   Future<Uint8List> handleVecU8({required Uint8List v, dynamic hint});
 
-  Future<Uint8List> handleZeroCopyResult({required int n, dynamic hint});
+  Future<VecOfPrimitivePack> handleVecOfPrimitive({required Uint8List v, dynamic hint});
+
+  Future<ZeroCopyVecOfPrimitivePack> handleZeroCopyVecOfPrimitive({required int n, dynamic hint});
 
   Future<MySize> handleStruct({required MySize arg, required MySize boxed, dynamic hint});
 
@@ -90,6 +92,10 @@ class ExoticOptionals {
   final Uint8List? zerocopy;
   final Int8List? int8List;
   final Uint8List? uint8List;
+  final Int32List? int32List;
+  final Int64List? int64List;
+  final Float32List? float32List;
+  final Float64List? float64List;
   final List<Attribute>? attributes;
   final List<Attribute?> attributesNullable;
   final List<Attribute?>? nullableAttributes;
@@ -103,6 +109,10 @@ class ExoticOptionals {
     this.zerocopy,
     this.int8List,
     this.uint8List,
+    this.int32List,
+    this.int64List,
+    this.float32List,
+    this.float64List,
     this.attributes,
     required this.attributesNullable,
     this.nullableAttributes,
@@ -137,6 +147,42 @@ class NewTypeInt {
 
   NewTypeInt({
     required this.field0,
+  });
+}
+
+class VecOfPrimitivePack {
+  final Int8List int8List;
+  final Uint8List uint8List;
+  final Int32List int32List;
+  final Int64List int64List;
+  final Float32List float32List;
+  final Float64List float64List;
+
+  VecOfPrimitivePack({
+    required this.int8List,
+    required this.uint8List,
+    required this.int32List,
+    required this.int64List,
+    required this.float32List,
+    required this.float64List,
+  });
+}
+
+class ZeroCopyVecOfPrimitivePack {
+  final Int8List int8List;
+  final Uint8List uint8List;
+  final Int32List int32List;
+  final Int64List int64List;
+  final Float32List float32List;
+  final Float64List float64List;
+
+  ZeroCopyVecOfPrimitivePack({
+    required this.int8List,
+    required this.uint8List,
+    required this.int32List,
+    required this.int64List,
+    required this.float32List,
+    required this.float64List,
   });
 }
 
@@ -175,11 +221,19 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeExample {
       parseSuccessData: _wire2api_uint_8_list,
       hint: hint));
 
-  Future<Uint8List> handleZeroCopyResult({required int n, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
-      debugName: 'handle_zero_copy_result',
-      callFfi: (port) => inner.wire_handle_zero_copy_result(port, _api2wire_i32(n)),
-      parseSuccessData: _wire2api_ZeroCopyBuffer_Uint8List,
-      hint: hint));
+  Future<VecOfPrimitivePack> handleVecOfPrimitive({required Uint8List v, dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+          debugName: 'handle_vec_of_primitive',
+          callFfi: (port) => inner.wire_handle_vec_of_primitive(port, _api2wire_uint_8_list(v)),
+          parseSuccessData: _wire2api_vec_of_primitive_pack,
+          hint: hint));
+
+  Future<ZeroCopyVecOfPrimitivePack> handleZeroCopyVecOfPrimitive({required int n, dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+          debugName: 'handle_zero_copy_vec_of_primitive',
+          callFfi: (port) => inner.wire_handle_zero_copy_vec_of_primitive(port, _api2wire_i32(n)),
+          parseSuccessData: _wire2api_zero_copy_vec_of_primitive_pack,
+          hint: hint));
 
   Future<MySize> handleStruct({required MySize arg, required MySize boxed, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
@@ -375,8 +429,24 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeExample {
     return inner.new_box_u8(raw);
   }
 
+  double _api2wire_f32(double raw) {
+    return raw;
+  }
+
   double _api2wire_f64(double raw) {
     return raw;
+  }
+
+  ffi.Pointer<wire_float_32_list> _api2wire_float_32_list(Float32List raw) {
+    final ans = inner.new_float_32_list(raw.length);
+    ans.ref.ptr.asTypedList(raw.length).setAll(0, raw);
+    return ans;
+  }
+
+  ffi.Pointer<wire_float_64_list> _api2wire_float_64_list(Float64List raw) {
+    final ans = inner.new_float_64_list(raw.length);
+    ans.ref.ptr.asTypedList(raw.length).setAll(0, raw);
+    return ans;
   }
 
   int _api2wire_i32(int raw) {
@@ -389,6 +459,18 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeExample {
 
   int _api2wire_i8(int raw) {
     return raw;
+  }
+
+  ffi.Pointer<wire_int_32_list> _api2wire_int_32_list(Int32List raw) {
+    final ans = inner.new_int_32_list(raw.length);
+    ans.ref.ptr.asTypedList(raw.length).setAll(0, raw);
+    return ans;
+  }
+
+  ffi.Pointer<wire_int_64_list> _api2wire_int_64_list(Int64List raw) {
+    final ans = inner.new_int_64_list(raw.length);
+    ans.ref.ptr.asTypedList(raw.length).setAll(0, raw);
+    return ans;
   }
 
   ffi.Pointer<wire_int_8_list> _api2wire_int_8_list(Int8List raw) {
@@ -493,6 +575,22 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeExample {
     return raw == null ? ffi.nullptr : _api2wire_box_u8(raw);
   }
 
+  ffi.Pointer<wire_float_32_list> _api2wire_opt_float_32_list(Float32List? raw) {
+    return raw == null ? ffi.nullptr : _api2wire_float_32_list(raw);
+  }
+
+  ffi.Pointer<wire_float_64_list> _api2wire_opt_float_64_list(Float64List? raw) {
+    return raw == null ? ffi.nullptr : _api2wire_float_64_list(raw);
+  }
+
+  ffi.Pointer<wire_int_32_list> _api2wire_opt_int_32_list(Int32List? raw) {
+    return raw == null ? ffi.nullptr : _api2wire_int_32_list(raw);
+  }
+
+  ffi.Pointer<wire_int_64_list> _api2wire_opt_int_64_list(Int64List? raw) {
+    return raw == null ? ffi.nullptr : _api2wire_int_64_list(raw);
+  }
+
   ffi.Pointer<wire_int_8_list> _api2wire_opt_int_8_list(Int8List? raw) {
     return raw == null ? ffi.nullptr : _api2wire_int_8_list(raw);
   }
@@ -563,6 +661,10 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeExample {
     wireObj.zerocopy = _api2wire_opt_ZeroCopyBuffer_Uint8List(apiObj.zerocopy);
     wireObj.int8list = _api2wire_opt_int_8_list(apiObj.int8List);
     wireObj.uint8list = _api2wire_opt_uint_8_list(apiObj.uint8List);
+    wireObj.int32list = _api2wire_opt_int_32_list(apiObj.int32List);
+    wireObj.int64list = _api2wire_opt_int_64_list(apiObj.int64List);
+    wireObj.float32list = _api2wire_opt_float_32_list(apiObj.float32List);
+    wireObj.float64list = _api2wire_opt_float_64_list(apiObj.float64List);
     wireObj.attributes = _api2wire_opt_list_attribute(apiObj.attributes);
     wireObj.attributes_nullable = _api2wire_list_opt_box_autoadd_attribute(apiObj.attributesNullable);
     wireObj.nullable_attributes = _api2wire_opt_list_opt_box_autoadd_attribute(apiObj.nullableAttributes);
@@ -605,6 +707,26 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeExample {
 // Section: wire2api
 String _wire2api_String(dynamic raw) {
   return raw as String;
+}
+
+Float32List _wire2api_ZeroCopyBuffer_Float32List(dynamic raw) {
+  return raw as Float32List;
+}
+
+Float64List _wire2api_ZeroCopyBuffer_Float64List(dynamic raw) {
+  return raw as Float64List;
+}
+
+Int32List _wire2api_ZeroCopyBuffer_Int32List(dynamic raw) {
+  return raw as Int32List;
+}
+
+Int64List _wire2api_ZeroCopyBuffer_Int64List(dynamic raw) {
+  return raw as Int64List;
+}
+
+Int8List _wire2api_ZeroCopyBuffer_Int8List(dynamic raw) {
+  return raw as Int8List;
 }
 
 Uint8List _wire2api_ZeroCopyBuffer_Uint8List(dynamic raw) {
@@ -669,7 +791,7 @@ Element _wire2api_element(dynamic raw) {
 
 ExoticOptionals _wire2api_exotic_optionals(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 11) throw Exception('unexpected arr length: expect 11 but see ${arr.length}');
+  if (arr.length != 15) throw Exception('unexpected arr length: expect 15 but see ${arr.length}');
   return ExoticOptionals(
     int32: _wire2api_opt_box_autoadd_i32(arr[0]),
     int64: _wire2api_opt_box_autoadd_i64(arr[1]),
@@ -678,15 +800,31 @@ ExoticOptionals _wire2api_exotic_optionals(dynamic raw) {
     zerocopy: _wire2api_opt_ZeroCopyBuffer_Uint8List(arr[4]),
     int8List: _wire2api_opt_int_8_list(arr[5]),
     uint8List: _wire2api_opt_uint_8_list(arr[6]),
-    attributes: _wire2api_opt_list_attribute(arr[7]),
-    attributesNullable: _wire2api_list_opt_box_autoadd_attribute(arr[8]),
-    nullableAttributes: _wire2api_opt_list_opt_box_autoadd_attribute(arr[9]),
-    newtypeint: _wire2api_opt_box_autoadd_new_type_int(arr[10]),
+    int32List: _wire2api_opt_int_32_list(arr[7]),
+    int64List: _wire2api_opt_int_64_list(arr[8]),
+    float32List: _wire2api_opt_float_32_list(arr[9]),
+    float64List: _wire2api_opt_float_64_list(arr[10]),
+    attributes: _wire2api_opt_list_attribute(arr[11]),
+    attributesNullable: _wire2api_list_opt_box_autoadd_attribute(arr[12]),
+    nullableAttributes: _wire2api_opt_list_opt_box_autoadd_attribute(arr[13]),
+    newtypeint: _wire2api_opt_box_autoadd_new_type_int(arr[14]),
   );
+}
+
+double _wire2api_f32(dynamic raw) {
+  return raw as double;
 }
 
 double _wire2api_f64(dynamic raw) {
   return raw as double;
+}
+
+Float32List _wire2api_float_32_list(dynamic raw) {
+  return raw as Float32List;
+}
+
+Float64List _wire2api_float_64_list(dynamic raw) {
+  return raw as Float64List;
 }
 
 int _wire2api_i32(dynamic raw) {
@@ -699,6 +837,14 @@ int _wire2api_i64(dynamic raw) {
 
 int _wire2api_i8(dynamic raw) {
   return raw as int;
+}
+
+Int32List _wire2api_int_32_list(dynamic raw) {
+  return raw as Int32List;
+}
+
+Int64List _wire2api_int_64_list(dynamic raw) {
+  return raw as Int64List;
 }
 
 Int8List _wire2api_int_8_list(dynamic raw) {
@@ -792,6 +938,22 @@ NewTypeInt? _wire2api_opt_box_autoadd_new_type_int(dynamic raw) {
   return raw == null ? null : _wire2api_box_autoadd_new_type_int(raw);
 }
 
+Float32List? _wire2api_opt_float_32_list(dynamic raw) {
+  return raw == null ? null : _wire2api_float_32_list(raw);
+}
+
+Float64List? _wire2api_opt_float_64_list(dynamic raw) {
+  return raw == null ? null : _wire2api_float_64_list(raw);
+}
+
+Int32List? _wire2api_opt_int_32_list(dynamic raw) {
+  return raw == null ? null : _wire2api_int_32_list(raw);
+}
+
+Int64List? _wire2api_opt_int_64_list(dynamic raw) {
+  return raw == null ? null : _wire2api_int_64_list(raw);
+}
+
 Int8List? _wire2api_opt_int_8_list(dynamic raw) {
   return raw == null ? null : _wire2api_int_8_list(raw);
 }
@@ -818,6 +980,32 @@ int _wire2api_u8(dynamic raw) {
 
 Uint8List _wire2api_uint_8_list(dynamic raw) {
   return raw as Uint8List;
+}
+
+VecOfPrimitivePack _wire2api_vec_of_primitive_pack(dynamic raw) {
+  final arr = raw as List<dynamic>;
+  if (arr.length != 6) throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
+  return VecOfPrimitivePack(
+    int8List: _wire2api_int_8_list(arr[0]),
+    uint8List: _wire2api_uint_8_list(arr[1]),
+    int32List: _wire2api_int_32_list(arr[2]),
+    int64List: _wire2api_int_64_list(arr[3]),
+    float32List: _wire2api_float_32_list(arr[4]),
+    float64List: _wire2api_float_64_list(arr[5]),
+  );
+}
+
+ZeroCopyVecOfPrimitivePack _wire2api_zero_copy_vec_of_primitive_pack(dynamic raw) {
+  final arr = raw as List<dynamic>;
+  if (arr.length != 6) throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
+  return ZeroCopyVecOfPrimitivePack(
+    int8List: _wire2api_ZeroCopyBuffer_Int8List(arr[0]),
+    uint8List: _wire2api_ZeroCopyBuffer_Uint8List(arr[1]),
+    int32List: _wire2api_ZeroCopyBuffer_Int32List(arr[2]),
+    int64List: _wire2api_ZeroCopyBuffer_Int64List(arr[3]),
+    float32List: _wire2api_ZeroCopyBuffer_Float32List(arr[4]),
+    float64List: _wire2api_ZeroCopyBuffer_Float64List(arr[5]),
+  );
 }
 
 // ignore_for_file: camel_case_types, non_constant_identifier_names, avoid_positional_boolean_parameters, annotate_overrides, constant_identifier_names
@@ -905,19 +1093,36 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   late final _wire_handle_vec_u8 =
       _wire_handle_vec_u8Ptr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
-  void wire_handle_zero_copy_result(
+  void wire_handle_vec_of_primitive(
+    int port,
+    ffi.Pointer<wire_uint_8_list> v,
+  ) {
+    return _wire_handle_vec_of_primitive(
+      port,
+      v,
+    );
+  }
+
+  late final _wire_handle_vec_of_primitivePtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>(
+          'wire_handle_vec_of_primitive');
+  late final _wire_handle_vec_of_primitive =
+      _wire_handle_vec_of_primitivePtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+
+  void wire_handle_zero_copy_vec_of_primitive(
     int port,
     int n,
   ) {
-    return _wire_handle_zero_copy_result(
+    return _wire_handle_zero_copy_vec_of_primitive(
       port,
       n,
     );
   }
 
-  late final _wire_handle_zero_copy_resultPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>('wire_handle_zero_copy_result');
-  late final _wire_handle_zero_copy_result = _wire_handle_zero_copy_resultPtr.asFunction<void Function(int, int)>();
+  late final _wire_handle_zero_copy_vec_of_primitivePtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>('wire_handle_zero_copy_vec_of_primitive');
+  late final _wire_handle_zero_copy_vec_of_primitive =
+      _wire_handle_zero_copy_vec_of_primitivePtr.asFunction<void Function(int, int)>();
 
   void wire_handle_struct(
     int port,
@@ -1297,6 +1502,54 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   late final _new_box_u8Ptr = _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Uint8> Function(ffi.Uint8)>>('new_box_u8');
   late final _new_box_u8 = _new_box_u8Ptr.asFunction<ffi.Pointer<ffi.Uint8> Function(int)>();
 
+  ffi.Pointer<wire_float_32_list> new_float_32_list(
+    int len,
+  ) {
+    return _new_float_32_list(
+      len,
+    );
+  }
+
+  late final _new_float_32_listPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_float_32_list> Function(ffi.Int32)>>('new_float_32_list');
+  late final _new_float_32_list = _new_float_32_listPtr.asFunction<ffi.Pointer<wire_float_32_list> Function(int)>();
+
+  ffi.Pointer<wire_float_64_list> new_float_64_list(
+    int len,
+  ) {
+    return _new_float_64_list(
+      len,
+    );
+  }
+
+  late final _new_float_64_listPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_float_64_list> Function(ffi.Int32)>>('new_float_64_list');
+  late final _new_float_64_list = _new_float_64_listPtr.asFunction<ffi.Pointer<wire_float_64_list> Function(int)>();
+
+  ffi.Pointer<wire_int_32_list> new_int_32_list(
+    int len,
+  ) {
+    return _new_int_32_list(
+      len,
+    );
+  }
+
+  late final _new_int_32_listPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_int_32_list> Function(ffi.Int32)>>('new_int_32_list');
+  late final _new_int_32_list = _new_int_32_listPtr.asFunction<ffi.Pointer<wire_int_32_list> Function(int)>();
+
+  ffi.Pointer<wire_int_64_list> new_int_64_list(
+    int len,
+  ) {
+    return _new_int_64_list(
+      len,
+    );
+  }
+
+  late final _new_int_64_listPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_int_64_list> Function(ffi.Int32)>>('new_int_64_list');
+  late final _new_int_64_list = _new_int_64_listPtr.asFunction<ffi.Pointer<wire_int_64_list> Function(int)>();
+
   ffi.Pointer<wire_int_8_list> new_int_8_list(
     int len,
   ) {
@@ -1435,6 +1688,34 @@ class wire_int_8_list extends ffi.Struct {
   external int len;
 }
 
+class wire_int_32_list extends ffi.Struct {
+  external ffi.Pointer<ffi.Int32> ptr;
+
+  @ffi.Int32()
+  external int len;
+}
+
+class wire_int_64_list extends ffi.Struct {
+  external ffi.Pointer<ffi.Int64> ptr;
+
+  @ffi.Int32()
+  external int len;
+}
+
+class wire_float_32_list extends ffi.Struct {
+  external ffi.Pointer<ffi.Float> ptr;
+
+  @ffi.Int32()
+  external int len;
+}
+
+class wire_float_64_list extends ffi.Struct {
+  external ffi.Pointer<ffi.Double> ptr;
+
+  @ffi.Int32()
+  external int len;
+}
+
 class wire_Attribute extends ffi.Struct {
   external ffi.Pointer<wire_uint_8_list> key;
 
@@ -1469,6 +1750,14 @@ class wire_ExoticOptionals extends ffi.Struct {
   external ffi.Pointer<wire_int_8_list> int8list;
 
   external ffi.Pointer<wire_uint_8_list> uint8list;
+
+  external ffi.Pointer<wire_int_32_list> int32list;
+
+  external ffi.Pointer<wire_int_64_list> int64list;
+
+  external ffi.Pointer<wire_float_32_list> float32list;
+
+  external ffi.Pointer<wire_float_64_list> float64list;
 
   external ffi.Pointer<wire_list_attribute> attributes;
 

--- a/frb_example/pure_dart/rust/src/api.rs
+++ b/frb_example/pure_dart/rust/src/api.rs
@@ -6,7 +6,6 @@ use std::thread;
 use std::time::Duration;
 
 use anyhow::{anyhow, Result};
-
 use flutter_rust_bridge::{StreamSink, ZeroCopyBuffer};
 
 pub fn simple_adder(a: i32, b: i32) -> Result<i32> {
@@ -27,14 +26,50 @@ pub fn handle_string(s: String) -> Result<String> {
     Ok(s + &s2)
 }
 
+// to check that `Vec<u8>` can be used as return type
 pub fn handle_vec_u8(v: Vec<u8>) -> Result<Vec<u8>> {
     println!("handle_vec_u8(first few elements: {:?})", &v[..5]);
     Ok(v.repeat(2))
 }
 
-pub fn handle_zero_copy_result(n: i32) -> Result<ZeroCopyBuffer<Vec<u8>>> {
-    println!("handle_zero_copy_result(n: {})", n);
-    Ok(ZeroCopyBuffer(vec![42u8; n as usize]))
+pub struct VecOfPrimitivePack {
+    pub int8list: Vec<i8>,
+    pub uint8list: Vec<u8>,
+    pub int32list: Vec<i32>,
+    pub int64list: Vec<i64>,
+    pub float32list: Vec<f32>,
+    pub float64list: Vec<f64>,
+}
+
+pub fn handle_vec_of_primitive(v: Vec<u8>) -> Result<VecOfPrimitivePack> {
+    Ok(VecOfPrimitivePack {
+        int8list: vec![42i8; n as usize],
+        uint8list: vec![42u8; n as usize],
+        int32list: vec![42i32; n as usize],
+        int64list: vec![42i64; n as usize],
+        float32list: vec![42.0f32; n as usize],
+        float64list: vec![42.0f64; n as usize],
+    })
+}
+
+pub struct ZeroCopyVecOfPrimitivePack {
+    pub int8list: ZeroCopyBuffer<Vec<i8>>,
+    pub uint8list: ZeroCopyBuffer<Vec<u8>>,
+    pub int32list: ZeroCopyBuffer<Vec<i32>>,
+    pub int64list: ZeroCopyBuffer<Vec<i64>>,
+    pub float32list: ZeroCopyBuffer<Vec<f32>>,
+    pub float64list: ZeroCopyBuffer<Vec<f64>>,
+}
+
+pub fn handle_zero_copy_vec_of_primitive(n: i32) -> Result<ZeroCopyVecOfPrimitivePack> {
+    Ok(ZeroCopyVecOfPrimitivePack {
+        int8list: ZeroCopyBuffer(vec![42i8; n as usize]),
+        uint8list: ZeroCopyBuffer(vec![42u8; n as usize]),
+        int32list: ZeroCopyBuffer(vec![42i32; n as usize]),
+        int64list: ZeroCopyBuffer(vec![42i64; n as usize]),
+        float32list: ZeroCopyBuffer(vec![42.0f32; n as usize]),
+        float64list: ZeroCopyBuffer(vec![42.0f64; n as usize]),
+    })
 }
 
 #[derive(Debug, Clone)]
@@ -169,6 +204,10 @@ pub struct ExoticOptionals {
     pub zerocopy: Option<ZeroCopyBuffer<Vec<u8>>>,
     pub int8list: Option<Vec<i8>>,
     pub uint8list: Option<Vec<u8>>,
+    pub int32list: Option<Vec<i32>>,
+    pub int64list: Option<Vec<i64>>,
+    pub float32list: Option<Vec<f32>>,
+    pub float64list: Option<Vec<f64>>,
     pub attributes: Option<Vec<Attribute>>,
     pub attributes_nullable: Vec<Option<Attribute>>,
     pub nullable_attributes: Option<Vec<Option<Attribute>>>,
@@ -176,21 +215,23 @@ pub struct ExoticOptionals {
 }
 
 pub fn handle_optional_increment(opt: Option<ExoticOptionals>) -> Result<Option<ExoticOptionals>> {
+    fn manipulate_list<T>(src: Option<Vec<T>>, push_value: T) -> Option<Vec<T>> {
+        let mut list = src.unwrap_or_else(Vec::new);
+        list.push(push_value);
+        Some(list)
+    }
+
     Ok(opt.map(|mut opt| ExoticOptionals {
         int32: Some(opt.int32.unwrap_or(0) + 1),
         int64: Some(opt.int64.unwrap_or(0) + 1),
         float64: Some(opt.float64.unwrap_or(0.) + 1.),
         boolean: Some(!opt.boolean.unwrap_or(false)),
-        int8list: Some({
-            let mut list = opt.int8list.unwrap_or_else(Vec::new);
-            list.push(0);
-            list
-        }),
-        uint8list: Some({
-            let mut list = opt.uint8list.unwrap_or_else(Vec::new);
-            list.push(0);
-            list
-        }),
+        int8list: manipulate_list(opt.int8list, 0),
+        uint8list: manipulate_list(opt.uint8list, 0),
+        int32list: manipulate_list(opt.int32list, 0),
+        int64list: manipulate_list(opt.int64list, 0),
+        float32list: manipulate_list(opt.float32list, 0.),
+        float64list: manipulate_list(opt.float64list, 0.),
         attributes: Some({
             let mut list = opt.attributes.unwrap_or_else(Vec::new);
             list.push(Attribute {


### PR DESCRIPTION
Closes #153

prerequisite: https://github.com/sunshine-protocol/allo-isolate/pull/15