### PR TITLE
Add llvm-compiler-opts as command-line argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.7.0
+
+* Add llvm-compiler-opts as command-line argument #210 (thanks @trobanga)
+
 ## 1.6.1
 
 * Remove extra newline on empty comment #203 (thanks @Desdaemon)

--- a/frb_codegen/src/commands.rs
+++ b/frb_codegen/src/commands.rs
@@ -11,6 +11,7 @@ pub fn bindgen_rust_to_dart(
     dart_class_name: &str,
     c_struct_names: Vec<String>,
     llvm_install_path: &str,
+    llvm_compiler_opts: &str,
 ) {
     cbindgen(rust_crate_dir, c_output_path, c_struct_names);
     ffigen(
@@ -18,6 +19,7 @@ pub fn bindgen_rust_to_dart(
         dart_output_path,
         dart_class_name,
         llvm_install_path,
+        llvm_compiler_opts,
     );
 }
 
@@ -129,7 +131,13 @@ include = [{}]
     );
 }
 
-fn ffigen(c_path: &str, dart_path: &str, dart_class_name: &str, llvm_path: &str) {
+fn ffigen(
+    c_path: &str,
+    dart_path: &str,
+    dart_class_name: &str,
+    llvm_path: &str,
+    llvm_compiler_opts: &str,
+) {
     debug!(
         "execute ffigen c_path={} dart_path={} llvm_path={:?}",
         c_path, dart_path, llvm_path
@@ -156,6 +164,15 @@ fn ffigen(c_path: &str, dart_path: &str, dart_class_name: &str, llvm_path: &str)
         llvm-path:
             - '{}'",
             config, llvm_path
+        );
+    }
+
+    if !llvm_compiler_opts.is_empty() {
+        config = format!(
+            "{}
+        compiler-opts:
+            - '{}'",
+            config, llvm_compiler_opts
         );
     }
 

--- a/frb_codegen/src/config.rs
+++ b/frb_codegen/src/config.rs
@@ -40,6 +40,9 @@ pub struct RawOpts {
     /// Path to the installed LLVM
     #[structopt(long)]
     pub llvm_path: Option<String>,
+    /// LLVM compiler opts
+    #[structopt(long)]
+    pub llvm_compiler_opts: Option<String>,
 }
 
 #[derive(Debug)]
@@ -53,6 +56,7 @@ pub struct Opts {
     pub dart_format_line_length: i32,
     pub skip_add_mod_to_lib: bool,
     pub llvm_path: String,
+    pub llvm_compiler_opts: String,
 }
 
 pub fn parse(raw: RawOpts) -> Opts {
@@ -85,6 +89,7 @@ pub fn parse(raw: RawOpts) -> Opts {
         dart_format_line_length: raw.dart_format_line_length.unwrap_or(80),
         skip_add_mod_to_lib: raw.skip_add_mod_to_lib,
         llvm_path: raw.llvm_path.unwrap_or_else(|| "".to_string()),
+        llvm_compiler_opts: raw.llvm_compiler_opts.unwrap_or_else(|| "".to_string()),
     }
 }
 

--- a/frb_codegen/src/main.rs
+++ b/frb_codegen/src/main.rs
@@ -90,6 +90,7 @@ fn main() {
                 &config.dart_wire_class_name(),
                 c_struct_names,
                 &config.llvm_path,
+                &config.llvm_compiler_opts,
             );
         },
     );


### PR DESCRIPTION
This works now
```
flutter_rust_bridge_codegen --rust-input frb_example/with_flutter/rust/src/api.rs --dart-output frb_example/with_flutter/lib/bridge_generated.dart --c-output frb_example/with_flutter/ios/Runner/bridge_generated.h --llvm-compiler-opts=-I/usr/lib/clang/13.0.0/include/
```