### PR TITLE
Adding an option to prevent free_WireSyncReturnStruct function from being generated

### DIFF
--- a/frb_codegen/src/config.rs
+++ b/frb_codegen/src/config.rs
@@ -58,6 +58,8 @@ pub struct RawOpts {
     /// Show debug messages.
     #[structopt(short, long)]
     pub verbose: bool,
+    #[structopt(long)]
+    pub exclude_sync_execution_mode_utility: Option<bool>,
 }
 
 #[derive(Debug)]
@@ -76,6 +78,7 @@ pub struct Opts {
     pub manifest_path: String,
     pub dart_root: Option<String>,
     pub build_runner: bool,
+    pub exclude_sync_execution_mode_utility: bool,
 }
 
 pub fn parse(raw: RawOpts) -> Opts {
@@ -154,6 +157,7 @@ pub fn parse(raw: RawOpts) -> Opts {
         manifest_path,
         dart_root,
         build_runner: !raw.no_build_runner,
+        exclude_sync_execution_mode_utility: raw.exclude_sync_execution_mode_utility.unwrap_or(false)
     }
 }
 

--- a/frb_codegen/src/lib.rs
+++ b/frb_codegen/src/lib.rs
@@ -46,6 +46,9 @@ pub fn frb_codegen(raw_opts: Opts) -> anyhow::Result<()> {
     let generated_rust = generator::rust::generate(
         &ir_file,
         &mod_from_rust_path(&config.rust_input_path, &config.rust_crate_dir),
+        Some(generator::rust::GeneratorOptions {
+            should_generate_sync_execution_mode_utility: Some(!config.exclude_sync_execution_mode_utility)
+        }),
     );
     fs::create_dir_all(&rust_output_dir)?;
     fs::write(&config.rust_output_path, generated_rust.code)?;


### PR DESCRIPTION
This PR adds a new command line option `exclude_sync_execution_mode_utility` to prevent the function `free_WireSyncReturnStruct` from being generated in the dart file. 

This is useful in scenarios where larger projects want to separate their rust code into multiple modules, and generate separate dart bridge code per module. Example below generates two dart classes. 

```bash
flutter_rust_bridge_codegen --rust-input rust/src/api.rs \
    --dart-output lib/bridge_generated_api.dart --rust-output rust/src/bridge_generated_api.rs \
    --class-name CoreApi
flutter_rust_bridge_codegen --rust-input rust/src/methods.rs \
    --dart-output lib/bridge_generated_methods.dart --rust-output rust/src/bridge_generated_methods.rs \
    --class-name MethodsApi 
```

However, `free_WireSyncReturnStruct` function is declared in both `bridge_generated_api.rs` and `bridge_generated_methods.rs` causing the build to fail. 


This PR was preceeded by some [discussion](https://github.com/fzyzcjy/flutter_rust_bridge/discussions/479) on flutter_rust_bridge repo. 