### PR TITLE
Support bridging functions with return types other than `Result<_>`

### DIFF
--- a/frb_codegen/src/api_types.rs
+++ b/frb_codegen/src/api_types.rs
@@ -68,6 +68,7 @@ pub struct ApiFunc {
     pub name: String,
     pub inputs: Vec<ApiField>,
     pub output: ApiType,
+    pub fallible: bool,
     pub mode: ApiFuncMode,
     pub comments: Vec<Comment>,
 }

--- a/frb_codegen/src/generator_rust.rs
+++ b/frb_codegen/src/generator_rust.rs
@@ -88,7 +88,7 @@ impl Generator {
             .collect::<Vec<_>>();
 
         format!(
-            r#"#![allow(non_camel_case_types, unused, clippy::redundant_closure, clippy::useless_conversion, non_snake_case)]
+            r#"#![allow(non_camel_case_types, unused, clippy::redundant_closure, clippy::useless_conversion, clippy::unit_arg, non_snake_case)]
         {}
 
         use crate::{}::*;

--- a/frb_codegen/src/generator_rust.rs
+++ b/frb_codegen/src/generator_rust.rs
@@ -277,6 +277,12 @@ impl Generator {
 
         let code_call_inner_func = format!("{}({})", func.name, inner_func_params.join(", "));
 
+        let code_call_inner_func_result = if func.fallible {
+            code_call_inner_func
+        } else {
+            format!("Ok({})", code_call_inner_func)
+        };
+
         let (handler_func_name, return_type, code_closure) = match func.mode {
             ApiFuncMode::Sync => (
                 "wrap_sync",
@@ -284,7 +290,7 @@ impl Generator {
                 format!(
                     "{}
                     {}",
-                    code_wire2api, code_call_inner_func,
+                    code_wire2api, code_call_inner_func_result,
                 ),
             ),
             ApiFuncMode::Normal | ApiFuncMode::Stream => (
@@ -294,7 +300,7 @@ impl Generator {
                     "{}
                     move |task_callback| {}
                     ",
-                    code_wire2api, code_call_inner_func
+                    code_wire2api, code_call_inner_func_result,
                 ),
             ),
         };

--- a/frb_codegen/src/parser.rs
+++ b/frb_codegen/src/parser.rs
@@ -101,6 +101,7 @@ impl<'a> Parser<'a> {
         let mut inputs = Vec::new();
         let mut output = None;
         let mut mode = None;
+        let mut fallible = true;
 
         for sig_input in &sig.inputs {
             if let FnArg::Typed(ref pat_type) = sig_input {
@@ -132,10 +133,8 @@ impl<'a> Parser<'a> {
                 if let Some(inner) = CAPTURE_RESULT.captures(&type_string) {
                     self.parse_type(&inner)
                 } else {
-                    panic!(
-                        "Functions must return `Result<_>`, but current type_string is: {}",
-                        type_string
-                    );
+                    fallible = false;
+                    self.parse_type(&type_string)
                 }
             } else {
                 panic!("unsupported output: {:?}", sig.output);
@@ -155,6 +154,7 @@ impl<'a> Parser<'a> {
             name: func_name,
             inputs,
             output: output.expect("unsupported output"),
+            fallible,
             mode: mode.expect("unsupported mode"),
             comments: extract_comments(&func.attrs),
         }

--- a/frb_codegen/src/parser.rs
+++ b/frb_codegen/src/parser.rs
@@ -128,16 +128,20 @@ impl<'a> Parser<'a> {
         }
 
         if output.is_none() {
-            output = Some(if let ReturnType::Type(_, ty) = &sig.output {
-                let type_string = type_to_string(ty);
-                if let Some(inner) = CAPTURE_RESULT.captures(&type_string) {
-                    self.parse_type(&inner)
-                } else {
-                    fallible = false;
-                    self.parse_type(&type_string)
+            output = Some(match &sig.output {
+                ReturnType::Type(_, ty) => {
+                    let type_string = type_to_string(ty);
+                    if let Some(inner) = CAPTURE_RESULT.captures(&type_string) {
+                        self.parse_type(&inner)
+                    } else {
+                        fallible = false;
+                        self.parse_type(&type_string)
+                    }
                 }
-            } else {
-                panic!("unsupported output: {:?}", sig.output);
+                ReturnType::Default => {
+                    fallible = false;
+                    ApiType::Primitive(ApiTypePrimitive::Unit)
+                }
             });
             mode = Some(
                 if let Some(ApiType::Delegate(ApiTypeDelegate::SyncReturnVecU8)) = output {

--- a/frb_example/pure_dart/rust/src/api.rs
+++ b/frb_example/pure_dart/rust/src/api.rs
@@ -46,7 +46,6 @@ pub fn handle_string(s: String) -> String {
 
 pub fn handle_return_unit() -> () {
     println!("handle_return_unit()");
-    ()
 }
 
 // to check that `Vec<u8>` can be used as return type
@@ -381,9 +380,8 @@ pub struct Customized {
     pub non_final_field: Option<String>,
 }
 
-pub fn handle_customized_struct(val: Customized) -> () {
+pub fn handle_customized_struct(val: Customized) {
     println!("{:#?}", val);
-    ()
 }
 
 #[frb]

--- a/frb_example/pure_dart/rust/src/api.rs
+++ b/frb_example/pure_dart/rust/src/api.rs
@@ -12,8 +12,8 @@ use flutter_rust_bridge::*;
 use crate::data::{MyEnum, MyStruct};
 
 /// Documentation on a simple adder function.
-pub fn simple_adder(a: i32, b: i32) -> Result<i32> {
-    Ok(a + b)
+pub fn simple_adder(a: i32, b: i32) -> i32 {
+    a + b
 }
 
 /**
@@ -22,37 +22,37 @@ pub fn simple_adder(a: i32, b: i32) -> Result<i32> {
 
  Newlines are preserved.
 */
-pub fn primitive_types(my_i32: i32, my_i64: i64, my_f64: f64, my_bool: bool) -> Result<i32> {
+pub fn primitive_types(my_i32: i32, my_i64: i64, my_f64: f64, my_bool: bool) -> i32 {
     println!(
         "primitive_types({}, {}, {}, {})",
         my_i32, my_i64, my_f64, my_bool
     );
-    Ok(42)
+    42
 }
 
-pub fn primitive_u32(my_u32: u32) -> Result<u32> {
+pub fn primitive_u32(my_u32: u32) -> u32 {
     println!("primitive_u32({})", my_u32);
     assert_eq!(my_u32, 0xff112233);
     let ret = 0xfe112233;
     println!("returning {}", ret);
-    Ok(ret)
+    ret
 }
 
-pub fn handle_string(s: String) -> Result<String> {
+pub fn handle_string(s: String) -> String {
     println!("handle_string({})", &s);
     let s2 = s.clone();
-    Ok(s + &s2)
+    s + &s2
 }
 
-pub fn handle_return_unit() -> Result<()> {
+pub fn handle_return_unit() -> () {
     println!("handle_return_unit()");
-    Ok(())
+    ()
 }
 
 // to check that `Vec<u8>` can be used as return type
-pub fn handle_vec_u8(v: Vec<u8>) -> Result<Vec<u8>> {
+pub fn handle_vec_u8(v: Vec<u8>) -> Vec<u8> {
     println!("handle_vec_u8(first few elements: {:?})", &v[..5]);
-    Ok(v.repeat(2))
+    v.repeat(2)
 }
 
 pub struct VecOfPrimitivePack {
@@ -68,8 +68,8 @@ pub struct VecOfPrimitivePack {
     pub float64list: Vec<f64>,
 }
 
-pub fn handle_vec_of_primitive(n: i32) -> Result<VecOfPrimitivePack> {
-    Ok(VecOfPrimitivePack {
+pub fn handle_vec_of_primitive(n: i32) -> VecOfPrimitivePack {
+    VecOfPrimitivePack {
         int8list: vec![42i8; n as usize],
         uint8list: vec![42u8; n as usize],
         int16list: vec![42i16; n as usize],
@@ -80,7 +80,7 @@ pub fn handle_vec_of_primitive(n: i32) -> Result<VecOfPrimitivePack> {
         uint64list: vec![42u64; n as usize],
         float32list: vec![42.0f32; n as usize],
         float64list: vec![42.0f64; n as usize],
-    })
+    }
 }
 
 pub struct ZeroCopyVecOfPrimitivePack {
@@ -96,8 +96,8 @@ pub struct ZeroCopyVecOfPrimitivePack {
     pub float64list: ZeroCopyBuffer<Vec<f64>>,
 }
 
-pub fn handle_zero_copy_vec_of_primitive(n: i32) -> Result<ZeroCopyVecOfPrimitivePack> {
-    Ok(ZeroCopyVecOfPrimitivePack {
+pub fn handle_zero_copy_vec_of_primitive(n: i32) -> ZeroCopyVecOfPrimitivePack {
+    ZeroCopyVecOfPrimitivePack {
         int8list: ZeroCopyBuffer(vec![42i8; n as usize]),
         uint8list: ZeroCopyBuffer(vec![42u8; n as usize]),
         int16list: ZeroCopyBuffer(vec![42i16; n as usize]),
@@ -108,7 +108,7 @@ pub fn handle_zero_copy_vec_of_primitive(n: i32) -> Result<ZeroCopyVecOfPrimitiv
         uint64list: ZeroCopyBuffer(vec![42u64; n as usize]),
         float32list: ZeroCopyBuffer(vec![42.0f32; n as usize]),
         float64list: ZeroCopyBuffer(vec![42.0f64; n as usize]),
-    })
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -117,34 +117,34 @@ pub struct MySize {
     pub height: i32,
 }
 
-pub fn handle_struct(arg: MySize, boxed: Box<MySize>) -> Result<MySize> {
+pub fn handle_struct(arg: MySize, boxed: Box<MySize>) -> MySize {
     println!("handle_struct({:?}, {:?})", &arg, &boxed);
-    Ok(MySize {
+    MySize {
         width: arg.width + boxed.width,
         height: arg.height + boxed.height,
-    })
+    }
 }
 
 #[derive(Debug)]
 pub struct NewTypeInt(pub i64);
 
-pub fn handle_newtype(arg: NewTypeInt) -> Result<NewTypeInt> {
+pub fn handle_newtype(arg: NewTypeInt) -> NewTypeInt {
     println!("handle_newtype({:?})", &arg);
-    Ok(NewTypeInt(arg.0 * 2))
+    NewTypeInt(arg.0 * 2)
 }
 
-pub fn handle_list_of_struct(mut l: Vec<MySize>) -> Result<Vec<MySize>> {
+pub fn handle_list_of_struct(mut l: Vec<MySize>) -> Vec<MySize> {
     println!("handle_list_of_struct({:?})", &l);
     let mut ans = l.clone();
     ans.append(&mut l);
-    Ok(ans)
+    ans
 }
 
-pub fn handle_string_list(names: Vec<String>) -> Result<Vec<String>> {
+pub fn handle_string_list(names: Vec<String>) -> Vec<String> {
     for name in &names {
         println!("Hello, {}", name);
     }
-    Ok(names)
+    names
 }
 
 #[derive(Debug, Clone)]
@@ -155,10 +155,10 @@ pub struct MyTreeNode {
     pub children: Vec<MyTreeNode>,
 }
 
-pub fn handle_complex_struct(s: MyTreeNode) -> Result<MyTreeNode> {
+pub fn handle_complex_struct(s: MyTreeNode) -> MyTreeNode {
     println!("handle_complex_struct({:?})", &s);
     let s_cloned = s.clone();
-    Ok(s)
+    s
 }
 
 pub fn handle_sync_return(mode: String) -> Result<SyncReturn<Vec<u8>>> {
@@ -206,15 +206,15 @@ pub fn return_err() -> Result<i32> {
     ))
 }
 
-pub fn return_panic() -> Result<i32> {
+pub fn return_panic() -> i32 {
     panic!("return_panic() is called, thus deliberately panic")
 }
 
-pub fn handle_optional_return(left: f64, right: f64) -> Result<Option<f64>> {
+pub fn handle_optional_return(left: f64, right: f64) -> Option<f64> {
     if right == 0. {
-        Ok(None)
+        None
     } else {
-        Ok(Some(left / right))
+        Some(left / right)
     }
 }
 
@@ -232,8 +232,8 @@ pub struct Attribute {
     pub value: String,
 }
 
-pub fn handle_optional_struct(document: Option<String>) -> Result<Option<Element>> {
-    Ok(document.map(|inner| Element {
+pub fn handle_optional_struct(document: Option<String>) -> Option<Element> {
+    document.map(|inner| Element {
         tag: Some("div".to_owned()),
         attributes: Some(vec![Attribute {
             key: "id".to_owned(),
@@ -248,7 +248,7 @@ pub fn handle_optional_struct(document: Option<String>) -> Result<Option<Element
             ..Default::default()
         }]),
         ..Default::default()
-    }))
+    })
 }
 
 #[derive(Debug)]
@@ -270,14 +270,14 @@ pub struct ExoticOptionals {
     pub newtypeint: Option<NewTypeInt>,
 }
 
-pub fn handle_optional_increment(opt: Option<ExoticOptionals>) -> Result<Option<ExoticOptionals>> {
+pub fn handle_optional_increment(opt: Option<ExoticOptionals>) -> Option<ExoticOptionals> {
     fn manipulate_list<T>(src: Option<Vec<T>>, push_value: T) -> Option<Vec<T>> {
         let mut list = src.unwrap_or_else(Vec::new);
         list.push(push_value);
         Some(list)
     }
 
-    Ok(opt.map(|mut opt| ExoticOptionals {
+    opt.map(|mut opt| ExoticOptionals {
         int32: Some(opt.int32.unwrap_or(0) + 1),
         int64: Some(opt.int64.unwrap_or(0) + 1),
         float64: Some(opt.float64.unwrap_or(0.) + 1.),
@@ -315,13 +315,13 @@ pub fn handle_optional_increment(opt: Option<ExoticOptionals>) -> Result<Option<
             list.0.push(0);
             list
         }),
-    }))
+    })
 }
 
-pub fn handle_increment_boxed_optional(opt: Option<Box<f64>>) -> Result<f64> {
+pub fn handle_increment_boxed_optional(opt: Option<Box<f64>>) -> f64 {
     match opt {
-        Some(e) => Ok(*e + 1.),
-        None => Ok(42.),
+        Some(e) => *e + 1.,
+        None => 42.,
     }
 }
 
@@ -335,11 +335,11 @@ pub fn handle_option_box_arguments(
     f64box: Option<Box<f64>>,
     boolbox: Option<Box<bool>>,
     structbox: Option<Box<ExoticOptionals>>,
-) -> Result<String> {
-    Ok(format!(
+) -> String {
+    format!(
         "handle_option_box_arguments({:?})",
         (i8box, u8box, i32box, i64box, f64box, boolbox, structbox)
-    ))
+    )
 }
 
 /// Simple enums.
@@ -355,8 +355,8 @@ pub enum Weekdays {
     Sunday,
 }
 
-pub fn handle_return_enum(input: String) -> Result<Option<Weekdays>> {
-    Ok(match input.as_str() {
+pub fn handle_return_enum(input: String) -> Option<Weekdays> {
+    match input.as_str() {
         "Monday" => Some(Weekdays::Monday),
         "Tuesday" => Some(Weekdays::Tuesday),
         "Wednesday" => Some(Weekdays::Wednesday),
@@ -365,12 +365,12 @@ pub fn handle_return_enum(input: String) -> Result<Option<Weekdays>> {
         "Saturday" => Some(Weekdays::Saturday),
         "Sunday" => Some(Weekdays::Sunday),
         _ => None,
-    })
+    }
 }
 
-pub fn handle_enum_parameter(weekday: Weekdays) -> Result<Weekdays> {
+pub fn handle_enum_parameter(weekday: Weekdays) -> Weekdays {
     println!("The weekday is {:?}", weekday);
-    Ok(weekday)
+    weekday
 }
 
 #[frb]
@@ -381,9 +381,9 @@ pub struct Customized {
     pub non_final_field: Option<String>,
 }
 
-pub fn handle_customized_struct(val: Customized) -> Result<()> {
+pub fn handle_customized_struct(val: Customized) -> () {
     println!("{:#?}", val);
-    Ok(())
+    ()
 }
 
 #[frb]
@@ -411,11 +411,11 @@ pub enum KitchenSink {
 }
 
 #[frb(unimpl_fn_attr)]
-pub fn handle_enum_struct(val: KitchenSink) -> Result<KitchenSink> {
+pub fn handle_enum_struct(val: KitchenSink) -> KitchenSink {
     use KitchenSink::*;
     use Weekdays::*;
     let inc = |x| x + 1;
-    Ok(match val {
+    match val {
         Primitives {
             int32,
             float64,
@@ -441,18 +441,18 @@ pub fn handle_enum_struct(val: KitchenSink) -> Result<KitchenSink> {
             Sunday => Monday,
         }),
         _ => val,
-    })
+    }
 }
 
 // Function that uses imported struct (from within this crate)
-pub fn use_imported_struct(my_struct: MyStruct) -> Result<bool> {
-    Ok(my_struct.content)
+pub fn use_imported_struct(my_struct: MyStruct) -> bool {
+    my_struct.content
 }
 
 // Function that uses imported enum (from within this crate)
-pub fn use_imported_enum(my_enum: MyEnum) -> Result<bool> {
+pub fn use_imported_enum(my_enum: MyEnum) -> bool {
     match my_enum {
-        MyEnum::False => Ok(false),
-        MyEnum::True => Ok(true),
+        MyEnum::False => false,
+        MyEnum::True => true,
     }
 }

--- a/frb_example/pure_dart/rust/src/api.rs
+++ b/frb_example/pure_dart/rust/src/api.rs
@@ -44,6 +44,7 @@ pub fn handle_string(s: String) -> String {
     s + &s2
 }
 
+#[allow(clippy::unused_unit)]
 pub fn handle_return_unit() -> () {
     println!("handle_return_unit()");
 }

--- a/frb_example/pure_dart/rust/src/bridge_generated.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.rs
@@ -3,6 +3,7 @@
     unused,
     clippy::redundant_closure,
     clippy::useless_conversion,
+    clippy::unit_arg,
     non_snake_case
 )]
 // AUTO GENERATED FILE, DO NOT EDIT.

--- a/frb_example/pure_dart/rust/src/bridge_generated.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.rs
@@ -28,7 +28,7 @@ pub extern "C" fn wire_simple_adder(port_: i64, a: i32, b: i32) {
         move || {
             let api_a = a.wire2api();
             let api_b = b.wire2api();
-            move |task_callback| simple_adder(api_a, api_b)
+            move |task_callback| Ok(simple_adder(api_a, api_b))
         },
     )
 }
@@ -52,7 +52,14 @@ pub extern "C" fn wire_primitive_types(
             let api_my_i64 = my_i64.wire2api();
             let api_my_f64 = my_f64.wire2api();
             let api_my_bool = my_bool.wire2api();
-            move |task_callback| primitive_types(api_my_i32, api_my_i64, api_my_f64, api_my_bool)
+            move |task_callback| {
+                Ok(primitive_types(
+                    api_my_i32,
+                    api_my_i64,
+                    api_my_f64,
+                    api_my_bool,
+                ))
+            }
         },
     )
 }
@@ -67,7 +74,7 @@ pub extern "C" fn wire_primitive_u32(port_: i64, my_u32: u32) {
         },
         move || {
             let api_my_u32 = my_u32.wire2api();
-            move |task_callback| primitive_u32(api_my_u32)
+            move |task_callback| Ok(primitive_u32(api_my_u32))
         },
     )
 }
@@ -82,7 +89,7 @@ pub extern "C" fn wire_handle_string(port_: i64, s: *mut wire_uint_8_list) {
         },
         move || {
             let api_s = s.wire2api();
-            move |task_callback| handle_string(api_s)
+            move |task_callback| Ok(handle_string(api_s))
         },
     )
 }
@@ -95,7 +102,7 @@ pub extern "C" fn wire_handle_return_unit(port_: i64) {
             port: Some(port_),
             mode: FfiCallMode::Normal,
         },
-        move || move |task_callback| handle_return_unit(),
+        move || move |task_callback| Ok(handle_return_unit()),
     )
 }
 
@@ -109,7 +116,7 @@ pub extern "C" fn wire_handle_vec_u8(port_: i64, v: *mut wire_uint_8_list) {
         },
         move || {
             let api_v = v.wire2api();
-            move |task_callback| handle_vec_u8(api_v)
+            move |task_callback| Ok(handle_vec_u8(api_v))
         },
     )
 }
@@ -124,7 +131,7 @@ pub extern "C" fn wire_handle_vec_of_primitive(port_: i64, n: i32) {
         },
         move || {
             let api_n = n.wire2api();
-            move |task_callback| handle_vec_of_primitive(api_n)
+            move |task_callback| Ok(handle_vec_of_primitive(api_n))
         },
     )
 }
@@ -139,7 +146,7 @@ pub extern "C" fn wire_handle_zero_copy_vec_of_primitive(port_: i64, n: i32) {
         },
         move || {
             let api_n = n.wire2api();
-            move |task_callback| handle_zero_copy_vec_of_primitive(api_n)
+            move |task_callback| Ok(handle_zero_copy_vec_of_primitive(api_n))
         },
     )
 }
@@ -155,7 +162,7 @@ pub extern "C" fn wire_handle_struct(port_: i64, arg: *mut wire_MySize, boxed: *
         move || {
             let api_arg = arg.wire2api();
             let api_boxed = boxed.wire2api();
-            move |task_callback| handle_struct(api_arg, api_boxed)
+            move |task_callback| Ok(handle_struct(api_arg, api_boxed))
         },
     )
 }
@@ -170,7 +177,7 @@ pub extern "C" fn wire_handle_newtype(port_: i64, arg: *mut wire_NewTypeInt) {
         },
         move || {
             let api_arg = arg.wire2api();
-            move |task_callback| handle_newtype(api_arg)
+            move |task_callback| Ok(handle_newtype(api_arg))
         },
     )
 }
@@ -185,7 +192,7 @@ pub extern "C" fn wire_handle_list_of_struct(port_: i64, l: *mut wire_list_my_si
         },
         move || {
             let api_l = l.wire2api();
-            move |task_callback| handle_list_of_struct(api_l)
+            move |task_callback| Ok(handle_list_of_struct(api_l))
         },
     )
 }
@@ -200,7 +207,7 @@ pub extern "C" fn wire_handle_string_list(port_: i64, names: *mut wire_StringLis
         },
         move || {
             let api_names = names.wire2api();
-            move |task_callback| handle_string_list(api_names)
+            move |task_callback| Ok(handle_string_list(api_names))
         },
     )
 }
@@ -215,7 +222,7 @@ pub extern "C" fn wire_handle_complex_struct(port_: i64, s: *mut wire_MyTreeNode
         },
         move || {
             let api_s = s.wire2api();
-            move |task_callback| handle_complex_struct(api_s)
+            move |task_callback| Ok(handle_complex_struct(api_s))
         },
     )
 }
@@ -272,7 +279,7 @@ pub extern "C" fn wire_return_panic(port_: i64) {
             port: Some(port_),
             mode: FfiCallMode::Normal,
         },
-        move || move |task_callback| return_panic(),
+        move || move |task_callback| Ok(return_panic()),
     )
 }
 
@@ -287,7 +294,7 @@ pub extern "C" fn wire_handle_optional_return(port_: i64, left: f64, right: f64)
         move || {
             let api_left = left.wire2api();
             let api_right = right.wire2api();
-            move |task_callback| handle_optional_return(api_left, api_right)
+            move |task_callback| Ok(handle_optional_return(api_left, api_right))
         },
     )
 }
@@ -302,7 +309,7 @@ pub extern "C" fn wire_handle_optional_struct(port_: i64, document: *mut wire_ui
         },
         move || {
             let api_document = document.wire2api();
-            move |task_callback| handle_optional_struct(api_document)
+            move |task_callback| Ok(handle_optional_struct(api_document))
         },
     )
 }
@@ -317,7 +324,7 @@ pub extern "C" fn wire_handle_optional_increment(port_: i64, opt: *mut wire_Exot
         },
         move || {
             let api_opt = opt.wire2api();
-            move |task_callback| handle_optional_increment(api_opt)
+            move |task_callback| Ok(handle_optional_increment(api_opt))
         },
     )
 }
@@ -332,7 +339,7 @@ pub extern "C" fn wire_handle_increment_boxed_optional(port_: i64, opt: *mut f64
         },
         move || {
             let api_opt = opt.wire2api();
-            move |task_callback| handle_increment_boxed_optional(api_opt)
+            move |task_callback| Ok(handle_increment_boxed_optional(api_opt))
         },
     )
 }
@@ -363,7 +370,7 @@ pub extern "C" fn wire_handle_option_box_arguments(
             let api_boolbox = boolbox.wire2api();
             let api_structbox = structbox.wire2api();
             move |task_callback| {
-                handle_option_box_arguments(
+                Ok(handle_option_box_arguments(
                     api_i8box,
                     api_u8box,
                     api_i32box,
@@ -371,7 +378,7 @@ pub extern "C" fn wire_handle_option_box_arguments(
                     api_f64box,
                     api_boolbox,
                     api_structbox,
-                )
+                ))
             }
         },
     )
@@ -387,7 +394,7 @@ pub extern "C" fn wire_handle_return_enum(port_: i64, input: *mut wire_uint_8_li
         },
         move || {
             let api_input = input.wire2api();
-            move |task_callback| handle_return_enum(api_input)
+            move |task_callback| Ok(handle_return_enum(api_input))
         },
     )
 }
@@ -402,7 +409,7 @@ pub extern "C" fn wire_handle_enum_parameter(port_: i64, weekday: i32) {
         },
         move || {
             let api_weekday = weekday.wire2api();
-            move |task_callback| handle_enum_parameter(api_weekday)
+            move |task_callback| Ok(handle_enum_parameter(api_weekday))
         },
     )
 }
@@ -417,7 +424,7 @@ pub extern "C" fn wire_handle_customized_struct(port_: i64, val: *mut wire_Custo
         },
         move || {
             let api_val = val.wire2api();
-            move |task_callback| handle_customized_struct(api_val)
+            move |task_callback| Ok(handle_customized_struct(api_val))
         },
     )
 }
@@ -432,7 +439,7 @@ pub extern "C" fn wire_handle_enum_struct(port_: i64, val: *mut wire_KitchenSink
         },
         move || {
             let api_val = val.wire2api();
-            move |task_callback| handle_enum_struct(api_val)
+            move |task_callback| Ok(handle_enum_struct(api_val))
         },
     )
 }
@@ -447,7 +454,7 @@ pub extern "C" fn wire_use_imported_struct(port_: i64, my_struct: *mut wire_MySt
         },
         move || {
             let api_my_struct = my_struct.wire2api();
-            move |task_callback| use_imported_struct(api_my_struct)
+            move |task_callback| Ok(use_imported_struct(api_my_struct))
         },
     )
 }
@@ -462,7 +469,7 @@ pub extern "C" fn wire_use_imported_enum(port_: i64, my_enum: i32) {
         },
         move || {
             let api_my_enum = my_enum.wire2api();
-            move |task_callback| use_imported_enum(api_my_enum)
+            move |task_callback| Ok(use_imported_enum(api_my_enum))
         },
     )
 }

--- a/frb_example/with_flutter/rust/src/api.rs
+++ b/frb_example/with_flutter/rust/src/api.rs
@@ -18,11 +18,11 @@ pub fn draw_mandelbrot(
     Ok(ZeroCopyBuffer(image))
 }
 
-pub fn passing_complex_structs(root: TreeNode) -> Result<String> {
-    Ok(format!(
+pub fn passing_complex_structs(root: TreeNode) -> String {
+    format!(
         "Hi this string is from Rust. I received a complex struct: {:?}",
         root
-    ))
+    )
 }
 
 #[derive(Debug, Clone)]
@@ -45,43 +45,43 @@ pub struct TreeNode {
 
 // following are used only for memory tests. Readers of this example do not need to consider it.
 
-pub fn off_topic_memory_test_input_array(input: Vec<u8>) -> Result<i32> {
-    Ok(input.len() as i32)
+pub fn off_topic_memory_test_input_array(input: Vec<u8>) -> i32 {
+    input.len() as i32
 }
 
-pub fn off_topic_memory_test_output_zero_copy_buffer(len: i32) -> Result<ZeroCopyBuffer<Vec<u8>>> {
-    Ok(ZeroCopyBuffer(vec![0u8; len as usize]))
+pub fn off_topic_memory_test_output_zero_copy_buffer(len: i32) -> ZeroCopyBuffer<Vec<u8>> {
+    ZeroCopyBuffer(vec![0u8; len as usize])
 }
 
-pub fn off_topic_memory_test_output_vec_u8(len: i32) -> Result<Vec<u8>> {
-    Ok(vec![0u8; len as usize])
+pub fn off_topic_memory_test_output_vec_u8(len: i32) -> Vec<u8> {
+    vec![0u8; len as usize]
 }
 
-pub fn off_topic_memory_test_input_vec_of_object(input: Vec<Size>) -> Result<i32> {
-    Ok(input.len() as i32)
+pub fn off_topic_memory_test_input_vec_of_object(input: Vec<Size>) -> i32 {
+    input.len() as i32
 }
 
-pub fn off_topic_memory_test_output_vec_of_object(len: i32) -> Result<Vec<Size>> {
+pub fn off_topic_memory_test_output_vec_of_object(len: i32) -> Vec<Size> {
     let item = Size {
         width: 42,
         height: 42,
     };
-    Ok(vec![item; len as usize])
+    vec![item; len as usize]
 }
 
-pub fn off_topic_memory_test_input_complex_struct(input: TreeNode) -> Result<i32> {
-    Ok(input.children.len() as i32)
+pub fn off_topic_memory_test_input_complex_struct(input: TreeNode) -> i32 {
+    input.children.len() as i32
 }
 
-pub fn off_topic_memory_test_output_complex_struct(len: i32) -> Result<TreeNode> {
+pub fn off_topic_memory_test_output_complex_struct(len: i32) -> TreeNode {
     let child = TreeNode {
         name: "child".to_string(),
         children: Vec::new(),
     };
-    Ok(TreeNode {
+    TreeNode {
         name: "root".to_string(),
         children: vec![child; len as usize],
-    })
+    }
 }
 
 pub fn off_topic_deliberately_return_error() -> Result<i32> {
@@ -89,7 +89,7 @@ pub fn off_topic_deliberately_return_error() -> Result<i32> {
     Err(anyhow!("deliberately return Error!"))
 }
 
-pub fn off_topic_deliberately_panic() -> Result<i32> {
+pub fn off_topic_deliberately_panic() -> i32 {
     std::env::set_var("RUST_BACKTRACE", "1"); // optional, just to see more info...
     panic!("deliberately panic!")
 }

--- a/frb_example/with_flutter/rust/src/bridge_generated.rs
+++ b/frb_example/with_flutter/rust/src/bridge_generated.rs
@@ -3,6 +3,7 @@
     unused,
     clippy::redundant_closure,
     clippy::useless_conversion,
+    clippy::unit_arg,
     non_snake_case
 )]
 // AUTO GENERATED FILE, DO NOT EDIT.

--- a/frb_example/with_flutter/rust/src/bridge_generated.rs
+++ b/frb_example/with_flutter/rust/src/bridge_generated.rs
@@ -51,7 +51,7 @@ pub extern "C" fn wire_passing_complex_structs(port_: i64, root: *mut wire_TreeN
         },
         move || {
             let api_root = root.wire2api();
-            move |task_callback| passing_complex_structs(api_root)
+            move |task_callback| Ok(passing_complex_structs(api_root))
         },
     )
 }
@@ -66,7 +66,7 @@ pub extern "C" fn wire_off_topic_memory_test_input_array(port_: i64, input: *mut
         },
         move || {
             let api_input = input.wire2api();
-            move |task_callback| off_topic_memory_test_input_array(api_input)
+            move |task_callback| Ok(off_topic_memory_test_input_array(api_input))
         },
     )
 }
@@ -81,7 +81,7 @@ pub extern "C" fn wire_off_topic_memory_test_output_zero_copy_buffer(port_: i64,
         },
         move || {
             let api_len = len.wire2api();
-            move |task_callback| off_topic_memory_test_output_zero_copy_buffer(api_len)
+            move |task_callback| Ok(off_topic_memory_test_output_zero_copy_buffer(api_len))
         },
     )
 }
@@ -96,7 +96,7 @@ pub extern "C" fn wire_off_topic_memory_test_output_vec_u8(port_: i64, len: i32)
         },
         move || {
             let api_len = len.wire2api();
-            move |task_callback| off_topic_memory_test_output_vec_u8(api_len)
+            move |task_callback| Ok(off_topic_memory_test_output_vec_u8(api_len))
         },
     )
 }
@@ -114,7 +114,7 @@ pub extern "C" fn wire_off_topic_memory_test_input_vec_of_object(
         },
         move || {
             let api_input = input.wire2api();
-            move |task_callback| off_topic_memory_test_input_vec_of_object(api_input)
+            move |task_callback| Ok(off_topic_memory_test_input_vec_of_object(api_input))
         },
     )
 }
@@ -129,7 +129,7 @@ pub extern "C" fn wire_off_topic_memory_test_output_vec_of_object(port_: i64, le
         },
         move || {
             let api_len = len.wire2api();
-            move |task_callback| off_topic_memory_test_output_vec_of_object(api_len)
+            move |task_callback| Ok(off_topic_memory_test_output_vec_of_object(api_len))
         },
     )
 }
@@ -147,7 +147,7 @@ pub extern "C" fn wire_off_topic_memory_test_input_complex_struct(
         },
         move || {
             let api_input = input.wire2api();
-            move |task_callback| off_topic_memory_test_input_complex_struct(api_input)
+            move |task_callback| Ok(off_topic_memory_test_input_complex_struct(api_input))
         },
     )
 }
@@ -162,7 +162,7 @@ pub extern "C" fn wire_off_topic_memory_test_output_complex_struct(port_: i64, l
         },
         move || {
             let api_len = len.wire2api();
-            move |task_callback| off_topic_memory_test_output_complex_struct(api_len)
+            move |task_callback| Ok(off_topic_memory_test_output_complex_struct(api_len))
         },
     )
 }
@@ -187,7 +187,7 @@ pub extern "C" fn wire_off_topic_deliberately_panic(port_: i64) {
             port: Some(port_),
             mode: FfiCallMode::Normal,
         },
-        move || move |task_callback| off_topic_deliberately_panic(),
+        move || move |task_callback| Ok(off_topic_deliberately_panic()),
     )
 }
 


### PR DESCRIPTION
Fixes #332

I implemented this by wrapping the returned type in `bridge_generated.rs` with `Ok(...)` whenever there's a non-`Result<_>` return type. So under the hood, the top-level return type is still always a special-cased `Result<_>`.

The _ideal_ solution would probably be to add support for parsing `Result<_>` as a type and giving it a generalized Dart<->Rust representation, so it could be supported inside nested structures. In the meantime this is a nice convenience for bridging infallible functions.

As an aside: I'm not really sure what `StreamSink` is used for, so I didn't touch anything related to it. `Result<_>` still seems to be required there as a return type, although there's also no error when it's not specified.