### PR TITLE
Revert "Support more types of the form`Vec<primitive_type>` and `ZeroCopyBuffer<Vec<primitive_type>>`, such as `Vec<f32>` and `ZeroCopyBuffer<Vec<f32>>` to be transformed into `Float32List` in Dart"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 1.3.0
-
-* Support more types of the form`Vec<primitive_type>` and `ZeroCopyBuffer<Vec<primitive_type>>`, such as `Vec<f32>` and `ZeroCopyBuffer<Vec<f32>>` to be transformed into `Float32List` in Dart.
-
 ## 1.2.3
 
 * Warn when `ffigen` emits any `[SEVERE]` log messages.

--- a/frb_codegen/src/generator_dart.rs
+++ b/frb_codegen/src/generator_dart.rs
@@ -201,9 +201,14 @@ fn generate_api2wire_func(ty: &ApiType) -> String {
             ApiTypeDelegate::String => {
                 "return _api2wire_uint_8_list(utf8.encoder.convert(raw));".to_string()
             }
-            ApiTypeDelegate::ZeroCopyBufferVecPrimitive(_) => {
-                format!("return _api2wire_{}(raw);", d.get_delegate().safe_ident())
-            }
+            ApiTypeDelegate::ZeroCopyBufferVecU8 => {
+                "return _api2wire_uint_8_list(raw);".to_string()
+            } // ApiTypeDelegate::Optional(_) => {
+              // format!(
+              // "return raw != null ? _api2wire_{}(raw) : ffi.nullptr;",
+              // d.get_delegate().safe_ident()
+              // )
+              // }
         },
         Optional(opt) => format!(
             "return raw == null ? ffi.nullptr : _api2wire_{}(raw);",
@@ -321,9 +326,7 @@ fn generate_wire2api_func(ty: &ApiType, api_file: &ApiFile) -> String {
         Primitive(p) => gen_simple_type_cast(&p.dart_api_type()),
         Delegate(d) => match d {
             ApiTypeDelegate::String => gen_simple_type_cast(&d.dart_api_type()),
-            ApiTypeDelegate::ZeroCopyBufferVecPrimitive(_) => {
-                gen_simple_type_cast(&d.dart_api_type())
-            }
+            ApiTypeDelegate::ZeroCopyBufferVecU8 => gen_simple_type_cast(&d.dart_api_type()),
         },
         Optional(opt) => format!(
             "return raw == null ? null : _wire2api_{}(raw);",

--- a/frb_codegen/src/generator_rust.rs
+++ b/frb_codegen/src/generator_rust.rs
@@ -308,9 +308,7 @@ impl Generator {
                 ApiTypeDelegate::String => "let vec: Vec<u8> = self.wire2api();
                 String::from_utf8_lossy(&vec).into_owned()"
                     .into(),
-                ApiTypeDelegate::ZeroCopyBufferVecPrimitive(_) => {
-                    "ZeroCopyBuffer(self.wire2api())".into()
-                }
+                ApiTypeDelegate::ZeroCopyBufferVecU8 => "ZeroCopyBuffer(self.wire2api())".into(),
             },
             PrimitiveList(_) => "unsafe {
                 let wrap = support::box_from_leak_ptr(self);

--- a/frb_example/pure_dart/dart/lib/bridge_generated.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.dart
@@ -23,9 +23,7 @@ abstract class FlutterRustBridgeExample extends FlutterRustBridgeBase<FlutterRus
 
   Future<Uint8List> handleVecU8({required Uint8List v, dynamic hint});
 
-  Future<VecOfPrimitivePack> handleVecOfPrimitive({required Uint8List v, dynamic hint});
-
-  Future<ZeroCopyVecOfPrimitivePack> handleZeroCopyVecOfPrimitive({required int n, dynamic hint});
+  Future<Uint8List> handleZeroCopyResult({required int n, dynamic hint});
 
   Future<MySize> handleStruct({required MySize arg, required MySize boxed, dynamic hint});
 
@@ -92,10 +90,6 @@ class ExoticOptionals {
   final Uint8List? zerocopy;
   final Int8List? int8List;
   final Uint8List? uint8List;
-  final Int32List? int32List;
-  final Int64List? int64List;
-  final Float32List? float32List;
-  final Float64List? float64List;
   final List<Attribute>? attributes;
   final List<Attribute?> attributesNullable;
   final List<Attribute?>? nullableAttributes;
@@ -109,10 +103,6 @@ class ExoticOptionals {
     this.zerocopy,
     this.int8List,
     this.uint8List,
-    this.int32List,
-    this.int64List,
-    this.float32List,
-    this.float64List,
     this.attributes,
     required this.attributesNullable,
     this.nullableAttributes,
@@ -147,42 +137,6 @@ class NewTypeInt {
 
   NewTypeInt({
     required this.field0,
-  });
-}
-
-class VecOfPrimitivePack {
-  final Int8List int8List;
-  final Uint8List uint8List;
-  final Int32List int32List;
-  final Int64List int64List;
-  final Float32List float32List;
-  final Float64List float64List;
-
-  VecOfPrimitivePack({
-    required this.int8List,
-    required this.uint8List,
-    required this.int32List,
-    required this.int64List,
-    required this.float32List,
-    required this.float64List,
-  });
-}
-
-class ZeroCopyVecOfPrimitivePack {
-  final Int8List int8List;
-  final Uint8List uint8List;
-  final Int32List int32List;
-  final Int64List int64List;
-  final Float32List float32List;
-  final Float64List float64List;
-
-  ZeroCopyVecOfPrimitivePack({
-    required this.int8List,
-    required this.uint8List,
-    required this.int32List,
-    required this.int64List,
-    required this.float32List,
-    required this.float64List,
   });
 }
 
@@ -221,19 +175,11 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeExample {
       parseSuccessData: _wire2api_uint_8_list,
       hint: hint));
 
-  Future<VecOfPrimitivePack> handleVecOfPrimitive({required Uint8List v, dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
-          debugName: 'handle_vec_of_primitive',
-          callFfi: (port) => inner.wire_handle_vec_of_primitive(port, _api2wire_uint_8_list(v)),
-          parseSuccessData: _wire2api_vec_of_primitive_pack,
-          hint: hint));
-
-  Future<ZeroCopyVecOfPrimitivePack> handleZeroCopyVecOfPrimitive({required int n, dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
-          debugName: 'handle_zero_copy_vec_of_primitive',
-          callFfi: (port) => inner.wire_handle_zero_copy_vec_of_primitive(port, _api2wire_i32(n)),
-          parseSuccessData: _wire2api_zero_copy_vec_of_primitive_pack,
-          hint: hint));
+  Future<Uint8List> handleZeroCopyResult({required int n, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+      debugName: 'handle_zero_copy_result',
+      callFfi: (port) => inner.wire_handle_zero_copy_result(port, _api2wire_i32(n)),
+      parseSuccessData: _wire2api_ZeroCopyBuffer_Uint8List,
+      hint: hint));
 
   Future<MySize> handleStruct({required MySize arg, required MySize boxed, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
@@ -429,24 +375,8 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeExample {
     return inner.new_box_u8(raw);
   }
 
-  double _api2wire_f32(double raw) {
-    return raw;
-  }
-
   double _api2wire_f64(double raw) {
     return raw;
-  }
-
-  ffi.Pointer<wire_float_32_list> _api2wire_float_32_list(Float32List raw) {
-    final ans = inner.new_float_32_list(raw.length);
-    ans.ref.ptr.asTypedList(raw.length).setAll(0, raw);
-    return ans;
-  }
-
-  ffi.Pointer<wire_float_64_list> _api2wire_float_64_list(Float64List raw) {
-    final ans = inner.new_float_64_list(raw.length);
-    ans.ref.ptr.asTypedList(raw.length).setAll(0, raw);
-    return ans;
   }
 
   int _api2wire_i32(int raw) {
@@ -459,18 +389,6 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeExample {
 
   int _api2wire_i8(int raw) {
     return raw;
-  }
-
-  ffi.Pointer<wire_int_32_list> _api2wire_int_32_list(Int32List raw) {
-    final ans = inner.new_int_32_list(raw.length);
-    ans.ref.ptr.asTypedList(raw.length).setAll(0, raw);
-    return ans;
-  }
-
-  ffi.Pointer<wire_int_64_list> _api2wire_int_64_list(Int64List raw) {
-    final ans = inner.new_int_64_list(raw.length);
-    ans.ref.ptr.asTypedList(raw.length).setAll(0, raw);
-    return ans;
   }
 
   ffi.Pointer<wire_int_8_list> _api2wire_int_8_list(Int8List raw) {
@@ -575,22 +493,6 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeExample {
     return raw == null ? ffi.nullptr : _api2wire_box_u8(raw);
   }
 
-  ffi.Pointer<wire_float_32_list> _api2wire_opt_float_32_list(Float32List? raw) {
-    return raw == null ? ffi.nullptr : _api2wire_float_32_list(raw);
-  }
-
-  ffi.Pointer<wire_float_64_list> _api2wire_opt_float_64_list(Float64List? raw) {
-    return raw == null ? ffi.nullptr : _api2wire_float_64_list(raw);
-  }
-
-  ffi.Pointer<wire_int_32_list> _api2wire_opt_int_32_list(Int32List? raw) {
-    return raw == null ? ffi.nullptr : _api2wire_int_32_list(raw);
-  }
-
-  ffi.Pointer<wire_int_64_list> _api2wire_opt_int_64_list(Int64List? raw) {
-    return raw == null ? ffi.nullptr : _api2wire_int_64_list(raw);
-  }
-
   ffi.Pointer<wire_int_8_list> _api2wire_opt_int_8_list(Int8List? raw) {
     return raw == null ? ffi.nullptr : _api2wire_int_8_list(raw);
   }
@@ -661,10 +563,6 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeExample {
     wireObj.zerocopy = _api2wire_opt_ZeroCopyBuffer_Uint8List(apiObj.zerocopy);
     wireObj.int8list = _api2wire_opt_int_8_list(apiObj.int8List);
     wireObj.uint8list = _api2wire_opt_uint_8_list(apiObj.uint8List);
-    wireObj.int32list = _api2wire_opt_int_32_list(apiObj.int32List);
-    wireObj.int64list = _api2wire_opt_int_64_list(apiObj.int64List);
-    wireObj.float32list = _api2wire_opt_float_32_list(apiObj.float32List);
-    wireObj.float64list = _api2wire_opt_float_64_list(apiObj.float64List);
     wireObj.attributes = _api2wire_opt_list_attribute(apiObj.attributes);
     wireObj.attributes_nullable = _api2wire_list_opt_box_autoadd_attribute(apiObj.attributesNullable);
     wireObj.nullable_attributes = _api2wire_opt_list_opt_box_autoadd_attribute(apiObj.nullableAttributes);
@@ -707,26 +605,6 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeExample {
 // Section: wire2api
 String _wire2api_String(dynamic raw) {
   return raw as String;
-}
-
-Float32List _wire2api_ZeroCopyBuffer_Float32List(dynamic raw) {
-  return raw as Float32List;
-}
-
-Float64List _wire2api_ZeroCopyBuffer_Float64List(dynamic raw) {
-  return raw as Float64List;
-}
-
-Int32List _wire2api_ZeroCopyBuffer_Int32List(dynamic raw) {
-  return raw as Int32List;
-}
-
-Int64List _wire2api_ZeroCopyBuffer_Int64List(dynamic raw) {
-  return raw as Int64List;
-}
-
-Int8List _wire2api_ZeroCopyBuffer_Int8List(dynamic raw) {
-  return raw as Int8List;
 }
 
 Uint8List _wire2api_ZeroCopyBuffer_Uint8List(dynamic raw) {
@@ -791,7 +669,7 @@ Element _wire2api_element(dynamic raw) {
 
 ExoticOptionals _wire2api_exotic_optionals(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 15) throw Exception('unexpected arr length: expect 15 but see ${arr.length}');
+  if (arr.length != 11) throw Exception('unexpected arr length: expect 11 but see ${arr.length}');
   return ExoticOptionals(
     int32: _wire2api_opt_box_autoadd_i32(arr[0]),
     int64: _wire2api_opt_box_autoadd_i64(arr[1]),
@@ -800,31 +678,15 @@ ExoticOptionals _wire2api_exotic_optionals(dynamic raw) {
     zerocopy: _wire2api_opt_ZeroCopyBuffer_Uint8List(arr[4]),
     int8List: _wire2api_opt_int_8_list(arr[5]),
     uint8List: _wire2api_opt_uint_8_list(arr[6]),
-    int32List: _wire2api_opt_int_32_list(arr[7]),
-    int64List: _wire2api_opt_int_64_list(arr[8]),
-    float32List: _wire2api_opt_float_32_list(arr[9]),
-    float64List: _wire2api_opt_float_64_list(arr[10]),
-    attributes: _wire2api_opt_list_attribute(arr[11]),
-    attributesNullable: _wire2api_list_opt_box_autoadd_attribute(arr[12]),
-    nullableAttributes: _wire2api_opt_list_opt_box_autoadd_attribute(arr[13]),
-    newtypeint: _wire2api_opt_box_autoadd_new_type_int(arr[14]),
+    attributes: _wire2api_opt_list_attribute(arr[7]),
+    attributesNullable: _wire2api_list_opt_box_autoadd_attribute(arr[8]),
+    nullableAttributes: _wire2api_opt_list_opt_box_autoadd_attribute(arr[9]),
+    newtypeint: _wire2api_opt_box_autoadd_new_type_int(arr[10]),
   );
-}
-
-double _wire2api_f32(dynamic raw) {
-  return raw as double;
 }
 
 double _wire2api_f64(dynamic raw) {
   return raw as double;
-}
-
-Float32List _wire2api_float_32_list(dynamic raw) {
-  return raw as Float32List;
-}
-
-Float64List _wire2api_float_64_list(dynamic raw) {
-  return raw as Float64List;
 }
 
 int _wire2api_i32(dynamic raw) {
@@ -837,14 +699,6 @@ int _wire2api_i64(dynamic raw) {
 
 int _wire2api_i8(dynamic raw) {
   return raw as int;
-}
-
-Int32List _wire2api_int_32_list(dynamic raw) {
-  return raw as Int32List;
-}
-
-Int64List _wire2api_int_64_list(dynamic raw) {
-  return raw as Int64List;
 }
 
 Int8List _wire2api_int_8_list(dynamic raw) {
@@ -938,22 +792,6 @@ NewTypeInt? _wire2api_opt_box_autoadd_new_type_int(dynamic raw) {
   return raw == null ? null : _wire2api_box_autoadd_new_type_int(raw);
 }
 
-Float32List? _wire2api_opt_float_32_list(dynamic raw) {
-  return raw == null ? null : _wire2api_float_32_list(raw);
-}
-
-Float64List? _wire2api_opt_float_64_list(dynamic raw) {
-  return raw == null ? null : _wire2api_float_64_list(raw);
-}
-
-Int32List? _wire2api_opt_int_32_list(dynamic raw) {
-  return raw == null ? null : _wire2api_int_32_list(raw);
-}
-
-Int64List? _wire2api_opt_int_64_list(dynamic raw) {
-  return raw == null ? null : _wire2api_int_64_list(raw);
-}
-
 Int8List? _wire2api_opt_int_8_list(dynamic raw) {
   return raw == null ? null : _wire2api_int_8_list(raw);
 }
@@ -980,32 +818,6 @@ int _wire2api_u8(dynamic raw) {
 
 Uint8List _wire2api_uint_8_list(dynamic raw) {
   return raw as Uint8List;
-}
-
-VecOfPrimitivePack _wire2api_vec_of_primitive_pack(dynamic raw) {
-  final arr = raw as List<dynamic>;
-  if (arr.length != 6) throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
-  return VecOfPrimitivePack(
-    int8List: _wire2api_int_8_list(arr[0]),
-    uint8List: _wire2api_uint_8_list(arr[1]),
-    int32List: _wire2api_int_32_list(arr[2]),
-    int64List: _wire2api_int_64_list(arr[3]),
-    float32List: _wire2api_float_32_list(arr[4]),
-    float64List: _wire2api_float_64_list(arr[5]),
-  );
-}
-
-ZeroCopyVecOfPrimitivePack _wire2api_zero_copy_vec_of_primitive_pack(dynamic raw) {
-  final arr = raw as List<dynamic>;
-  if (arr.length != 6) throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
-  return ZeroCopyVecOfPrimitivePack(
-    int8List: _wire2api_ZeroCopyBuffer_Int8List(arr[0]),
-    uint8List: _wire2api_ZeroCopyBuffer_Uint8List(arr[1]),
-    int32List: _wire2api_ZeroCopyBuffer_Int32List(arr[2]),
-    int64List: _wire2api_ZeroCopyBuffer_Int64List(arr[3]),
-    float32List: _wire2api_ZeroCopyBuffer_Float32List(arr[4]),
-    float64List: _wire2api_ZeroCopyBuffer_Float64List(arr[5]),
-  );
 }
 
 // ignore_for_file: camel_case_types, non_constant_identifier_names, avoid_positional_boolean_parameters, annotate_overrides, constant_identifier_names
@@ -1093,36 +905,19 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   late final _wire_handle_vec_u8 =
       _wire_handle_vec_u8Ptr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
-  void wire_handle_vec_of_primitive(
-    int port,
-    ffi.Pointer<wire_uint_8_list> v,
-  ) {
-    return _wire_handle_vec_of_primitive(
-      port,
-      v,
-    );
-  }
-
-  late final _wire_handle_vec_of_primitivePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>(
-          'wire_handle_vec_of_primitive');
-  late final _wire_handle_vec_of_primitive =
-      _wire_handle_vec_of_primitivePtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
-
-  void wire_handle_zero_copy_vec_of_primitive(
+  void wire_handle_zero_copy_result(
     int port,
     int n,
   ) {
-    return _wire_handle_zero_copy_vec_of_primitive(
+    return _wire_handle_zero_copy_result(
       port,
       n,
     );
   }
 
-  late final _wire_handle_zero_copy_vec_of_primitivePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>('wire_handle_zero_copy_vec_of_primitive');
-  late final _wire_handle_zero_copy_vec_of_primitive =
-      _wire_handle_zero_copy_vec_of_primitivePtr.asFunction<void Function(int, int)>();
+  late final _wire_handle_zero_copy_resultPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>('wire_handle_zero_copy_result');
+  late final _wire_handle_zero_copy_result = _wire_handle_zero_copy_resultPtr.asFunction<void Function(int, int)>();
 
   void wire_handle_struct(
     int port,
@@ -1502,54 +1297,6 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   late final _new_box_u8Ptr = _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Uint8> Function(ffi.Uint8)>>('new_box_u8');
   late final _new_box_u8 = _new_box_u8Ptr.asFunction<ffi.Pointer<ffi.Uint8> Function(int)>();
 
-  ffi.Pointer<wire_float_32_list> new_float_32_list(
-    int len,
-  ) {
-    return _new_float_32_list(
-      len,
-    );
-  }
-
-  late final _new_float_32_listPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_float_32_list> Function(ffi.Int32)>>('new_float_32_list');
-  late final _new_float_32_list = _new_float_32_listPtr.asFunction<ffi.Pointer<wire_float_32_list> Function(int)>();
-
-  ffi.Pointer<wire_float_64_list> new_float_64_list(
-    int len,
-  ) {
-    return _new_float_64_list(
-      len,
-    );
-  }
-
-  late final _new_float_64_listPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_float_64_list> Function(ffi.Int32)>>('new_float_64_list');
-  late final _new_float_64_list = _new_float_64_listPtr.asFunction<ffi.Pointer<wire_float_64_list> Function(int)>();
-
-  ffi.Pointer<wire_int_32_list> new_int_32_list(
-    int len,
-  ) {
-    return _new_int_32_list(
-      len,
-    );
-  }
-
-  late final _new_int_32_listPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_int_32_list> Function(ffi.Int32)>>('new_int_32_list');
-  late final _new_int_32_list = _new_int_32_listPtr.asFunction<ffi.Pointer<wire_int_32_list> Function(int)>();
-
-  ffi.Pointer<wire_int_64_list> new_int_64_list(
-    int len,
-  ) {
-    return _new_int_64_list(
-      len,
-    );
-  }
-
-  late final _new_int_64_listPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_int_64_list> Function(ffi.Int32)>>('new_int_64_list');
-  late final _new_int_64_list = _new_int_64_listPtr.asFunction<ffi.Pointer<wire_int_64_list> Function(int)>();
-
   ffi.Pointer<wire_int_8_list> new_int_8_list(
     int len,
   ) {
@@ -1688,34 +1435,6 @@ class wire_int_8_list extends ffi.Struct {
   external int len;
 }
 
-class wire_int_32_list extends ffi.Struct {
-  external ffi.Pointer<ffi.Int32> ptr;
-
-  @ffi.Int32()
-  external int len;
-}
-
-class wire_int_64_list extends ffi.Struct {
-  external ffi.Pointer<ffi.Int64> ptr;
-
-  @ffi.Int32()
-  external int len;
-}
-
-class wire_float_32_list extends ffi.Struct {
-  external ffi.Pointer<ffi.Float> ptr;
-
-  @ffi.Int32()
-  external int len;
-}
-
-class wire_float_64_list extends ffi.Struct {
-  external ffi.Pointer<ffi.Double> ptr;
-
-  @ffi.Int32()
-  external int len;
-}
-
 class wire_Attribute extends ffi.Struct {
   external ffi.Pointer<wire_uint_8_list> key;
 
@@ -1750,14 +1469,6 @@ class wire_ExoticOptionals extends ffi.Struct {
   external ffi.Pointer<wire_int_8_list> int8list;
 
   external ffi.Pointer<wire_uint_8_list> uint8list;
-
-  external ffi.Pointer<wire_int_32_list> int32list;
-
-  external ffi.Pointer<wire_int_64_list> int64list;
-
-  external ffi.Pointer<wire_float_32_list> float32list;
-
-  external ffi.Pointer<wire_float_64_list> float64list;
 
   external ffi.Pointer<wire_list_attribute> attributes;
 

--- a/frb_example/pure_dart/rust/src/api.rs
+++ b/frb_example/pure_dart/rust/src/api.rs
@@ -6,6 +6,7 @@ use std::thread;
 use std::time::Duration;
 
 use anyhow::{anyhow, Result};
+
 use flutter_rust_bridge::{StreamSink, ZeroCopyBuffer};
 
 pub fn simple_adder(a: i32, b: i32) -> Result<i32> {
@@ -26,50 +27,14 @@ pub fn handle_string(s: String) -> Result<String> {
     Ok(s + &s2)
 }
 
-// to check that `Vec<u8>` can be used as return type
 pub fn handle_vec_u8(v: Vec<u8>) -> Result<Vec<u8>> {
     println!("handle_vec_u8(first few elements: {:?})", &v[..5]);
     Ok(v.repeat(2))
 }
 
-pub struct VecOfPrimitivePack {
-    pub int8list: Vec<i8>,
-    pub uint8list: Vec<u8>,
-    pub int32list: Vec<i32>,
-    pub int64list: Vec<i64>,
-    pub float32list: Vec<f32>,
-    pub float64list: Vec<f64>,
-}
-
-pub fn handle_vec_of_primitive(v: Vec<u8>) -> Result<VecOfPrimitivePack> {
-    Ok(VecOfPrimitivePack {
-        int8list: vec![42i8; n as usize],
-        uint8list: vec![42u8; n as usize],
-        int32list: vec![42i32; n as usize],
-        int64list: vec![42i64; n as usize],
-        float32list: vec![42.0f32; n as usize],
-        float64list: vec![42.0f64; n as usize],
-    })
-}
-
-pub struct ZeroCopyVecOfPrimitivePack {
-    pub int8list: ZeroCopyBuffer<Vec<i8>>,
-    pub uint8list: ZeroCopyBuffer<Vec<u8>>,
-    pub int32list: ZeroCopyBuffer<Vec<i32>>,
-    pub int64list: ZeroCopyBuffer<Vec<i64>>,
-    pub float32list: ZeroCopyBuffer<Vec<f32>>,
-    pub float64list: ZeroCopyBuffer<Vec<f64>>,
-}
-
-pub fn handle_zero_copy_vec_of_primitive(n: i32) -> Result<ZeroCopyVecOfPrimitivePack> {
-    Ok(ZeroCopyVecOfPrimitivePack {
-        int8list: ZeroCopyBuffer(vec![42i8; n as usize]),
-        uint8list: ZeroCopyBuffer(vec![42u8; n as usize]),
-        int32list: ZeroCopyBuffer(vec![42i32; n as usize]),
-        int64list: ZeroCopyBuffer(vec![42i64; n as usize]),
-        float32list: ZeroCopyBuffer(vec![42.0f32; n as usize]),
-        float64list: ZeroCopyBuffer(vec![42.0f64; n as usize]),
-    })
+pub fn handle_zero_copy_result(n: i32) -> Result<ZeroCopyBuffer<Vec<u8>>> {
+    println!("handle_zero_copy_result(n: {})", n);
+    Ok(ZeroCopyBuffer(vec![42u8; n as usize]))
 }
 
 #[derive(Debug, Clone)]
@@ -204,10 +169,6 @@ pub struct ExoticOptionals {
     pub zerocopy: Option<ZeroCopyBuffer<Vec<u8>>>,
     pub int8list: Option<Vec<i8>>,
     pub uint8list: Option<Vec<u8>>,
-    pub int32list: Option<Vec<i32>>,
-    pub int64list: Option<Vec<i64>>,
-    pub float32list: Option<Vec<f32>>,
-    pub float64list: Option<Vec<f64>>,
     pub attributes: Option<Vec<Attribute>>,
     pub attributes_nullable: Vec<Option<Attribute>>,
     pub nullable_attributes: Option<Vec<Option<Attribute>>>,
@@ -215,23 +176,21 @@ pub struct ExoticOptionals {
 }
 
 pub fn handle_optional_increment(opt: Option<ExoticOptionals>) -> Result<Option<ExoticOptionals>> {
-    fn manipulate_list<T>(src: Option<Vec<T>>, push_value: T) -> Option<Vec<T>> {
-        let mut list = src.unwrap_or_else(Vec::new);
-        list.push(push_value);
-        Some(list)
-    }
-
     Ok(opt.map(|mut opt| ExoticOptionals {
         int32: Some(opt.int32.unwrap_or(0) + 1),
         int64: Some(opt.int64.unwrap_or(0) + 1),
         float64: Some(opt.float64.unwrap_or(0.) + 1.),
         boolean: Some(!opt.boolean.unwrap_or(false)),
-        int8list: manipulate_list(opt.int8list, 0),
-        uint8list: manipulate_list(opt.uint8list, 0),
-        int32list: manipulate_list(opt.int32list, 0),
-        int64list: manipulate_list(opt.int64list, 0),
-        float32list: manipulate_list(opt.float32list, 0.),
-        float64list: manipulate_list(opt.float64list, 0.),
+        int8list: Some({
+            let mut list = opt.int8list.unwrap_or_else(Vec::new);
+            list.push(0);
+            list
+        }),
+        uint8list: Some({
+            let mut list = opt.uint8list.unwrap_or_else(Vec::new);
+            list.push(0);
+            list
+        }),
         attributes: Some({
             let mut list = opt.attributes.unwrap_or_else(Vec::new);
             list.push(Attribute {

--- a/frb_example/pure_dart/rust/src/bridge_generated.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.rs
@@ -83,31 +83,16 @@ pub extern "C" fn wire_handle_vec_u8(port: i64, v: *mut wire_uint_8_list) {
 }
 
 #[no_mangle]
-pub extern "C" fn wire_handle_vec_of_primitive(port: i64, v: *mut wire_uint_8_list) {
+pub extern "C" fn wire_handle_zero_copy_result(port: i64, n: i32) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {
-            debug_name: "handle_vec_of_primitive",
-            port,
-            mode: FfiCallMode::Normal,
-        },
-        move || {
-            let api_v = v.wire2api();
-            move |task_callback| handle_vec_of_primitive(api_v)
-        },
-    );
-}
-
-#[no_mangle]
-pub extern "C" fn wire_handle_zero_copy_vec_of_primitive(port: i64, n: i32) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
-        WrapInfo {
-            debug_name: "handle_zero_copy_vec_of_primitive",
+            debug_name: "handle_zero_copy_result",
             port,
             mode: FfiCallMode::Normal,
         },
         move || {
             let api_n = n.wire2api();
-            move |task_callback| handle_zero_copy_vec_of_primitive(api_n)
+            move |task_callback| handle_zero_copy_result(api_n)
         },
     );
 }
@@ -332,42 +317,10 @@ pub struct wire_ExoticOptionals {
     zerocopy: *mut wire_uint_8_list,
     int8list: *mut wire_int_8_list,
     uint8list: *mut wire_uint_8_list,
-    int32list: *mut wire_int_32_list,
-    int64list: *mut wire_int_64_list,
-    float32list: *mut wire_float_32_list,
-    float64list: *mut wire_float_64_list,
     attributes: *mut wire_list_attribute,
     attributes_nullable: *mut wire_list_opt_box_autoadd_attribute,
     nullable_attributes: *mut wire_list_opt_box_autoadd_attribute,
     newtypeint: *mut wire_NewTypeInt,
-}
-
-#[repr(C)]
-#[derive(Clone)]
-pub struct wire_float_32_list {
-    ptr: *mut f32,
-    len: i32,
-}
-
-#[repr(C)]
-#[derive(Clone)]
-pub struct wire_float_64_list {
-    ptr: *mut f64,
-    len: i32,
-}
-
-#[repr(C)]
-#[derive(Clone)]
-pub struct wire_int_32_list {
-    ptr: *mut i32,
-    len: i32,
-}
-
-#[repr(C)]
-#[derive(Clone)]
-pub struct wire_int_64_list {
-    ptr: *mut i64,
-    len: i32,
 }
 
 #[repr(C)]
@@ -518,42 +471,6 @@ pub extern "C" fn new_box_my_size() -> *mut wire_MySize {
 #[no_mangle]
 pub extern "C" fn new_box_u8(value: u8) -> *mut u8 {
     support::new_leak_box_ptr(value)
-}
-
-#[no_mangle]
-pub extern "C" fn new_float_32_list(len: i32) -> *mut wire_float_32_list {
-    let ans = wire_float_32_list {
-        ptr: support::new_leak_vec_ptr(Default::default(), len),
-        len,
-    };
-    support::new_leak_box_ptr(ans)
-}
-
-#[no_mangle]
-pub extern "C" fn new_float_64_list(len: i32) -> *mut wire_float_64_list {
-    let ans = wire_float_64_list {
-        ptr: support::new_leak_vec_ptr(Default::default(), len),
-        len,
-    };
-    support::new_leak_box_ptr(ans)
-}
-
-#[no_mangle]
-pub extern "C" fn new_int_32_list(len: i32) -> *mut wire_int_32_list {
-    let ans = wire_int_32_list {
-        ptr: support::new_leak_vec_ptr(Default::default(), len),
-        len,
-    };
-    support::new_leak_box_ptr(ans)
-}
-
-#[no_mangle]
-pub extern "C" fn new_int_64_list(len: i32) -> *mut wire_int_64_list {
-    let ans = wire_int_64_list {
-        ptr: support::new_leak_vec_ptr(Default::default(), len),
-        len,
-    };
-    support::new_leak_box_ptr(ans)
 }
 
 #[no_mangle]
@@ -775,10 +692,6 @@ impl Wire2Api<ExoticOptionals> for wire_ExoticOptionals {
             zerocopy: self.zerocopy.wire2api(),
             int8list: self.int8list.wire2api(),
             uint8list: self.uint8list.wire2api(),
-            int32list: self.int32list.wire2api(),
-            int64list: self.int64list.wire2api(),
-            float32list: self.float32list.wire2api(),
-            float64list: self.float64list.wire2api(),
             attributes: self.attributes.wire2api(),
             attributes_nullable: self.attributes_nullable.wire2api(),
             nullable_attributes: self.nullable_attributes.wire2api(),
@@ -787,33 +700,9 @@ impl Wire2Api<ExoticOptionals> for wire_ExoticOptionals {
     }
 }
 
-impl Wire2Api<f32> for f32 {
-    fn wire2api(self) -> f32 {
-        self
-    }
-}
-
 impl Wire2Api<f64> for f64 {
     fn wire2api(self) -> f64 {
         self
-    }
-}
-
-impl Wire2Api<Vec<f32>> for *mut wire_float_32_list {
-    fn wire2api(self) -> Vec<f32> {
-        unsafe {
-            let wrap = support::box_from_leak_ptr(self);
-            support::vec_from_leak_ptr(wrap.ptr, wrap.len)
-        }
-    }
-}
-
-impl Wire2Api<Vec<f64>> for *mut wire_float_64_list {
-    fn wire2api(self) -> Vec<f64> {
-        unsafe {
-            let wrap = support::box_from_leak_ptr(self);
-            support::vec_from_leak_ptr(wrap.ptr, wrap.len)
-        }
     }
 }
 
@@ -832,24 +721,6 @@ impl Wire2Api<i64> for i64 {
 impl Wire2Api<i8> for i8 {
     fn wire2api(self) -> i8 {
         self
-    }
-}
-
-impl Wire2Api<Vec<i32>> for *mut wire_int_32_list {
-    fn wire2api(self) -> Vec<i32> {
-        unsafe {
-            let wrap = support::box_from_leak_ptr(self);
-            support::vec_from_leak_ptr(wrap.ptr, wrap.len)
-        }
-    }
-}
-
-impl Wire2Api<Vec<i64>> for *mut wire_int_64_list {
-    fn wire2api(self) -> Vec<i64> {
-        unsafe {
-            let wrap = support::box_from_leak_ptr(self);
-            support::vec_from_leak_ptr(wrap.ptr, wrap.len)
-        }
     }
 }
 
@@ -1087,46 +958,6 @@ impl Wire2Api<Option<Box<u8>>> for *mut u8 {
     }
 }
 
-impl Wire2Api<Option<Vec<f32>>> for *mut wire_float_32_list {
-    fn wire2api(self) -> Option<Vec<f32>> {
-        if self.is_null() {
-            None
-        } else {
-            Some(self.wire2api())
-        }
-    }
-}
-
-impl Wire2Api<Option<Vec<f64>>> for *mut wire_float_64_list {
-    fn wire2api(self) -> Option<Vec<f64>> {
-        if self.is_null() {
-            None
-        } else {
-            Some(self.wire2api())
-        }
-    }
-}
-
-impl Wire2Api<Option<Vec<i32>>> for *mut wire_int_32_list {
-    fn wire2api(self) -> Option<Vec<i32>> {
-        if self.is_null() {
-            None
-        } else {
-            Some(self.wire2api())
-        }
-    }
-}
-
-impl Wire2Api<Option<Vec<i64>>> for *mut wire_int_64_list {
-    fn wire2api(self) -> Option<Vec<i64>> {
-        if self.is_null() {
-            None
-        } else {
-            Some(self.wire2api())
-        }
-    }
-}
-
 impl Wire2Api<Option<Vec<i8>>> for *mut wire_int_8_list {
     fn wire2api(self) -> Option<Vec<i8>> {
         if self.is_null() {
@@ -1213,10 +1044,6 @@ impl NewWithNullPtr for wire_ExoticOptionals {
             zerocopy: std::ptr::null_mut(),
             int8list: std::ptr::null_mut(),
             uint8list: std::ptr::null_mut(),
-            int32list: std::ptr::null_mut(),
-            int64list: std::ptr::null_mut(),
-            float32list: std::ptr::null_mut(),
-            float64list: std::ptr::null_mut(),
             attributes: std::ptr::null_mut(),
             attributes_nullable: std::ptr::null_mut(),
             nullable_attributes: std::ptr::null_mut(),
@@ -1282,10 +1109,6 @@ impl support::IntoDart for ExoticOptionals {
             self.zerocopy.into_dart(),
             self.int8list.into_dart(),
             self.uint8list.into_dart(),
-            self.int32list.into_dart(),
-            self.int64list.into_dart(),
-            self.float32list.into_dart(),
-            self.float64list.into_dart(),
             self.attributes.into_dart(),
             self.attributes_nullable.into_dart(),
             self.nullable_attributes.into_dart(),
@@ -1315,34 +1138,6 @@ impl support::IntoDart for MyTreeNode {
 impl support::IntoDart for NewTypeInt {
     fn into_dart(self) -> support::DartCObject {
         vec![self.0.into_dart()].into_dart()
-    }
-}
-
-impl support::IntoDart for VecOfPrimitivePack {
-    fn into_dart(self) -> support::DartCObject {
-        vec![
-            self.int8list.into_dart(),
-            self.uint8list.into_dart(),
-            self.int32list.into_dart(),
-            self.int64list.into_dart(),
-            self.float32list.into_dart(),
-            self.float64list.into_dart(),
-        ]
-        .into_dart()
-    }
-}
-
-impl support::IntoDart for ZeroCopyVecOfPrimitivePack {
-    fn into_dart(self) -> support::DartCObject {
-        vec![
-            self.int8list.into_dart(),
-            self.uint8list.into_dart(),
-            self.int32list.into_dart(),
-            self.int64list.into_dart(),
-            self.float32list.into_dart(),
-            self.float64list.into_dart(),
-        ]
-        .into_dart()
     }
 }
 


### PR DESCRIPTION
Reverts fzyzcjy/flutter_rust_bridge#150