### PR TITLE
CLI improvements

### DIFF
--- a/frb_codegen/src/commands.rs
+++ b/frb_codegen/src/commands.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use std::process::Command;
 use std::process::Output;
 
-use log::{debug, error, warn};
+use log::{debug, error, warn, info};
 
 /// Known failures that occur from external commands.
 /// If an error occurs frequently enough, consider adding it here and use
@@ -286,5 +286,17 @@ pub fn format_dart(path: &str, line_length: i32) {
             String::from_utf8_lossy(&res.stderr)
         );
         std::process::exit(Failures::Dartfmt as _);
+    }
+}
+
+pub fn build_runner(dart_root: &str) {
+    info!("Running build_runner at {}", dart_root);
+    let out = if cfg!(windows) {
+        call_shell(&format!("cd \"{}\"; dart run build_runner build --delete-conflicting-outputs", dart_root))
+    } else {
+        call_shell(&format!("cd \"{}\" && dart run build_runner build --delete-conflicting-outputs", dart_root))
+    };
+    if !out.status.success() {
+        error!("Failed to run build_runner for {}: {}", dart_root, String::from_utf8_lossy(&out.stdout));
     }
 }

--- a/frb_codegen/src/commands.rs
+++ b/frb_codegen/src/commands.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use std::process::Command;
 use std::process::Output;
 
-use log::{debug, error, warn, info};
+use log::{debug, error, info, warn};
 
 /// Known failures that occur from external commands.
 /// If an error occurs frequently enough, consider adding it here and use
@@ -292,11 +292,21 @@ pub fn format_dart(path: &str, line_length: i32) {
 pub fn build_runner(dart_root: &str) {
     info!("Running build_runner at {}", dart_root);
     let out = if cfg!(windows) {
-        call_shell(&format!("cd \"{}\"; dart run build_runner build --delete-conflicting-outputs", dart_root))
+        call_shell(&format!(
+            "cd \"{}\"; dart run build_runner build --delete-conflicting-outputs",
+            dart_root
+        ))
     } else {
-        call_shell(&format!("cd \"{}\" && dart run build_runner build --delete-conflicting-outputs", dart_root))
+        call_shell(&format!(
+            "cd \"{}\" && dart run build_runner build --delete-conflicting-outputs",
+            dart_root
+        ))
     };
     if !out.status.success() {
-        error!("Failed to run build_runner for {}: {}", dart_root, String::from_utf8_lossy(&out.stdout));
+        error!(
+            "Failed to run build_runner for {}: {}",
+            dart_root,
+            String::from_utf8_lossy(&out.stdout)
+        );
     }
 }

--- a/frb_codegen/src/config.rs
+++ b/frb_codegen/src/config.rs
@@ -270,7 +270,7 @@ impl Opts {
     pub fn dart_output_path_name(&self) -> Option<&str> {
         let name = Path::new(&self.dart_output_path);
         let root = name.file_name()?.to_str()?;
-        if let Some((name, _)) = root.split_once('.') {
+        if let Some((name, _)) = root.rsplit_once('.') {
             Some(name)
         } else {
             Some(root)
@@ -278,7 +278,11 @@ impl Opts {
     }
 
     pub fn dart_output_freezed_path(&self) -> Option<String> {
-        let name = self.dart_output_path_name()?;
-        Some(canon_path(&format!("{}.freezed.dart", name)))
+        Some(
+            Path::new(&self.dart_output_path)
+                .with_extension("freezed.dart")
+                .to_str()?
+                .to_owned(),
+        )
     }
 }

--- a/frb_codegen/src/config.rs
+++ b/frb_codegen/src/config.rs
@@ -49,6 +49,15 @@ pub struct RawOpts {
     /// LLVM compiler opts
     #[structopt(long)]
     pub llvm_compiler_opts: Option<String>,
+    /// Path to root of Dart project, otherwise inferred from --dart-output
+    #[structopt(long)]
+    pub dart_root: Option<String>,
+    /// Skip running build_runner even when codegen-capable code is detected
+    #[structopt(long)]
+    pub no_build_runner: bool,
+    /// Show debug messages.
+    #[structopt(short, long)]
+    pub verbose: bool
 }
 
 #[derive(Debug)]
@@ -65,6 +74,8 @@ pub struct Opts {
     pub llvm_path: Vec<String>,
     pub llvm_compiler_opts: String,
     pub manifest_path: String,
+    pub dart_root: Option<String>,
+    pub build_runner: bool,
 }
 
 pub fn parse(raw: RawOpts) -> Opts {
@@ -91,6 +102,14 @@ pub fn parse(raw: RawOpts) -> Opts {
         fallback_c_output_path()
             .unwrap_or_else(|_| panic!("{}", format_fail_to_guess_error("c_output")))
     }));
+
+    let dart_root = {
+        let dart_output = &raw.dart_output;
+        raw.dart_root
+            .as_deref()
+            .map(canon_path)
+            .or_else(|| fallback_dart_root(dart_output).ok())
+    };
 
     Opts {
         rust_input_path,
@@ -121,6 +140,8 @@ pub fn parse(raw: RawOpts) -> Opts {
         }),
         llvm_compiler_opts: raw.llvm_compiler_opts.unwrap_or_else(|| "".to_string()),
         manifest_path,
+        dart_root,
+        build_runner: !raw.no_build_runner,
     }
 }
 
@@ -177,6 +198,21 @@ fn fallback_rust_output_path(rust_input_path: &str) -> Result<String> {
         .to_string())
 }
 
+fn fallback_dart_root(dart_output_path: &str) -> Result<String> {
+    let mut res = canon_pathbuf(dart_output_path);
+    while res.pop() {
+        if res.join("pubspec.yaml").is_file() {
+            return res
+                .to_str()
+                .map(ToString::to_string)
+                .ok_or_else(|| anyhow!("Non-utf8 path"));
+        }
+    }
+    Err(anyhow!(
+        "Root of Dart library could not be inferred from Dart output"
+    ))
+}
+
 fn fallback_class_name(rust_crate_dir: &str) -> Result<String> {
     let cargo_toml_path = Path::new(rust_crate_dir).join("Cargo.toml");
     let cargo_toml_content = fs::read_to_string(cargo_toml_path)?;
@@ -194,10 +230,15 @@ fn fallback_class_name(rust_crate_dir: &str) -> Result<String> {
 }
 
 fn canon_path(sub_path: &str) -> String {
+    let path = canon_pathbuf(sub_path);
+    path_to_string(path).unwrap_or_else(|_| panic!("fail to parse path: {}", sub_path))
+}
+
+fn canon_pathbuf(sub_path: &str) -> PathBuf {
     let mut path =
         env::current_dir().unwrap_or_else(|_| panic!("fail to parse path: {}", sub_path));
     path.push(sub_path);
-    path_to_string(path).unwrap_or_else(|_| panic!("fail to parse path: {}", sub_path))
+    path
 }
 
 fn path_to_string(path: PathBuf) -> Result<String, OsString> {

--- a/frb_codegen/src/config.rs
+++ b/frb_codegen/src/config.rs
@@ -57,7 +57,7 @@ pub struct RawOpts {
     pub no_build_runner: bool,
     /// Show debug messages.
     #[structopt(short, long)]
-    pub verbose: bool
+    pub verbose: bool,
 }
 
 #[derive(Debug)]

--- a/frb_codegen/src/config.rs
+++ b/frb_codegen/src/config.rs
@@ -27,7 +27,7 @@ pub struct RawOpts {
 
     /// Path of output generated C header
     #[structopt(short, long)]
-    pub c_output: Option<String>,
+    pub c_output: Option<Vec<String>>,
     /// Crate directory for your Rust project
     #[structopt(long)]
     pub rust_crate_dir: Option<String>,
@@ -65,7 +65,7 @@ pub struct Opts {
     pub rust_input_path: String,
     pub dart_output_path: String,
     pub dart_decl_output_path: Option<String>,
-    pub c_output_path: String,
+    pub c_output_path: Vec<String>,
     pub rust_crate_dir: String,
     pub rust_output_path: String,
     pub class_name: String,
@@ -98,10 +98,18 @@ pub fn parse(raw: RawOpts) -> Opts {
         fallback_class_name(&*rust_crate_dir)
             .unwrap_or_else(|_| panic!("{}", format_fail_to_guess_error("class_name")))
     });
-    let c_output_path = canon_path(&raw.c_output.unwrap_or_else(|| {
-        fallback_c_output_path()
-            .unwrap_or_else(|_| panic!("{}", format_fail_to_guess_error("c_output")))
-    }));
+    let c_output_path = raw
+        .c_output
+        .map(|outputs| {
+            outputs
+                .iter()
+                .map(|output| canon_path(output))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_else(|| {
+            vec![fallback_c_output_path()
+                .unwrap_or_else(|_| panic!("{}", format_fail_to_guess_error("c_output")))]
+        });
 
     let dart_root = {
         let dart_output = &raw.dart_output;

--- a/frb_codegen/src/config.rs
+++ b/frb_codegen/src/config.rs
@@ -257,4 +257,15 @@ impl Opts {
     pub fn dart_wire_class_name(&self) -> String {
         format!("{}Wire", self.class_name)
     }
+
+    /// Returns None if the path terminates in "..", or not utf8.
+    pub fn dart_output_path_name(&self) -> Option<&str> {
+        let name = Path::new(&self.dart_output_path);
+        let root = name.file_name()?.to_str()?;
+        if let Some((name, _)) = root.split_once('.') {
+            Some(name)
+        } else {
+            Some(root)
+        }
+    }
 }

--- a/frb_codegen/src/config.rs
+++ b/frb_codegen/src/config.rs
@@ -268,4 +268,9 @@ impl Opts {
             Some(root)
         }
     }
+
+    pub fn dart_output_freezed_path(&self) -> Option<String> {
+        let name = self.dart_output_path_name()?;
+        Some(canon_path(&format!("{}.freezed.dart", name)))
+    }
 }

--- a/frb_codegen/src/generator/dart/mod.rs
+++ b/frb_codegen/src/generator/dart/mod.rs
@@ -36,6 +36,7 @@ pub fn generate(
     dart_api_class_name: &str,
     dart_api_impl_class_name: &str,
     dart_wire_class_name: &str,
+    dart_output_file_root: &str,
 ) -> (Output, bool) {
     let distinct_types = ir_file.distinct_types(true, true);
     let distinct_input_types = ir_file.distinct_types(true, false);
@@ -71,7 +72,7 @@ pub fn generate(
     let freezed_header = if needs_freezed {
         DartBasicCode {
             import: "import 'package:freezed_annotation/freezed_annotation.dart';".to_string(),
-            part: "part 'bridge_generated.freezed.dart';".to_string(),
+            part: format!("part '{}.freezed.dart';", dart_output_file_root),
             body: "".to_string(),
         }
     } else {

--- a/frb_codegen/src/generator/dart/mod.rs
+++ b/frb_codegen/src/generator/dart/mod.rs
@@ -36,7 +36,7 @@ pub fn generate(
     dart_api_class_name: &str,
     dart_api_impl_class_name: &str,
     dart_wire_class_name: &str,
-) -> Output {
+) -> (Output, bool) {
     let distinct_types = ir_file.distinct_types(true, true);
     let distinct_input_types = ir_file.distinct_types(true, false);
     let distinct_output_types = ir_file.distinct_types(false, true);
@@ -150,7 +150,7 @@ pub fn generate(
 
     let file_prelude = DartBasicCode {
         import: format!("{}
-            
+
                 // ignore_for_file: non_constant_identifier_names, unused_element, duplicate_ignore, directives_ordering, curly_braces_in_flow_control_structures, unnecessary_lambdas, slash_for_doc_comments, prefer_const_literals_to_create_immutables, implicit_dynamic_list_literal, duplicate_import, unused_import
                 ",
                 CODE_HEADER
@@ -159,11 +159,14 @@ pub fn generate(
         body: "".to_string(),
     };
 
-    Output {
-        file_prelude,
-        decl_code,
-        impl_code,
-    }
+    (
+        Output {
+            file_prelude,
+            decl_code,
+            impl_code,
+        },
+        needs_freezed,
+    )
 }
 
 fn generate_api_func(func: &IrFunc) -> (String, String, String) {

--- a/frb_codegen/src/main.rs
+++ b/frb_codegen/src/main.rs
@@ -67,6 +67,7 @@ fn main() {
         &config.dart_api_class_name(),
         &config.dart_api_impl_class_name(),
         &config.dart_wire_class_name(),
+        config.dart_output_path_name().expect("Invalid dart_output_path_name"),
     );
 
     info!("Phase: Other things");

--- a/frb_codegen/src/main.rs
+++ b/frb_codegen/src/main.rs
@@ -67,7 +67,9 @@ fn main() {
         &config.dart_api_class_name(),
         &config.dart_api_impl_class_name(),
         &config.dart_wire_class_name(),
-        config.dart_output_path_name().expect("Invalid dart_output_path_name"),
+        config
+            .dart_output_path_name()
+            .expect("Invalid dart_output_path_name"),
     );
 
     info!("Phase: Other things");

--- a/frb_codegen/src/main.rs
+++ b/frb_codegen/src/main.rs
@@ -38,7 +38,6 @@ fn main() {
     info!("Picked config: {:?}", &config);
 
     let rust_output_dir = Path::new(&config.rust_output_path).parent().unwrap();
-    let c_output_dir = Path::new(&config.c_output_path).parent().unwrap();
     let dart_output_dir = Path::new(&config.dart_output_path).parent().unwrap();
 
     info!("Phase: Parse source code to AST");
@@ -120,12 +119,13 @@ fn main() {
     ]
     .concat();
     let c_dummy_code = generator::c::generate_dummy(&effective_func_names);
-    fs::create_dir_all(c_output_dir).unwrap();
-    fs::write(
-        &config.c_output_path,
-        fs::read_to_string(temp_bindgen_c_output_file).unwrap() + "\n" + &c_dummy_code,
-    )
-    .unwrap();
+    for output in &config.c_output_path {
+        fs::create_dir_all(Path::new(output).parent().unwrap()).unwrap();
+        fs::write(
+            &output,
+            fs::read_to_string(&temp_bindgen_c_output_file).unwrap() + "\n" + &c_dummy_code,
+        ).unwrap();
+    }
 
     fs::create_dir_all(&dart_output_dir).unwrap();
     let generated_dart_wire_code_raw = fs::read_to_string(temp_dart_wire_file).unwrap();

--- a/frb_codegen/src/main.rs
+++ b/frb_codegen/src/main.rs
@@ -124,7 +124,8 @@ fn main() {
         fs::write(
             &output,
             fs::read_to_string(&temp_bindgen_c_output_file).unwrap() + "\n" + &c_dummy_code,
-        ).unwrap();
+        )
+        .unwrap();
     }
 
     fs::create_dir_all(&dart_output_dir).unwrap();

--- a/frb_codegen/src/main.rs
+++ b/frb_codegen/src/main.rs
@@ -169,14 +169,21 @@ fn main() {
         .unwrap();
     }
 
+    let dart_root = &config.dart_root;
     if needs_freezed && config.build_runner {
-        let dart_root = config.dart_root.unwrap_or_else(|| {
+        let dart_root = dart_root.as_ref().unwrap_or_else(|| {
             panic!(
                 "build_runner configured to run, but Dart root could not be inferred.
 Please specify --dart-root, or disable build_runner with --no-build-runner."
             )
         });
-        commands::build_runner(&dart_root);
+        commands::build_runner(dart_root);
+        commands::format_dart(
+            &config
+                .dart_output_freezed_path()
+                .expect("Invalid freezed file path"),
+            config.dart_format_line_length,
+        );
     }
 
     commands::format_dart(&config.dart_output_path, config.dart_format_line_length);

--- a/frb_example/pure_dart/dart/pubspec.lock
+++ b/frb_example/pure_dart/dart/pubspec.lock
@@ -5,168 +5,168 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "34.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "3.2.0"
   args:
     dependency: transitive
     description:
       name: args
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.3.0"
   async:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
   build:
     dependency: transitive
     description:
       name: build
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.2.1"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.1"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.6"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.7"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "7.2.3"
   built_collection:
     dependency: transitive
     description:
       name: built_collection
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "5.1.1"
   built_value:
     dependency: transitive
     description:
       name: built_value
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "8.1.4"
   charcode:
     dependency: transitive
     description:
       name: charcode
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.1"
   checked_yaml:
     dependency: transitive
     description:
       name: checked_yaml
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
   cli_util:
     dependency: transitive
     description:
       name: cli_util
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.3.5"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "4.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.15.0"
   convert:
     dependency: transitive
     description:
       name: convert
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.1"
   coverage:
     dependency: transitive
     description:
       name: coverage
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.3"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.1"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.2.1"
   file:
     dependency: transitive
     description:
       name: file
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "6.1.2"
   fixnum:
     dependency: transitive
     description:
       name: fixnum
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
   flutter_rust_bridge:
@@ -180,309 +180,309 @@ packages:
     dependency: "direct dev"
     description:
       name: freezed
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.1"
   freezed_annotation:
     dependency: "direct main"
     description:
       name: freezed_annotation
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
   frontend_server_client:
     dependency: transitive
     description:
       name: frontend_server_client
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.2"
   glob:
     dependency: transitive
     description:
       name: glob
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.2"
   graphs:
     dependency: transitive
     description:
       name: graphs
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "3.2.0"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.0"
   io:
     dependency: transitive
     description:
       name: io
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.3"
   js:
     dependency: transitive
     description:
       name: js
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.4"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "4.4.0"
   lints:
     dependency: "direct main"
     description:
       name: lints
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.1"
   logging:
     dependency: transitive
     description:
       name: logging
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.2"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
   meta:
     dependency: "direct main"
     description:
       name: meta
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.7.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.1"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.2"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.1"
   pool:
     dependency: transitive
     description:
       name: pool
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.5.0"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.0"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.1"
   source_gen:
     dependency: transitive
     description:
       name: source_gen
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.1"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.10.10"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
   stream_transform:
     dependency: transitive
     description:
       name: stream_transform
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
   test:
     dependency: "direct main"
     description:
       name: test
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.20.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.4.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.4.11"
   timing:
     dependency: transitive
     description:
       name: timing
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
   vm_service:
     dependency: "direct main"
     description:
       name: vm_service
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "7.5.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.1"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.16.0-100.0.dev <3.0.0"

--- a/justfile
+++ b/justfile
@@ -24,10 +24,8 @@ gen-bridge: build
     {{frb_bin}} -r {{frb_flutter}}/rust/src/api.rs \
                 -d {{frb_flutter}}/lib/bridge_generated.dart \
                 -c {{frb_flutter}}/ios/Runner/bridge_generated.h \
+                -c {{frb_flutter}}/macos/Runner/bridge_generated.h \
                 --dart-format-line-length {{line_length}}
-    cp {{frb_flutter}}/ios/Runner/bridge_generated.h \
-       {{frb_flutter}}/macos/Runner/bridge_generated.h
-
 
 alias l := lint
 lint:

--- a/justfile
+++ b/justfile
@@ -10,7 +10,7 @@ dylib := if os() == "windows" {
     "libflutter_rust_bridge_example.so"
 }
 
-default: gen-bridge lint
+default: gen-bridge
 
 alias b := build
 build:

--- a/justfile
+++ b/justfile
@@ -16,7 +16,8 @@ alias b := build
 build:
     cd frb_codegen && cargo build
 
-gen-bridge-rust-only: build
+alias g := gen-bridge
+gen-bridge: build
     {{frb_bin}} -r {{frb_pure}}/rust/src/api.rs \
                 -d {{frb_pure}}/dart/lib/bridge_generated.dart \
                 --dart-format-line-length {{line_length}}
@@ -27,9 +28,6 @@ gen-bridge-rust-only: build
     cp {{frb_flutter}}/ios/Runner/bridge_generated.h \
        {{frb_flutter}}/macos/Runner/bridge_generated.h
 
-alias g := gen-bridge
-gen-bridge: gen-bridge-rust-only
-    cd {{frb_pure}}/dart && dart run build_runner build
 
 alias l := lint
 lint:


### PR DESCRIPTION
Resolves #344.

- Added `--verbose` flag
- Added `--dart-root` flag to specify root of Dart library, by default inferred
- Runs `dart run build_runner build` at the Dart root if freezed code is detected, also lint generated files
- Added `--no-build-runner` to skip running build_runner
- Fixed "bridge_generated.freezed.dart" being hardcoded
- Allow specifying multiple `--c-output`