### PR TITLE
Avoid converting syn types to strings before parsing

### DIFF
--- a/frb_codegen/src/ir/func.rs
+++ b/frb_codegen/src/ir/func.rs
@@ -16,6 +16,20 @@ impl IrFunc {
     }
 }
 
+/// Represents a function's output type
+#[derive(Debug, Clone)]
+pub enum IrFuncOutput {
+    ResultType(IrType),
+    Type(IrType),
+}
+
+/// Represents the type of an argument to a function
+#[derive(Debug, Clone)]
+pub enum IrFuncArg {
+    StreamSinkType(IrType),
+    Type(IrType),
+}
+
 #[derive(Debug, Clone, PartialOrd, PartialEq)]
 pub enum IrFuncMode {
     Normal,


### PR DESCRIPTION
Closes #340 

This is already a good number of changes to start with, but there's a few followups that might be useful here, including:
- Better error handling. Right now everything either panics or returns an `Option` as an output type. `Result`s would be more friendly to work with.
- Unifying the `IrFunc` model with `IrFuncOutput` and `IrFuncArg`. The way I've implemented it, just the type from each `IrFuncArg` and `IrFuncOutput` is extracted and stored in `IrFunc` along with the `fallible` and `mode` information. This would also be a good opportunity to forbid more combinations in function signatures, like `StreamSink` along with another return type.

I tried to keep functionality as similar as possible; all the existing test cases are interpreted without any changes. There is one significant difference in that types with leading paths are _always allowed_ now, whereas it used to only work for "special" types (e.g. `anyhow::Result<_>`) before. Everything before the last path segment is ignored. I left it this way for simplicity/consistency, but it's easy enough to change now if necessary.