### PR TITLE
Remove M1 specific sections in the book

### DIFF
--- a/book/src/template/setup_others.md
+++ b/book/src/template/setup_others.md
@@ -3,22 +3,3 @@
 For all remaining platforms, there are no required setup steps to take, apart from those listed in [Desktop support for Flutter](https://docs.flutter.dev/desktop). If you need to check your progress, run `flutter doctor -v` and it will display the status of your toolchain and any actionable steps. The rest of this page
 documents additional hints for each of the platforms that might be useful for newcomers to
 Flutter and/or Rust.
-
-## Apple Silicon hosts
-
-For Apple Silicon hosts building Flutter apps, make sure to read [these notes](https://github.com/flutter/flutter/wiki/Developing-with-Flutter-on-Apple-Silicon)
-on the official Flutter repo.
-
-As of writing (Feb 2022) it is possible to build Flutter apps for other architectures using
-the arm64 Dart SDK, albeit unofficially. Using [`flutter_m1_patcher`](https://pub.dev/packages/flutter_m1_patcher)
-will replace the Dart SDK bundled with Flutter with your installation of Dart SDK via Homebrew.
-You will need to repeat this process after every `flutter upgrade`:
-
-```bash
-dart pub global activate flutter_m1_patcher
-flutterpatch
-```
-
-This process will be superseded by [flutter/flutter#60118](https://github.com/flutter/flutter/issues/60118) once
-it lands.
-

--- a/book/src/troubleshooting.md
+++ b/book/src/troubleshooting.md
@@ -21,42 +21,7 @@ If you are running macOS, you will need to specify a path to your llvm:
 ```shell
 flutter_rust_bridge_codegen --rust-input path/to/your/api.rs --dart-output path/to/file/being/bridge_generated.dart --llvm-path /usr/local/homebrew/opt/llvm/
 ```
-If you are on Intel, you can install llvm using `brew install llvm` and it will be installed at `/usr/local/homebrew/opt/llvm/` by default.
-
-If you are on M1, you need to install the x86 versions of everything and run them through Rosetta 2, since Flutter does not support M1 yet. Start by installing Rosetta 2 if you haven't already:
-
-```shell
-/usr/sbin/softwareupdate --install-rosetta
-```
-Then, install an x86 version of brew to `/usr/local`:
-```shell
-arch -x86_64 zsh
-cd /usr/local && mkdir homebrew
-curl -L https://github.com/Homebrew/brew/tarball/master | tar xz --strip 1 -C homebrew
-```
-Then, you need to use the x86 brew to install the x86 version of llvm:
-```shell
-arch -x86_64 /usr/local/homebrew/bin/brew install llvm
-```
-Reference [this article](https://www.wisdomgeek.com/development/installing-intel-based-packages-using-homebrew-on-the-m1-mac/) for details.
-
-And when you build with cargo, you need to select x86 as the target:
-
-```shell
-cargo build --target=x86_64-apple-darwin
-```
-
-## On M1 MacOS, ` Failed to load dynamic library '/opt/homebrew/opt/llvm/lib/libclang.dylib'`
-
-Full possible error:
-
-```
-Invalid argument(s): Failed to load dynamic library '/opt/homebrew/opt/llvm/lib/libclang.dylib': dlopen(/opt/homebrew/opt/llvm/lib/libclang.dylib, 0x0001): tried: '/opt/homebrew/opt/llvm/lib/libclang.dylib' (mach-o file, but is an incompatible architecture (have 'arm64', need 'x86_64')), '/usr/lib/libclang.dylib' (no such file), '/opt/homebrew/Cellar/llvm/13.0.0_2/lib/libclang.dylib' (mach-o file, but is an incompatible architecture (have 'arm64', need 'x86_64')), '/usr/lib/libclang.dylib' (no such file)
-```
-
-Solution: Install the arm64 version of dart and put that in PATH instead of the x86_64 version that flutter ships. See https://github.com/dart-lang/ffigen/issues/260.
-
-Related: https://github.com/fzyzcjy/flutter_rust_bridge/issues/318#issuecomment-1037718638
+You can install llvm using `brew install llvm` and it will be installed at `/usr/local/homebrew/opt/llvm/` by default.
 
 ## Freezed file is sometimes not generated when it should be
 


### PR DESCRIPTION
Since the release of Flutter 3, Apple silicon should be fully supported and the specific sections should no longer be needed.