### PR TITLE
Refactor command module

### DIFF
--- a/frb_codegen/src/commands.rs
+++ b/frb_codegen/src/commands.rs
@@ -127,7 +127,7 @@ fn execute_command(bin: &str, args: &[&str], current_dir: Option<&str>) -> Outpu
             String::from_utf8_lossy(&result.stderr)
         );
     }
-    return result;
+    result
 }
 
 fn cbindgen(rust_crate_dir: &str, c_output_path: &str, c_struct_names: Vec<String>) {
@@ -220,7 +220,7 @@ fn ffigen(
         )
         .unwrap();
         for path in llvm_path {
-            write!(&mut config, "           - '{}'\n", path).unwrap();
+            writeln!(&mut config, "           - '{}'", path).unwrap();
         }
     }
 

--- a/frb_codegen/src/commands.rs
+++ b/frb_codegen/src/commands.rs
@@ -55,7 +55,7 @@ pub fn check_shell_executable(cmd: &str) {
     // TODO: Implement check_shell_executable on Windows
     let res = execute_command(
         "powershell",
-        &["-Command", &format!("& { Get-Command -Name {} }", cmd)],
+        &["-Command", &format!("& {{ Get-Command -Name {} }}", cmd)],
         None,
     );
     todo!("{:#?}", res);

--- a/frb_codegen/src/commands.rs
+++ b/frb_codegen/src/commands.rs
@@ -52,8 +52,13 @@ Note: This command might be available via cargo, in which case it can be install
 
 #[cfg(windows)]
 pub fn check_shell_executable(cmd: &str) {
-    warn!("check_shell_executable not implemented on Windows");
     // TODO: Implement check_shell_executable on Windows
+    let res = execute_command(
+        "powershell",
+        &["-Command", &format!("& { Get-Command -Name {} }", cmd)],
+        None,
+    );
+    todo!("{:#?}", res);
 }
 
 pub fn bindgen_rust_to_dart(

--- a/frb_codegen/src/commands.rs
+++ b/frb_codegen/src/commands.rs
@@ -26,7 +26,6 @@ ffigen is not available, please run \"dart pub global activate ffigen\" first."
         std::process::exit(Failures::MissingExe as _);
     }
 
-    check_shell_executable("flutter_rust_bridge_codegen");
     check_shell_executable("cbindgen");
 }
 

--- a/frb_codegen/src/commands.rs
+++ b/frb_codegen/src/commands.rs
@@ -19,8 +19,10 @@ pub fn ensure_tools_available() {
     let output = execute_command("dart", &["pub", "global", "list"], None);
     let output = String::from_utf8_lossy(&output.stdout);
     if !output.contains("ffigen") {
-        error!("
-ffigen is not available, please run \"dart pub global activate ffigen\" first.");
+        error!(
+            "
+ffigen is not available, please run \"dart pub global activate ffigen\" first."
+        );
         std::process::exit(Failures::MissingExe as _);
     }
 
@@ -30,7 +32,11 @@ ffigen is not available, please run \"dart pub global activate ffigen\" first.")
 
 #[cfg(not(windows))]
 pub fn check_shell_executable(cmd: &str) {
-    let res = execute_command("sh", &["-c", &format!("test -x \"$(which {})\"", cmd)], None);
+    let res = execute_command(
+        "sh",
+        &["-c", &format!("test -x \"$(which {})\"", cmd)],
+        None,
+    );
     if !res.status.success() {
         error!(
             "

--- a/frb_codegen/src/commands.rs
+++ b/frb_codegen/src/commands.rs
@@ -29,8 +29,14 @@ ffigen is not available, please run \"dart pub global activate ffigen\" first."
     check_shell_executable("cbindgen");
 }
 
-#[cfg(not(windows))]
 pub fn check_shell_executable(cmd: &str) {
+    #[cfg(windows)]
+    let res = execute_command(
+        "powershell",
+        &["-c", &format!("Get-Command -Name {}", cmd)],
+        None,
+    );
+    #[cfg(not(windows))]
     let res = execute_command(
         "sh",
         &["-c", &format!("test -x \"$(which {})\"", cmd)],
@@ -48,17 +54,6 @@ Note: This command might be available via cargo, in which case it can be install
         );
         std::process::exit(Failures::MissingExe as _);
     }
-}
-
-#[cfg(windows)]
-pub fn check_shell_executable(cmd: &str) {
-    // TODO: Implement check_shell_executable on Windows
-    let res = execute_command(
-        "powershell",
-        &["-Command", &format!("& {{ Get-Command -Name {} }}", cmd)],
-        None,
-    );
-    todo!("{:#?}", res);
 }
 
 pub fn bindgen_rust_to_dart(

--- a/frb_codegen/src/config.rs
+++ b/frb_codegen/src/config.rs
@@ -45,7 +45,7 @@ pub struct RawOpts {
     pub skip_add_mod_to_lib: bool,
     /// Path to the installed LLVM
     #[structopt(long)]
-    pub llvm_path: Option<String>,
+    pub llvm_path: Option<Vec<String>>,
     /// LLVM compiler opts
     #[structopt(long)]
     pub llvm_compiler_opts: Option<String>,
@@ -62,7 +62,7 @@ pub struct Opts {
     pub class_name: String,
     pub dart_format_line_length: i32,
     pub skip_add_mod_to_lib: bool,
-    pub llvm_path: String,
+    pub llvm_path: Vec<String>,
     pub llvm_compiler_opts: String,
     pub manifest_path: String,
 }
@@ -105,7 +105,20 @@ pub fn parse(raw: RawOpts) -> Opts {
         class_name,
         dart_format_line_length: raw.dart_format_line_length.unwrap_or(80),
         skip_add_mod_to_lib: raw.skip_add_mod_to_lib,
-        llvm_path: raw.llvm_path.unwrap_or_else(|| "".to_string()),
+        llvm_path: raw.llvm_path.unwrap_or_else(|| {
+            vec![
+                "/opt/homebrew/opt/llvm".to_owned(), // Homebrew root
+                "/usr/local/opt/llvm".to_owned(),    // Homebrew x86-64 root
+                // Possible Linux LLVM roots
+                "/usr/lib/llvm-9/lib".to_owned(),
+                "/usr/lib/llvm-10/lib".to_owned(),
+                "/usr/lib/llvm-11/lib".to_owned(),
+                "/usr/lib/llvm-12/lib".to_owned(),
+                "/usr/lib/llvm-13/lib".to_owned(),
+                "/usr/lib/".to_owned(),
+                "/usr/lib64/".to_owned(),
+            ]
+        }),
         llvm_compiler_opts: raw.llvm_compiler_opts.unwrap_or_else(|| "".to_string()),
         manifest_path,
     }

--- a/frb_codegen/src/main.rs
+++ b/frb_codegen/src/main.rs
@@ -7,6 +7,7 @@ use pathdiff::diff_paths;
 use structopt::StructOpt;
 
 use crate::api_types::ApiType;
+use crate::commands::ensure_tools_available;
 use crate::config::RawOpts;
 use crate::others::*;
 use crate::utils::*;
@@ -25,6 +26,8 @@ mod utils;
 
 fn main() {
     env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
+
+    ensure_tools_available();
 
     let config = config::parse(RawOpts::from_args());
     info!("Picked config: {:?}", &config);
@@ -98,7 +101,7 @@ fn main() {
                 temp_dart_wire_file.path().as_os_str().to_str().unwrap(),
                 &config.dart_wire_class_name(),
                 c_struct_names,
-                &config.llvm_path,
+                &config.llvm_path[..],
                 &config.llvm_compiler_opts,
             );
         },

--- a/justfile
+++ b/justfile
@@ -48,4 +48,4 @@ clean:
     cd {{frb_flutter}} && flutter clean
     cd {{frb_flutter}}/rust && cargo clean
 
-# vim:expandtab:tabstop=4:shiftwidth=4
+# vim:expandtab:ts=4:sw=4


### PR DESCRIPTION
Partial fix #323

A few changes in the internal API:
- execute_command now takes a binary, a list of arguments and returns Output marked with `#[must_use]`
- Common failures are enumerated and handled, otherwise panic
- Changed llvm-path to take multiple parameters, and add some default search paths for LLVM