### PR TITLE
Support more types of the formVec<primitive_type> and ZeroCopyBuffer<Vec<primitive_type>>, such as Vec<f32> and ZeroCopyBuffer<Vec<f32>> to be transformed into Float32List in Dart 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.0
+
+* Support more types of the form`Vec<primitive_type>` and `ZeroCopyBuffer<Vec<primitive_type>>`, such as `Vec<f32>` and `ZeroCopyBuffer<Vec<f32>>` to be transformed into `Float32List` in Dart.
+
 ## 1.2.3
 
 * Warn when `ffigen` emits any `[SEVERE]` log messages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,9 @@
 ## 1.3.0
 
-* Support more types of the form`Vec<primitive_type>` and `ZeroCopyBuffer<Vec<primitive_type>>`, such as `Vec<f32>` and `ZeroCopyBuffer<Vec<f32>>` to be transformed into `Float32List` in Dart.
+* Support more types of the form`Vec<primitive_type>` and `ZeroCopyBuffer<Vec<primitive_type>>`, such as `Vec<f32>` and `ZeroCopyBuffer<Vec<f32>>` to be transformed into `Float32List` in Dart. (#162, #153)
 
-## 1.2.3
-
-* Warn when `ffigen` emits any `[SEVERE]` log messages.
 * Do not generate unnecessary Dart to Rust wire code to fix bugs such as when `Vec<ZeroCopyBuffer<Vec<u8>>>` is in output argument.
+* Warn when `ffigen` emits any `[SEVERE]` log messages.
 * Make outputs change less when input of codegen changes.
 * Simplify `Wire2Api<Option<T>>` generated code.
 

--- a/frb_codegen/src/api_types.rs
+++ b/frb_codegen/src/api_types.rs
@@ -369,7 +369,7 @@ impl ApiTypeChild for ApiTypeDelegate {
     fn rust_api_type(&self) -> String {
         match self {
             ApiTypeDelegate::String => "String".to_owned(),
-            ApiTypeDelegate::ZeroCopyBufferVecPrimitive(primitive) => {
+            ApiTypeDelegate::ZeroCopyBufferVecPrimitive(_) => {
                 format!("ZeroCopyBuffer<{}>", self.get_delegate().rust_api_type())
             }
         }

--- a/frb_codegen/src/api_types.rs
+++ b/frb_codegen/src/api_types.rs
@@ -228,8 +228,13 @@ pub trait ApiTypeChild {
 pub enum ApiTypePrimitive {
     U8,
     I8,
+    U16,
+    I16,
+    U32,
     I32,
+    U64,
     I64,
+    F32,
     F64,
     Bool,
 }
@@ -241,12 +246,17 @@ impl ApiTypeChild for ApiTypePrimitive {
 
     fn dart_api_type(&self) -> String {
         match self {
-            ApiTypePrimitive::U8 => "int",
-            ApiTypePrimitive::I8 => "int",
-            ApiTypePrimitive::I32 => "int",
-            ApiTypePrimitive::I64 => "int",
-            ApiTypePrimitive::F64 => "double",
+            ApiTypePrimitive::U8
+            | ApiTypePrimitive::I8
+            | ApiTypePrimitive::U16
+            | ApiTypePrimitive::I16
+            | ApiTypePrimitive::U32
+            | ApiTypePrimitive::I32
+            // NOTE: does NOT support `u64`, since a u64 cannot be fit into a Dart int(i64)
+            | ApiTypePrimitive::I64 => "int",
+            ApiTypePrimitive::F32 | ApiTypePrimitive::F64 => "double",
             ApiTypePrimitive::Bool => "bool",
+            _ => panic!("dart_api_type does not support {:?}", &self),
         }
         .to_string()
     }
@@ -263,8 +273,13 @@ impl ApiTypeChild for ApiTypePrimitive {
         match self {
             ApiTypePrimitive::U8 => "u8",
             ApiTypePrimitive::I8 => "i8",
+            ApiTypePrimitive::U16 => "u16",
+            ApiTypePrimitive::I16 => "i16",
+            ApiTypePrimitive::U32 => "u32",
             ApiTypePrimitive::I32 => "i32",
+            ApiTypePrimitive::U64 => "u64",
             ApiTypePrimitive::I64 => "i64",
+            ApiTypePrimitive::F32 => "f32",
             ApiTypePrimitive::F64 => "f64",
             ApiTypePrimitive::Bool => "bool",
         }
@@ -280,8 +295,13 @@ impl ApiTypePrimitive {
         match self {
             ApiTypePrimitive::U8 | ApiTypePrimitive::Bool => "ffi.Uint8",
             ApiTypePrimitive::I8 => "ffi.Int8",
+            ApiTypePrimitive::U16 => "ffi.Uint16",
+            ApiTypePrimitive::I16 => "ffi.Int16",
+            ApiTypePrimitive::U32 => "ffi.Uint32",
             ApiTypePrimitive::I32 => "ffi.Int32",
+            ApiTypePrimitive::U64 => "ffi.Uint64",
             ApiTypePrimitive::I64 => "ffi.Int64",
+            ApiTypePrimitive::F32 => "ffi.Float",
             ApiTypePrimitive::F64 => "ffi.Double",
         }
     }
@@ -289,8 +309,13 @@ impl ApiTypePrimitive {
         match s {
             "u8" => Some(ApiTypePrimitive::U8),
             "i8" => Some(ApiTypePrimitive::I8),
+            "u16" => Some(ApiTypePrimitive::U16),
+            "i16" => Some(ApiTypePrimitive::I16),
+            "u32" => Some(ApiTypePrimitive::U32),
             "i32" => Some(ApiTypePrimitive::I32),
+            "u64" => Some(ApiTypePrimitive::U64),
             "i64" => Some(ApiTypePrimitive::I64),
+            "f32" => Some(ApiTypePrimitive::F32),
             "f64" => Some(ApiTypePrimitive::F64),
             "bool" => Some(ApiTypePrimitive::Bool),
             _ => None,
@@ -380,7 +405,13 @@ impl ApiTypeChild for ApiTypePrimitiveList {
         match &self.primitive {
             ApiTypePrimitive::U8 => "Uint8List",
             ApiTypePrimitive::I8 => "Int8List",
+            ApiTypePrimitive::U16 => "Uint16List",
+            ApiTypePrimitive::I16 => "Int16List",
+            ApiTypePrimitive::U32 => "Uint32List",
+            ApiTypePrimitive::I32 => "Int32List",
+            ApiTypePrimitive::U64 => "Uint64List",
             ApiTypePrimitive::I64 => "Int64List",
+            ApiTypePrimitive::F32 => "Float32List",
             ApiTypePrimitive::F64 => "Float64List",
             _ => panic!("does not support {:?} yet", &self.primitive),
         }

--- a/frb_codegen/src/api_types.rs
+++ b/frb_codegen/src/api_types.rs
@@ -252,11 +252,10 @@ impl ApiTypeChild for ApiTypePrimitive {
             | ApiTypePrimitive::I16
             | ApiTypePrimitive::U32
             | ApiTypePrimitive::I32
-            // NOTE: does NOT support `u64`, since a u64 cannot be fit into a Dart int(i64)
+            | ApiTypePrimitive::U64
             | ApiTypePrimitive::I64 => "int",
             ApiTypePrimitive::F32 | ApiTypePrimitive::F64 => "double",
             ApiTypePrimitive::Bool => "bool",
-            _ => panic!("dart_api_type does not support {:?}", &self),
         }
         .to_string()
     }

--- a/frb_codegen/src/generator_dart.rs
+++ b/frb_codegen/src/generator_dart.rs
@@ -201,7 +201,7 @@ fn generate_api2wire_func(ty: &ApiType) -> String {
             ApiTypeDelegate::String => {
                 "return _api2wire_uint_8_list(utf8.encoder.convert(raw));".to_string()
             }
-            ApiTypeDelegate::ZeroCopyBufferVecU8 => {
+            ApiTypeDelegate::ZeroCopyBufferVecPrimitive => {
                 "return _api2wire_uint_8_list(raw);".to_string()
             } // ApiTypeDelegate::Optional(_) => {
               // format!(
@@ -326,7 +326,7 @@ fn generate_wire2api_func(ty: &ApiType, api_file: &ApiFile) -> String {
         Primitive(p) => gen_simple_type_cast(&p.dart_api_type()),
         Delegate(d) => match d {
             ApiTypeDelegate::String => gen_simple_type_cast(&d.dart_api_type()),
-            ApiTypeDelegate::ZeroCopyBufferVecU8 => gen_simple_type_cast(&d.dart_api_type()),
+            ApiTypeDelegate::ZeroCopyBufferVecPrimitive => gen_simple_type_cast(&d.dart_api_type()),
         },
         Optional(opt) => format!(
             "return raw == null ? null : _wire2api_{}(raw);",

--- a/frb_codegen/src/generator_dart.rs
+++ b/frb_codegen/src/generator_dart.rs
@@ -201,14 +201,9 @@ fn generate_api2wire_func(ty: &ApiType) -> String {
             ApiTypeDelegate::String => {
                 "return _api2wire_uint_8_list(utf8.encoder.convert(raw));".to_string()
             }
-            ApiTypeDelegate::ZeroCopyBufferVecPrimitive => {
-                "return _api2wire_uint_8_list(raw);".to_string()
-            } // ApiTypeDelegate::Optional(_) => {
-              // format!(
-              // "return raw != null ? _api2wire_{}(raw) : ffi.nullptr;",
-              // d.get_delegate().safe_ident()
-              // )
-              // }
+            ApiTypeDelegate::ZeroCopyBufferVecPrimitive(_) => {
+                format!("return _api2wire_{}(raw);", d.get_delegate().safe_ident())
+            }
         },
         Optional(opt) => format!(
             "return raw == null ? ffi.nullptr : _api2wire_{}(raw);",
@@ -326,7 +321,9 @@ fn generate_wire2api_func(ty: &ApiType, api_file: &ApiFile) -> String {
         Primitive(p) => gen_simple_type_cast(&p.dart_api_type()),
         Delegate(d) => match d {
             ApiTypeDelegate::String => gen_simple_type_cast(&d.dart_api_type()),
-            ApiTypeDelegate::ZeroCopyBufferVecPrimitive => gen_simple_type_cast(&d.dart_api_type()),
+            ApiTypeDelegate::ZeroCopyBufferVecPrimitive(_) => {
+                gen_simple_type_cast(&d.dart_api_type())
+            }
         },
         Optional(opt) => format!(
             "return raw == null ? null : _wire2api_{}(raw);",

--- a/frb_codegen/src/generator_rust.rs
+++ b/frb_codegen/src/generator_rust.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
-use crate::api_types::*;
 use crate::api_types::ApiType::*;
+use crate::api_types::*;
 use crate::others::*;
 
 pub const HANDLER_NAME: &str = "FLUTTER_RUST_BRIDGE_HANDLER";
@@ -151,7 +151,7 @@ impl Generator {
                 })
                 .collect::<Vec<_>>(),
         ]
-            .concat();
+        .concat();
 
         let inner_func_params = [
             match func.mode {
@@ -163,7 +163,7 @@ impl Generator {
                 .map(|field| format!("api_{}", field.name.rust_style()))
                 .collect::<Vec<_>>(),
         ]
-            .concat();
+        .concat();
 
         // println!("generate_wire_func: {}", func.name);
         self.extern_func_collector.generate(
@@ -316,7 +316,7 @@ impl Generator {
                 let wrap = support::box_from_leak_ptr(self);
                 support::vec_from_leak_ptr(wrap.ptr, wrap.len)
             }"
-                .into(),
+            .into(),
             GeneralList(_) => "
             let vec = unsafe {
                 let wrap = support::box_from_leak_ptr(self);
@@ -352,7 +352,7 @@ impl Generator {
                 } else {
                     format!("{}({})", ty.rust_api_type(), fields_str)
                 }
-                    .into()
+                .into()
             }
             // implicit delegation
             Optional(_) => "if self.is_null() { None } else { Some(self.wire2api()) }".into(),
@@ -446,8 +446,7 @@ impl Generator {
             }}
             impl support::IntoDartExceptPrimitive for {} {{}}
             ",
-            s.name, body,
-            s.name,
+            s.name, body, s.name,
         )
     }
 }

--- a/frb_codegen/src/generator_rust.rs
+++ b/frb_codegen/src/generator_rust.rs
@@ -308,7 +308,7 @@ impl Generator {
                 ApiTypeDelegate::String => "let vec: Vec<u8> = self.wire2api();
                 String::from_utf8_lossy(&vec).into_owned()"
                     .into(),
-                ApiTypeDelegate::ZeroCopyBufferVecPrimitive => {
+                ApiTypeDelegate::ZeroCopyBufferVecPrimitive(_) => {
                     "ZeroCopyBuffer(self.wire2api())".into()
                 }
             },

--- a/frb_codegen/src/generator_rust.rs
+++ b/frb_codegen/src/generator_rust.rs
@@ -308,7 +308,9 @@ impl Generator {
                 ApiTypeDelegate::String => "let vec: Vec<u8> = self.wire2api();
                 String::from_utf8_lossy(&vec).into_owned()"
                     .into(),
-                ApiTypeDelegate::ZeroCopyBufferVecU8 => "ZeroCopyBuffer(self.wire2api())".into(),
+                ApiTypeDelegate::ZeroCopyBufferVecPrimitive => {
+                    "ZeroCopyBuffer(self.wire2api())".into()
+                }
             },
             PrimitiveList(_) => "unsafe {
                 let wrap = support::box_from_leak_ptr(self);

--- a/frb_codegen/src/generator_rust.rs
+++ b/frb_codegen/src/generator_rust.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
-use crate::api_types::ApiType::*;
 use crate::api_types::*;
+use crate::api_types::ApiType::*;
 use crate::others::*;
 
 pub const HANDLER_NAME: &str = "FLUTTER_RUST_BRIDGE_HANDLER";
@@ -151,7 +151,7 @@ impl Generator {
                 })
                 .collect::<Vec<_>>(),
         ]
-        .concat();
+            .concat();
 
         let inner_func_params = [
             match func.mode {
@@ -163,7 +163,7 @@ impl Generator {
                 .map(|field| format!("api_{}", field.name.rust_style()))
                 .collect::<Vec<_>>(),
         ]
-        .concat();
+            .concat();
 
         // println!("generate_wire_func: {}", func.name);
         self.extern_func_collector.generate(
@@ -316,7 +316,7 @@ impl Generator {
                 let wrap = support::box_from_leak_ptr(self);
                 support::vec_from_leak_ptr(wrap.ptr, wrap.len)
             }"
-            .into(),
+                .into(),
             GeneralList(_) => "
             let vec = unsafe {
                 let wrap = support::box_from_leak_ptr(self);
@@ -352,7 +352,7 @@ impl Generator {
                 } else {
                     format!("{}({})", ty.rust_api_type(), fields_str)
                 }
-                .into()
+                    .into()
             }
             // implicit delegation
             Optional(_) => "if self.is_null() { None } else { Some(self.wire2api()) }".into(),
@@ -438,13 +438,16 @@ impl Generator {
 
         format!(
             "impl support::IntoDart for {} {{
-            fn into_dart(self) -> support::DartCObject {{
-                vec![
-                    {}
-                ].into_dart()
+                fn into_dart(self) -> support::DartCObject {{
+                    vec![
+                        {}
+                    ].into_dart()
+                }}
             }}
-        }}",
+            impl support::IntoDartExceptPrimitive for {} {{}}
+            ",
             s.name, body,
+            s.name,
         )
     }
 }

--- a/frb_codegen/src/parser.rs
+++ b/frb_codegen/src/parser.rs
@@ -133,7 +133,7 @@ impl<'a> Parser<'a> {
 
                 if let Some(inner_type_str) = CAPTURE_ZERO_COPY_BUFFER.captures(ty) {
                     if let Some(ApiType::PrimitiveList(ApiTypePrimitiveList { primitive })) =
-                        self.try_parse_list(inner_type_str)
+                        self.try_parse_list(&inner_type_str)
                     {
                         return Some(ApiType::Delegate(
                             ApiTypeDelegate::ZeroCopyBufferVecPrimitive(primitive),

--- a/frb_codegen/src/parser.rs
+++ b/frb_codegen/src/parser.rs
@@ -104,7 +104,7 @@ impl<'a> Parser<'a> {
     fn parse_type(&mut self, ty: &str) -> ApiType {
         debug!("parse_type: {}", ty);
         None.or_else(|| ApiTypePrimitive::try_from_rust_str(ty).map(Primitive))
-            .or_else(|| ApiTypeDelegate::try_from_rust_str(ty).map(Delegate))
+            .or_else(|| self.try_parse_api_type_delegate(ty))
             .or_else(|| self.try_parse_list(ty))
             .or_else(|| self.try_parse_box(ty))
             .or_else(|| self.try_parse_option(ty))
@@ -120,6 +120,30 @@ impl<'a> Parser<'a> {
         CAPTURE_STREAM_SINK
             .captures(ty)
             .map(|inner| self.parse_type(&inner))
+    }
+
+    fn try_parse_api_type_delegate(&mut self, ty: &str) -> Option<ApiType> {
+        match ty {
+            "String" => Some(ApiType::Delegate(ApiTypeDelegate::String)),
+            _ => {
+                lazy_static! {
+                    static ref CAPTURE_ZERO_COPY_BUFFER: GenericCapture =
+                        GenericCapture::new("ZeroCopyBuffer");
+                }
+
+                if let Some(inner_type_str) = CAPTURE_ZERO_COPY_BUFFER.captures(ty) {
+                    if let Some(ApiType::PrimitiveList(ApiTypePrimitiveList { primitive })) =
+                        self.try_parse_list(inner_type_str)
+                    {
+                        return Some(ApiType::Delegate(
+                            ApiTypeDelegate::ZeroCopyBufferVecPrimitive(primitive),
+                        ));
+                    }
+                }
+
+                None
+            }
+        }
     }
 
     fn try_parse_list(&mut self, ty: &str) -> Option<ApiType> {

--- a/frb_example/pure_dart/dart/lib/bridge_generated.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.dart
@@ -23,7 +23,7 @@ abstract class FlutterRustBridgeExample extends FlutterRustBridgeBase<FlutterRus
 
   Future<Uint8List> handleVecU8({required Uint8List v, dynamic hint});
 
-  Future<VecOfPrimitivePack> handleVecOfPrimitive({required Uint8List v, dynamic hint});
+  Future<VecOfPrimitivePack> handleVecOfPrimitive({required int n, dynamic hint});
 
   Future<ZeroCopyVecOfPrimitivePack> handleZeroCopyVecOfPrimitive({required int n, dynamic hint});
 
@@ -237,10 +237,10 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeExample {
       parseSuccessData: _wire2api_uint_8_list,
       hint: hint));
 
-  Future<VecOfPrimitivePack> handleVecOfPrimitive({required Uint8List v, dynamic hint}) =>
+  Future<VecOfPrimitivePack> handleVecOfPrimitive({required int n, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
           debugName: 'handle_vec_of_primitive',
-          callFfi: (port) => inner.wire_handle_vec_of_primitive(port, _api2wire_uint_8_list(v)),
+          callFfi: (port) => inner.wire_handle_vec_of_primitive(port, _api2wire_i32(n)),
           parseSuccessData: _wire2api_vec_of_primitive_pack,
           hint: hint));
 
@@ -1167,19 +1167,17 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
 
   void wire_handle_vec_of_primitive(
     int port,
-    ffi.Pointer<wire_uint_8_list> v,
+    int n,
   ) {
     return _wire_handle_vec_of_primitive(
       port,
-      v,
+      n,
     );
   }
 
   late final _wire_handle_vec_of_primitivePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>(
-          'wire_handle_vec_of_primitive');
-  late final _wire_handle_vec_of_primitive =
-      _wire_handle_vec_of_primitivePtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>('wire_handle_vec_of_primitive');
+  late final _wire_handle_vec_of_primitive = _wire_handle_vec_of_primitivePtr.asFunction<void Function(int, int)>();
 
   void wire_handle_zero_copy_vec_of_primitive(
     int port,

--- a/frb_example/pure_dart/dart/lib/bridge_generated.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.dart
@@ -23,7 +23,9 @@ abstract class FlutterRustBridgeExample extends FlutterRustBridgeBase<FlutterRus
 
   Future<Uint8List> handleVecU8({required Uint8List v, dynamic hint});
 
-  Future<Uint8List> handleZeroCopyResult({required int n, dynamic hint});
+  Future<VecOfPrimitivePack> handleVecOfPrimitive({required Uint8List v, dynamic hint});
+
+  Future<ZeroCopyVecOfPrimitivePack> handleZeroCopyVecOfPrimitive({required int n, dynamic hint});
 
   Future<MySize> handleStruct({required MySize arg, required MySize boxed, dynamic hint});
 
@@ -90,6 +92,10 @@ class ExoticOptionals {
   final Uint8List? zerocopy;
   final Int8List? int8List;
   final Uint8List? uint8List;
+  final Int32List? int32List;
+  final Int64List? int64List;
+  final Float32List? float32List;
+  final Float64List? float64List;
   final List<Attribute>? attributes;
   final List<Attribute?> attributesNullable;
   final List<Attribute?>? nullableAttributes;
@@ -103,6 +109,10 @@ class ExoticOptionals {
     this.zerocopy,
     this.int8List,
     this.uint8List,
+    this.int32List,
+    this.int64List,
+    this.float32List,
+    this.float64List,
     this.attributes,
     required this.attributesNullable,
     this.nullableAttributes,
@@ -137,6 +147,42 @@ class NewTypeInt {
 
   NewTypeInt({
     required this.field0,
+  });
+}
+
+class VecOfPrimitivePack {
+  final Int8List int8List;
+  final Uint8List uint8List;
+  final Int32List int32List;
+  final Int64List int64List;
+  final Float32List float32List;
+  final Float64List float64List;
+
+  VecOfPrimitivePack({
+    required this.int8List,
+    required this.uint8List,
+    required this.int32List,
+    required this.int64List,
+    required this.float32List,
+    required this.float64List,
+  });
+}
+
+class ZeroCopyVecOfPrimitivePack {
+  final Int8List int8List;
+  final Uint8List uint8List;
+  final Int32List int32List;
+  final Int64List int64List;
+  final Float32List float32List;
+  final Float64List float64List;
+
+  ZeroCopyVecOfPrimitivePack({
+    required this.int8List,
+    required this.uint8List,
+    required this.int32List,
+    required this.int64List,
+    required this.float32List,
+    required this.float64List,
   });
 }
 
@@ -175,11 +221,19 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeExample {
       parseSuccessData: _wire2api_uint_8_list,
       hint: hint));
 
-  Future<Uint8List> handleZeroCopyResult({required int n, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
-      debugName: 'handle_zero_copy_result',
-      callFfi: (port) => inner.wire_handle_zero_copy_result(port, _api2wire_i32(n)),
-      parseSuccessData: _wire2api_ZeroCopyBuffer_Uint8List,
-      hint: hint));
+  Future<VecOfPrimitivePack> handleVecOfPrimitive({required Uint8List v, dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+          debugName: 'handle_vec_of_primitive',
+          callFfi: (port) => inner.wire_handle_vec_of_primitive(port, _api2wire_uint_8_list(v)),
+          parseSuccessData: _wire2api_vec_of_primitive_pack,
+          hint: hint));
+
+  Future<ZeroCopyVecOfPrimitivePack> handleZeroCopyVecOfPrimitive({required int n, dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+          debugName: 'handle_zero_copy_vec_of_primitive',
+          callFfi: (port) => inner.wire_handle_zero_copy_vec_of_primitive(port, _api2wire_i32(n)),
+          parseSuccessData: _wire2api_zero_copy_vec_of_primitive_pack,
+          hint: hint));
 
   Future<MySize> handleStruct({required MySize arg, required MySize boxed, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
@@ -375,8 +429,24 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeExample {
     return inner.new_box_u8(raw);
   }
 
+  double _api2wire_f32(double raw) {
+    return raw;
+  }
+
   double _api2wire_f64(double raw) {
     return raw;
+  }
+
+  ffi.Pointer<wire_float_32_list> _api2wire_float_32_list(Float32List raw) {
+    final ans = inner.new_float_32_list(raw.length);
+    ans.ref.ptr.asTypedList(raw.length).setAll(0, raw);
+    return ans;
+  }
+
+  ffi.Pointer<wire_float_64_list> _api2wire_float_64_list(Float64List raw) {
+    final ans = inner.new_float_64_list(raw.length);
+    ans.ref.ptr.asTypedList(raw.length).setAll(0, raw);
+    return ans;
   }
 
   int _api2wire_i32(int raw) {
@@ -389,6 +459,18 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeExample {
 
   int _api2wire_i8(int raw) {
     return raw;
+  }
+
+  ffi.Pointer<wire_int_32_list> _api2wire_int_32_list(Int32List raw) {
+    final ans = inner.new_int_32_list(raw.length);
+    ans.ref.ptr.asTypedList(raw.length).setAll(0, raw);
+    return ans;
+  }
+
+  ffi.Pointer<wire_int_64_list> _api2wire_int_64_list(Int64List raw) {
+    final ans = inner.new_int_64_list(raw.length);
+    ans.ref.ptr.asTypedList(raw.length).setAll(0, raw);
+    return ans;
   }
 
   ffi.Pointer<wire_int_8_list> _api2wire_int_8_list(Int8List raw) {
@@ -493,6 +575,22 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeExample {
     return raw == null ? ffi.nullptr : _api2wire_box_u8(raw);
   }
 
+  ffi.Pointer<wire_float_32_list> _api2wire_opt_float_32_list(Float32List? raw) {
+    return raw == null ? ffi.nullptr : _api2wire_float_32_list(raw);
+  }
+
+  ffi.Pointer<wire_float_64_list> _api2wire_opt_float_64_list(Float64List? raw) {
+    return raw == null ? ffi.nullptr : _api2wire_float_64_list(raw);
+  }
+
+  ffi.Pointer<wire_int_32_list> _api2wire_opt_int_32_list(Int32List? raw) {
+    return raw == null ? ffi.nullptr : _api2wire_int_32_list(raw);
+  }
+
+  ffi.Pointer<wire_int_64_list> _api2wire_opt_int_64_list(Int64List? raw) {
+    return raw == null ? ffi.nullptr : _api2wire_int_64_list(raw);
+  }
+
   ffi.Pointer<wire_int_8_list> _api2wire_opt_int_8_list(Int8List? raw) {
     return raw == null ? ffi.nullptr : _api2wire_int_8_list(raw);
   }
@@ -563,6 +661,10 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeExample {
     wireObj.zerocopy = _api2wire_opt_ZeroCopyBuffer_Uint8List(apiObj.zerocopy);
     wireObj.int8list = _api2wire_opt_int_8_list(apiObj.int8List);
     wireObj.uint8list = _api2wire_opt_uint_8_list(apiObj.uint8List);
+    wireObj.int32list = _api2wire_opt_int_32_list(apiObj.int32List);
+    wireObj.int64list = _api2wire_opt_int_64_list(apiObj.int64List);
+    wireObj.float32list = _api2wire_opt_float_32_list(apiObj.float32List);
+    wireObj.float64list = _api2wire_opt_float_64_list(apiObj.float64List);
     wireObj.attributes = _api2wire_opt_list_attribute(apiObj.attributes);
     wireObj.attributes_nullable = _api2wire_list_opt_box_autoadd_attribute(apiObj.attributesNullable);
     wireObj.nullable_attributes = _api2wire_opt_list_opt_box_autoadd_attribute(apiObj.nullableAttributes);
@@ -605,6 +707,26 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeExample {
 // Section: wire2api
 String _wire2api_String(dynamic raw) {
   return raw as String;
+}
+
+Float32List _wire2api_ZeroCopyBuffer_Float32List(dynamic raw) {
+  return raw as Float32List;
+}
+
+Float64List _wire2api_ZeroCopyBuffer_Float64List(dynamic raw) {
+  return raw as Float64List;
+}
+
+Int32List _wire2api_ZeroCopyBuffer_Int32List(dynamic raw) {
+  return raw as Int32List;
+}
+
+Int64List _wire2api_ZeroCopyBuffer_Int64List(dynamic raw) {
+  return raw as Int64List;
+}
+
+Int8List _wire2api_ZeroCopyBuffer_Int8List(dynamic raw) {
+  return raw as Int8List;
 }
 
 Uint8List _wire2api_ZeroCopyBuffer_Uint8List(dynamic raw) {
@@ -669,7 +791,7 @@ Element _wire2api_element(dynamic raw) {
 
 ExoticOptionals _wire2api_exotic_optionals(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 11) throw Exception('unexpected arr length: expect 11 but see ${arr.length}');
+  if (arr.length != 15) throw Exception('unexpected arr length: expect 15 but see ${arr.length}');
   return ExoticOptionals(
     int32: _wire2api_opt_box_autoadd_i32(arr[0]),
     int64: _wire2api_opt_box_autoadd_i64(arr[1]),
@@ -678,15 +800,31 @@ ExoticOptionals _wire2api_exotic_optionals(dynamic raw) {
     zerocopy: _wire2api_opt_ZeroCopyBuffer_Uint8List(arr[4]),
     int8List: _wire2api_opt_int_8_list(arr[5]),
     uint8List: _wire2api_opt_uint_8_list(arr[6]),
-    attributes: _wire2api_opt_list_attribute(arr[7]),
-    attributesNullable: _wire2api_list_opt_box_autoadd_attribute(arr[8]),
-    nullableAttributes: _wire2api_opt_list_opt_box_autoadd_attribute(arr[9]),
-    newtypeint: _wire2api_opt_box_autoadd_new_type_int(arr[10]),
+    int32List: _wire2api_opt_int_32_list(arr[7]),
+    int64List: _wire2api_opt_int_64_list(arr[8]),
+    float32List: _wire2api_opt_float_32_list(arr[9]),
+    float64List: _wire2api_opt_float_64_list(arr[10]),
+    attributes: _wire2api_opt_list_attribute(arr[11]),
+    attributesNullable: _wire2api_list_opt_box_autoadd_attribute(arr[12]),
+    nullableAttributes: _wire2api_opt_list_opt_box_autoadd_attribute(arr[13]),
+    newtypeint: _wire2api_opt_box_autoadd_new_type_int(arr[14]),
   );
+}
+
+double _wire2api_f32(dynamic raw) {
+  return raw as double;
 }
 
 double _wire2api_f64(dynamic raw) {
   return raw as double;
+}
+
+Float32List _wire2api_float_32_list(dynamic raw) {
+  return raw as Float32List;
+}
+
+Float64List _wire2api_float_64_list(dynamic raw) {
+  return raw as Float64List;
 }
 
 int _wire2api_i32(dynamic raw) {
@@ -699,6 +837,14 @@ int _wire2api_i64(dynamic raw) {
 
 int _wire2api_i8(dynamic raw) {
   return raw as int;
+}
+
+Int32List _wire2api_int_32_list(dynamic raw) {
+  return raw as Int32List;
+}
+
+Int64List _wire2api_int_64_list(dynamic raw) {
+  return raw as Int64List;
 }
 
 Int8List _wire2api_int_8_list(dynamic raw) {
@@ -792,6 +938,22 @@ NewTypeInt? _wire2api_opt_box_autoadd_new_type_int(dynamic raw) {
   return raw == null ? null : _wire2api_box_autoadd_new_type_int(raw);
 }
 
+Float32List? _wire2api_opt_float_32_list(dynamic raw) {
+  return raw == null ? null : _wire2api_float_32_list(raw);
+}
+
+Float64List? _wire2api_opt_float_64_list(dynamic raw) {
+  return raw == null ? null : _wire2api_float_64_list(raw);
+}
+
+Int32List? _wire2api_opt_int_32_list(dynamic raw) {
+  return raw == null ? null : _wire2api_int_32_list(raw);
+}
+
+Int64List? _wire2api_opt_int_64_list(dynamic raw) {
+  return raw == null ? null : _wire2api_int_64_list(raw);
+}
+
 Int8List? _wire2api_opt_int_8_list(dynamic raw) {
   return raw == null ? null : _wire2api_int_8_list(raw);
 }
@@ -818,6 +980,32 @@ int _wire2api_u8(dynamic raw) {
 
 Uint8List _wire2api_uint_8_list(dynamic raw) {
   return raw as Uint8List;
+}
+
+VecOfPrimitivePack _wire2api_vec_of_primitive_pack(dynamic raw) {
+  final arr = raw as List<dynamic>;
+  if (arr.length != 6) throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
+  return VecOfPrimitivePack(
+    int8List: _wire2api_int_8_list(arr[0]),
+    uint8List: _wire2api_uint_8_list(arr[1]),
+    int32List: _wire2api_int_32_list(arr[2]),
+    int64List: _wire2api_int_64_list(arr[3]),
+    float32List: _wire2api_float_32_list(arr[4]),
+    float64List: _wire2api_float_64_list(arr[5]),
+  );
+}
+
+ZeroCopyVecOfPrimitivePack _wire2api_zero_copy_vec_of_primitive_pack(dynamic raw) {
+  final arr = raw as List<dynamic>;
+  if (arr.length != 6) throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
+  return ZeroCopyVecOfPrimitivePack(
+    int8List: _wire2api_ZeroCopyBuffer_Int8List(arr[0]),
+    uint8List: _wire2api_ZeroCopyBuffer_Uint8List(arr[1]),
+    int32List: _wire2api_ZeroCopyBuffer_Int32List(arr[2]),
+    int64List: _wire2api_ZeroCopyBuffer_Int64List(arr[3]),
+    float32List: _wire2api_ZeroCopyBuffer_Float32List(arr[4]),
+    float64List: _wire2api_ZeroCopyBuffer_Float64List(arr[5]),
+  );
 }
 
 // ignore_for_file: camel_case_types, non_constant_identifier_names, avoid_positional_boolean_parameters, annotate_overrides, constant_identifier_names
@@ -905,19 +1093,36 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   late final _wire_handle_vec_u8 =
       _wire_handle_vec_u8Ptr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
-  void wire_handle_zero_copy_result(
+  void wire_handle_vec_of_primitive(
+    int port,
+    ffi.Pointer<wire_uint_8_list> v,
+  ) {
+    return _wire_handle_vec_of_primitive(
+      port,
+      v,
+    );
+  }
+
+  late final _wire_handle_vec_of_primitivePtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>(
+          'wire_handle_vec_of_primitive');
+  late final _wire_handle_vec_of_primitive =
+      _wire_handle_vec_of_primitivePtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+
+  void wire_handle_zero_copy_vec_of_primitive(
     int port,
     int n,
   ) {
-    return _wire_handle_zero_copy_result(
+    return _wire_handle_zero_copy_vec_of_primitive(
       port,
       n,
     );
   }
 
-  late final _wire_handle_zero_copy_resultPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>('wire_handle_zero_copy_result');
-  late final _wire_handle_zero_copy_result = _wire_handle_zero_copy_resultPtr.asFunction<void Function(int, int)>();
+  late final _wire_handle_zero_copy_vec_of_primitivePtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>('wire_handle_zero_copy_vec_of_primitive');
+  late final _wire_handle_zero_copy_vec_of_primitive =
+      _wire_handle_zero_copy_vec_of_primitivePtr.asFunction<void Function(int, int)>();
 
   void wire_handle_struct(
     int port,
@@ -1297,6 +1502,54 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   late final _new_box_u8Ptr = _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Uint8> Function(ffi.Uint8)>>('new_box_u8');
   late final _new_box_u8 = _new_box_u8Ptr.asFunction<ffi.Pointer<ffi.Uint8> Function(int)>();
 
+  ffi.Pointer<wire_float_32_list> new_float_32_list(
+    int len,
+  ) {
+    return _new_float_32_list(
+      len,
+    );
+  }
+
+  late final _new_float_32_listPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_float_32_list> Function(ffi.Int32)>>('new_float_32_list');
+  late final _new_float_32_list = _new_float_32_listPtr.asFunction<ffi.Pointer<wire_float_32_list> Function(int)>();
+
+  ffi.Pointer<wire_float_64_list> new_float_64_list(
+    int len,
+  ) {
+    return _new_float_64_list(
+      len,
+    );
+  }
+
+  late final _new_float_64_listPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_float_64_list> Function(ffi.Int32)>>('new_float_64_list');
+  late final _new_float_64_list = _new_float_64_listPtr.asFunction<ffi.Pointer<wire_float_64_list> Function(int)>();
+
+  ffi.Pointer<wire_int_32_list> new_int_32_list(
+    int len,
+  ) {
+    return _new_int_32_list(
+      len,
+    );
+  }
+
+  late final _new_int_32_listPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_int_32_list> Function(ffi.Int32)>>('new_int_32_list');
+  late final _new_int_32_list = _new_int_32_listPtr.asFunction<ffi.Pointer<wire_int_32_list> Function(int)>();
+
+  ffi.Pointer<wire_int_64_list> new_int_64_list(
+    int len,
+  ) {
+    return _new_int_64_list(
+      len,
+    );
+  }
+
+  late final _new_int_64_listPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_int_64_list> Function(ffi.Int32)>>('new_int_64_list');
+  late final _new_int_64_list = _new_int_64_listPtr.asFunction<ffi.Pointer<wire_int_64_list> Function(int)>();
+
   ffi.Pointer<wire_int_8_list> new_int_8_list(
     int len,
   ) {
@@ -1435,6 +1688,34 @@ class wire_int_8_list extends ffi.Struct {
   external int len;
 }
 
+class wire_int_32_list extends ffi.Struct {
+  external ffi.Pointer<ffi.Int32> ptr;
+
+  @ffi.Int32()
+  external int len;
+}
+
+class wire_int_64_list extends ffi.Struct {
+  external ffi.Pointer<ffi.Int64> ptr;
+
+  @ffi.Int32()
+  external int len;
+}
+
+class wire_float_32_list extends ffi.Struct {
+  external ffi.Pointer<ffi.Float> ptr;
+
+  @ffi.Int32()
+  external int len;
+}
+
+class wire_float_64_list extends ffi.Struct {
+  external ffi.Pointer<ffi.Double> ptr;
+
+  @ffi.Int32()
+  external int len;
+}
+
 class wire_Attribute extends ffi.Struct {
   external ffi.Pointer<wire_uint_8_list> key;
 
@@ -1469,6 +1750,14 @@ class wire_ExoticOptionals extends ffi.Struct {
   external ffi.Pointer<wire_int_8_list> int8list;
 
   external ffi.Pointer<wire_uint_8_list> uint8list;
+
+  external ffi.Pointer<wire_int_32_list> int32list;
+
+  external ffi.Pointer<wire_int_64_list> int64list;
+
+  external ffi.Pointer<wire_float_32_list> float32list;
+
+  external ffi.Pointer<wire_float_64_list> float64list;
 
   external ffi.Pointer<wire_list_attribute> attributes;
 

--- a/frb_example/pure_dart/dart/lib/bridge_generated.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.dart
@@ -153,7 +153,11 @@ class NewTypeInt {
 class VecOfPrimitivePack {
   final Int8List int8List;
   final Uint8List uint8List;
+  final Int16List int16List;
+  final Uint16List uint16List;
+  final Uint32List uint32List;
   final Int32List int32List;
+  final Uint64List uint64List;
   final Int64List int64List;
   final Float32List float32List;
   final Float64List float64List;
@@ -161,7 +165,11 @@ class VecOfPrimitivePack {
   VecOfPrimitivePack({
     required this.int8List,
     required this.uint8List,
+    required this.int16List,
+    required this.uint16List,
+    required this.uint32List,
     required this.int32List,
+    required this.uint64List,
     required this.int64List,
     required this.float32List,
     required this.float64List,
@@ -171,7 +179,11 @@ class VecOfPrimitivePack {
 class ZeroCopyVecOfPrimitivePack {
   final Int8List int8List;
   final Uint8List uint8List;
+  final Int16List int16List;
+  final Uint16List uint16List;
+  final Uint32List uint32List;
   final Int32List int32List;
+  final Uint64List uint64List;
   final Int64List int64List;
   final Float32List float32List;
   final Float64List float64List;
@@ -179,7 +191,11 @@ class ZeroCopyVecOfPrimitivePack {
   ZeroCopyVecOfPrimitivePack({
     required this.int8List,
     required this.uint8List,
+    required this.int16List,
+    required this.uint16List,
+    required this.uint32List,
     required this.int32List,
+    required this.uint64List,
     required this.int64List,
     required this.float32List,
     required this.float64List,
@@ -717,6 +733,10 @@ Float64List _wire2api_ZeroCopyBuffer_Float64List(dynamic raw) {
   return raw as Float64List;
 }
 
+Int16List _wire2api_ZeroCopyBuffer_Int16List(dynamic raw) {
+  return raw as Int16List;
+}
+
 Int32List _wire2api_ZeroCopyBuffer_Int32List(dynamic raw) {
   return raw as Int32List;
 }
@@ -727,6 +747,18 @@ Int64List _wire2api_ZeroCopyBuffer_Int64List(dynamic raw) {
 
 Int8List _wire2api_ZeroCopyBuffer_Int8List(dynamic raw) {
   return raw as Int8List;
+}
+
+Uint16List _wire2api_ZeroCopyBuffer_Uint16List(dynamic raw) {
+  return raw as Uint16List;
+}
+
+Uint32List _wire2api_ZeroCopyBuffer_Uint32List(dynamic raw) {
+  return raw as Uint32List;
+}
+
+Uint64List _wire2api_ZeroCopyBuffer_Uint64List(dynamic raw) {
+  return raw as Uint64List;
 }
 
 Uint8List _wire2api_ZeroCopyBuffer_Uint8List(dynamic raw) {
@@ -827,6 +859,10 @@ Float64List _wire2api_float_64_list(dynamic raw) {
   return raw as Float64List;
 }
 
+int _wire2api_i16(dynamic raw) {
+  return raw as int;
+}
+
 int _wire2api_i32(dynamic raw) {
   return raw as int;
 }
@@ -837,6 +873,10 @@ int _wire2api_i64(dynamic raw) {
 
 int _wire2api_i8(dynamic raw) {
   return raw as int;
+}
+
+Int16List _wire2api_int_16_list(dynamic raw) {
+  return raw as Int16List;
 }
 
 Int32List _wire2api_int_32_list(dynamic raw) {
@@ -974,8 +1014,32 @@ Uint8List? _wire2api_opt_uint_8_list(dynamic raw) {
   return raw == null ? null : _wire2api_uint_8_list(raw);
 }
 
+int _wire2api_u16(dynamic raw) {
+  return raw as int;
+}
+
+int _wire2api_u32(dynamic raw) {
+  return raw as int;
+}
+
+int _wire2api_u64(dynamic raw) {
+  return raw as int;
+}
+
 int _wire2api_u8(dynamic raw) {
   return raw as int;
+}
+
+Uint16List _wire2api_uint_16_list(dynamic raw) {
+  return raw as Uint16List;
+}
+
+Uint32List _wire2api_uint_32_list(dynamic raw) {
+  return raw as Uint32List;
+}
+
+Uint64List _wire2api_uint_64_list(dynamic raw) {
+  return raw as Uint64List;
 }
 
 Uint8List _wire2api_uint_8_list(dynamic raw) {
@@ -984,27 +1048,35 @@ Uint8List _wire2api_uint_8_list(dynamic raw) {
 
 VecOfPrimitivePack _wire2api_vec_of_primitive_pack(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 6) throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
+  if (arr.length != 10) throw Exception('unexpected arr length: expect 10 but see ${arr.length}');
   return VecOfPrimitivePack(
     int8List: _wire2api_int_8_list(arr[0]),
     uint8List: _wire2api_uint_8_list(arr[1]),
-    int32List: _wire2api_int_32_list(arr[2]),
-    int64List: _wire2api_int_64_list(arr[3]),
-    float32List: _wire2api_float_32_list(arr[4]),
-    float64List: _wire2api_float_64_list(arr[5]),
+    int16List: _wire2api_int_16_list(arr[2]),
+    uint16List: _wire2api_uint_16_list(arr[3]),
+    uint32List: _wire2api_uint_32_list(arr[4]),
+    int32List: _wire2api_int_32_list(arr[5]),
+    uint64List: _wire2api_uint_64_list(arr[6]),
+    int64List: _wire2api_int_64_list(arr[7]),
+    float32List: _wire2api_float_32_list(arr[8]),
+    float64List: _wire2api_float_64_list(arr[9]),
   );
 }
 
 ZeroCopyVecOfPrimitivePack _wire2api_zero_copy_vec_of_primitive_pack(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 6) throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
+  if (arr.length != 10) throw Exception('unexpected arr length: expect 10 but see ${arr.length}');
   return ZeroCopyVecOfPrimitivePack(
     int8List: _wire2api_ZeroCopyBuffer_Int8List(arr[0]),
     uint8List: _wire2api_ZeroCopyBuffer_Uint8List(arr[1]),
-    int32List: _wire2api_ZeroCopyBuffer_Int32List(arr[2]),
-    int64List: _wire2api_ZeroCopyBuffer_Int64List(arr[3]),
-    float32List: _wire2api_ZeroCopyBuffer_Float32List(arr[4]),
-    float64List: _wire2api_ZeroCopyBuffer_Float64List(arr[5]),
+    int16List: _wire2api_ZeroCopyBuffer_Int16List(arr[2]),
+    uint16List: _wire2api_ZeroCopyBuffer_Uint16List(arr[3]),
+    uint32List: _wire2api_ZeroCopyBuffer_Uint32List(arr[4]),
+    int32List: _wire2api_ZeroCopyBuffer_Int32List(arr[5]),
+    uint64List: _wire2api_ZeroCopyBuffer_Uint64List(arr[6]),
+    int64List: _wire2api_ZeroCopyBuffer_Int64List(arr[7]),
+    float32List: _wire2api_ZeroCopyBuffer_Float32List(arr[8]),
+    float64List: _wire2api_ZeroCopyBuffer_Float64List(arr[9]),
   );
 }
 

--- a/frb_example/pure_dart/dart/lib/main.dart
+++ b/frb_example/pure_dart/dart/lib/main.dart
@@ -3,7 +3,6 @@ import 'dart:typed_data';
 
 import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
 import 'package:flutter_rust_bridge_example/bridge_generated.dart';
-
 import 'package:test/test.dart';
 
 void main(List<String> args) async {
@@ -19,74 +18,95 @@ void main(List<String> args) async {
     print('call functions');
 
     print('dart call simpleAdder');
-    expect(await api.simpleAdder(a: 42, b: 100), 142);
+    {
+      expect(await api.simpleAdder(a: 42, b: 100), 142);
+    }
 
     print('dart call primitiveTypes');
-    expect(
-        await api.primitiveTypes(myI32: 123, myI64: 10000000000000, myF64: 12345678901234567890.123, myBool: true), 42);
+    {
+      expect(await api.primitiveTypes(myI32: 123, myI64: 10000000000000, myF64: 12345678901234567890.123, myBool: true),
+          42);
+    }
 
     print('dart call handleString');
-    expect(await api.handleString(s: "Hello, world!"), "Hello, world!Hello, world!");
+    {
+      expect(await api.handleString(s: "Hello, world!"), "Hello, world!Hello, world!");
+    }
 
     print('dart call handleVecU8');
-    final len = 100000;
-    expect(await api.handleVecU8(v: Uint8List.fromList(List.filled(len, 127))),
-        Uint8List.fromList(List.filled(len * 2, 127)));
+    {
+      final len = 100000;
+      expect(await api.handleVecU8(v: Uint8List.fromList(List.filled(len, 127))),
+          Uint8List.fromList(List.filled(len * 2, 127)));
+    }
 
-    print('dart call handleZeroCopyResult');
-    final n = 100000;
-    expect(await api.handleZeroCopyResult(n: n), Uint8List.fromList(List.filled(n, 42)));
+    print('dart call handleVecOfPrimitive');
+    {
+      final n = 100000;
+      final resp = await api.handleVecOfPrimitive(n: n);
+      expect(resp.uint8List, Uint8List.fromList(List.filled(n, 42)));
+      expect(resp.int8List, Int8List.fromList(List.filled(n, 42)));
+      expect(resp.uint16List, Uint16List.fromList(List.filled(n, 42)));
+      expect(resp.int16List, Int16List.fromList(List.filled(n, 42)));
+      expect(resp.uint32List, Uint32List.fromList(List.filled(n, 42)));
+      expect(resp.int32List, Int32List.fromList(List.filled(n, 42)));
+      expect(resp.uint64List, Uint64List.fromList(List.filled(n, 42)));
+      expect(resp.int64List, Int64List.fromList(List.filled(n, 42)));
+      expect(resp.float32List, Float32List.fromList(List.filled(n, 42)));
+      expect(resp.float64List, Float64List.fromList(List.filled(n, 42)));
+    }
+
+    print('dart call handleZeroCopyVecOfPrimitive');
+    {
+      final n = 100000;
+      final resp = await api.handleZeroCopyVecOfPrimitive(n: n);
+      expect(resp.uint8List, Uint8List.fromList(List.filled(n, 42)));
+      expect(resp.int8List, Int8List.fromList(List.filled(n, 42)));
+      expect(resp.uint16List, Uint16List.fromList(List.filled(n, 42)));
+      expect(resp.int16List, Int16List.fromList(List.filled(n, 42)));
+      expect(resp.uint32List, Uint32List.fromList(List.filled(n, 42)));
+      expect(resp.int32List, Int32List.fromList(List.filled(n, 42)));
+      expect(resp.uint64List, Uint64List.fromList(List.filled(n, 42)));
+      expect(resp.int64List, Int64List.fromList(List.filled(n, 42)));
+      expect(resp.float32List, Float32List.fromList(List.filled(n, 42)));
+      expect(resp.float64List, Float64List.fromList(List.filled(n, 42)));
+    }
 
     print('dart call handleStruct');
-    final structResp =
-        await api.handleStruct(arg: MySize(width: 42, height: 100), boxed: MySize(width: 1000, height: 10000));
-    expect(structResp.width, 42 + 1000);
-    expect(structResp.height, 100 + 10000);
+    {
+      final structResp =
+          await api.handleStruct(arg: MySize(width: 42, height: 100), boxed: MySize(width: 1000, height: 10000));
+      expect(structResp.width, 42 + 1000);
+      expect(structResp.height, 100 + 10000);
+    }
 
     print('dart call handleNewtype');
-    final newtypeResp = await api.handleNewtype(arg: NewTypeInt(field0: 42));
-    expect(newtypeResp.field0, 84);
+    {
+      final newtypeResp = await api.handleNewtype(arg: NewTypeInt(field0: 42));
+      expect(newtypeResp.field0, 84);
+    }
 
     print('dart call handleListOfStruct');
-    final listOfStructResp =
-        await api.handleListOfStruct(l: [MySize(width: 42, height: 100), MySize(width: 420, height: 1000)]);
-    expect(listOfStructResp.length, 4);
-    expect(listOfStructResp[0].width, 42);
-    expect(listOfStructResp[1].width, 420);
-    expect(listOfStructResp[2].width, 42);
-    expect(listOfStructResp[3].width, 420);
+    {
+      final listOfStructResp =
+          await api.handleListOfStruct(l: [MySize(width: 42, height: 100), MySize(width: 420, height: 1000)]);
+      expect(listOfStructResp.length, 4);
+      expect(listOfStructResp[0].width, 42);
+      expect(listOfStructResp[1].width, 420);
+      expect(listOfStructResp[2].width, 42);
+      expect(listOfStructResp[3].width, 420);
+    }
 
     print('dart call handleComplexStruct');
-    final arrLen = 5;
-    final complexStructResp = await api.handleComplexStruct(
-      s: MyTreeNode(
-        valueI32: 100,
-        valueVecU8: Uint8List.fromList(List.filled(arrLen, 100)),
-        children: [
-          MyTreeNode(
-            valueI32: 110,
-            valueVecU8: Uint8List.fromList(List.filled(arrLen, 110)),
-            children: [
-              MyTreeNode(
-                valueI32: 111,
-                valueVecU8: Uint8List.fromList(List.filled(arrLen, 111)),
-                children: [],
-              ),
-            ],
-          ),
-          MyTreeNode(
-            valueI32: 120,
-            valueVecU8: Uint8List.fromList(List.filled(arrLen, 120)),
-            children: [],
-          ),
-        ],
-      ),
-    );
-    expect(complexStructResp.valueI32, 100);
-    expect(complexStructResp.valueVecU8, List.filled(arrLen, 100));
-    expect(complexStructResp.children[0].valueVecU8, List.filled(arrLen, 110));
-    expect(complexStructResp.children[0].children[0].valueVecU8, List.filled(arrLen, 111));
-    expect(complexStructResp.children[1].valueVecU8, List.filled(arrLen, 120));
+    {
+      final arrLen = 5;
+      final complexStructResp = await api.handleComplexStruct(s: _createMyTreeNode(arrLen: arrLen));
+      expect(complexStructResp.valueI32, 100);
+      expect(complexStructResp.valueVecU8, List.filled(arrLen, 100));
+      expect(complexStructResp.children[0].valueVecU8, List.filled(arrLen, 110));
+      expect(complexStructResp.children[0].children[0].valueVecU8, List.filled(arrLen, 111));
+      expect(complexStructResp.children[1].valueVecU8, List.filled(arrLen, 120));
+    }
 
     print('dart call handle_stream');
     {
@@ -100,21 +120,105 @@ void main(List<String> args) async {
     }
 
     print('dart call returnErr');
-    try {
-      await api.returnErr();
-      fail("exception not thrown");
-    } catch (e) {
-      print('dart catch e: $e');
-      expect(e, isA<FfiException>());
+    {
+      try {
+        await api.returnErr();
+        fail("exception not thrown");
+      } catch (e) {
+        print('dart catch e: $e');
+        expect(e, isA<FfiException>());
+      }
     }
 
     print('dart call returnPanic');
-    try {
-      await api.returnPanic();
-      fail("exception not thrown");
-    } catch (e) {
-      print('dart catch e: $e');
-      expect(e, isA<FfiException>());
+    {
+      try {
+        await api.returnPanic();
+        fail("exception not thrown");
+      } catch (e) {
+        print('dart catch e: $e');
+        expect(e, isA<FfiException>());
+      }
+    }
+
+    print('dart call handleOptionalReturn');
+    {
+      expect((await api.handleOptionalReturn(left: 1, right: 1))!, 1);
+      expect(await api.handleOptionalReturn(left: 2, right: 0), null);
+    }
+
+    print('dart call handleOptionalStruct');
+    {
+      {
+        expect(await api.handleOptionalStruct(), null);
+      }
+
+      {
+        final message = 'Hello there.';
+        final ret = await api.handleOptionalStruct(document: message);
+        if (ret == null) fail('handleOptionalStruct returned null for non-null document');
+        expect(ret.tag, 'div');
+        expect(ret.text, null);
+        expect(ret.attributes?[0].key, 'id');
+        expect(ret.attributes?[0].value, 'root');
+
+        expect(ret.children?[0].tag, 'p');
+        expect(ret.children?[0].text, null);
+        expect(ret.children?[0].attributes, null);
+        expect(ret.children?[0].children?[0].text, message);
+      }
+    }
+
+    print('dart call handleOptionalIncrement');
+    {
+      expect(await api.handleOptionalIncrement(), null);
+
+      var ret = await api.handleOptionalIncrement(opt: ExoticOptionals(attributesNullable: []));
+      if (ret == null) fail('increment returned null for non-null params');
+      final loopFor = 100;
+      for (var i = 1; i < loopFor; i++) {
+        ret = await api.handleOptionalIncrement(opt: ret);
+      }
+      if (ret == null) fail('ret nulled after loop');
+      expect(ret.int32, loopFor);
+      expect(ret.int32, loopFor);
+      expect(ret.float64, loopFor);
+      expect(ret.boolean, false);
+      expect(ret.zerocopy?.length, loopFor);
+      expect(ret.int8List?.length, loopFor);
+      expect(ret.uint8List?.length, loopFor);
+      expect(ret.attributesNullable.length, loopFor);
+      expect(ret.nullableAttributes?.length, loopFor);
+      expect(ret.newtypeint?.field0, loopFor);
+    }
+
+    print('dart call handleIncrementBoxedOptional');
+    {
+      {
+        expect(await api.handleIncrementBoxedOptional(), 42);
+      }
+
+      {
+        var ret = 0.0;
+        final loopFor = 100;
+        for (var i = 0; i < loopFor; i++) {
+          ret = await api.handleIncrementBoxedOptional(opt: ret);
+        }
+        expect(ret, loopFor);
+      }
+    }
+
+    print('dart call handleOptionBoxArguments');
+    {
+      print(await api.handleOptionBoxArguments());
+
+      {
+        final optional10 = await api.handleOptionBoxArguments(
+          boolbox: true,
+          structbox: await api.handleOptionalIncrement(opt: ExoticOptionals(attributesNullable: [])),
+        );
+        print(optional10);
+      }
     }
 
     _createGarbage();
@@ -123,77 +227,10 @@ void main(List<String> args) async {
     await Future.delayed(Duration(seconds: 1));
 
     print('loop and call many times');
-    var obj = complexStructResp;
+    var obj = _createMyTreeNode(arrLen: 5);
     for (var i = 0; i < 500; ++i) {
       obj = await api.handleComplexStruct(s: obj);
     }
-
-    print('dart call handleOptionalReturn');
-    final optional1 = await api.handleOptionalReturn(left: 1, right: 1);
-    expect(optional1!, 1);
-    final optional2 = await api.handleOptionalReturn(left: 2, right: 0);
-    expect(optional2, null);
-
-    final optional3 = await api.handleOptionalStruct();
-    expect(optional3, null);
-
-    final message = 'Hello there.';
-    final optional4 = await api.handleOptionalStruct(document: message);
-    if (optional4 == null) return fail('handleOptionalStruct returned null for non-null document');
-    expect(optional4.tag, 'div');
-    expect(optional4.text, null);
-    expect(optional4.attributes?[0].key, 'id');
-    expect(optional4.attributes?[0].value, 'root');
-
-    expect(optional4.children?[0].tag, 'p');
-    expect(optional4.children?[0].text, null);
-    expect(optional4.children?[0].attributes, null);
-    expect(optional4.children?[0].children?[0].text, message);
-
-    print('dart call handleOptionalIncrement');
-    final optional5 = await api.handleOptionalIncrement();
-    expect(optional5, null);
-
-    var optional6 = await api.handleOptionalIncrement(
-      opt: ExoticOptionals(
-        attributesNullable: [],
-      ),
-    );
-    if (optional6 == null) return fail('increment returned null for non-null params');
-    final loopFor = 100;
-    for (var i = 1; i < loopFor; i++) {
-      optional6 = await api.handleOptionalIncrement(opt: optional6);
-    }
-    if (optional6 == null) return fail('optional6 nulled after loop');
-    expect(optional6.int32, loopFor);
-    expect(optional6.int32, loopFor);
-    expect(optional6.float64, loopFor);
-    expect(optional6.boolean, false);
-    expect(optional6.zerocopy?.length, loopFor);
-    expect(optional6.int8List?.length, loopFor);
-    expect(optional6.uint8List?.length, loopFor);
-    expect(optional6.attributesNullable.length, loopFor);
-    expect(optional6.nullableAttributes?.length, loopFor);
-    expect(optional6.newtypeint?.field0, loopFor);
-
-    print('dart call handleIncrementBoxedOptional');
-    final optional7 = await api.handleIncrementBoxedOptional();
-    expect(optional7, 42);
-    var optional8 = 0.0;
-    for (var i = 0; i < loopFor; i++) {
-      optional8 = await api.handleIncrementBoxedOptional(opt: optional8);
-    }
-    expect(optional8, loopFor);
-
-    print('dart call handleOptionBoxArguments');
-    final optional9 = await api.handleOptionBoxArguments();
-    print(optional9);
-
-    final optional10 = await api.handleOptionBoxArguments(
-      boolbox: true,
-      structbox: optional6,
-    );
-    print(optional10);
 
     print('flutter_rust_bridge example program end');
   });
@@ -207,4 +244,29 @@ int _createGarbage() {
     cum += l[42];
   }
   return cum;
+}
+
+MyTreeNode _createMyTreeNode({required int arrLen}) {
+  return MyTreeNode(
+    valueI32: 100,
+    valueVecU8: Uint8List.fromList(List.filled(arrLen, 100)),
+    children: [
+      MyTreeNode(
+        valueI32: 110,
+        valueVecU8: Uint8List.fromList(List.filled(arrLen, 110)),
+        children: [
+          MyTreeNode(
+            valueI32: 111,
+            valueVecU8: Uint8List.fromList(List.filled(arrLen, 111)),
+            children: [],
+          ),
+        ],
+      ),
+      MyTreeNode(
+        valueI32: 120,
+        valueVecU8: Uint8List.fromList(List.filled(arrLen, 120)),
+        children: [],
+      ),
+    ],
+  );
 }

--- a/frb_example/pure_dart/dart/lib/main.dart
+++ b/frb_example/pure_dart/dart/lib/main.dart
@@ -42,7 +42,7 @@ void main(List<String> args) async {
 
     print('dart call handleVecOfPrimitive');
     {
-      final n = 100000;
+      final n = 10000;
       final resp = await api.handleVecOfPrimitive(n: n);
       expect(resp.uint8List, Uint8List.fromList(List.filled(n, 42)));
       expect(resp.int8List, Int8List.fromList(List.filled(n, 42)));
@@ -58,7 +58,7 @@ void main(List<String> args) async {
 
     print('dart call handleZeroCopyVecOfPrimitive');
     {
-      final n = 100000;
+      final n = 10000;
       final resp = await api.handleZeroCopyVecOfPrimitive(n: n);
       expect(resp.uint8List, Uint8List.fromList(List.filled(n, 42)));
       expect(resp.int8List, Int8List.fromList(List.filled(n, 42)));
@@ -175,7 +175,7 @@ void main(List<String> args) async {
 
       var ret = await api.handleOptionalIncrement(opt: ExoticOptionals(attributesNullable: []));
       if (ret == null) fail('increment returned null for non-null params');
-      final loopFor = 100;
+      final loopFor = 20;
       for (var i = 1; i < loopFor; i++) {
         ret = await api.handleOptionalIncrement(opt: ret);
       }
@@ -239,7 +239,7 @@ void main(List<String> args) async {
 int _createGarbage() {
   print('dart create garbage (thus make it more possible to GC)');
   var cum = 0;
-  for (var i = 0; i < 5000; ++i) {
+  for (var i = 0; i < 1000; ++i) {
     final l = List.filled(5000, 42);
     cum += l[42];
   }

--- a/frb_example/pure_dart/dart/run.sh
+++ b/frb_example/pure_dart/dart/run.sh
@@ -14,4 +14,4 @@ fi
 # need to be AOT, since prod environment is AOT, and JIT+valgrind will have strange problems
 dart compile exe lib/main.dart -o main.exe
 
-PYTHONUNBUFFERED=1 ./valgrind_util.py ./main.exe "${CARGO_TARGET_DIR}/debug/libflutter_rust_bridge_example.so"
+PYTHONUNBUFFERED=1 ./valgrind_util.py ./main.exe "${CARGO_TARGET_DIR}/debug/libflutter_rust_bridge_example.so" --chain-stack-traces

--- a/frb_example/pure_dart/rust/Cargo.lock
+++ b/frb_example/pure_dart/rust/Cargo.lock
@@ -20,8 +20,7 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 [[package]]
 name = "allo-isolate"
 version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95c5a443c8b833fc57ee060bb52639fb687d94e640737e71be5c8cccbbbb790c"
+source = "git+https://github.com/fzyzcjy/allo-isolate#a0eed01d41919f60d4cb2bd351cea20e253c8e78"
 dependencies = [
  "atomic",
 ]

--- a/frb_example/pure_dart/rust/Cargo.lock
+++ b/frb_example/pure_dart/rust/Cargo.lock
@@ -20,7 +20,7 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 [[package]]
 name = "allo-isolate"
 version = "0.1.10"
-source = "git+https://github.com/fzyzcjy/allo-isolate#a0eed01d41919f60d4cb2bd351cea20e253c8e78"
+source = "git+https://github.com/fzyzcjy/allo-isolate#2e80cc6faa8cae351cf3f1809eeabdbee36f7df5"
 dependencies = [
  "atomic",
 ]

--- a/frb_example/pure_dart/rust/src/api.rs
+++ b/frb_example/pure_dart/rust/src/api.rs
@@ -35,7 +35,11 @@ pub fn handle_vec_u8(v: Vec<u8>) -> Result<Vec<u8>> {
 pub struct VecOfPrimitivePack {
     pub int8list: Vec<i8>,
     pub uint8list: Vec<u8>,
+    pub int16list: Vec<i16>,
+    pub uint16list: Vec<u16>,
+    pub uint32list: Vec<u32>,
     pub int32list: Vec<i32>,
+    pub uint64list: Vec<u64>,
     pub int64list: Vec<i64>,
     pub float32list: Vec<f32>,
     pub float64list: Vec<f64>,
@@ -45,8 +49,12 @@ pub fn handle_vec_of_primitive(v: Vec<u8>) -> Result<VecOfPrimitivePack> {
     Ok(VecOfPrimitivePack {
         int8list: vec![42i8; n as usize],
         uint8list: vec![42u8; n as usize],
+        int16list: vec![42i16; n as usize],
+        uint16list: vec![42u16; n as usize],
         int32list: vec![42i32; n as usize],
+        uint32list: vec![42u32; n as usize],
         int64list: vec![42i64; n as usize],
+        uint64list: vec![42u64; n as usize],
         float32list: vec![42.0f32; n as usize],
         float64list: vec![42.0f64; n as usize],
     })
@@ -55,7 +63,11 @@ pub fn handle_vec_of_primitive(v: Vec<u8>) -> Result<VecOfPrimitivePack> {
 pub struct ZeroCopyVecOfPrimitivePack {
     pub int8list: ZeroCopyBuffer<Vec<i8>>,
     pub uint8list: ZeroCopyBuffer<Vec<u8>>,
+    pub int16list: ZeroCopyBuffer<Vec<i16>>,
+    pub uint16list: ZeroCopyBuffer<Vec<u16>>,
+    pub uint32list: ZeroCopyBuffer<Vec<u32>>,
     pub int32list: ZeroCopyBuffer<Vec<i32>>,
+    pub uint64list: ZeroCopyBuffer<Vec<u64>>,
     pub int64list: ZeroCopyBuffer<Vec<i64>>,
     pub float32list: ZeroCopyBuffer<Vec<f32>>,
     pub float64list: ZeroCopyBuffer<Vec<f64>>,
@@ -65,8 +77,12 @@ pub fn handle_zero_copy_vec_of_primitive(n: i32) -> Result<ZeroCopyVecOfPrimitiv
     Ok(ZeroCopyVecOfPrimitivePack {
         int8list: ZeroCopyBuffer(vec![42i8; n as usize]),
         uint8list: ZeroCopyBuffer(vec![42u8; n as usize]),
+        int16list: ZeroCopyBuffer(vec![42i16; n as usize]),
+        uint16list: ZeroCopyBuffer(vec![42u16; n as usize]),
         int32list: ZeroCopyBuffer(vec![42i32; n as usize]),
+        uint32list: ZeroCopyBuffer(vec![42u32; n as usize]),
         int64list: ZeroCopyBuffer(vec![42i64; n as usize]),
+        uint64list: ZeroCopyBuffer(vec![42u64; n as usize]),
         float32list: ZeroCopyBuffer(vec![42.0f32; n as usize]),
         float64list: ZeroCopyBuffer(vec![42.0f64; n as usize]),
     })

--- a/frb_example/pure_dart/rust/src/api.rs
+++ b/frb_example/pure_dart/rust/src/api.rs
@@ -6,7 +6,6 @@ use std::thread;
 use std::time::Duration;
 
 use anyhow::{anyhow, Result};
-
 use flutter_rust_bridge::{StreamSink, ZeroCopyBuffer};
 
 pub fn simple_adder(a: i32, b: i32) -> Result<i32> {
@@ -27,14 +26,50 @@ pub fn handle_string(s: String) -> Result<String> {
     Ok(s + &s2)
 }
 
+// to check that `Vec<u8>` can be used as return type
 pub fn handle_vec_u8(v: Vec<u8>) -> Result<Vec<u8>> {
     println!("handle_vec_u8(first few elements: {:?})", &v[..5]);
     Ok(v.repeat(2))
 }
 
-pub fn handle_zero_copy_result(n: i32) -> Result<ZeroCopyBuffer<Vec<u8>>> {
-    println!("handle_zero_copy_result(n: {})", n);
-    Ok(ZeroCopyBuffer(vec![42u8; n as usize]))
+pub struct VecOfPrimitivePack {
+    pub int8list: Vec<i8>,
+    pub uint8list: Vec<u8>,
+    pub int32list: Vec<i32>,
+    pub int64list: Vec<i64>,
+    pub float32list: Vec<f32>,
+    pub float64list: Vec<f64>,
+}
+
+pub fn handle_vec_of_primitive(v: Vec<u8>) -> Result<VecOfPrimitivePack> {
+    Ok(VecOfPrimitivePack {
+        int8list: vec![42i8; n as usize],
+        uint8list: vec![42u8; n as usize],
+        int32list: vec![42i32; n as usize],
+        int64list: vec![42i64; n as usize],
+        float32list: vec![42.0f32; n as usize],
+        float64list: vec![42.0f64; n as usize],
+    })
+}
+
+pub struct ZeroCopyVecOfPrimitivePack {
+    pub int8list: ZeroCopyBuffer<Vec<i8>>,
+    pub uint8list: ZeroCopyBuffer<Vec<u8>>,
+    pub int32list: ZeroCopyBuffer<Vec<i32>>,
+    pub int64list: ZeroCopyBuffer<Vec<i64>>,
+    pub float32list: ZeroCopyBuffer<Vec<f32>>,
+    pub float64list: ZeroCopyBuffer<Vec<f64>>,
+}
+
+pub fn handle_zero_copy_vec_of_primitive(n: i32) -> Result<ZeroCopyVecOfPrimitivePack> {
+    Ok(ZeroCopyVecOfPrimitivePack {
+        int8list: ZeroCopyBuffer(vec![42i8; n as usize]),
+        uint8list: ZeroCopyBuffer(vec![42u8; n as usize]),
+        int32list: ZeroCopyBuffer(vec![42i32; n as usize]),
+        int64list: ZeroCopyBuffer(vec![42i64; n as usize]),
+        float32list: ZeroCopyBuffer(vec![42.0f32; n as usize]),
+        float64list: ZeroCopyBuffer(vec![42.0f64; n as usize]),
+    })
 }
 
 #[derive(Debug, Clone)]
@@ -169,6 +204,10 @@ pub struct ExoticOptionals {
     pub zerocopy: Option<ZeroCopyBuffer<Vec<u8>>>,
     pub int8list: Option<Vec<i8>>,
     pub uint8list: Option<Vec<u8>>,
+    pub int32list: Option<Vec<i32>>,
+    pub int64list: Option<Vec<i64>>,
+    pub float32list: Option<Vec<f32>>,
+    pub float64list: Option<Vec<f64>>,
     pub attributes: Option<Vec<Attribute>>,
     pub attributes_nullable: Vec<Option<Attribute>>,
     pub nullable_attributes: Option<Vec<Option<Attribute>>>,
@@ -176,21 +215,23 @@ pub struct ExoticOptionals {
 }
 
 pub fn handle_optional_increment(opt: Option<ExoticOptionals>) -> Result<Option<ExoticOptionals>> {
+    fn manipulate_list<T>(src: Option<Vec<T>>, push_value: T) -> Option<Vec<T>> {
+        let mut list = src.unwrap_or_else(Vec::new);
+        list.push(push_value);
+        Some(list)
+    }
+
     Ok(opt.map(|mut opt| ExoticOptionals {
         int32: Some(opt.int32.unwrap_or(0) + 1),
         int64: Some(opt.int64.unwrap_or(0) + 1),
         float64: Some(opt.float64.unwrap_or(0.) + 1.),
         boolean: Some(!opt.boolean.unwrap_or(false)),
-        int8list: Some({
-            let mut list = opt.int8list.unwrap_or_else(Vec::new);
-            list.push(0);
-            list
-        }),
-        uint8list: Some({
-            let mut list = opt.uint8list.unwrap_or_else(Vec::new);
-            list.push(0);
-            list
-        }),
+        int8list: manipulate_list(opt.int8list, 0),
+        uint8list: manipulate_list(opt.uint8list, 0),
+        int32list: manipulate_list(opt.int32list, 0),
+        int64list: manipulate_list(opt.int64list, 0),
+        float32list: manipulate_list(opt.float32list, 0.),
+        float64list: manipulate_list(opt.float64list, 0.),
         attributes: Some({
             let mut list = opt.attributes.unwrap_or_else(Vec::new);
             list.push(Attribute {

--- a/frb_example/pure_dart/rust/src/api.rs
+++ b/frb_example/pure_dart/rust/src/api.rs
@@ -45,7 +45,7 @@ pub struct VecOfPrimitivePack {
     pub float64list: Vec<f64>,
 }
 
-pub fn handle_vec_of_primitive(v: Vec<u8>) -> Result<VecOfPrimitivePack> {
+pub fn handle_vec_of_primitive(n: i32) -> Result<VecOfPrimitivePack> {
     Ok(VecOfPrimitivePack {
         int8list: vec![42i8; n as usize],
         uint8list: vec![42u8; n as usize],

--- a/frb_example/pure_dart/rust/src/bridge_generated.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.rs
@@ -1259,6 +1259,7 @@ impl support::IntoDart for Attribute {
         vec![self.key.into_dart(), self.value.into_dart()].into_dart()
     }
 }
+impl support::IntoDartExceptPrimitive for Attribute {}
 
 impl support::IntoDart for Element {
     fn into_dart(self) -> support::DartCObject {
@@ -1271,6 +1272,7 @@ impl support::IntoDart for Element {
         .into_dart()
     }
 }
+impl support::IntoDartExceptPrimitive for Element {}
 
 impl support::IntoDart for ExoticOptionals {
     fn into_dart(self) -> support::DartCObject {
@@ -1294,12 +1296,14 @@ impl support::IntoDart for ExoticOptionals {
         .into_dart()
     }
 }
+impl support::IntoDartExceptPrimitive for ExoticOptionals {}
 
 impl support::IntoDart for MySize {
     fn into_dart(self) -> support::DartCObject {
         vec![self.width.into_dart(), self.height.into_dart()].into_dart()
     }
 }
+impl support::IntoDartExceptPrimitive for MySize {}
 
 impl support::IntoDart for MyTreeNode {
     fn into_dart(self) -> support::DartCObject {
@@ -1311,12 +1315,14 @@ impl support::IntoDart for MyTreeNode {
         .into_dart()
     }
 }
+impl support::IntoDartExceptPrimitive for MyTreeNode {}
 
 impl support::IntoDart for NewTypeInt {
     fn into_dart(self) -> support::DartCObject {
         vec![self.0.into_dart()].into_dart()
     }
 }
+impl support::IntoDartExceptPrimitive for NewTypeInt {}
 
 impl support::IntoDart for VecOfPrimitivePack {
     fn into_dart(self) -> support::DartCObject {
@@ -1335,6 +1341,7 @@ impl support::IntoDart for VecOfPrimitivePack {
         .into_dart()
     }
 }
+impl support::IntoDartExceptPrimitive for VecOfPrimitivePack {}
 
 impl support::IntoDart for ZeroCopyVecOfPrimitivePack {
     fn into_dart(self) -> support::DartCObject {
@@ -1353,6 +1360,7 @@ impl support::IntoDart for ZeroCopyVecOfPrimitivePack {
         .into_dart()
     }
 }
+impl support::IntoDartExceptPrimitive for ZeroCopyVecOfPrimitivePack {}
 
 // Section: executor
 support::lazy_static! {

--- a/frb_example/pure_dart/rust/src/bridge_generated.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.rs
@@ -1323,7 +1323,11 @@ impl support::IntoDart for VecOfPrimitivePack {
         vec![
             self.int8list.into_dart(),
             self.uint8list.into_dart(),
+            self.int16list.into_dart(),
+            self.uint16list.into_dart(),
+            self.uint32list.into_dart(),
             self.int32list.into_dart(),
+            self.uint64list.into_dart(),
             self.int64list.into_dart(),
             self.float32list.into_dart(),
             self.float64list.into_dart(),
@@ -1337,7 +1341,11 @@ impl support::IntoDart for ZeroCopyVecOfPrimitivePack {
         vec![
             self.int8list.into_dart(),
             self.uint8list.into_dart(),
+            self.int16list.into_dart(),
+            self.uint16list.into_dart(),
+            self.uint32list.into_dart(),
             self.int32list.into_dart(),
+            self.uint64list.into_dart(),
             self.int64list.into_dart(),
             self.float32list.into_dart(),
             self.float64list.into_dart(),

--- a/frb_example/pure_dart/rust/src/bridge_generated.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.rs
@@ -83,7 +83,7 @@ pub extern "C" fn wire_handle_vec_u8(port: i64, v: *mut wire_uint_8_list) {
 }
 
 #[no_mangle]
-pub extern "C" fn wire_handle_vec_of_primitive(port: i64, v: *mut wire_uint_8_list) {
+pub extern "C" fn wire_handle_vec_of_primitive(port: i64, n: i32) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {
             debug_name: "handle_vec_of_primitive",
@@ -91,8 +91,8 @@ pub extern "C" fn wire_handle_vec_of_primitive(port: i64, v: *mut wire_uint_8_li
             mode: FfiCallMode::Normal,
         },
         move || {
-            let api_v = v.wire2api();
-            move |task_callback| handle_vec_of_primitive(api_v)
+            let api_n = n.wire2api();
+            move |task_callback| handle_vec_of_primitive(api_n)
         },
     );
 }

--- a/frb_example/with_flutter/rust/Cargo.lock
+++ b/frb_example/with_flutter/rust/Cargo.lock
@@ -26,8 +26,7 @@ checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 [[package]]
 name = "allo-isolate"
 version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95c5a443c8b833fc57ee060bb52639fb687d94e640737e71be5c8cccbbbb790c"
+source = "git+https://github.com/fzyzcjy/allo-isolate#a721081ff085ccbacef77b625c2a3537f84c1d31"
 dependencies = [
  "atomic",
 ]

--- a/frb_example/with_flutter/rust/src/bridge_generated.rs
+++ b/frb_example/with_flutter/rust/src/bridge_generated.rs
@@ -430,12 +430,14 @@ impl support::IntoDart for Size {
         vec![self.width.into_dart(), self.height.into_dart()].into_dart()
     }
 }
+impl support::IntoDartExceptPrimitive for Size {}
 
 impl support::IntoDart for TreeNode {
     fn into_dart(self) -> support::DartCObject {
         vec![self.name.into_dart(), self.children.into_dart()].into_dart()
     }
 }
+impl support::IntoDartExceptPrimitive for TreeNode {}
 
 // Section: executor
 support::lazy_static! {

--- a/frb_rust/Cargo.lock
+++ b/frb_rust/Cargo.lock
@@ -5,7 +5,7 @@ version = 3
 [[package]]
 name = "allo-isolate"
 version = "0.1.10"
-source = "git+https://github.com/fzyzcjy/allo-isolate#a0eed01d41919f60d4cb2bd351cea20e253c8e78"
+source = "git+https://github.com/fzyzcjy/allo-isolate#2e80cc6faa8cae351cf3f1809eeabdbee36f7df5"
 dependencies = [
  "atomic",
 ]

--- a/frb_rust/Cargo.lock
+++ b/frb_rust/Cargo.lock
@@ -5,8 +5,7 @@ version = 3
 [[package]]
 name = "allo-isolate"
 version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95c5a443c8b833fc57ee060bb52639fb687d94e640737e71be5c8cccbbbb790c"
+source = "git+https://github.com/fzyzcjy/allo-isolate#a0eed01d41919f60d4cb2bd351cea20e253c8e78"
 dependencies = [
  "atomic",
 ]

--- a/frb_rust/Cargo.toml
+++ b/frb_rust/Cargo.toml
@@ -9,8 +9,8 @@ keywords = ["flutter", "dart", "ffi", "code-generation", "bindings"]
 categories = ["development-tools::ffi"]
 
 [dependencies]
-#allo-isolate = "0.1.10"
-allo-isolate = { git = "https://github.com/fzyzcjy/allo-isolate" } # hack, until upstream PR is merged and released
+allo-isolate = "0.1.11"
+#allo-isolate = { git = "https://github.com/fzyzcjy/allo-isolate" } # hack, until upstream PR is merged and released
 anyhow = "1.0.44"
 threadpool = "1.8.1"
 lazy_static = "1.4.0"

--- a/frb_rust/Cargo.toml
+++ b/frb_rust/Cargo.toml
@@ -9,7 +9,8 @@ keywords = ["flutter", "dart", "ffi", "code-generation", "bindings"]
 categories = ["development-tools::ffi"]
 
 [dependencies]
-allo-isolate = "0.1.10"
+#allo-isolate = "0.1.10"
+allo-isolate = { git = "https://github.com/fzyzcjy/allo-isolate" } # hack, until upstream PR is merged and released
 anyhow = "1.0.44"
 threadpool = "1.8.1"
 lazy_static = "1.4.0"

--- a/frb_rust/src/support.rs
+++ b/frb_rust/src/support.rs
@@ -3,8 +3,8 @@
 
 use std::mem;
 
+pub use allo_isolate::{IntoDart, IntoDartExceptPrimitive};
 pub use allo_isolate::ffi::DartCObject;
-pub use allo_isolate::IntoDart;
 pub use lazy_static::lazy_static;
 
 pub use crate::handler::DefaultHandler;

--- a/frb_rust/src/support.rs
+++ b/frb_rust/src/support.rs
@@ -3,8 +3,8 @@
 
 use std::mem;
 
-pub use allo_isolate::{IntoDart, IntoDartExceptPrimitive};
 pub use allo_isolate::ffi::DartCObject;
+pub use allo_isolate::{IntoDart, IntoDartExceptPrimitive};
 pub use lazy_static::lazy_static;
 
 pub use crate::handler::DefaultHandler;


### PR DESCRIPTION
originally #150 but that one is accidentially merged... so create again

related https://github.com/sunshine-protocol/allo-isolate/pull/15

Closes #153