### PR TITLE
Updated stream chapter in book

### DIFF
--- a/book/src/feature/stream.md
+++ b/book/src/feature/stream.md
@@ -38,15 +38,15 @@ pub fn create_log_stream(s: StreamSink<LogEntry>) {
 }
 ```
 
+Now Rust will probably complain at you because `IntoDart` is not implemented for `LogEntry`. This is expected, because `flutter_rust_bridge` will generate this trait implementation for you.
+To fix this error you should just rerun `flutter_rust_bridge_codegen`.
+
 
 Generated Dart code:
 
 ```Dart
 Stream<LogEntry> createLogStream();
 ```
-
-Now Rust will probably complain at you because `IntoDart` is not implemented for `LogEntry`. This is expected, because `flutter_rust_bridge` will generate this trait implementation for you.
-To fix this error you should just rerun `flutter_rust_bridge_codegen`.
 
 Now let us use it in Dart:
 

--- a/book/src/feature/stream.md
+++ b/book/src/feature/stream.md
@@ -38,11 +38,15 @@ pub fn create_log_stream(s: StreamSink<LogEntry>) {
 }
 ```
 
+
 Generated Dart code:
 
 ```Dart
 Stream<LogEntry> createLogStream();
 ```
+
+Now Rust will probably complain at you because `IntoDart` is not implemented for `LogEntry`. This is expected, because `flutter_rust_bridge` will generate this trait implementation for you.
+To fix this error you should just rerun `flutter_rust_bridge_codegen`.
 
 Now let us use it in Dart:
 


### PR DESCRIPTION
Now includes section about rerunning `flutter_rust_bridge_codegen` to generate `IntoDart` trait implementation