### PR TITLE
Update iOS headers section of book with code that ensures symbols do not get stripped

### DIFF
--- a/book/src/integrate/ios_headers.md
+++ b/book/src/integrate/ios_headers.md
@@ -26,10 +26,13 @@ and in `ios/Runner/AppDelegate.swift`:
      _ application: UIApplication,
      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
  ) -> Bool {
-+    dummy_method_to_enforce_bundling()
++    let dummy = dummy_method_to_enforce_bundling()
++    print(dummy)
      ..
  }
 ```
+
+It is important that you use the result of `dummy_method_to_enforce_bundling()` (like in the example above), otherwise the symbols might still get stripped.
 
 
 ## MacOS


### PR DESCRIPTION
For context, see https://github.com/fzyzcjy/flutter_rust_bridge/issues/496.