### PR TITLE
When writing files in frb_codegen, create directories if they don't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* When running codegen, create folders for output paths if they don't exist
+
 ## 1.12.0
 
 * Redesign documentation and make it a mdBook #272


### PR DESCRIPTION
This patch adds `fs::create_dir_all` calls to `frb_codegen/src/main.rs` to ensure directories exist before trying to write files in them.

## Justification

Currently, running `frb_codegen` with `--rust-output folder_does_not_exist/code.rs` causes the program to exit with a filesystem error (tested on Windows 10).

I'm creating a bindgen script, in which I run `frb_codegen` and tell it to write my generated dart code to to a folder called `generated`. I'd like to gitignore my auto-generated code. However, my `generated` folder only contains auto-generated files, which means the folder itself isn't created when the repo is checked out for the first time. As a result, my bindgen script encounters the error above. I can create the folder using my shell script, but I think it's reasonable for `frb_codegen` to create the directories if they don't exist since it already creates nonexistent files.