### PR TITLE
Add default LLVM installation path for Windows

### DIFF
--- a/frb_codegen/src/config.rs
+++ b/frb_codegen/src/config.rs
@@ -144,6 +144,7 @@ pub fn parse(raw: RawOpts) -> Opts {
                 "/usr/lib/llvm-13/lib".to_owned(),
                 "/usr/lib/".to_owned(),
                 "/usr/lib64/".to_owned(),
+                "C:/Program Files/llvm".to_owned(),  // Default on Windows
             ]
         }),
         llvm_compiler_opts: raw.llvm_compiler_opts.unwrap_or_else(|| "".to_string()),

--- a/frb_codegen/src/config.rs
+++ b/frb_codegen/src/config.rs
@@ -144,7 +144,9 @@ pub fn parse(raw: RawOpts) -> Opts {
                 "/usr/lib/llvm-13/lib".to_owned(),
                 "/usr/lib/".to_owned(),
                 "/usr/lib64/".to_owned(),
-                "C:/Program Files/llvm".to_owned()   // Default on Windows
+                "C:/Program Files/llvm".to_owned(), // Default on Windows
+                "C:/Program Files/LLVM".to_owned(),
+                "C:/msys64/mingw64".to_owned(), // https://packages.msys2.org/package/mingw-w64-x86_64-clang
             ]
         }),
         llvm_compiler_opts: raw.llvm_compiler_opts.unwrap_or_else(|| "".to_string()),

--- a/frb_codegen/src/config.rs
+++ b/frb_codegen/src/config.rs
@@ -144,7 +144,7 @@ pub fn parse(raw: RawOpts) -> Opts {
                 "/usr/lib/llvm-13/lib".to_owned(),
                 "/usr/lib/".to_owned(),
                 "/usr/lib64/".to_owned(),
-                "C:/Program Files/llvm".to_owned(),  // Default on Windows
+                "C:/Program Files/llvm".to_owned()   // Default on Windows
             ]
         }),
         llvm_compiler_opts: raw.llvm_compiler_opts.unwrap_or_else(|| "".to_string()),


### PR DESCRIPTION
Mitigates the issue described in [this comment](https://github.com/fzyzcjy/flutter_rust_bridge/issues/407#issuecomment-1104671598).