### PR TITLE
Speculative fix for `store_dart_post_cobject` signature mismatch with `ffigen` >= 6.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -571,5 +571,5 @@ jobs:
         if: ${{ matrix.os.family != 'osx' }}
         run: sed -i -e 's/^typedef uintptr_t =.*$/typedef uintptr_t = ffi.UnsignedLong;/g' frb_example/pure_dart/dart/lib/bridge_generated.dart
 
-      - name: "Check no code change (If fail: Please ensure you have run codegen on examples and commit those changes!)"
+      - name: "Check no code change (If fail: Please ensure you have run codegen on examples and commit those changes! On Windows, see https://github.com/fzyzcjy/flutter_rust_bridge/pull/536#issuecomment-1170259918 for additional instructions.)"
         run: git diff --exit-code

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
       - uses: dart-lang/setup-dart@v1
 
       - name: Install ffigen
-        run: dart pub global activate ffigen ^5.0.0 # TODO migrate to 6.x later
+        run: dart pub global activate ffigen ^6.0.0
 
       - name: Install dart dependencies
         working-directory: ./frb_example/pure_dart/dart
@@ -324,7 +324,7 @@ jobs:
 
       - uses: dart-lang/setup-dart@v1
       - name: Install ffigen
-        run: dart pub global activate ffigen ^5.0.0 # TODO migrate to 6.x later
+        run: dart pub global activate ffigen ^6.0.0
       - name: Install llvm dependency (Linux)
         run: sudo apt update && sudo apt-get install -y libclang-dev
       - name: Build codegen
@@ -385,7 +385,7 @@ jobs:
 
       - uses: dart-lang/setup-dart@v1
       - name: Install ffigen
-        run: dart pub global activate ffigen ^5.0.0 # TODO migrate to 6.x later
+        run: dart pub global activate ffigen ^6.0.0
       - name: Install llvm dependency (Linux)
         run: sudo apt update && sudo apt-get install -y libclang-dev
 
@@ -528,7 +528,7 @@ jobs:
       - uses: dart-lang/setup-dart@v1
 
       - name: Install dart global dependency
-        run: dart pub global activate ffigen ^5.0.0 # TODO migrate to 6.x later
+        run: dart pub global activate ffigen ^6.0.0
 
       # needed by `ffigen`, see https://github.com/dart-lang/ffigen#installing-llvm
       - name: Install llvm dependency (Linux)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
       - uses: dart-lang/setup-dart@v1
 
       - name: Install ffigen
-        run: dart pub global activate ffigen ^6.0.0
+        run: dart pub global activate ffigen ^6.0.1
 
       - name: Install dart dependencies
         working-directory: ./frb_example/pure_dart/dart
@@ -324,7 +324,7 @@ jobs:
 
       - uses: dart-lang/setup-dart@v1
       - name: Install ffigen
-        run: dart pub global activate ffigen ^6.0.0
+        run: dart pub global activate ffigen ^6.0.1
       - name: Install llvm dependency (Linux)
         run: sudo apt update && sudo apt-get install -y libclang-dev
       - name: Build codegen
@@ -385,7 +385,7 @@ jobs:
 
       - uses: dart-lang/setup-dart@v1
       - name: Install ffigen
-        run: dart pub global activate ffigen ^6.0.0
+        run: dart pub global activate ffigen ^6.0.1
       - name: Install llvm dependency (Linux)
         run: sudo apt update && sudo apt-get install -y libclang-dev
 
@@ -528,7 +528,7 @@ jobs:
       - uses: dart-lang/setup-dart@v1
 
       - name: Install dart global dependency
-        run: dart pub global activate ffigen ^6.0.0
+        run: dart pub global activate ffigen ^6.0.1
 
       # needed by `ffigen`, see https://github.com/dart-lang/ffigen#installing-llvm
       - name: Install llvm dependency (Linux)

--- a/.github/workflows/post_release.yaml
+++ b/.github/workflows/post_release.yaml
@@ -44,7 +44,7 @@ jobs:
       - uses: dart-lang/setup-dart@v1
 
       - name: Install ffigen
-        run: dart pub global activate ffigen ^5.0.0 # TODO migrate to 6.x later
+        run: dart pub global activate ffigen ^6.0.1
 
       - name: Install dart dependencies
         working-directory: ./frb_example/pure_dart/dart
@@ -179,7 +179,7 @@ jobs:
       - uses: dart-lang/setup-dart@v1
 
       - name: Install dart global dependency
-        run: dart pub global activate ffigen ^5.0.0 # TODO migrate to 6.x later
+        run: dart pub global activate ffigen ^6.0.1
 
       # needed by `ffigen`, see https://github.com/dart-lang/ffigen#installing-llvm
       - name: Install llvm dependency (Linux)

--- a/frb_codegen/src/generator/dart/ty_primitive.rs
+++ b/frb_codegen/src/generator/dart/ty_primitive.rs
@@ -8,7 +8,6 @@ type_dart_generator_struct!(TypePrimitiveGenerator, IrTypePrimitive);
 impl TypeDartGeneratorTrait for TypePrimitiveGenerator<'_> {
     fn api2wire_body(&self) -> Option<String> {
         Some(match self.ir {
-            IrTypePrimitive::Bool => "return raw ? 1 : 0;".to_owned(),
             _ => "return raw;".to_string(),
         })
     }

--- a/frb_codegen/src/generator/dart/ty_primitive.rs
+++ b/frb_codegen/src/generator/dart/ty_primitive.rs
@@ -7,9 +7,7 @@ type_dart_generator_struct!(TypePrimitiveGenerator, IrTypePrimitive);
 
 impl TypeDartGeneratorTrait for TypePrimitiveGenerator<'_> {
     fn api2wire_body(&self) -> Option<String> {
-        Some(match self.ir {
-            _ => "return raw;".to_string(),
-        })
+        Some("return raw;".to_string())
     }
 
     fn wire2api_body(&self) -> String {

--- a/frb_codegen/src/ir/ty_primitive.rs
+++ b/frb_codegen/src/ir/ty_primitive.rs
@@ -44,7 +44,6 @@ impl IrTypeTrait for IrTypePrimitive {
 
     fn dart_wire_type(&self) -> String {
         match self {
-            IrTypePrimitive::Bool => "int".to_owned(),
             _ => self.dart_api_type(),
         }
     }
@@ -62,12 +61,12 @@ impl IrTypeTrait for IrTypePrimitive {
             IrTypePrimitive::U32 => "u32",
             IrTypePrimitive::I32 => "i32",
             IrTypePrimitive::U64 => "u64",
+            IrTypePrimitive::Unit => "unit",
+            IrTypePrimitive::Usize => "usize",
             IrTypePrimitive::I64 => "i64",
             IrTypePrimitive::F32 => "f32",
             IrTypePrimitive::F64 => "f64",
             IrTypePrimitive::Bool => "bool",
-            IrTypePrimitive::Unit => "unit",
-            IrTypePrimitive::Usize => "usize",
         }
         .to_string()
     }
@@ -79,7 +78,7 @@ impl IrTypePrimitive {
     /// whenever primitives are put behind a pointer.
     pub fn dart_native_type(&self) -> &'static str {
         match self {
-            IrTypePrimitive::U8 | IrTypePrimitive::Bool => "ffi.Uint8",
+            IrTypePrimitive::U8 => "ffi.Uint8",
             IrTypePrimitive::I8 => "ffi.Int8",
             IrTypePrimitive::U16 => "ffi.Uint16",
             IrTypePrimitive::I16 => "ffi.Int16",
@@ -87,10 +86,11 @@ impl IrTypePrimitive {
             IrTypePrimitive::I32 => "ffi.Int32",
             IrTypePrimitive::U64 => "ffi.Uint64",
             IrTypePrimitive::I64 => "ffi.Int64",
+            IrTypePrimitive::Usize => "ffi.Usize",
             IrTypePrimitive::F32 => "ffi.Float",
             IrTypePrimitive::F64 => "ffi.Double",
+            IrTypePrimitive::Bool => "ffi.Bool",
             IrTypePrimitive::Unit => "ffi.Void",
-            IrTypePrimitive::Usize => "ffi.Usize",
         }
     }
     pub fn try_from_rust_str(s: &str) -> Option<Self> {

--- a/frb_codegen/src/ir/ty_primitive.rs
+++ b/frb_codegen/src/ir/ty_primitive.rs
@@ -43,9 +43,7 @@ impl IrTypeTrait for IrTypePrimitive {
     }
 
     fn dart_wire_type(&self) -> String {
-        match self {
-            _ => self.dart_api_type(),
-        }
+        self.dart_api_type()
     }
 
     fn rust_api_type(&self) -> String {

--- a/frb_dart/lib/src/basic.dart
+++ b/frb_dart/lib/src/basic.dart
@@ -153,7 +153,7 @@ abstract class FlutterRustBridgeWireBase {
   void store_dart_post_cobject(
     ffi.Pointer<
             ffi.NativeFunction<
-                ffi.Uint8 Function(ffi.Int64, ffi.Pointer<ffi.Void>)>>
+                ffi.Bool Function(ffi.Int64, ffi.Pointer<ffi.Void>)>>
         ptr,
   );
 

--- a/frb_example/pure_dart/dart/lib/bridge_generated.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.dart
@@ -28,11 +28,7 @@ abstract class FlutterRustBridgeExample {
   /// Newlines are preserved.
   ///
   Future<int> primitiveTypes(
-      {required int myI32,
-      required int myI64,
-      required double myF64,
-      required bool myBool,
-      dynamic hint});
+      {required int myI32, required int myI64, required double myF64, required bool myBool, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kPrimitiveTypesConstMeta;
 
@@ -52,18 +48,15 @@ abstract class FlutterRustBridgeExample {
 
   FlutterRustBridgeTaskConstMeta get kHandleVecU8ConstMeta;
 
-  Future<VecOfPrimitivePack> handleVecOfPrimitive(
-      {required int n, dynamic hint});
+  Future<VecOfPrimitivePack> handleVecOfPrimitive({required int n, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleVecOfPrimitiveConstMeta;
 
-  Future<ZeroCopyVecOfPrimitivePack> handleZeroCopyVecOfPrimitive(
-      {required int n, dynamic hint});
+  Future<ZeroCopyVecOfPrimitivePack> handleZeroCopyVecOfPrimitive({required int n, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleZeroCopyVecOfPrimitiveConstMeta;
 
-  Future<MySize> handleStruct(
-      {required MySize arg, required MySize boxed, dynamic hint});
+  Future<MySize> handleStruct({required MySize arg, required MySize boxed, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleStructConstMeta;
 
@@ -71,13 +64,11 @@ abstract class FlutterRustBridgeExample {
 
   FlutterRustBridgeTaskConstMeta get kHandleNewtypeConstMeta;
 
-  Future<List<MySize>> handleListOfStruct(
-      {required List<MySize> l, dynamic hint});
+  Future<List<MySize>> handleListOfStruct({required List<MySize> l, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleListOfStructConstMeta;
 
-  Future<List<String>> handleStringList(
-      {required List<String> names, dynamic hint});
+  Future<List<String>> handleStringList({required List<String> names, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleStringListConstMeta;
 
@@ -105,8 +96,7 @@ abstract class FlutterRustBridgeExample {
 
   FlutterRustBridgeTaskConstMeta get kReturnPanicConstMeta;
 
-  Future<double?> handleOptionalReturn(
-      {required double left, required double right, dynamic hint});
+  Future<double?> handleOptionalReturn({required double left, required double right, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleOptionalReturnConstMeta;
 
@@ -114,8 +104,7 @@ abstract class FlutterRustBridgeExample {
 
   FlutterRustBridgeTaskConstMeta get kHandleOptionalStructConstMeta;
 
-  Future<ExoticOptionals?> handleOptionalIncrement(
-      {ExoticOptionals? opt, dynamic hint});
+  Future<ExoticOptionals?> handleOptionalIncrement({ExoticOptionals? opt, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleOptionalIncrementConstMeta;
 
@@ -139,8 +128,7 @@ abstract class FlutterRustBridgeExample {
 
   FlutterRustBridgeTaskConstMeta get kHandleReturnEnumConstMeta;
 
-  Future<Weekdays> handleEnumParameter(
-      {required Weekdays weekday, dynamic hint});
+  Future<Weekdays> handleEnumParameter({required Weekdays weekday, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleEnumParameterConstMeta;
 
@@ -148,8 +136,7 @@ abstract class FlutterRustBridgeExample {
 
   FlutterRustBridgeTaskConstMeta get kHandleCustomizedStructConstMeta;
 
-  Future<KitchenSink> handleEnumStruct(
-      {required KitchenSink val, dynamic hint});
+  Future<KitchenSink> handleEnumStruct({required KitchenSink val, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleEnumStructConstMeta;
 
@@ -165,8 +152,7 @@ abstract class FlutterRustBridgeExample {
 
   FlutterRustBridgeTaskConstMeta get kGetAppSettingsConstMeta;
 
-  Future<bool> isAppEmbedded(
-      {required ApplicationSettings appSettings, dynamic hint});
+  Future<bool> isAppEmbedded({required ApplicationSettings appSettings, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kIsAppEmbeddedConstMeta;
 
@@ -496,90 +482,69 @@ class ZeroCopyVecOfPrimitivePack {
   });
 }
 
-class FlutterRustBridgeExampleImpl
-    extends FlutterRustBridgeBase<FlutterRustBridgeExampleWire>
+class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBridgeExampleWire>
     implements FlutterRustBridgeExample {
   factory FlutterRustBridgeExampleImpl(ffi.DynamicLibrary dylib) =>
       FlutterRustBridgeExampleImpl.raw(FlutterRustBridgeExampleWire(dylib));
 
-  FlutterRustBridgeExampleImpl.raw(FlutterRustBridgeExampleWire inner)
-      : super(inner);
+  FlutterRustBridgeExampleImpl.raw(FlutterRustBridgeExampleWire inner) : super(inner);
 
-  Future<int> simpleAdder({required int a, required int b, dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_simple_adder(port_, _api2wire_i32(a), _api2wire_i32(b)),
+  Future<int> simpleAdder({required int a, required int b, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_simple_adder(port_, _api2wire_i32(a), _api2wire_i32(b)),
         parseSuccessData: _wire2api_i32,
         constMeta: kSimpleAdderConstMeta,
         argValues: [a, b],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kSimpleAdderConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kSimpleAdderConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "simple_adder",
         argNames: ["a", "b"],
       );
 
   Future<int> primitiveTypes(
-          {required int myI32,
-          required int myI64,
-          required double myF64,
-          required bool myBool,
-          dynamic hint}) =>
+          {required int myI32, required int myI64, required double myF64, required bool myBool, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_primitive_types(
-            port_,
-            _api2wire_i32(myI32),
-            _api2wire_i64(myI64),
-            _api2wire_f64(myF64),
-            myBool),
+        callFfi: (port_) =>
+            inner.wire_primitive_types(port_, _api2wire_i32(myI32), _api2wire_i64(myI64), _api2wire_f64(myF64), myBool),
         parseSuccessData: _wire2api_i32,
         constMeta: kPrimitiveTypesConstMeta,
         argValues: [myI32, myI64, myF64, myBool],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kPrimitiveTypesConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kPrimitiveTypesConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "primitive_types",
         argNames: ["myI32", "myI64", "myF64", "myBool"],
       );
 
-  Future<int> primitiveU32({required int myU32, dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_primitive_u32(port_, _api2wire_u32(myU32)),
+  Future<int> primitiveU32({required int myU32, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_primitive_u32(port_, _api2wire_u32(myU32)),
         parseSuccessData: _wire2api_u32,
         constMeta: kPrimitiveU32ConstMeta,
         argValues: [myU32],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kPrimitiveU32ConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kPrimitiveU32ConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "primitive_u32",
         argNames: ["myU32"],
       );
 
-  Future<String> handleString({required String s, dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_handle_string(port_, _api2wire_String(s)),
+  Future<String> handleString({required String s, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_handle_string(port_, _api2wire_String(s)),
         parseSuccessData: _wire2api_String,
         constMeta: kHandleStringConstMeta,
         argValues: [s],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleStringConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleStringConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_string",
         argNames: ["s"],
       );
 
-  Future<void> handleReturnUnit({dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
+  Future<void> handleReturnUnit({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_handle_return_unit(port_),
         parseSuccessData: _wire2api_unit,
         constMeta: kHandleReturnUnitConstMeta,
@@ -587,178 +552,147 @@ class FlutterRustBridgeExampleImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleReturnUnitConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleReturnUnitConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_return_unit",
         argNames: [],
       );
 
-  Future<Uint8List> handleVecU8({required Uint8List v, dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_handle_vec_u8(port_, _api2wire_uint_8_list(v)),
+  Future<Uint8List> handleVecU8({required Uint8List v, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_handle_vec_u8(port_, _api2wire_uint_8_list(v)),
         parseSuccessData: _wire2api_uint_8_list,
         constMeta: kHandleVecU8ConstMeta,
         argValues: [v],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleVecU8ConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleVecU8ConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_vec_u8",
         argNames: ["v"],
       );
 
-  Future<VecOfPrimitivePack> handleVecOfPrimitive(
-          {required int n, dynamic hint}) =>
+  Future<VecOfPrimitivePack> handleVecOfPrimitive({required int n, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_handle_vec_of_primitive(port_, _api2wire_i32(n)),
+        callFfi: (port_) => inner.wire_handle_vec_of_primitive(port_, _api2wire_i32(n)),
         parseSuccessData: _wire2api_vec_of_primitive_pack,
         constMeta: kHandleVecOfPrimitiveConstMeta,
         argValues: [n],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleVecOfPrimitiveConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleVecOfPrimitiveConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_vec_of_primitive",
         argNames: ["n"],
       );
 
-  Future<ZeroCopyVecOfPrimitivePack> handleZeroCopyVecOfPrimitive(
-          {required int n, dynamic hint}) =>
+  Future<ZeroCopyVecOfPrimitivePack> handleZeroCopyVecOfPrimitive({required int n, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_zero_copy_vec_of_primitive(
-            port_, _api2wire_i32(n)),
+        callFfi: (port_) => inner.wire_handle_zero_copy_vec_of_primitive(port_, _api2wire_i32(n)),
         parseSuccessData: _wire2api_zero_copy_vec_of_primitive_pack,
         constMeta: kHandleZeroCopyVecOfPrimitiveConstMeta,
         argValues: [n],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleZeroCopyVecOfPrimitiveConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleZeroCopyVecOfPrimitiveConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_zero_copy_vec_of_primitive",
         argNames: ["n"],
       );
 
-  Future<MySize> handleStruct(
-          {required MySize arg, required MySize boxed, dynamic hint}) =>
+  Future<MySize> handleStruct({required MySize arg, required MySize boxed, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_struct(port_,
-            _api2wire_box_autoadd_my_size(arg), _api2wire_box_my_size(boxed)),
+        callFfi: (port_) =>
+            inner.wire_handle_struct(port_, _api2wire_box_autoadd_my_size(arg), _api2wire_box_my_size(boxed)),
         parseSuccessData: _wire2api_my_size,
         constMeta: kHandleStructConstMeta,
         argValues: [arg, boxed],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleStructConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleStructConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_struct",
         argNames: ["arg", "boxed"],
       );
 
-  Future<NewTypeInt> handleNewtype({required NewTypeInt arg, dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_newtype(
-            port_, _api2wire_box_autoadd_new_type_int(arg)),
+  Future<NewTypeInt> handleNewtype({required NewTypeInt arg, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_handle_newtype(port_, _api2wire_box_autoadd_new_type_int(arg)),
         parseSuccessData: _wire2api_new_type_int,
         constMeta: kHandleNewtypeConstMeta,
         argValues: [arg],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleNewtypeConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleNewtypeConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_newtype",
         argNames: ["arg"],
       );
 
-  Future<List<MySize>> handleListOfStruct(
-          {required List<MySize> l, dynamic hint}) =>
+  Future<List<MySize>> handleListOfStruct({required List<MySize> l, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_handle_list_of_struct(port_, _api2wire_list_my_size(l)),
+        callFfi: (port_) => inner.wire_handle_list_of_struct(port_, _api2wire_list_my_size(l)),
         parseSuccessData: _wire2api_list_my_size,
         constMeta: kHandleListOfStructConstMeta,
         argValues: [l],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleListOfStructConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleListOfStructConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_list_of_struct",
         argNames: ["l"],
       );
 
-  Future<List<String>> handleStringList(
-          {required List<String> names, dynamic hint}) =>
+  Future<List<String>> handleStringList({required List<String> names, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_handle_string_list(port_, _api2wire_StringList(names)),
+        callFfi: (port_) => inner.wire_handle_string_list(port_, _api2wire_StringList(names)),
         parseSuccessData: _wire2api_StringList,
         constMeta: kHandleStringListConstMeta,
         argValues: [names],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleStringListConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleStringListConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_string_list",
         argNames: ["names"],
       );
 
-  Future<MyTreeNode> handleComplexStruct(
-          {required MyTreeNode s, dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_complex_struct(
-            port_, _api2wire_box_autoadd_my_tree_node(s)),
+  Future<MyTreeNode> handleComplexStruct({required MyTreeNode s, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_handle_complex_struct(port_, _api2wire_box_autoadd_my_tree_node(s)),
         parseSuccessData: _wire2api_my_tree_node,
         constMeta: kHandleComplexStructConstMeta,
         argValues: [s],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleComplexStructConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleComplexStructConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_complex_struct",
         argNames: ["s"],
       );
 
-  Uint8List handleSyncReturn({required String mode, dynamic hint}) =>
-      executeSync(FlutterRustBridgeSyncTask(
+  Uint8List handleSyncReturn({required String mode, dynamic hint}) => executeSync(FlutterRustBridgeSyncTask(
         callFfi: () => inner.wire_handle_sync_return(_api2wire_String(mode)),
         constMeta: kHandleSyncReturnConstMeta,
         argValues: [mode],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleSyncReturnConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleSyncReturnConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_sync_return",
         argNames: ["mode"],
       );
 
-  Stream<String> handleStream({required String arg, dynamic hint}) =>
-      executeStream(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_handle_stream(port_, _api2wire_String(arg)),
+  Stream<String> handleStream({required String arg, dynamic hint}) => executeStream(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_handle_stream(port_, _api2wire_String(arg)),
         parseSuccessData: _wire2api_String,
         constMeta: kHandleStreamConstMeta,
         argValues: [arg],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleStreamConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleStreamConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_stream",
         argNames: ["arg"],
       );
 
-  Stream<MyStreamEntry> handleStreamOfStruct({dynamic hint}) =>
-      executeStream(FlutterRustBridgeTask(
+  Stream<MyStreamEntry> handleStreamOfStruct({dynamic hint}) => executeStream(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_handle_stream_of_struct(port_),
         parseSuccessData: _wire2api_my_stream_entry,
         constMeta: kHandleStreamOfStructConstMeta,
@@ -766,8 +700,7 @@ class FlutterRustBridgeExampleImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleStreamOfStructConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleStreamOfStructConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_stream_of_struct",
         argNames: [],
       );
@@ -780,14 +713,12 @@ class FlutterRustBridgeExampleImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kReturnErrConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kReturnErrConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "return_err",
         argNames: [],
       );
 
-  Future<int> returnPanic({dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
+  Future<int> returnPanic({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_return_panic(port_),
         parseSuccessData: _wire2api_i32,
         constMeta: kReturnPanicConstMeta,
@@ -795,74 +726,62 @@ class FlutterRustBridgeExampleImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kReturnPanicConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kReturnPanicConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "return_panic",
         argNames: [],
       );
 
-  Future<double?> handleOptionalReturn(
-          {required double left, required double right, dynamic hint}) =>
+  Future<double?> handleOptionalReturn({required double left, required double right, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_optional_return(
-            port_, _api2wire_f64(left), _api2wire_f64(right)),
+        callFfi: (port_) => inner.wire_handle_optional_return(port_, _api2wire_f64(left), _api2wire_f64(right)),
         parseSuccessData: _wire2api_opt_box_autoadd_f64,
         constMeta: kHandleOptionalReturnConstMeta,
         argValues: [left, right],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleOptionalReturnConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleOptionalReturnConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_optional_return",
         argNames: ["left", "right"],
       );
 
-  Future<Element?> handleOptionalStruct({String? document, dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_optional_struct(
-            port_, _api2wire_opt_String(document)),
+  Future<Element?> handleOptionalStruct({String? document, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_handle_optional_struct(port_, _api2wire_opt_String(document)),
         parseSuccessData: _wire2api_opt_box_autoadd_element,
         constMeta: kHandleOptionalStructConstMeta,
         argValues: [document],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleOptionalStructConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleOptionalStructConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_optional_struct",
         argNames: ["document"],
       );
 
-  Future<ExoticOptionals?> handleOptionalIncrement(
-          {ExoticOptionals? opt, dynamic hint}) =>
+  Future<ExoticOptionals?> handleOptionalIncrement({ExoticOptionals? opt, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_optional_increment(
-            port_, _api2wire_opt_box_autoadd_exotic_optionals(opt)),
+        callFfi: (port_) =>
+            inner.wire_handle_optional_increment(port_, _api2wire_opt_box_autoadd_exotic_optionals(opt)),
         parseSuccessData: _wire2api_opt_box_autoadd_exotic_optionals,
         constMeta: kHandleOptionalIncrementConstMeta,
         argValues: [opt],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleOptionalIncrementConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleOptionalIncrementConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_optional_increment",
         argNames: ["opt"],
       );
 
-  Future<double> handleIncrementBoxedOptional({double? opt, dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_increment_boxed_optional(
-            port_, _api2wire_opt_box_f64(opt)),
+  Future<double> handleIncrementBoxedOptional({double? opt, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_handle_increment_boxed_optional(port_, _api2wire_opt_box_f64(opt)),
         parseSuccessData: _wire2api_f64,
         constMeta: kHandleIncrementBoxedOptionalConstMeta,
         argValues: [opt],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleIncrementBoxedOptionalConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleIncrementBoxedOptionalConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_increment_boxed_optional",
         argNames: ["opt"],
       );
@@ -892,121 +811,91 @@ class FlutterRustBridgeExampleImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleOptionBoxArgumentsConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleOptionBoxArgumentsConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_option_box_arguments",
-        argNames: [
-          "i8Box",
-          "u8Box",
-          "i32Box",
-          "i64Box",
-          "f64Box",
-          "boolbox",
-          "structbox"
-        ],
+        argNames: ["i8Box", "u8Box", "i32Box", "i64Box", "f64Box", "boolbox", "structbox"],
       );
 
-  Future<Weekdays?> handleReturnEnum({required String input, dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_handle_return_enum(port_, _api2wire_String(input)),
+  Future<Weekdays?> handleReturnEnum({required String input, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_handle_return_enum(port_, _api2wire_String(input)),
         parseSuccessData: _wire2api_opt_weekdays,
         constMeta: kHandleReturnEnumConstMeta,
         argValues: [input],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleReturnEnumConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleReturnEnumConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_return_enum",
         argNames: ["input"],
       );
 
-  Future<Weekdays> handleEnumParameter(
-          {required Weekdays weekday, dynamic hint}) =>
+  Future<Weekdays> handleEnumParameter({required Weekdays weekday, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_enum_parameter(
-            port_, _api2wire_weekdays(weekday)),
+        callFfi: (port_) => inner.wire_handle_enum_parameter(port_, _api2wire_weekdays(weekday)),
         parseSuccessData: _wire2api_weekdays,
         constMeta: kHandleEnumParameterConstMeta,
         argValues: [weekday],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleEnumParameterConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleEnumParameterConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_enum_parameter",
         argNames: ["weekday"],
       );
 
-  Future<void> handleCustomizedStruct(
-          {required Customized val, dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_customized_struct(
-            port_, _api2wire_box_autoadd_customized(val)),
+  Future<void> handleCustomizedStruct({required Customized val, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_handle_customized_struct(port_, _api2wire_box_autoadd_customized(val)),
         parseSuccessData: _wire2api_unit,
         constMeta: kHandleCustomizedStructConstMeta,
         argValues: [val],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleCustomizedStructConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleCustomizedStructConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_customized_struct",
         argNames: ["val"],
       );
 
-  Future<KitchenSink> handleEnumStruct(
-          {required KitchenSink val, dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_enum_struct(
-            port_, _api2wire_box_autoadd_kitchen_sink(val)),
+  Future<KitchenSink> handleEnumStruct({required KitchenSink val, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_handle_enum_struct(port_, _api2wire_box_autoadd_kitchen_sink(val)),
         parseSuccessData: _wire2api_kitchen_sink,
         constMeta: kHandleEnumStructConstMeta,
         argValues: [val],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleEnumStructConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleEnumStructConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_enum_struct",
         argNames: ["val"],
       );
 
-  Future<bool> useImportedStruct({required MyStruct myStruct, dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_use_imported_struct(
-            port_, _api2wire_box_autoadd_my_struct(myStruct)),
+  Future<bool> useImportedStruct({required MyStruct myStruct, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_use_imported_struct(port_, _api2wire_box_autoadd_my_struct(myStruct)),
         parseSuccessData: _wire2api_bool,
         constMeta: kUseImportedStructConstMeta,
         argValues: [myStruct],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kUseImportedStructConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kUseImportedStructConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "use_imported_struct",
         argNames: ["myStruct"],
       );
 
-  Future<bool> useImportedEnum({required MyEnum myEnum, dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_use_imported_enum(port_, _api2wire_my_enum(myEnum)),
+  Future<bool> useImportedEnum({required MyEnum myEnum, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_use_imported_enum(port_, _api2wire_my_enum(myEnum)),
         parseSuccessData: _wire2api_bool,
         constMeta: kUseImportedEnumConstMeta,
         argValues: [myEnum],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kUseImportedEnumConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kUseImportedEnumConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "use_imported_enum",
         argNames: ["myEnum"],
       );
 
-  Future<ApplicationSettings> getAppSettings({dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
+  Future<ApplicationSettings> getAppSettings({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_get_app_settings(port_),
         parseSuccessData: _wire2api_application_settings,
         constMeta: kGetAppSettingsConstMeta,
@@ -1014,31 +903,26 @@ class FlutterRustBridgeExampleImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kGetAppSettingsConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kGetAppSettingsConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "get_app_settings",
         argNames: [],
       );
 
-  Future<bool> isAppEmbedded(
-          {required ApplicationSettings appSettings, dynamic hint}) =>
+  Future<bool> isAppEmbedded({required ApplicationSettings appSettings, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_is_app_embedded(
-            port_, _api2wire_box_autoadd_application_settings(appSettings)),
+        callFfi: (port_) => inner.wire_is_app_embedded(port_, _api2wire_box_autoadd_application_settings(appSettings)),
         parseSuccessData: _wire2api_bool,
         constMeta: kIsAppEmbeddedConstMeta,
         argValues: [appSettings],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kIsAppEmbeddedConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kIsAppEmbeddedConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "is_app_embedded",
         argNames: ["appSettings"],
       );
 
-  Future<ApplicationMessage> getMessage({dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
+  Future<ApplicationMessage> getMessage({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_get_message(port_),
         parseSuccessData: _wire2api_application_message,
         constMeta: kGetMessageConstMeta,
@@ -1046,14 +930,12 @@ class FlutterRustBridgeExampleImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kGetMessageConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kGetMessageConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "get_message",
         argNames: [],
       );
 
-  Future<Uint8List> getArray({dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
+  Future<Uint8List> getArray({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_get_array(port_),
         parseSuccessData: _wire2api_uint_8_list,
         constMeta: kGetArrayConstMeta,
@@ -1061,14 +943,12 @@ class FlutterRustBridgeExampleImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kGetArrayConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kGetArrayConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "get_array",
         argNames: [],
       );
 
-  Future<List<Point>> getComplexArray({dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
+  Future<List<Point>> getComplexArray({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_get_complex_array(port_),
         parseSuccessData: _wire2api_list_point,
         constMeta: kGetComplexArrayConstMeta,
@@ -1076,14 +956,12 @@ class FlutterRustBridgeExampleImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kGetComplexArrayConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kGetComplexArrayConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "get_complex_array",
         argNames: [],
       );
 
-  Future<int> getUsize({required int u, dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
+  Future<int> getUsize({required int u, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_get_usize(port_, _api2wire_usize(u)),
         parseSuccessData: _wire2api_usize,
         constMeta: kGetUsizeConstMeta,
@@ -1091,30 +969,25 @@ class FlutterRustBridgeExampleImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kGetUsizeConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kGetUsizeConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "get_usize",
         argNames: ["u"],
       );
 
-  Future<UserId> nextUserId({required UserId userId, dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_next_user_id(
-            port_, _api2wire_box_autoadd_user_id(userId)),
+  Future<UserId> nextUserId({required UserId userId, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_next_user_id(port_, _api2wire_box_autoadd_user_id(userId)),
         parseSuccessData: _wire2api_user_id,
         constMeta: kNextUserIdConstMeta,
         argValues: [userId],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kNextUserIdConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kNextUserIdConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "next_user_id",
         argNames: ["userId"],
       );
 
-  Stream<Event> registerEventListener({dynamic hint}) =>
-      executeStream(FlutterRustBridgeTask(
+  Stream<Event> registerEventListener({dynamic hint}) => executeStream(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_register_event_listener(port_),
         parseSuccessData: _wire2api_event,
         constMeta: kRegisterEventListenerConstMeta,
@@ -1122,14 +995,12 @@ class FlutterRustBridgeExampleImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kRegisterEventListenerConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kRegisterEventListenerConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "register_event_listener",
         argNames: [],
       );
 
-  Future<void> closeEventListener({dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
+  Future<void> closeEventListener({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_close_event_listener(port_),
         parseSuccessData: _wire2api_unit,
         constMeta: kCloseEventListenerConstMeta,
@@ -1137,14 +1008,12 @@ class FlutterRustBridgeExampleImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kCloseEventListenerConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kCloseEventListenerConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "close_event_listener",
         argNames: [],
       );
 
-  Future<void> createEvent({dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
+  Future<void> createEvent({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_create_event(port_),
         parseSuccessData: _wire2api_unit,
         constMeta: kCreateEventConstMeta,
@@ -1152,8 +1021,7 @@ class FlutterRustBridgeExampleImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kCreateEventConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kCreateEventConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "create_event",
         argNames: [],
       );
@@ -1171,8 +1039,7 @@ class FlutterRustBridgeExampleImpl
     return ans;
   }
 
-  ffi.Pointer<wire_uint_8_list> _api2wire_ZeroCopyBuffer_Uint8List(
-      Uint8List raw) {
+  ffi.Pointer<wire_uint_8_list> _api2wire_ZeroCopyBuffer_Uint8List(Uint8List raw) {
     return _api2wire_uint_8_list(raw);
   }
 
@@ -1184,15 +1051,13 @@ class FlutterRustBridgeExampleImpl
     return raw;
   }
 
-  ffi.Pointer<wire_ApplicationEnv> _api2wire_box_application_env(
-      ApplicationEnv raw) {
+  ffi.Pointer<wire_ApplicationEnv> _api2wire_box_application_env(ApplicationEnv raw) {
     final ptr = inner.new_box_application_env();
     _api_fill_to_wire_application_env(raw, ptr.ref);
     return ptr;
   }
 
-  ffi.Pointer<wire_ApplicationSettings>
-      _api2wire_box_autoadd_application_settings(ApplicationSettings raw) {
+  ffi.Pointer<wire_ApplicationSettings> _api2wire_box_autoadd_application_settings(ApplicationSettings raw) {
     final ptr = inner.new_box_autoadd_application_settings();
     _api_fill_to_wire_application_settings(raw, ptr.ref);
     return ptr;
@@ -1208,15 +1073,13 @@ class FlutterRustBridgeExampleImpl
     return inner.new_box_autoadd_bool(raw);
   }
 
-  ffi.Pointer<wire_Customized> _api2wire_box_autoadd_customized(
-      Customized raw) {
+  ffi.Pointer<wire_Customized> _api2wire_box_autoadd_customized(Customized raw) {
     final ptr = inner.new_box_autoadd_customized();
     _api_fill_to_wire_customized(raw, ptr.ref);
     return ptr;
   }
 
-  ffi.Pointer<wire_ExoticOptionals> _api2wire_box_autoadd_exotic_optionals(
-      ExoticOptionals raw) {
+  ffi.Pointer<wire_ExoticOptionals> _api2wire_box_autoadd_exotic_optionals(ExoticOptionals raw) {
     final ptr = inner.new_box_autoadd_exotic_optionals();
     _api_fill_to_wire_exotic_optionals(raw, ptr.ref);
     return ptr;
@@ -1234,8 +1097,7 @@ class FlutterRustBridgeExampleImpl
     return inner.new_box_autoadd_i64(raw);
   }
 
-  ffi.Pointer<wire_KitchenSink> _api2wire_box_autoadd_kitchen_sink(
-      KitchenSink raw) {
+  ffi.Pointer<wire_KitchenSink> _api2wire_box_autoadd_kitchen_sink(KitchenSink raw) {
     final ptr = inner.new_box_autoadd_kitchen_sink();
     _api_fill_to_wire_kitchen_sink(raw, ptr.ref);
     return ptr;
@@ -1253,15 +1115,13 @@ class FlutterRustBridgeExampleImpl
     return ptr;
   }
 
-  ffi.Pointer<wire_MyTreeNode> _api2wire_box_autoadd_my_tree_node(
-      MyTreeNode raw) {
+  ffi.Pointer<wire_MyTreeNode> _api2wire_box_autoadd_my_tree_node(MyTreeNode raw) {
     final ptr = inner.new_box_autoadd_my_tree_node();
     _api_fill_to_wire_my_tree_node(raw, ptr.ref);
     return ptr;
   }
 
-  ffi.Pointer<wire_NewTypeInt> _api2wire_box_autoadd_new_type_int(
-      NewTypeInt raw) {
+  ffi.Pointer<wire_NewTypeInt> _api2wire_box_autoadd_new_type_int(NewTypeInt raw) {
     final ptr = inner.new_box_autoadd_new_type_int();
     _api_fill_to_wire_new_type_int(raw, ptr.ref);
     return ptr;
@@ -1277,8 +1137,7 @@ class FlutterRustBridgeExampleImpl
     return inner.new_box_bool(raw);
   }
 
-  ffi.Pointer<wire_ExoticOptionals> _api2wire_box_exotic_optionals(
-      ExoticOptionals raw) {
+  ffi.Pointer<wire_ExoticOptionals> _api2wire_box_exotic_optionals(ExoticOptionals raw) {
     final ptr = inner.new_box_exotic_optionals();
     _api_fill_to_wire_exotic_optionals(raw, ptr.ref);
     return ptr;
@@ -1366,8 +1225,7 @@ class FlutterRustBridgeExampleImpl
     return ans;
   }
 
-  ffi.Pointer<wire_list_application_env_var> _api2wire_list_application_env_var(
-      List<ApplicationEnvVar> raw) {
+  ffi.Pointer<wire_list_application_env_var> _api2wire_list_application_env_var(List<ApplicationEnvVar> raw) {
     final ans = inner.new_list_application_env_var(raw.length);
     for (var i = 0; i < raw.length; ++i) {
       _api_fill_to_wire_application_env_var(raw[i], ans.ref.ptr[i]);
@@ -1375,8 +1233,7 @@ class FlutterRustBridgeExampleImpl
     return ans;
   }
 
-  ffi.Pointer<wire_list_attribute> _api2wire_list_attribute(
-      List<Attribute> raw) {
+  ffi.Pointer<wire_list_attribute> _api2wire_list_attribute(List<Attribute> raw) {
     final ans = inner.new_list_attribute(raw.length);
     for (var i = 0; i < raw.length; ++i) {
       _api_fill_to_wire_attribute(raw[i], ans.ref.ptr[i]);
@@ -1392,8 +1249,7 @@ class FlutterRustBridgeExampleImpl
     return ans;
   }
 
-  ffi.Pointer<wire_list_my_tree_node> _api2wire_list_my_tree_node(
-      List<MyTreeNode> raw) {
+  ffi.Pointer<wire_list_my_tree_node> _api2wire_list_my_tree_node(List<MyTreeNode> raw) {
     final ans = inner.new_list_my_tree_node(raw.length);
     for (var i = 0; i < raw.length; ++i) {
       _api_fill_to_wire_my_tree_node(raw[i], ans.ref.ptr[i]);
@@ -1401,8 +1257,7 @@ class FlutterRustBridgeExampleImpl
     return ans;
   }
 
-  ffi.Pointer<wire_list_opt_box_autoadd_attribute>
-      _api2wire_list_opt_box_autoadd_attribute(List<Attribute?> raw) {
+  ffi.Pointer<wire_list_opt_box_autoadd_attribute> _api2wire_list_opt_box_autoadd_attribute(List<Attribute?> raw) {
     final ans = inner.new_list_opt_box_autoadd_attribute(raw.length);
     for (var i = 0; i < raw.length; ++i) {
       _api_fill_to_wire_opt_box_autoadd_attribute(raw[i], ans.ref.ptr[i]);
@@ -1418,13 +1273,11 @@ class FlutterRustBridgeExampleImpl
     return raw == null ? ffi.nullptr : _api2wire_String(raw);
   }
 
-  ffi.Pointer<wire_uint_8_list> _api2wire_opt_ZeroCopyBuffer_Uint8List(
-      Uint8List? raw) {
+  ffi.Pointer<wire_uint_8_list> _api2wire_opt_ZeroCopyBuffer_Uint8List(Uint8List? raw) {
     return raw == null ? ffi.nullptr : _api2wire_ZeroCopyBuffer_Uint8List(raw);
   }
 
-  ffi.Pointer<wire_Attribute> _api2wire_opt_box_autoadd_attribute(
-      Attribute? raw) {
+  ffi.Pointer<wire_Attribute> _api2wire_opt_box_autoadd_attribute(Attribute? raw) {
     return raw == null ? ffi.nullptr : _api2wire_box_autoadd_attribute(raw);
   }
 
@@ -1432,11 +1285,8 @@ class FlutterRustBridgeExampleImpl
     return raw == null ? ffi.nullptr : _api2wire_box_autoadd_bool(raw);
   }
 
-  ffi.Pointer<wire_ExoticOptionals> _api2wire_opt_box_autoadd_exotic_optionals(
-      ExoticOptionals? raw) {
-    return raw == null
-        ? ffi.nullptr
-        : _api2wire_box_autoadd_exotic_optionals(raw);
+  ffi.Pointer<wire_ExoticOptionals> _api2wire_opt_box_autoadd_exotic_optionals(ExoticOptionals? raw) {
+    return raw == null ? ffi.nullptr : _api2wire_box_autoadd_exotic_optionals(raw);
   }
 
   ffi.Pointer<ffi.Double> _api2wire_opt_box_autoadd_f64(double? raw) {
@@ -1451,8 +1301,7 @@ class FlutterRustBridgeExampleImpl
     return raw == null ? ffi.nullptr : _api2wire_box_autoadd_i64(raw);
   }
 
-  ffi.Pointer<wire_NewTypeInt> _api2wire_opt_box_autoadd_new_type_int(
-      NewTypeInt? raw) {
+  ffi.Pointer<wire_NewTypeInt> _api2wire_opt_box_autoadd_new_type_int(NewTypeInt? raw) {
     return raw == null ? ffi.nullptr : _api2wire_box_autoadd_new_type_int(raw);
   }
 
@@ -1460,8 +1309,7 @@ class FlutterRustBridgeExampleImpl
     return raw == null ? ffi.nullptr : _api2wire_box_bool(raw);
   }
 
-  ffi.Pointer<wire_ExoticOptionals> _api2wire_opt_box_exotic_optionals(
-      ExoticOptionals? raw) {
+  ffi.Pointer<wire_ExoticOptionals> _api2wire_opt_box_exotic_optionals(ExoticOptionals? raw) {
     return raw == null ? ffi.nullptr : _api2wire_box_exotic_optionals(raw);
   }
 
@@ -1485,13 +1333,11 @@ class FlutterRustBridgeExampleImpl
     return raw == null ? ffi.nullptr : _api2wire_box_u8(raw);
   }
 
-  ffi.Pointer<wire_float_32_list> _api2wire_opt_float_32_list(
-      Float32List? raw) {
+  ffi.Pointer<wire_float_32_list> _api2wire_opt_float_32_list(Float32List? raw) {
     return raw == null ? ffi.nullptr : _api2wire_float_32_list(raw);
   }
 
-  ffi.Pointer<wire_float_64_list> _api2wire_opt_float_64_list(
-      Float64List? raw) {
+  ffi.Pointer<wire_float_64_list> _api2wire_opt_float_64_list(Float64List? raw) {
     return raw == null ? ffi.nullptr : _api2wire_float_64_list(raw);
   }
 
@@ -1507,16 +1353,12 @@ class FlutterRustBridgeExampleImpl
     return raw == null ? ffi.nullptr : _api2wire_int_8_list(raw);
   }
 
-  ffi.Pointer<wire_list_attribute> _api2wire_opt_list_attribute(
-      List<Attribute>? raw) {
+  ffi.Pointer<wire_list_attribute> _api2wire_opt_list_attribute(List<Attribute>? raw) {
     return raw == null ? ffi.nullptr : _api2wire_list_attribute(raw);
   }
 
-  ffi.Pointer<wire_list_opt_box_autoadd_attribute>
-      _api2wire_opt_list_opt_box_autoadd_attribute(List<Attribute?>? raw) {
-    return raw == null
-        ? ffi.nullptr
-        : _api2wire_list_opt_box_autoadd_attribute(raw);
+  ffi.Pointer<wire_list_opt_box_autoadd_attribute> _api2wire_opt_list_opt_box_autoadd_attribute(List<Attribute?>? raw) {
+    return raw == null ? ffi.nullptr : _api2wire_list_opt_box_autoadd_attribute(raw);
   }
 
   ffi.Pointer<wire_uint_8_list> _api2wire_opt_uint_8_list(Uint8List? raw) {
@@ -1547,19 +1389,16 @@ class FlutterRustBridgeExampleImpl
 
   // Section: api_fill_to_wire
 
-  void _api_fill_to_wire_application_env(
-      ApplicationEnv apiObj, wire_ApplicationEnv wireObj) {
+  void _api_fill_to_wire_application_env(ApplicationEnv apiObj, wire_ApplicationEnv wireObj) {
     wireObj.vars = _api2wire_list_application_env_var(apiObj.vars);
   }
 
-  void _api_fill_to_wire_application_env_var(
-      ApplicationEnvVar apiObj, wire_ApplicationEnvVar wireObj) {
+  void _api_fill_to_wire_application_env_var(ApplicationEnvVar apiObj, wire_ApplicationEnvVar wireObj) {
     wireObj.field0 = _api2wire_String(apiObj.field0);
     wireObj.field1 = _api2wire_bool(apiObj.field1);
   }
 
-  void _api_fill_to_wire_application_settings(
-      ApplicationSettings apiObj, wire_ApplicationSettings wireObj) {
+  void _api_fill_to_wire_application_settings(ApplicationSettings apiObj, wire_ApplicationSettings wireObj) {
     wireObj.name = _api2wire_String(apiObj.name);
     wireObj.version = _api2wire_String(apiObj.version);
     wireObj.mode = _api2wire_application_mode(apiObj.mode);
@@ -1571,24 +1410,20 @@ class FlutterRustBridgeExampleImpl
     wireObj.value = _api2wire_String(apiObj.value);
   }
 
-  void _api_fill_to_wire_box_application_env(
-      ApplicationEnv apiObj, ffi.Pointer<wire_ApplicationEnv> wireObj) {
+  void _api_fill_to_wire_box_application_env(ApplicationEnv apiObj, ffi.Pointer<wire_ApplicationEnv> wireObj) {
     _api_fill_to_wire_application_env(apiObj, wireObj.ref);
   }
 
   void _api_fill_to_wire_box_autoadd_application_settings(
-      ApplicationSettings apiObj,
-      ffi.Pointer<wire_ApplicationSettings> wireObj) {
+      ApplicationSettings apiObj, ffi.Pointer<wire_ApplicationSettings> wireObj) {
     _api_fill_to_wire_application_settings(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_attribute(
-      Attribute apiObj, ffi.Pointer<wire_Attribute> wireObj) {
+  void _api_fill_to_wire_box_autoadd_attribute(Attribute apiObj, ffi.Pointer<wire_Attribute> wireObj) {
     _api_fill_to_wire_attribute(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_customized(
-      Customized apiObj, ffi.Pointer<wire_Customized> wireObj) {
+  void _api_fill_to_wire_box_autoadd_customized(Customized apiObj, ffi.Pointer<wire_Customized> wireObj) {
     _api_fill_to_wire_customized(apiObj, wireObj.ref);
   }
 
@@ -1597,59 +1432,48 @@ class FlutterRustBridgeExampleImpl
     _api_fill_to_wire_exotic_optionals(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_kitchen_sink(
-      KitchenSink apiObj, ffi.Pointer<wire_KitchenSink> wireObj) {
+  void _api_fill_to_wire_box_autoadd_kitchen_sink(KitchenSink apiObj, ffi.Pointer<wire_KitchenSink> wireObj) {
     _api_fill_to_wire_kitchen_sink(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_my_size(
-      MySize apiObj, ffi.Pointer<wire_MySize> wireObj) {
+  void _api_fill_to_wire_box_autoadd_my_size(MySize apiObj, ffi.Pointer<wire_MySize> wireObj) {
     _api_fill_to_wire_my_size(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_my_struct(
-      MyStruct apiObj, ffi.Pointer<wire_MyStruct> wireObj) {
+  void _api_fill_to_wire_box_autoadd_my_struct(MyStruct apiObj, ffi.Pointer<wire_MyStruct> wireObj) {
     _api_fill_to_wire_my_struct(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_my_tree_node(
-      MyTreeNode apiObj, ffi.Pointer<wire_MyTreeNode> wireObj) {
+  void _api_fill_to_wire_box_autoadd_my_tree_node(MyTreeNode apiObj, ffi.Pointer<wire_MyTreeNode> wireObj) {
     _api_fill_to_wire_my_tree_node(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_new_type_int(
-      NewTypeInt apiObj, ffi.Pointer<wire_NewTypeInt> wireObj) {
+  void _api_fill_to_wire_box_autoadd_new_type_int(NewTypeInt apiObj, ffi.Pointer<wire_NewTypeInt> wireObj) {
     _api_fill_to_wire_new_type_int(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_user_id(
-      UserId apiObj, ffi.Pointer<wire_UserId> wireObj) {
+  void _api_fill_to_wire_box_autoadd_user_id(UserId apiObj, ffi.Pointer<wire_UserId> wireObj) {
     _api_fill_to_wire_user_id(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_exotic_optionals(
-      ExoticOptionals apiObj, ffi.Pointer<wire_ExoticOptionals> wireObj) {
+  void _api_fill_to_wire_box_exotic_optionals(ExoticOptionals apiObj, ffi.Pointer<wire_ExoticOptionals> wireObj) {
     _api_fill_to_wire_exotic_optionals(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_kitchen_sink(
-      KitchenSink apiObj, ffi.Pointer<wire_KitchenSink> wireObj) {
+  void _api_fill_to_wire_box_kitchen_sink(KitchenSink apiObj, ffi.Pointer<wire_KitchenSink> wireObj) {
     _api_fill_to_wire_kitchen_sink(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_my_size(
-      MySize apiObj, ffi.Pointer<wire_MySize> wireObj) {
+  void _api_fill_to_wire_box_my_size(MySize apiObj, ffi.Pointer<wire_MySize> wireObj) {
     _api_fill_to_wire_my_size(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_customized(
-      Customized apiObj, wire_Customized wireObj) {
+  void _api_fill_to_wire_customized(Customized apiObj, wire_Customized wireObj) {
     wireObj.final_field = _api2wire_String(apiObj.finalField);
     wireObj.non_final_field = _api2wire_opt_String(apiObj.nonFinalField);
   }
 
-  void _api_fill_to_wire_exotic_optionals(
-      ExoticOptionals apiObj, wire_ExoticOptionals wireObj) {
+  void _api_fill_to_wire_exotic_optionals(ExoticOptionals apiObj, wire_ExoticOptionals wireObj) {
     wireObj.int32 = _api2wire_opt_box_autoadd_i32(apiObj.int32);
     wireObj.int64 = _api2wire_opt_box_autoadd_i64(apiObj.int64);
     wireObj.float64 = _api2wire_opt_box_autoadd_f64(apiObj.float64);
@@ -1662,16 +1486,12 @@ class FlutterRustBridgeExampleImpl
     wireObj.float32list = _api2wire_opt_float_32_list(apiObj.float32List);
     wireObj.float64list = _api2wire_opt_float_64_list(apiObj.float64List);
     wireObj.attributes = _api2wire_opt_list_attribute(apiObj.attributes);
-    wireObj.attributes_nullable =
-        _api2wire_list_opt_box_autoadd_attribute(apiObj.attributesNullable);
-    wireObj.nullable_attributes =
-        _api2wire_opt_list_opt_box_autoadd_attribute(apiObj.nullableAttributes);
-    wireObj.newtypeint =
-        _api2wire_opt_box_autoadd_new_type_int(apiObj.newtypeint);
+    wireObj.attributes_nullable = _api2wire_list_opt_box_autoadd_attribute(apiObj.attributesNullable);
+    wireObj.nullable_attributes = _api2wire_opt_list_opt_box_autoadd_attribute(apiObj.nullableAttributes);
+    wireObj.newtypeint = _api2wire_opt_box_autoadd_new_type_int(apiObj.newtypeint);
   }
 
-  void _api_fill_to_wire_kitchen_sink(
-      KitchenSink apiObj, wire_KitchenSink wireObj) {
+  void _api_fill_to_wire_kitchen_sink(KitchenSink apiObj, wire_KitchenSink wireObj) {
     if (apiObj is Empty) {
       wireObj.tag = 0;
       return;
@@ -1686,23 +1506,19 @@ class FlutterRustBridgeExampleImpl
     if (apiObj is Nested) {
       wireObj.tag = 2;
       wireObj.kind = inner.inflate_KitchenSink_Nested();
-      wireObj.kind.ref.Nested.ref.field0 =
-          _api2wire_box_kitchen_sink(apiObj.field0);
+      wireObj.kind.ref.Nested.ref.field0 = _api2wire_box_kitchen_sink(apiObj.field0);
       wireObj.kind.ref.Nested.ref.field1 = _api2wire_i32(apiObj.field1);
     }
     if (apiObj is Optional) {
       wireObj.tag = 3;
       wireObj.kind = inner.inflate_KitchenSink_Optional();
-      wireObj.kind.ref.Optional.ref.field0 =
-          _api2wire_opt_box_autoadd_i32(apiObj.field0);
-      wireObj.kind.ref.Optional.ref.field1 =
-          _api2wire_opt_box_autoadd_i32(apiObj.field1);
+      wireObj.kind.ref.Optional.ref.field0 = _api2wire_opt_box_autoadd_i32(apiObj.field0);
+      wireObj.kind.ref.Optional.ref.field1 = _api2wire_opt_box_autoadd_i32(apiObj.field1);
     }
     if (apiObj is Buffer) {
       wireObj.tag = 4;
       wireObj.kind = inner.inflate_KitchenSink_Buffer();
-      wireObj.kind.ref.Buffer.ref.field0 =
-          _api2wire_ZeroCopyBuffer_Uint8List(apiObj.field0);
+      wireObj.kind.ref.Buffer.ref.field0 = _api2wire_ZeroCopyBuffer_Uint8List(apiObj.field0);
     }
     if (apiObj is Enums) {
       wireObj.tag = 5;
@@ -1720,39 +1536,31 @@ class FlutterRustBridgeExampleImpl
     wireObj.content = _api2wire_bool(apiObj.content);
   }
 
-  void _api_fill_to_wire_my_tree_node(
-      MyTreeNode apiObj, wire_MyTreeNode wireObj) {
+  void _api_fill_to_wire_my_tree_node(MyTreeNode apiObj, wire_MyTreeNode wireObj) {
     wireObj.value_i32 = _api2wire_i32(apiObj.valueI32);
     wireObj.value_vec_u8 = _api2wire_uint_8_list(apiObj.valueVecU8);
     wireObj.value_boolean = _api2wire_bool(apiObj.valueBoolean);
     wireObj.children = _api2wire_list_my_tree_node(apiObj.children);
   }
 
-  void _api_fill_to_wire_new_type_int(
-      NewTypeInt apiObj, wire_NewTypeInt wireObj) {
+  void _api_fill_to_wire_new_type_int(NewTypeInt apiObj, wire_NewTypeInt wireObj) {
     wireObj.field0 = _api2wire_i64(apiObj.field0);
   }
 
-  void _api_fill_to_wire_opt_box_autoadd_attribute(
-      Attribute? apiObj, ffi.Pointer<wire_Attribute> wireObj) {
-    if (apiObj != null)
-      _api_fill_to_wire_box_autoadd_attribute(apiObj, wireObj);
+  void _api_fill_to_wire_opt_box_autoadd_attribute(Attribute? apiObj, ffi.Pointer<wire_Attribute> wireObj) {
+    if (apiObj != null) _api_fill_to_wire_box_autoadd_attribute(apiObj, wireObj);
   }
 
   void _api_fill_to_wire_opt_box_autoadd_exotic_optionals(
       ExoticOptionals? apiObj, ffi.Pointer<wire_ExoticOptionals> wireObj) {
-    if (apiObj != null)
-      _api_fill_to_wire_box_autoadd_exotic_optionals(apiObj, wireObj);
+    if (apiObj != null) _api_fill_to_wire_box_autoadd_exotic_optionals(apiObj, wireObj);
   }
 
-  void _api_fill_to_wire_opt_box_autoadd_new_type_int(
-      NewTypeInt? apiObj, ffi.Pointer<wire_NewTypeInt> wireObj) {
-    if (apiObj != null)
-      _api_fill_to_wire_box_autoadd_new_type_int(apiObj, wireObj);
+  void _api_fill_to_wire_opt_box_autoadd_new_type_int(NewTypeInt? apiObj, ffi.Pointer<wire_NewTypeInt> wireObj) {
+    if (apiObj != null) _api_fill_to_wire_box_autoadd_new_type_int(apiObj, wireObj);
   }
 
-  void _api_fill_to_wire_opt_box_exotic_optionals(
-      ExoticOptionals? apiObj, ffi.Pointer<wire_ExoticOptionals> wireObj) {
+  void _api_fill_to_wire_opt_box_exotic_optionals(ExoticOptionals? apiObj, ffi.Pointer<wire_ExoticOptionals> wireObj) {
     if (apiObj != null) _api_fill_to_wire_box_exotic_optionals(apiObj, wireObj);
   }
 
@@ -1816,8 +1624,7 @@ Uint8List _wire2api_ZeroCopyBuffer_Uint8List(dynamic raw) {
 
 ApplicationEnv _wire2api_application_env(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 1)
-    throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+  if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
   return ApplicationEnv(
     vars: _wire2api_list_application_env_var(arr[0]),
   );
@@ -1825,8 +1632,7 @@ ApplicationEnv _wire2api_application_env(dynamic raw) {
 
 ApplicationEnvVar _wire2api_application_env_var(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 2)
-    throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+  if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
   return ApplicationEnvVar(
     field0: _wire2api_String(arr[0]),
     field1: _wire2api_bool(arr[1]),
@@ -1857,8 +1663,7 @@ ApplicationMode _wire2api_application_mode(dynamic raw) {
 
 ApplicationSettings _wire2api_application_settings(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 4)
-    throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
+  if (arr.length != 4) throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
   return ApplicationSettings(
     name: _wire2api_String(arr[0]),
     version: _wire2api_String(arr[1]),
@@ -1869,8 +1674,7 @@ ApplicationSettings _wire2api_application_settings(dynamic raw) {
 
 Attribute _wire2api_attribute(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 2)
-    throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+  if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
   return Attribute(
     key: _wire2api_String(arr[0]),
     value: _wire2api_String(arr[1]),
@@ -1923,8 +1727,7 @@ KitchenSink _wire2api_box_kitchen_sink(dynamic raw) {
 
 Element _wire2api_element(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 4)
-    throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
+  if (arr.length != 4) throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
   return Element(
     tag: _wire2api_opt_String(arr[0]),
     text: _wire2api_opt_String(arr[1]),
@@ -1935,8 +1738,7 @@ Element _wire2api_element(dynamic raw) {
 
 Event _wire2api_event(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 2)
-    throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+  if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
   return Event(
     address: _wire2api_String(arr[0]),
     payload: _wire2api_String(arr[1]),
@@ -1945,8 +1747,7 @@ Event _wire2api_event(dynamic raw) {
 
 ExoticOptionals _wire2api_exotic_optionals(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 15)
-    throw Exception('unexpected arr length: expect 15 but see ${arr.length}');
+  if (arr.length != 15) throw Exception('unexpected arr length: expect 15 but see ${arr.length}');
   return ExoticOptionals(
     int32: _wire2api_opt_box_autoadd_i32(arr[0]),
     int64: _wire2api_opt_box_autoadd_i64(arr[1]),
@@ -2068,9 +1869,7 @@ List<MyTreeNode> _wire2api_list_my_tree_node(dynamic raw) {
 }
 
 List<Attribute?> _wire2api_list_opt_box_autoadd_attribute(dynamic raw) {
-  return (raw as List<dynamic>)
-      .map(_wire2api_opt_box_autoadd_attribute)
-      .toList();
+  return (raw as List<dynamic>).map(_wire2api_opt_box_autoadd_attribute).toList();
 }
 
 List<Point> _wire2api_list_point(dynamic raw) {
@@ -2079,8 +1878,7 @@ List<Point> _wire2api_list_point(dynamic raw) {
 
 MySize _wire2api_my_size(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 2)
-    throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+  if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
   return MySize(
     width: _wire2api_i32(arr[0]),
     height: _wire2api_i32(arr[1]),
@@ -2089,8 +1887,7 @@ MySize _wire2api_my_size(dynamic raw) {
 
 MyStreamEntry _wire2api_my_stream_entry(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 1)
-    throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+  if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
   return MyStreamEntry(
     hello: _wire2api_String(arr[0]),
   );
@@ -2098,8 +1895,7 @@ MyStreamEntry _wire2api_my_stream_entry(dynamic raw) {
 
 MyTreeNode _wire2api_my_tree_node(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 4)
-    throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
+  if (arr.length != 4) throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
   return MyTreeNode(
     valueI32: _wire2api_i32(arr[0]),
     valueVecU8: _wire2api_uint_8_list(arr[1]),
@@ -2110,8 +1906,7 @@ MyTreeNode _wire2api_my_tree_node(dynamic raw) {
 
 NewTypeInt _wire2api_new_type_int(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 1)
-    throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+  if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
   return NewTypeInt(
     field0: _wire2api_i64(arr[0]),
   );
@@ -2199,8 +1994,7 @@ Weekdays? _wire2api_opt_weekdays(dynamic raw) {
 
 Point _wire2api_point(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 2)
-    throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+  if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
   return Point(
     x: _wire2api_f32(arr[0]),
     y: _wire2api_f32(arr[1]),
@@ -2245,8 +2039,7 @@ void _wire2api_unit(dynamic raw) {
 
 UserId _wire2api_user_id(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 1)
-    throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+  if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
   return UserId(
     value: _wire2api_u32(arr[0]),
   );
@@ -2258,8 +2051,7 @@ int _wire2api_usize(dynamic raw) {
 
 VecOfPrimitivePack _wire2api_vec_of_primitive_pack(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 10)
-    throw Exception('unexpected arr length: expect 10 but see ${arr.length}');
+  if (arr.length != 10) throw Exception('unexpected arr length: expect 10 but see ${arr.length}');
   return VecOfPrimitivePack(
     int8List: _wire2api_int_8_list(arr[0]),
     uint8List: _wire2api_uint_8_list(arr[1]),
@@ -2278,11 +2070,9 @@ Weekdays _wire2api_weekdays(dynamic raw) {
   return Weekdays.values[raw];
 }
 
-ZeroCopyVecOfPrimitivePack _wire2api_zero_copy_vec_of_primitive_pack(
-    dynamic raw) {
+ZeroCopyVecOfPrimitivePack _wire2api_zero_copy_vec_of_primitive_pack(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 10)
-    throw Exception('unexpected arr length: expect 10 but see ${arr.length}');
+  if (arr.length != 10) throw Exception('unexpected arr length: expect 10 but see ${arr.length}');
   return ZeroCopyVecOfPrimitivePack(
     int8List: _wire2api_ZeroCopyBuffer_Int8List(arr[0]),
     uint8List: _wire2api_ZeroCopyBuffer_Uint8List(arr[1]),
@@ -2306,17 +2096,13 @@ ZeroCopyVecOfPrimitivePack _wire2api_zero_copy_vec_of_primitive_pack(
 /// generated by flutter_rust_bridge
 class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   /// Holds the symbol lookup function.
-  final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
-      _lookup;
+  final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName) _lookup;
 
   /// The symbols are looked up in [dynamicLibrary].
-  FlutterRustBridgeExampleWire(ffi.DynamicLibrary dynamicLibrary)
-      : _lookup = dynamicLibrary.lookup;
+  FlutterRustBridgeExampleWire(ffi.DynamicLibrary dynamicLibrary) : _lookup = dynamicLibrary.lookup;
 
   /// The symbols are looked up with [lookup].
-  FlutterRustBridgeExampleWire.fromLookup(
-      ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
-          lookup)
+  FlutterRustBridgeExampleWire.fromLookup(ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName) lookup)
       : _lookup = lookup;
 
   void wire_simple_adder(
@@ -2331,12 +2117,9 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_simple_adderPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-              ffi.Int64, ffi.Int32, ffi.Int32)>>('wire_simple_adder');
-  late final _wire_simple_adder =
-      _wire_simple_adderPtr.asFunction<void Function(int, int, int)>();
+  late final _wire_simple_adderPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32, ffi.Int32)>>('wire_simple_adder');
+  late final _wire_simple_adder = _wire_simple_adderPtr.asFunction<void Function(int, int, int)>();
 
   void wire_primitive_types(
     int port_,
@@ -2354,12 +2137,10 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_primitive_typesPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64, ffi.Int32, ffi.Int64, ffi.Double,
-              ffi.Bool)>>('wire_primitive_types');
-  late final _wire_primitive_types = _wire_primitive_typesPtr
-      .asFunction<void Function(int, int, int, double, bool)>();
+  late final _wire_primitive_typesPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32, ffi.Int64, ffi.Double, ffi.Bool)>>(
+          'wire_primitive_types');
+  late final _wire_primitive_types = _wire_primitive_typesPtr.asFunction<void Function(int, int, int, double, bool)>();
 
   void wire_primitive_u32(
     int port_,
@@ -2372,10 +2153,8 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _wire_primitive_u32Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Uint32)>>(
-          'wire_primitive_u32');
-  late final _wire_primitive_u32 =
-      _wire_primitive_u32Ptr.asFunction<void Function(int, int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Uint32)>>('wire_primitive_u32');
+  late final _wire_primitive_u32 = _wire_primitive_u32Ptr.asFunction<void Function(int, int)>();
 
   void wire_handle_string(
     int port_,
@@ -2387,12 +2166,10 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_handle_stringPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-              ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>('wire_handle_string');
-  late final _wire_handle_string = _wire_handle_stringPtr
-      .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+  late final _wire_handle_stringPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>('wire_handle_string');
+  late final _wire_handle_string =
+      _wire_handle_stringPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_handle_return_unit(
     int port_,
@@ -2403,10 +2180,8 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _wire_handle_return_unitPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
-          'wire_handle_return_unit');
-  late final _wire_handle_return_unit =
-      _wire_handle_return_unitPtr.asFunction<void Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_handle_return_unit');
+  late final _wire_handle_return_unit = _wire_handle_return_unitPtr.asFunction<void Function(int)>();
 
   void wire_handle_vec_u8(
     int port_,
@@ -2418,12 +2193,10 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_handle_vec_u8Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-              ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>('wire_handle_vec_u8');
-  late final _wire_handle_vec_u8 = _wire_handle_vec_u8Ptr
-      .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+  late final _wire_handle_vec_u8Ptr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>('wire_handle_vec_u8');
+  late final _wire_handle_vec_u8 =
+      _wire_handle_vec_u8Ptr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_handle_vec_of_primitive(
     int port_,
@@ -2436,10 +2209,8 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _wire_handle_vec_of_primitivePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>(
-          'wire_handle_vec_of_primitive');
-  late final _wire_handle_vec_of_primitive =
-      _wire_handle_vec_of_primitivePtr.asFunction<void Function(int, int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>('wire_handle_vec_of_primitive');
+  late final _wire_handle_vec_of_primitive = _wire_handle_vec_of_primitivePtr.asFunction<void Function(int, int)>();
 
   void wire_handle_zero_copy_vec_of_primitive(
     int port_,
@@ -2452,11 +2223,9 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _wire_handle_zero_copy_vec_of_primitivePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>(
-          'wire_handle_zero_copy_vec_of_primitive');
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>('wire_handle_zero_copy_vec_of_primitive');
   late final _wire_handle_zero_copy_vec_of_primitive =
-      _wire_handle_zero_copy_vec_of_primitivePtr
-          .asFunction<void Function(int, int)>();
+      _wire_handle_zero_copy_vec_of_primitivePtr.asFunction<void Function(int, int)>();
 
   void wire_handle_struct(
     int port_,
@@ -2470,12 +2239,11 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_handle_structPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64, ffi.Pointer<wire_MySize>,
-              ffi.Pointer<wire_MySize>)>>('wire_handle_struct');
-  late final _wire_handle_struct = _wire_handle_structPtr.asFunction<
-      void Function(int, ffi.Pointer<wire_MySize>, ffi.Pointer<wire_MySize>)>();
+  late final _wire_handle_structPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_MySize>, ffi.Pointer<wire_MySize>)>>(
+          'wire_handle_struct');
+  late final _wire_handle_struct =
+      _wire_handle_structPtr.asFunction<void Function(int, ffi.Pointer<wire_MySize>, ffi.Pointer<wire_MySize>)>();
 
   void wire_handle_newtype(
     int port_,
@@ -2487,12 +2255,10 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_handle_newtypePtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-              ffi.Int64, ffi.Pointer<wire_NewTypeInt>)>>('wire_handle_newtype');
-  late final _wire_handle_newtype = _wire_handle_newtypePtr
-      .asFunction<void Function(int, ffi.Pointer<wire_NewTypeInt>)>();
+  late final _wire_handle_newtypePtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_NewTypeInt>)>>('wire_handle_newtype');
+  late final _wire_handle_newtype =
+      _wire_handle_newtypePtr.asFunction<void Function(int, ffi.Pointer<wire_NewTypeInt>)>();
 
   void wire_handle_list_of_struct(
     int port_,
@@ -2504,12 +2270,11 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_handle_list_of_structPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64,
-              ffi.Pointer<wire_list_my_size>)>>('wire_handle_list_of_struct');
-  late final _wire_handle_list_of_struct = _wire_handle_list_of_structPtr
-      .asFunction<void Function(int, ffi.Pointer<wire_list_my_size>)>();
+  late final _wire_handle_list_of_structPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_list_my_size>)>>(
+          'wire_handle_list_of_struct');
+  late final _wire_handle_list_of_struct =
+      _wire_handle_list_of_structPtr.asFunction<void Function(int, ffi.Pointer<wire_list_my_size>)>();
 
   void wire_handle_string_list(
     int port_,
@@ -2521,12 +2286,11 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_handle_string_listPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64,
-              ffi.Pointer<wire_StringList>)>>('wire_handle_string_list');
-  late final _wire_handle_string_list = _wire_handle_string_listPtr
-      .asFunction<void Function(int, ffi.Pointer<wire_StringList>)>();
+  late final _wire_handle_string_listPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_StringList>)>>(
+          'wire_handle_string_list');
+  late final _wire_handle_string_list =
+      _wire_handle_string_listPtr.asFunction<void Function(int, ffi.Pointer<wire_StringList>)>();
 
   void wire_handle_complex_struct(
     int port_,
@@ -2538,12 +2302,11 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_handle_complex_structPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64,
-              ffi.Pointer<wire_MyTreeNode>)>>('wire_handle_complex_struct');
-  late final _wire_handle_complex_struct = _wire_handle_complex_structPtr
-      .asFunction<void Function(int, ffi.Pointer<wire_MyTreeNode>)>();
+  late final _wire_handle_complex_structPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_MyTreeNode>)>>(
+          'wire_handle_complex_struct');
+  late final _wire_handle_complex_struct =
+      _wire_handle_complex_structPtr.asFunction<void Function(int, ffi.Pointer<wire_MyTreeNode>)>();
 
   WireSyncReturnStruct wire_handle_sync_return(
     ffi.Pointer<wire_uint_8_list> mode,
@@ -2553,12 +2316,11 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_handle_sync_returnPtr = _lookup<
-      ffi.NativeFunction<
-          WireSyncReturnStruct Function(
-              ffi.Pointer<wire_uint_8_list>)>>('wire_handle_sync_return');
-  late final _wire_handle_sync_return = _wire_handle_sync_returnPtr.asFunction<
-      WireSyncReturnStruct Function(ffi.Pointer<wire_uint_8_list>)>();
+  late final _wire_handle_sync_returnPtr =
+      _lookup<ffi.NativeFunction<WireSyncReturnStruct Function(ffi.Pointer<wire_uint_8_list>)>>(
+          'wire_handle_sync_return');
+  late final _wire_handle_sync_return =
+      _wire_handle_sync_returnPtr.asFunction<WireSyncReturnStruct Function(ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_handle_stream(
     int port_,
@@ -2570,12 +2332,10 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_handle_streamPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-              ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>('wire_handle_stream');
-  late final _wire_handle_stream = _wire_handle_streamPtr
-      .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+  late final _wire_handle_streamPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>('wire_handle_stream');
+  late final _wire_handle_stream =
+      _wire_handle_streamPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_handle_stream_of_struct(
     int port_,
@@ -2586,10 +2346,8 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _wire_handle_stream_of_structPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
-          'wire_handle_stream_of_struct');
-  late final _wire_handle_stream_of_struct =
-      _wire_handle_stream_of_structPtr.asFunction<void Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_handle_stream_of_struct');
+  late final _wire_handle_stream_of_struct = _wire_handle_stream_of_structPtr.asFunction<void Function(int)>();
 
   void wire_return_err(
     int port_,
@@ -2599,11 +2357,8 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_return_errPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
-          'wire_return_err');
-  late final _wire_return_err =
-      _wire_return_errPtr.asFunction<void Function(int)>();
+  late final _wire_return_errPtr = _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_return_err');
+  late final _wire_return_err = _wire_return_errPtr.asFunction<void Function(int)>();
 
   void wire_return_panic(
     int port_,
@@ -2613,11 +2368,8 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_return_panicPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
-          'wire_return_panic');
-  late final _wire_return_panic =
-      _wire_return_panicPtr.asFunction<void Function(int)>();
+  late final _wire_return_panicPtr = _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_return_panic');
+  late final _wire_return_panic = _wire_return_panicPtr.asFunction<void Function(int)>();
 
   void wire_handle_optional_return(
     int port_,
@@ -2631,12 +2383,10 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_handle_optional_returnPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64, ffi.Double,
-              ffi.Double)>>('wire_handle_optional_return');
-  late final _wire_handle_optional_return = _wire_handle_optional_returnPtr
-      .asFunction<void Function(int, double, double)>();
+  late final _wire_handle_optional_returnPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Double, ffi.Double)>>('wire_handle_optional_return');
+  late final _wire_handle_optional_return =
+      _wire_handle_optional_returnPtr.asFunction<void Function(int, double, double)>();
 
   void wire_handle_optional_struct(
     int port_,
@@ -2648,12 +2398,11 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_handle_optional_structPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64,
-              ffi.Pointer<wire_uint_8_list>)>>('wire_handle_optional_struct');
-  late final _wire_handle_optional_struct = _wire_handle_optional_structPtr
-      .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+  late final _wire_handle_optional_structPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>(
+          'wire_handle_optional_struct');
+  late final _wire_handle_optional_struct =
+      _wire_handle_optional_structPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_handle_optional_increment(
     int port_,
@@ -2665,13 +2414,11 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_handle_optional_incrementPtr = _lookup<
-          ffi.NativeFunction<
-              ffi.Void Function(ffi.Int64, ffi.Pointer<wire_ExoticOptionals>)>>(
-      'wire_handle_optional_increment');
+  late final _wire_handle_optional_incrementPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_ExoticOptionals>)>>(
+          'wire_handle_optional_increment');
   late final _wire_handle_optional_increment =
-      _wire_handle_optional_incrementPtr
-          .asFunction<void Function(int, ffi.Pointer<wire_ExoticOptionals>)>();
+      _wire_handle_optional_incrementPtr.asFunction<void Function(int, ffi.Pointer<wire_ExoticOptionals>)>();
 
   void wire_handle_increment_boxed_optional(
     int port_,
@@ -2683,13 +2430,11 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_handle_increment_boxed_optionalPtr = _lookup<
-          ffi.NativeFunction<
-              ffi.Void Function(ffi.Int64, ffi.Pointer<ffi.Double>)>>(
-      'wire_handle_increment_boxed_optional');
+  late final _wire_handle_increment_boxed_optionalPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<ffi.Double>)>>(
+          'wire_handle_increment_boxed_optional');
   late final _wire_handle_increment_boxed_optional =
-      _wire_handle_increment_boxed_optionalPtr
-          .asFunction<void Function(int, ffi.Pointer<ffi.Double>)>();
+      _wire_handle_increment_boxed_optionalPtr.asFunction<void Function(int, ffi.Pointer<ffi.Double>)>();
 
   void wire_handle_option_box_arguments(
     int port_,
@@ -2714,28 +2459,19 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _wire_handle_option_box_argumentsPtr = _lookup<
-          ffi.NativeFunction<
-              ffi.Void Function(
-                  ffi.Int64,
-                  ffi.Pointer<ffi.Int8>,
-                  ffi.Pointer<ffi.Uint8>,
-                  ffi.Pointer<ffi.Int32>,
-                  ffi.Pointer<ffi.Int64>,
-                  ffi.Pointer<ffi.Double>,
-                  ffi.Pointer<ffi.Bool>,
-                  ffi.Pointer<wire_ExoticOptionals>)>>(
-      'wire_handle_option_box_arguments');
-  late final _wire_handle_option_box_arguments =
-      _wire_handle_option_box_argumentsPtr.asFunction<
-          void Function(
-              int,
+      ffi.NativeFunction<
+          ffi.Void Function(
+              ffi.Int64,
               ffi.Pointer<ffi.Int8>,
               ffi.Pointer<ffi.Uint8>,
               ffi.Pointer<ffi.Int32>,
               ffi.Pointer<ffi.Int64>,
               ffi.Pointer<ffi.Double>,
               ffi.Pointer<ffi.Bool>,
-              ffi.Pointer<wire_ExoticOptionals>)>();
+              ffi.Pointer<wire_ExoticOptionals>)>>('wire_handle_option_box_arguments');
+  late final _wire_handle_option_box_arguments = _wire_handle_option_box_argumentsPtr.asFunction<
+      void Function(int, ffi.Pointer<ffi.Int8>, ffi.Pointer<ffi.Uint8>, ffi.Pointer<ffi.Int32>, ffi.Pointer<ffi.Int64>,
+          ffi.Pointer<ffi.Double>, ffi.Pointer<ffi.Bool>, ffi.Pointer<wire_ExoticOptionals>)>();
 
   void wire_handle_return_enum(
     int port_,
@@ -2747,12 +2483,11 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_handle_return_enumPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64,
-              ffi.Pointer<wire_uint_8_list>)>>('wire_handle_return_enum');
-  late final _wire_handle_return_enum = _wire_handle_return_enumPtr
-      .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+  late final _wire_handle_return_enumPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>(
+          'wire_handle_return_enum');
+  late final _wire_handle_return_enum =
+      _wire_handle_return_enumPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_handle_enum_parameter(
     int port_,
@@ -2765,10 +2500,8 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _wire_handle_enum_parameterPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>(
-          'wire_handle_enum_parameter');
-  late final _wire_handle_enum_parameter =
-      _wire_handle_enum_parameterPtr.asFunction<void Function(int, int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>('wire_handle_enum_parameter');
+  late final _wire_handle_enum_parameter = _wire_handle_enum_parameterPtr.asFunction<void Function(int, int)>();
 
   void wire_handle_customized_struct(
     int port_,
@@ -2780,12 +2513,11 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_handle_customized_structPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64,
-              ffi.Pointer<wire_Customized>)>>('wire_handle_customized_struct');
-  late final _wire_handle_customized_struct = _wire_handle_customized_structPtr
-      .asFunction<void Function(int, ffi.Pointer<wire_Customized>)>();
+  late final _wire_handle_customized_structPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_Customized>)>>(
+          'wire_handle_customized_struct');
+  late final _wire_handle_customized_struct =
+      _wire_handle_customized_structPtr.asFunction<void Function(int, ffi.Pointer<wire_Customized>)>();
 
   void wire_handle_enum_struct(
     int port_,
@@ -2797,12 +2529,11 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_handle_enum_structPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64,
-              ffi.Pointer<wire_KitchenSink>)>>('wire_handle_enum_struct');
-  late final _wire_handle_enum_struct = _wire_handle_enum_structPtr
-      .asFunction<void Function(int, ffi.Pointer<wire_KitchenSink>)>();
+  late final _wire_handle_enum_structPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_KitchenSink>)>>(
+          'wire_handle_enum_struct');
+  late final _wire_handle_enum_struct =
+      _wire_handle_enum_structPtr.asFunction<void Function(int, ffi.Pointer<wire_KitchenSink>)>();
 
   void wire_use_imported_struct(
     int port_,
@@ -2814,12 +2545,10 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_use_imported_structPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64,
-              ffi.Pointer<wire_MyStruct>)>>('wire_use_imported_struct');
-  late final _wire_use_imported_struct = _wire_use_imported_structPtr
-      .asFunction<void Function(int, ffi.Pointer<wire_MyStruct>)>();
+  late final _wire_use_imported_structPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_MyStruct>)>>('wire_use_imported_struct');
+  late final _wire_use_imported_struct =
+      _wire_use_imported_structPtr.asFunction<void Function(int, ffi.Pointer<wire_MyStruct>)>();
 
   void wire_use_imported_enum(
     int port_,
@@ -2832,10 +2561,8 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _wire_use_imported_enumPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>(
-          'wire_use_imported_enum');
-  late final _wire_use_imported_enum =
-      _wire_use_imported_enumPtr.asFunction<void Function(int, int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>('wire_use_imported_enum');
+  late final _wire_use_imported_enum = _wire_use_imported_enumPtr.asFunction<void Function(int, int)>();
 
   void wire_get_app_settings(
     int port_,
@@ -2846,10 +2573,8 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _wire_get_app_settingsPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
-          'wire_get_app_settings');
-  late final _wire_get_app_settings =
-      _wire_get_app_settingsPtr.asFunction<void Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_get_app_settings');
+  late final _wire_get_app_settings = _wire_get_app_settingsPtr.asFunction<void Function(int)>();
 
   void wire_is_app_embedded(
     int port_,
@@ -2861,12 +2586,11 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_is_app_embeddedPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64,
-              ffi.Pointer<wire_ApplicationSettings>)>>('wire_is_app_embedded');
-  late final _wire_is_app_embedded = _wire_is_app_embeddedPtr
-      .asFunction<void Function(int, ffi.Pointer<wire_ApplicationSettings>)>();
+  late final _wire_is_app_embeddedPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_ApplicationSettings>)>>(
+          'wire_is_app_embedded');
+  late final _wire_is_app_embedded =
+      _wire_is_app_embeddedPtr.asFunction<void Function(int, ffi.Pointer<wire_ApplicationSettings>)>();
 
   void wire_get_message(
     int port_,
@@ -2876,11 +2600,8 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_get_messagePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
-          'wire_get_message');
-  late final _wire_get_message =
-      _wire_get_messagePtr.asFunction<void Function(int)>();
+  late final _wire_get_messagePtr = _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_get_message');
+  late final _wire_get_message = _wire_get_messagePtr.asFunction<void Function(int)>();
 
   void wire_get_array(
     int port_,
@@ -2890,11 +2611,8 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_get_arrayPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
-          'wire_get_array');
-  late final _wire_get_array =
-      _wire_get_arrayPtr.asFunction<void Function(int)>();
+  late final _wire_get_arrayPtr = _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_get_array');
+  late final _wire_get_array = _wire_get_arrayPtr.asFunction<void Function(int)>();
 
   void wire_get_complex_array(
     int port_,
@@ -2905,10 +2623,8 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _wire_get_complex_arrayPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
-          'wire_get_complex_array');
-  late final _wire_get_complex_array =
-      _wire_get_complex_arrayPtr.asFunction<void Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_get_complex_array');
+  late final _wire_get_complex_array = _wire_get_complex_arrayPtr.asFunction<void Function(int)>();
 
   void wire_get_usize(
     int port_,
@@ -2921,10 +2637,8 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _wire_get_usizePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, uintptr_t)>>(
-          'wire_get_usize');
-  late final _wire_get_usize =
-      _wire_get_usizePtr.asFunction<void Function(int, int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, uintptr_t)>>('wire_get_usize');
+  late final _wire_get_usize = _wire_get_usizePtr.asFunction<void Function(int, int)>();
 
   void wire_next_user_id(
     int port_,
@@ -2936,12 +2650,9 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_next_user_idPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-              ffi.Int64, ffi.Pointer<wire_UserId>)>>('wire_next_user_id');
-  late final _wire_next_user_id = _wire_next_user_idPtr
-      .asFunction<void Function(int, ffi.Pointer<wire_UserId>)>();
+  late final _wire_next_user_idPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_UserId>)>>('wire_next_user_id');
+  late final _wire_next_user_id = _wire_next_user_idPtr.asFunction<void Function(int, ffi.Pointer<wire_UserId>)>();
 
   void wire_register_event_listener(
     int port_,
@@ -2952,10 +2663,8 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _wire_register_event_listenerPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
-          'wire_register_event_listener');
-  late final _wire_register_event_listener =
-      _wire_register_event_listenerPtr.asFunction<void Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_register_event_listener');
+  late final _wire_register_event_listener = _wire_register_event_listenerPtr.asFunction<void Function(int)>();
 
   void wire_close_event_listener(
     int port_,
@@ -2966,10 +2675,8 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _wire_close_event_listenerPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
-          'wire_close_event_listener');
-  late final _wire_close_event_listener =
-      _wire_close_event_listenerPtr.asFunction<void Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_close_event_listener');
+  late final _wire_close_event_listener = _wire_close_event_listenerPtr.asFunction<void Function(int)>();
 
   void wire_create_event(
     int port_,
@@ -2979,11 +2686,8 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_create_eventPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
-          'wire_create_event');
-  late final _wire_create_event =
-      _wire_create_eventPtr.asFunction<void Function(int)>();
+  late final _wire_create_eventPtr = _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_create_event');
+  late final _wire_create_event = _wire_create_eventPtr.asFunction<void Function(int)>();
 
   ffi.Pointer<wire_StringList> new_StringList(
     int len,
@@ -2993,42 +2697,37 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_StringListPtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<wire_StringList> Function(ffi.Int32)>>(
-      'new_StringList');
-  late final _new_StringList = _new_StringListPtr
-      .asFunction<ffi.Pointer<wire_StringList> Function(int)>();
+  late final _new_StringListPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_StringList> Function(ffi.Int32)>>('new_StringList');
+  late final _new_StringList = _new_StringListPtr.asFunction<ffi.Pointer<wire_StringList> Function(int)>();
 
   ffi.Pointer<wire_ApplicationEnv> new_box_application_env() {
     return _new_box_application_env();
   }
 
   late final _new_box_application_envPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_ApplicationEnv> Function()>>(
-          'new_box_application_env');
-  late final _new_box_application_env = _new_box_application_envPtr
-      .asFunction<ffi.Pointer<wire_ApplicationEnv> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_ApplicationEnv> Function()>>('new_box_application_env');
+  late final _new_box_application_env =
+      _new_box_application_envPtr.asFunction<ffi.Pointer<wire_ApplicationEnv> Function()>();
 
   ffi.Pointer<wire_ApplicationSettings> new_box_autoadd_application_settings() {
     return _new_box_autoadd_application_settings();
   }
 
-  late final _new_box_autoadd_application_settingsPtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<wire_ApplicationSettings> Function()>>(
-      'new_box_autoadd_application_settings');
+  late final _new_box_autoadd_application_settingsPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_ApplicationSettings> Function()>>(
+          'new_box_autoadd_application_settings');
   late final _new_box_autoadd_application_settings =
-      _new_box_autoadd_application_settingsPtr
-          .asFunction<ffi.Pointer<wire_ApplicationSettings> Function()>();
+      _new_box_autoadd_application_settingsPtr.asFunction<ffi.Pointer<wire_ApplicationSettings> Function()>();
 
   ffi.Pointer<wire_Attribute> new_box_autoadd_attribute() {
     return _new_box_autoadd_attribute();
   }
 
   late final _new_box_autoadd_attributePtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Attribute> Function()>>(
-          'new_box_autoadd_attribute');
-  late final _new_box_autoadd_attribute = _new_box_autoadd_attributePtr
-      .asFunction<ffi.Pointer<wire_Attribute> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Attribute> Function()>>('new_box_autoadd_attribute');
+  late final _new_box_autoadd_attribute =
+      _new_box_autoadd_attributePtr.asFunction<ffi.Pointer<wire_Attribute> Function()>();
 
   ffi.Pointer<ffi.Bool> new_box_autoadd_bool(
     bool value,
@@ -3039,31 +2738,26 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _new_box_autoadd_boolPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Bool> Function(ffi.Bool)>>(
-          'new_box_autoadd_bool');
-  late final _new_box_autoadd_bool = _new_box_autoadd_boolPtr
-      .asFunction<ffi.Pointer<ffi.Bool> Function(bool)>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Bool> Function(ffi.Bool)>>('new_box_autoadd_bool');
+  late final _new_box_autoadd_bool = _new_box_autoadd_boolPtr.asFunction<ffi.Pointer<ffi.Bool> Function(bool)>();
 
   ffi.Pointer<wire_Customized> new_box_autoadd_customized() {
     return _new_box_autoadd_customized();
   }
 
   late final _new_box_autoadd_customizedPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Customized> Function()>>(
-          'new_box_autoadd_customized');
-  late final _new_box_autoadd_customized = _new_box_autoadd_customizedPtr
-      .asFunction<ffi.Pointer<wire_Customized> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Customized> Function()>>('new_box_autoadd_customized');
+  late final _new_box_autoadd_customized =
+      _new_box_autoadd_customizedPtr.asFunction<ffi.Pointer<wire_Customized> Function()>();
 
   ffi.Pointer<wire_ExoticOptionals> new_box_autoadd_exotic_optionals() {
     return _new_box_autoadd_exotic_optionals();
   }
 
   late final _new_box_autoadd_exotic_optionalsPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_ExoticOptionals> Function()>>(
-          'new_box_autoadd_exotic_optionals');
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_ExoticOptionals> Function()>>('new_box_autoadd_exotic_optionals');
   late final _new_box_autoadd_exotic_optionals =
-      _new_box_autoadd_exotic_optionalsPtr
-          .asFunction<ffi.Pointer<wire_ExoticOptionals> Function()>();
+      _new_box_autoadd_exotic_optionalsPtr.asFunction<ffi.Pointer<wire_ExoticOptionals> Function()>();
 
   ffi.Pointer<ffi.Double> new_box_autoadd_f64(
     double value,
@@ -3074,10 +2768,8 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _new_box_autoadd_f64Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Double> Function(ffi.Double)>>(
-          'new_box_autoadd_f64');
-  late final _new_box_autoadd_f64 = _new_box_autoadd_f64Ptr
-      .asFunction<ffi.Pointer<ffi.Double> Function(double)>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Double> Function(ffi.Double)>>('new_box_autoadd_f64');
+  late final _new_box_autoadd_f64 = _new_box_autoadd_f64Ptr.asFunction<ffi.Pointer<ffi.Double> Function(double)>();
 
   ffi.Pointer<ffi.Int32> new_box_autoadd_i32(
     int value,
@@ -3088,10 +2780,8 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _new_box_autoadd_i32Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int32> Function(ffi.Int32)>>(
-          'new_box_autoadd_i32');
-  late final _new_box_autoadd_i32 = _new_box_autoadd_i32Ptr
-      .asFunction<ffi.Pointer<ffi.Int32> Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int32> Function(ffi.Int32)>>('new_box_autoadd_i32');
+  late final _new_box_autoadd_i32 = _new_box_autoadd_i32Ptr.asFunction<ffi.Pointer<ffi.Int32> Function(int)>();
 
   ffi.Pointer<ffi.Int64> new_box_autoadd_i64(
     int value,
@@ -3102,70 +2792,60 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _new_box_autoadd_i64Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int64> Function(ffi.Int64)>>(
-          'new_box_autoadd_i64');
-  late final _new_box_autoadd_i64 = _new_box_autoadd_i64Ptr
-      .asFunction<ffi.Pointer<ffi.Int64> Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int64> Function(ffi.Int64)>>('new_box_autoadd_i64');
+  late final _new_box_autoadd_i64 = _new_box_autoadd_i64Ptr.asFunction<ffi.Pointer<ffi.Int64> Function(int)>();
 
   ffi.Pointer<wire_KitchenSink> new_box_autoadd_kitchen_sink() {
     return _new_box_autoadd_kitchen_sink();
   }
 
   late final _new_box_autoadd_kitchen_sinkPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_KitchenSink> Function()>>(
-          'new_box_autoadd_kitchen_sink');
-  late final _new_box_autoadd_kitchen_sink = _new_box_autoadd_kitchen_sinkPtr
-      .asFunction<ffi.Pointer<wire_KitchenSink> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_KitchenSink> Function()>>('new_box_autoadd_kitchen_sink');
+  late final _new_box_autoadd_kitchen_sink =
+      _new_box_autoadd_kitchen_sinkPtr.asFunction<ffi.Pointer<wire_KitchenSink> Function()>();
 
   ffi.Pointer<wire_MySize> new_box_autoadd_my_size() {
     return _new_box_autoadd_my_size();
   }
 
   late final _new_box_autoadd_my_sizePtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_MySize> Function()>>(
-          'new_box_autoadd_my_size');
-  late final _new_box_autoadd_my_size = _new_box_autoadd_my_sizePtr
-      .asFunction<ffi.Pointer<wire_MySize> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_MySize> Function()>>('new_box_autoadd_my_size');
+  late final _new_box_autoadd_my_size = _new_box_autoadd_my_sizePtr.asFunction<ffi.Pointer<wire_MySize> Function()>();
 
   ffi.Pointer<wire_MyStruct> new_box_autoadd_my_struct() {
     return _new_box_autoadd_my_struct();
   }
 
   late final _new_box_autoadd_my_structPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_MyStruct> Function()>>(
-          'new_box_autoadd_my_struct');
-  late final _new_box_autoadd_my_struct = _new_box_autoadd_my_structPtr
-      .asFunction<ffi.Pointer<wire_MyStruct> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_MyStruct> Function()>>('new_box_autoadd_my_struct');
+  late final _new_box_autoadd_my_struct =
+      _new_box_autoadd_my_structPtr.asFunction<ffi.Pointer<wire_MyStruct> Function()>();
 
   ffi.Pointer<wire_MyTreeNode> new_box_autoadd_my_tree_node() {
     return _new_box_autoadd_my_tree_node();
   }
 
   late final _new_box_autoadd_my_tree_nodePtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_MyTreeNode> Function()>>(
-          'new_box_autoadd_my_tree_node');
-  late final _new_box_autoadd_my_tree_node = _new_box_autoadd_my_tree_nodePtr
-      .asFunction<ffi.Pointer<wire_MyTreeNode> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_MyTreeNode> Function()>>('new_box_autoadd_my_tree_node');
+  late final _new_box_autoadd_my_tree_node =
+      _new_box_autoadd_my_tree_nodePtr.asFunction<ffi.Pointer<wire_MyTreeNode> Function()>();
 
   ffi.Pointer<wire_NewTypeInt> new_box_autoadd_new_type_int() {
     return _new_box_autoadd_new_type_int();
   }
 
   late final _new_box_autoadd_new_type_intPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_NewTypeInt> Function()>>(
-          'new_box_autoadd_new_type_int');
-  late final _new_box_autoadd_new_type_int = _new_box_autoadd_new_type_intPtr
-      .asFunction<ffi.Pointer<wire_NewTypeInt> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_NewTypeInt> Function()>>('new_box_autoadd_new_type_int');
+  late final _new_box_autoadd_new_type_int =
+      _new_box_autoadd_new_type_intPtr.asFunction<ffi.Pointer<wire_NewTypeInt> Function()>();
 
   ffi.Pointer<wire_UserId> new_box_autoadd_user_id() {
     return _new_box_autoadd_user_id();
   }
 
   late final _new_box_autoadd_user_idPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_UserId> Function()>>(
-          'new_box_autoadd_user_id');
-  late final _new_box_autoadd_user_id = _new_box_autoadd_user_idPtr
-      .asFunction<ffi.Pointer<wire_UserId> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_UserId> Function()>>('new_box_autoadd_user_id');
+  late final _new_box_autoadd_user_id = _new_box_autoadd_user_idPtr.asFunction<ffi.Pointer<wire_UserId> Function()>();
 
   ffi.Pointer<ffi.Bool> new_box_bool(
     bool value,
@@ -3175,21 +2855,17 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_box_boolPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Bool> Function(ffi.Bool)>>(
-          'new_box_bool');
-  late final _new_box_bool =
-      _new_box_boolPtr.asFunction<ffi.Pointer<ffi.Bool> Function(bool)>();
+  late final _new_box_boolPtr = _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Bool> Function(ffi.Bool)>>('new_box_bool');
+  late final _new_box_bool = _new_box_boolPtr.asFunction<ffi.Pointer<ffi.Bool> Function(bool)>();
 
   ffi.Pointer<wire_ExoticOptionals> new_box_exotic_optionals() {
     return _new_box_exotic_optionals();
   }
 
   late final _new_box_exotic_optionalsPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_ExoticOptionals> Function()>>(
-          'new_box_exotic_optionals');
-  late final _new_box_exotic_optionals = _new_box_exotic_optionalsPtr
-      .asFunction<ffi.Pointer<wire_ExoticOptionals> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_ExoticOptionals> Function()>>('new_box_exotic_optionals');
+  late final _new_box_exotic_optionals =
+      _new_box_exotic_optionalsPtr.asFunction<ffi.Pointer<wire_ExoticOptionals> Function()>();
 
   ffi.Pointer<ffi.Double> new_box_f64(
     double value,
@@ -3199,11 +2875,8 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_box_f64Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Double> Function(ffi.Double)>>(
-          'new_box_f64');
-  late final _new_box_f64 =
-      _new_box_f64Ptr.asFunction<ffi.Pointer<ffi.Double> Function(double)>();
+  late final _new_box_f64Ptr = _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Double> Function(ffi.Double)>>('new_box_f64');
+  late final _new_box_f64 = _new_box_f64Ptr.asFunction<ffi.Pointer<ffi.Double> Function(double)>();
 
   ffi.Pointer<ffi.Int32> new_box_i32(
     int value,
@@ -3213,11 +2886,8 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_box_i32Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int32> Function(ffi.Int32)>>(
-          'new_box_i32');
-  late final _new_box_i32 =
-      _new_box_i32Ptr.asFunction<ffi.Pointer<ffi.Int32> Function(int)>();
+  late final _new_box_i32Ptr = _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int32> Function(ffi.Int32)>>('new_box_i32');
+  late final _new_box_i32 = _new_box_i32Ptr.asFunction<ffi.Pointer<ffi.Int32> Function(int)>();
 
   ffi.Pointer<ffi.Int64> new_box_i64(
     int value,
@@ -3227,11 +2897,8 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_box_i64Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int64> Function(ffi.Int64)>>(
-          'new_box_i64');
-  late final _new_box_i64 =
-      _new_box_i64Ptr.asFunction<ffi.Pointer<ffi.Int64> Function(int)>();
+  late final _new_box_i64Ptr = _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int64> Function(ffi.Int64)>>('new_box_i64');
+  late final _new_box_i64 = _new_box_i64Ptr.asFunction<ffi.Pointer<ffi.Int64> Function(int)>();
 
   ffi.Pointer<ffi.Int8> new_box_i8(
     int value,
@@ -3241,31 +2908,23 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_box_i8Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int8> Function(ffi.Int8)>>(
-          'new_box_i8');
-  late final _new_box_i8 =
-      _new_box_i8Ptr.asFunction<ffi.Pointer<ffi.Int8> Function(int)>();
+  late final _new_box_i8Ptr = _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int8> Function(ffi.Int8)>>('new_box_i8');
+  late final _new_box_i8 = _new_box_i8Ptr.asFunction<ffi.Pointer<ffi.Int8> Function(int)>();
 
   ffi.Pointer<wire_KitchenSink> new_box_kitchen_sink() {
     return _new_box_kitchen_sink();
   }
 
   late final _new_box_kitchen_sinkPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_KitchenSink> Function()>>(
-          'new_box_kitchen_sink');
-  late final _new_box_kitchen_sink = _new_box_kitchen_sinkPtr
-      .asFunction<ffi.Pointer<wire_KitchenSink> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_KitchenSink> Function()>>('new_box_kitchen_sink');
+  late final _new_box_kitchen_sink = _new_box_kitchen_sinkPtr.asFunction<ffi.Pointer<wire_KitchenSink> Function()>();
 
   ffi.Pointer<wire_MySize> new_box_my_size() {
     return _new_box_my_size();
   }
 
-  late final _new_box_my_sizePtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_MySize> Function()>>(
-          'new_box_my_size');
-  late final _new_box_my_size =
-      _new_box_my_sizePtr.asFunction<ffi.Pointer<wire_MySize> Function()>();
+  late final _new_box_my_sizePtr = _lookup<ffi.NativeFunction<ffi.Pointer<wire_MySize> Function()>>('new_box_my_size');
+  late final _new_box_my_size = _new_box_my_sizePtr.asFunction<ffi.Pointer<wire_MySize> Function()>();
 
   ffi.Pointer<ffi.Uint8> new_box_u8(
     int value,
@@ -3275,11 +2934,8 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_box_u8Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Uint8> Function(ffi.Uint8)>>(
-          'new_box_u8');
-  late final _new_box_u8 =
-      _new_box_u8Ptr.asFunction<ffi.Pointer<ffi.Uint8> Function(int)>();
+  late final _new_box_u8Ptr = _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Uint8> Function(ffi.Uint8)>>('new_box_u8');
+  late final _new_box_u8 = _new_box_u8Ptr.asFunction<ffi.Pointer<ffi.Uint8> Function(int)>();
 
   ffi.Pointer<wire_float_32_list> new_float_32_list(
     int len,
@@ -3289,12 +2945,9 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_float_32_listPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<wire_float_32_list> Function(
-              ffi.Int32)>>('new_float_32_list');
-  late final _new_float_32_list = _new_float_32_listPtr
-      .asFunction<ffi.Pointer<wire_float_32_list> Function(int)>();
+  late final _new_float_32_listPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_float_32_list> Function(ffi.Int32)>>('new_float_32_list');
+  late final _new_float_32_list = _new_float_32_listPtr.asFunction<ffi.Pointer<wire_float_32_list> Function(int)>();
 
   ffi.Pointer<wire_float_64_list> new_float_64_list(
     int len,
@@ -3304,12 +2957,9 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_float_64_listPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<wire_float_64_list> Function(
-              ffi.Int32)>>('new_float_64_list');
-  late final _new_float_64_list = _new_float_64_listPtr
-      .asFunction<ffi.Pointer<wire_float_64_list> Function(int)>();
+  late final _new_float_64_listPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_float_64_list> Function(ffi.Int32)>>('new_float_64_list');
+  late final _new_float_64_list = _new_float_64_listPtr.asFunction<ffi.Pointer<wire_float_64_list> Function(int)>();
 
   ffi.Pointer<wire_int_32_list> new_int_32_list(
     int len,
@@ -3319,12 +2969,9 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_int_32_listPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<wire_int_32_list> Function(
-              ffi.Int32)>>('new_int_32_list');
-  late final _new_int_32_list = _new_int_32_listPtr
-      .asFunction<ffi.Pointer<wire_int_32_list> Function(int)>();
+  late final _new_int_32_listPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_int_32_list> Function(ffi.Int32)>>('new_int_32_list');
+  late final _new_int_32_list = _new_int_32_listPtr.asFunction<ffi.Pointer<wire_int_32_list> Function(int)>();
 
   ffi.Pointer<wire_int_64_list> new_int_64_list(
     int len,
@@ -3334,12 +2981,9 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_int_64_listPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<wire_int_64_list> Function(
-              ffi.Int32)>>('new_int_64_list');
-  late final _new_int_64_list = _new_int_64_listPtr
-      .asFunction<ffi.Pointer<wire_int_64_list> Function(int)>();
+  late final _new_int_64_listPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_int_64_list> Function(ffi.Int32)>>('new_int_64_list');
+  late final _new_int_64_list = _new_int_64_listPtr.asFunction<ffi.Pointer<wire_int_64_list> Function(int)>();
 
   ffi.Pointer<wire_int_8_list> new_int_8_list(
     int len,
@@ -3349,11 +2993,9 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_int_8_listPtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<wire_int_8_list> Function(ffi.Int32)>>(
-      'new_int_8_list');
-  late final _new_int_8_list = _new_int_8_listPtr
-      .asFunction<ffi.Pointer<wire_int_8_list> Function(int)>();
+  late final _new_int_8_listPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_int_8_list> Function(ffi.Int32)>>('new_int_8_list');
+  late final _new_int_8_list = _new_int_8_listPtr.asFunction<ffi.Pointer<wire_int_8_list> Function(int)>();
 
   ffi.Pointer<wire_list_application_env_var> new_list_application_env_var(
     int len,
@@ -3363,12 +3005,11 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_list_application_env_varPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<wire_list_application_env_var> Function(
-              ffi.Int32)>>('new_list_application_env_var');
-  late final _new_list_application_env_var = _new_list_application_env_varPtr
-      .asFunction<ffi.Pointer<wire_list_application_env_var> Function(int)>();
+  late final _new_list_application_env_varPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_list_application_env_var> Function(ffi.Int32)>>(
+          'new_list_application_env_var');
+  late final _new_list_application_env_var =
+      _new_list_application_env_varPtr.asFunction<ffi.Pointer<wire_list_application_env_var> Function(int)>();
 
   ffi.Pointer<wire_list_attribute> new_list_attribute(
     int len,
@@ -3378,12 +3019,9 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_list_attributePtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<wire_list_attribute> Function(
-              ffi.Int32)>>('new_list_attribute');
-  late final _new_list_attribute = _new_list_attributePtr
-      .asFunction<ffi.Pointer<wire_list_attribute> Function(int)>();
+  late final _new_list_attributePtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_list_attribute> Function(ffi.Int32)>>('new_list_attribute');
+  late final _new_list_attribute = _new_list_attributePtr.asFunction<ffi.Pointer<wire_list_attribute> Function(int)>();
 
   ffi.Pointer<wire_list_my_size> new_list_my_size(
     int len,
@@ -3393,12 +3031,9 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_list_my_sizePtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<wire_list_my_size> Function(
-              ffi.Int32)>>('new_list_my_size');
-  late final _new_list_my_size = _new_list_my_sizePtr
-      .asFunction<ffi.Pointer<wire_list_my_size> Function(int)>();
+  late final _new_list_my_sizePtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_list_my_size> Function(ffi.Int32)>>('new_list_my_size');
+  late final _new_list_my_size = _new_list_my_sizePtr.asFunction<ffi.Pointer<wire_list_my_size> Function(int)>();
 
   ffi.Pointer<wire_list_my_tree_node> new_list_my_tree_node(
     int len,
@@ -3408,15 +3043,12 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_list_my_tree_nodePtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<wire_list_my_tree_node> Function(
-              ffi.Int32)>>('new_list_my_tree_node');
-  late final _new_list_my_tree_node = _new_list_my_tree_nodePtr
-      .asFunction<ffi.Pointer<wire_list_my_tree_node> Function(int)>();
+  late final _new_list_my_tree_nodePtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_list_my_tree_node> Function(ffi.Int32)>>('new_list_my_tree_node');
+  late final _new_list_my_tree_node =
+      _new_list_my_tree_nodePtr.asFunction<ffi.Pointer<wire_list_my_tree_node> Function(int)>();
 
-  ffi.Pointer<wire_list_opt_box_autoadd_attribute>
-      new_list_opt_box_autoadd_attribute(
+  ffi.Pointer<wire_list_opt_box_autoadd_attribute> new_list_opt_box_autoadd_attribute(
     int len,
   ) {
     return _new_list_opt_box_autoadd_attribute(
@@ -3424,13 +3056,11 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_list_opt_box_autoadd_attributePtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<wire_list_opt_box_autoadd_attribute> Function(
-              ffi.Int32)>>('new_list_opt_box_autoadd_attribute');
-  late final _new_list_opt_box_autoadd_attribute =
-      _new_list_opt_box_autoadd_attributePtr.asFunction<
-          ffi.Pointer<wire_list_opt_box_autoadd_attribute> Function(int)>();
+  late final _new_list_opt_box_autoadd_attributePtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_list_opt_box_autoadd_attribute> Function(ffi.Int32)>>(
+          'new_list_opt_box_autoadd_attribute');
+  late final _new_list_opt_box_autoadd_attribute = _new_list_opt_box_autoadd_attributePtr
+      .asFunction<ffi.Pointer<wire_list_opt_box_autoadd_attribute> Function(int)>();
 
   ffi.Pointer<wire_uint_8_list> new_uint_8_list(
     int len,
@@ -3440,63 +3070,54 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_uint_8_listPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<wire_uint_8_list> Function(
-              ffi.Int32)>>('new_uint_8_list');
-  late final _new_uint_8_list = _new_uint_8_listPtr
-      .asFunction<ffi.Pointer<wire_uint_8_list> Function(int)>();
+  late final _new_uint_8_listPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_uint_8_list> Function(ffi.Int32)>>('new_uint_8_list');
+  late final _new_uint_8_list = _new_uint_8_listPtr.asFunction<ffi.Pointer<wire_uint_8_list> Function(int)>();
 
   ffi.Pointer<KitchenSinkKind> inflate_KitchenSink_Primitives() {
     return _inflate_KitchenSink_Primitives();
   }
 
   late final _inflate_KitchenSink_PrimitivesPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>(
-          'inflate_KitchenSink_Primitives');
+      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>('inflate_KitchenSink_Primitives');
   late final _inflate_KitchenSink_Primitives =
-      _inflate_KitchenSink_PrimitivesPtr
-          .asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
+      _inflate_KitchenSink_PrimitivesPtr.asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
 
   ffi.Pointer<KitchenSinkKind> inflate_KitchenSink_Nested() {
     return _inflate_KitchenSink_Nested();
   }
 
   late final _inflate_KitchenSink_NestedPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>(
-          'inflate_KitchenSink_Nested');
-  late final _inflate_KitchenSink_Nested = _inflate_KitchenSink_NestedPtr
-      .asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>('inflate_KitchenSink_Nested');
+  late final _inflate_KitchenSink_Nested =
+      _inflate_KitchenSink_NestedPtr.asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
 
   ffi.Pointer<KitchenSinkKind> inflate_KitchenSink_Optional() {
     return _inflate_KitchenSink_Optional();
   }
 
   late final _inflate_KitchenSink_OptionalPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>(
-          'inflate_KitchenSink_Optional');
-  late final _inflate_KitchenSink_Optional = _inflate_KitchenSink_OptionalPtr
-      .asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>('inflate_KitchenSink_Optional');
+  late final _inflate_KitchenSink_Optional =
+      _inflate_KitchenSink_OptionalPtr.asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
 
   ffi.Pointer<KitchenSinkKind> inflate_KitchenSink_Buffer() {
     return _inflate_KitchenSink_Buffer();
   }
 
   late final _inflate_KitchenSink_BufferPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>(
-          'inflate_KitchenSink_Buffer');
-  late final _inflate_KitchenSink_Buffer = _inflate_KitchenSink_BufferPtr
-      .asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>('inflate_KitchenSink_Buffer');
+  late final _inflate_KitchenSink_Buffer =
+      _inflate_KitchenSink_BufferPtr.asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
 
   ffi.Pointer<KitchenSinkKind> inflate_KitchenSink_Enums() {
     return _inflate_KitchenSink_Enums();
   }
 
   late final _inflate_KitchenSink_EnumsPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>(
-          'inflate_KitchenSink_Enums');
-  late final _inflate_KitchenSink_Enums = _inflate_KitchenSink_EnumsPtr
-      .asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>('inflate_KitchenSink_Enums');
+  late final _inflate_KitchenSink_Enums =
+      _inflate_KitchenSink_EnumsPtr.asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
 
   void free_WireSyncReturnStruct(
     WireSyncReturnStruct val,
@@ -3507,10 +3128,9 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _free_WireSyncReturnStructPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(WireSyncReturnStruct)>>(
-          'free_WireSyncReturnStruct');
-  late final _free_WireSyncReturnStruct = _free_WireSyncReturnStructPtr
-      .asFunction<void Function(WireSyncReturnStruct)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(WireSyncReturnStruct)>>('free_WireSyncReturnStruct');
+  late final _free_WireSyncReturnStruct =
+      _free_WireSyncReturnStructPtr.asFunction<void Function(WireSyncReturnStruct)>();
 
   void store_dart_post_cobject(
     DartPostCObjectFnType ptr,
@@ -3521,10 +3141,8 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _store_dart_post_cobjectPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(DartPostCObjectFnType)>>(
-          'store_dart_post_cobject');
-  late final _store_dart_post_cobject = _store_dart_post_cobjectPtr
-      .asFunction<void Function(DartPostCObjectFnType)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(DartPostCObjectFnType)>>('store_dart_post_cobject');
+  late final _store_dart_post_cobject = _store_dart_post_cobjectPtr.asFunction<void Function(DartPostCObjectFnType)>();
 }
 
 class wire_uint_8_list extends ffi.Struct {
@@ -3769,6 +3387,5 @@ class wire_UserId extends ffi.Struct {
 }
 
 typedef uintptr_t = ffi.UnsignedLongLong;
-typedef DartPostCObjectFnType = ffi.Pointer<
-    ffi.NativeFunction<ffi.Bool Function(DartPort, ffi.Pointer<ffi.Void>)>>;
+typedef DartPostCObjectFnType = ffi.Pointer<ffi.NativeFunction<ffi.Bool Function(DartPort, ffi.Pointer<ffi.Void>)>>;
 typedef DartPort = ffi.Int64;

--- a/frb_example/pure_dart/dart/lib/bridge_generated.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.dart
@@ -3386,6 +3386,6 @@ class wire_UserId extends ffi.Struct {
   external int value;
 }
 
-typedef uintptr_t = ffi.UnsignedLongLong;
+typedef uintptr_t = ffi.UnsignedLong;
 typedef DartPostCObjectFnType = ffi.Pointer<ffi.NativeFunction<ffi.Bool Function(DartPort, ffi.Pointer<ffi.Void>)>>;
 typedef DartPort = ffi.Int64;

--- a/frb_example/pure_dart/dart/lib/bridge_generated.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.dart
@@ -1047,8 +1047,8 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
     return raw.index;
   }
 
-  int _api2wire_bool(bool raw) {
-    return raw ? 1 : 0;
+  bool _api2wire_bool(bool raw) {
+    return raw;
   }
 
   ffi.Pointer<wire_ApplicationEnv> _api2wire_box_application_env(ApplicationEnv raw) {
@@ -1069,7 +1069,7 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
     return ptr;
   }
 
-  ffi.Pointer<ffi.Uint8> _api2wire_box_autoadd_bool(bool raw) {
+  ffi.Pointer<ffi.Bool> _api2wire_box_autoadd_bool(bool raw) {
     return inner.new_box_autoadd_bool(raw);
   }
 
@@ -1133,7 +1133,7 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
     return ptr;
   }
 
-  ffi.Pointer<ffi.Uint8> _api2wire_box_bool(bool raw) {
+  ffi.Pointer<ffi.Bool> _api2wire_box_bool(bool raw) {
     return inner.new_box_bool(raw);
   }
 
@@ -1281,7 +1281,7 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
     return raw == null ? ffi.nullptr : _api2wire_box_autoadd_attribute(raw);
   }
 
-  ffi.Pointer<ffi.Uint8> _api2wire_opt_box_autoadd_bool(bool? raw) {
+  ffi.Pointer<ffi.Bool> _api2wire_opt_box_autoadd_bool(bool? raw) {
     return raw == null ? ffi.nullptr : _api2wire_box_autoadd_bool(raw);
   }
 
@@ -1305,7 +1305,7 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
     return raw == null ? ffi.nullptr : _api2wire_box_autoadd_new_type_int(raw);
   }
 
-  ffi.Pointer<ffi.Uint8> _api2wire_opt_box_bool(bool? raw) {
+  ffi.Pointer<ffi.Bool> _api2wire_opt_box_bool(bool? raw) {
     return raw == null ? ffi.nullptr : _api2wire_box_bool(raw);
   }
 
@@ -2133,14 +2133,14 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
       my_i32,
       my_i64,
       my_f64,
-      my_bool ? 1 : 0,
+      my_bool,
     );
   }
 
   late final _wire_primitive_typesPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32, ffi.Int64, ffi.Double, ffi.Uint8)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32, ffi.Int64, ffi.Double, ffi.Bool)>>(
           'wire_primitive_types');
-  late final _wire_primitive_types = _wire_primitive_typesPtr.asFunction<void Function(int, int, int, double, int)>();
+  late final _wire_primitive_types = _wire_primitive_typesPtr.asFunction<void Function(int, int, int, double, bool)>();
 
   void wire_primitive_u32(
     int port_,
@@ -2443,7 +2443,7 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     ffi.Pointer<ffi.Int32> i32box,
     ffi.Pointer<ffi.Int64> i64box,
     ffi.Pointer<ffi.Double> f64box,
-    ffi.Pointer<ffi.Uint8> boolbox,
+    ffi.Pointer<ffi.Bool> boolbox,
     ffi.Pointer<wire_ExoticOptionals> structbox,
   ) {
     return _wire_handle_option_box_arguments(
@@ -2467,11 +2467,11 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
               ffi.Pointer<ffi.Int32>,
               ffi.Pointer<ffi.Int64>,
               ffi.Pointer<ffi.Double>,
-              ffi.Pointer<ffi.Uint8>,
+              ffi.Pointer<ffi.Bool>,
               ffi.Pointer<wire_ExoticOptionals>)>>('wire_handle_option_box_arguments');
   late final _wire_handle_option_box_arguments = _wire_handle_option_box_argumentsPtr.asFunction<
       void Function(int, ffi.Pointer<ffi.Int8>, ffi.Pointer<ffi.Uint8>, ffi.Pointer<ffi.Int32>, ffi.Pointer<ffi.Int64>,
-          ffi.Pointer<ffi.Double>, ffi.Pointer<ffi.Uint8>, ffi.Pointer<wire_ExoticOptionals>)>();
+          ffi.Pointer<ffi.Double>, ffi.Pointer<ffi.Bool>, ffi.Pointer<wire_ExoticOptionals>)>();
 
   void wire_handle_return_enum(
     int port_,
@@ -2729,17 +2729,17 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   late final _new_box_autoadd_attribute =
       _new_box_autoadd_attributePtr.asFunction<ffi.Pointer<wire_Attribute> Function()>();
 
-  ffi.Pointer<ffi.Uint8> new_box_autoadd_bool(
+  ffi.Pointer<ffi.Bool> new_box_autoadd_bool(
     bool value,
   ) {
     return _new_box_autoadd_bool(
-      value ? 1 : 0,
+      value,
     );
   }
 
   late final _new_box_autoadd_boolPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Uint8> Function(ffi.Uint8)>>('new_box_autoadd_bool');
-  late final _new_box_autoadd_bool = _new_box_autoadd_boolPtr.asFunction<ffi.Pointer<ffi.Uint8> Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Bool> Function(ffi.Bool)>>('new_box_autoadd_bool');
+  late final _new_box_autoadd_bool = _new_box_autoadd_boolPtr.asFunction<ffi.Pointer<ffi.Bool> Function(bool)>();
 
   ffi.Pointer<wire_Customized> new_box_autoadd_customized() {
     return _new_box_autoadd_customized();
@@ -2847,16 +2847,16 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
       _lookup<ffi.NativeFunction<ffi.Pointer<wire_UserId> Function()>>('new_box_autoadd_user_id');
   late final _new_box_autoadd_user_id = _new_box_autoadd_user_idPtr.asFunction<ffi.Pointer<wire_UserId> Function()>();
 
-  ffi.Pointer<ffi.Uint8> new_box_bool(
+  ffi.Pointer<ffi.Bool> new_box_bool(
     bool value,
   ) {
     return _new_box_bool(
-      value ? 1 : 0,
+      value,
     );
   }
 
-  late final _new_box_boolPtr = _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Uint8> Function(ffi.Uint8)>>('new_box_bool');
-  late final _new_box_bool = _new_box_boolPtr.asFunction<ffi.Pointer<ffi.Uint8> Function(int)>();
+  late final _new_box_boolPtr = _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Bool> Function(ffi.Bool)>>('new_box_bool');
+  late final _new_box_bool = _new_box_boolPtr.asFunction<ffi.Pointer<ffi.Bool> Function(bool)>();
 
   ffi.Pointer<wire_ExoticOptionals> new_box_exotic_optionals() {
     return _new_box_exotic_optionals();
@@ -3192,8 +3192,8 @@ class wire_MyTreeNode extends ffi.Struct {
 
   external ffi.Pointer<wire_uint_8_list> value_vec_u8;
 
-  @ffi.Uint8()
-  external int value_boolean;
+  @ffi.Bool()
+  external bool value_boolean;
 
   external ffi.Pointer<wire_list_my_tree_node> children;
 }
@@ -3260,7 +3260,7 @@ class wire_ExoticOptionals extends ffi.Struct {
 
   external ffi.Pointer<ffi.Double> float64;
 
-  external ffi.Pointer<ffi.Uint8> boolean;
+  external ffi.Pointer<ffi.Bool> boolean;
 
   external ffi.Pointer<wire_uint_8_list> zerocopy;
 
@@ -3300,8 +3300,8 @@ class KitchenSink_Primitives extends ffi.Struct {
   @ffi.Double()
   external double float64;
 
-  @ffi.Uint8()
-  external int boolean;
+  @ffi.Bool()
+  external bool boolean;
 }
 
 class KitchenSink_Nested extends ffi.Struct {
@@ -3348,15 +3348,15 @@ class KitchenSink_Enums extends ffi.Struct {
 }
 
 class wire_MyStruct extends ffi.Struct {
-  @ffi.Uint8()
-  external int content;
+  @ffi.Bool()
+  external bool content;
 }
 
 class wire_ApplicationEnvVar extends ffi.Struct {
   external ffi.Pointer<wire_uint_8_list> field0;
 
-  @ffi.Uint8()
-  external int field1;
+  @ffi.Bool()
+  external bool field1;
 }
 
 class wire_list_application_env_var extends ffi.Struct {
@@ -3386,6 +3386,6 @@ class wire_UserId extends ffi.Struct {
   external int value;
 }
 
-typedef uintptr_t = ffi.UnsignedLong;
-typedef DartPostCObjectFnType = ffi.Pointer<ffi.NativeFunction<ffi.Uint8 Function(DartPort, ffi.Pointer<ffi.Void>)>>;
+typedef uintptr_t = ffi.UnsignedLongLong;
+typedef DartPostCObjectFnType = ffi.Pointer<ffi.NativeFunction<ffi.Bool Function(DartPort, ffi.Pointer<ffi.Void>)>>;
 typedef DartPort = ffi.Int64;

--- a/frb_example/pure_dart/dart/lib/bridge_generated.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.dart
@@ -28,7 +28,11 @@ abstract class FlutterRustBridgeExample {
   /// Newlines are preserved.
   ///
   Future<int> primitiveTypes(
-      {required int myI32, required int myI64, required double myF64, required bool myBool, dynamic hint});
+      {required int myI32,
+      required int myI64,
+      required double myF64,
+      required bool myBool,
+      dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kPrimitiveTypesConstMeta;
 
@@ -48,15 +52,18 @@ abstract class FlutterRustBridgeExample {
 
   FlutterRustBridgeTaskConstMeta get kHandleVecU8ConstMeta;
 
-  Future<VecOfPrimitivePack> handleVecOfPrimitive({required int n, dynamic hint});
+  Future<VecOfPrimitivePack> handleVecOfPrimitive(
+      {required int n, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleVecOfPrimitiveConstMeta;
 
-  Future<ZeroCopyVecOfPrimitivePack> handleZeroCopyVecOfPrimitive({required int n, dynamic hint});
+  Future<ZeroCopyVecOfPrimitivePack> handleZeroCopyVecOfPrimitive(
+      {required int n, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleZeroCopyVecOfPrimitiveConstMeta;
 
-  Future<MySize> handleStruct({required MySize arg, required MySize boxed, dynamic hint});
+  Future<MySize> handleStruct(
+      {required MySize arg, required MySize boxed, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleStructConstMeta;
 
@@ -64,11 +71,13 @@ abstract class FlutterRustBridgeExample {
 
   FlutterRustBridgeTaskConstMeta get kHandleNewtypeConstMeta;
 
-  Future<List<MySize>> handleListOfStruct({required List<MySize> l, dynamic hint});
+  Future<List<MySize>> handleListOfStruct(
+      {required List<MySize> l, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleListOfStructConstMeta;
 
-  Future<List<String>> handleStringList({required List<String> names, dynamic hint});
+  Future<List<String>> handleStringList(
+      {required List<String> names, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleStringListConstMeta;
 
@@ -96,7 +105,8 @@ abstract class FlutterRustBridgeExample {
 
   FlutterRustBridgeTaskConstMeta get kReturnPanicConstMeta;
 
-  Future<double?> handleOptionalReturn({required double left, required double right, dynamic hint});
+  Future<double?> handleOptionalReturn(
+      {required double left, required double right, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleOptionalReturnConstMeta;
 
@@ -104,7 +114,8 @@ abstract class FlutterRustBridgeExample {
 
   FlutterRustBridgeTaskConstMeta get kHandleOptionalStructConstMeta;
 
-  Future<ExoticOptionals?> handleOptionalIncrement({ExoticOptionals? opt, dynamic hint});
+  Future<ExoticOptionals?> handleOptionalIncrement(
+      {ExoticOptionals? opt, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleOptionalIncrementConstMeta;
 
@@ -128,7 +139,8 @@ abstract class FlutterRustBridgeExample {
 
   FlutterRustBridgeTaskConstMeta get kHandleReturnEnumConstMeta;
 
-  Future<Weekdays> handleEnumParameter({required Weekdays weekday, dynamic hint});
+  Future<Weekdays> handleEnumParameter(
+      {required Weekdays weekday, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleEnumParameterConstMeta;
 
@@ -136,7 +148,8 @@ abstract class FlutterRustBridgeExample {
 
   FlutterRustBridgeTaskConstMeta get kHandleCustomizedStructConstMeta;
 
-  Future<KitchenSink> handleEnumStruct({required KitchenSink val, dynamic hint});
+  Future<KitchenSink> handleEnumStruct(
+      {required KitchenSink val, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleEnumStructConstMeta;
 
@@ -152,7 +165,8 @@ abstract class FlutterRustBridgeExample {
 
   FlutterRustBridgeTaskConstMeta get kGetAppSettingsConstMeta;
 
-  Future<bool> isAppEmbedded({required ApplicationSettings appSettings, dynamic hint});
+  Future<bool> isAppEmbedded(
+      {required ApplicationSettings appSettings, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kIsAppEmbeddedConstMeta;
 
@@ -482,69 +496,90 @@ class ZeroCopyVecOfPrimitivePack {
   });
 }
 
-class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBridgeExampleWire>
+class FlutterRustBridgeExampleImpl
+    extends FlutterRustBridgeBase<FlutterRustBridgeExampleWire>
     implements FlutterRustBridgeExample {
   factory FlutterRustBridgeExampleImpl(ffi.DynamicLibrary dylib) =>
       FlutterRustBridgeExampleImpl.raw(FlutterRustBridgeExampleWire(dylib));
 
-  FlutterRustBridgeExampleImpl.raw(FlutterRustBridgeExampleWire inner) : super(inner);
+  FlutterRustBridgeExampleImpl.raw(FlutterRustBridgeExampleWire inner)
+      : super(inner);
 
-  Future<int> simpleAdder({required int a, required int b, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_simple_adder(port_, _api2wire_i32(a), _api2wire_i32(b)),
+  Future<int> simpleAdder({required int a, required int b, dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) =>
+            inner.wire_simple_adder(port_, _api2wire_i32(a), _api2wire_i32(b)),
         parseSuccessData: _wire2api_i32,
         constMeta: kSimpleAdderConstMeta,
         argValues: [a, b],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kSimpleAdderConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kSimpleAdderConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "simple_adder",
         argNames: ["a", "b"],
       );
 
   Future<int> primitiveTypes(
-          {required int myI32, required int myI64, required double myF64, required bool myBool, dynamic hint}) =>
+          {required int myI32,
+          required int myI64,
+          required double myF64,
+          required bool myBool,
+          dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_primitive_types(port_, _api2wire_i32(myI32), _api2wire_i64(myI64), _api2wire_f64(myF64), myBool),
+        callFfi: (port_) => inner.wire_primitive_types(
+            port_,
+            _api2wire_i32(myI32),
+            _api2wire_i64(myI64),
+            _api2wire_f64(myF64),
+            myBool),
         parseSuccessData: _wire2api_i32,
         constMeta: kPrimitiveTypesConstMeta,
         argValues: [myI32, myI64, myF64, myBool],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kPrimitiveTypesConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kPrimitiveTypesConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "primitive_types",
         argNames: ["myI32", "myI64", "myF64", "myBool"],
       );
 
-  Future<int> primitiveU32({required int myU32, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_primitive_u32(port_, _api2wire_u32(myU32)),
+  Future<int> primitiveU32({required int myU32, dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) =>
+            inner.wire_primitive_u32(port_, _api2wire_u32(myU32)),
         parseSuccessData: _wire2api_u32,
         constMeta: kPrimitiveU32ConstMeta,
         argValues: [myU32],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kPrimitiveU32ConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kPrimitiveU32ConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "primitive_u32",
         argNames: ["myU32"],
       );
 
-  Future<String> handleString({required String s, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_string(port_, _api2wire_String(s)),
+  Future<String> handleString({required String s, dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) =>
+            inner.wire_handle_string(port_, _api2wire_String(s)),
         parseSuccessData: _wire2api_String,
         constMeta: kHandleStringConstMeta,
         argValues: [s],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleStringConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleStringConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_string",
         argNames: ["s"],
       );
 
-  Future<void> handleReturnUnit({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+  Future<void> handleReturnUnit({dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_handle_return_unit(port_),
         parseSuccessData: _wire2api_unit,
         constMeta: kHandleReturnUnitConstMeta,
@@ -552,147 +587,178 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleReturnUnitConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleReturnUnitConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_return_unit",
         argNames: [],
       );
 
-  Future<Uint8List> handleVecU8({required Uint8List v, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_vec_u8(port_, _api2wire_uint_8_list(v)),
+  Future<Uint8List> handleVecU8({required Uint8List v, dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) =>
+            inner.wire_handle_vec_u8(port_, _api2wire_uint_8_list(v)),
         parseSuccessData: _wire2api_uint_8_list,
         constMeta: kHandleVecU8ConstMeta,
         argValues: [v],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleVecU8ConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleVecU8ConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_vec_u8",
         argNames: ["v"],
       );
 
-  Future<VecOfPrimitivePack> handleVecOfPrimitive({required int n, dynamic hint}) =>
+  Future<VecOfPrimitivePack> handleVecOfPrimitive(
+          {required int n, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_vec_of_primitive(port_, _api2wire_i32(n)),
+        callFfi: (port_) =>
+            inner.wire_handle_vec_of_primitive(port_, _api2wire_i32(n)),
         parseSuccessData: _wire2api_vec_of_primitive_pack,
         constMeta: kHandleVecOfPrimitiveConstMeta,
         argValues: [n],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleVecOfPrimitiveConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleVecOfPrimitiveConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_vec_of_primitive",
         argNames: ["n"],
       );
 
-  Future<ZeroCopyVecOfPrimitivePack> handleZeroCopyVecOfPrimitive({required int n, dynamic hint}) =>
+  Future<ZeroCopyVecOfPrimitivePack> handleZeroCopyVecOfPrimitive(
+          {required int n, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_zero_copy_vec_of_primitive(port_, _api2wire_i32(n)),
+        callFfi: (port_) => inner.wire_handle_zero_copy_vec_of_primitive(
+            port_, _api2wire_i32(n)),
         parseSuccessData: _wire2api_zero_copy_vec_of_primitive_pack,
         constMeta: kHandleZeroCopyVecOfPrimitiveConstMeta,
         argValues: [n],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleZeroCopyVecOfPrimitiveConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleZeroCopyVecOfPrimitiveConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_zero_copy_vec_of_primitive",
         argNames: ["n"],
       );
 
-  Future<MySize> handleStruct({required MySize arg, required MySize boxed, dynamic hint}) =>
+  Future<MySize> handleStruct(
+          {required MySize arg, required MySize boxed, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_handle_struct(port_, _api2wire_box_autoadd_my_size(arg), _api2wire_box_my_size(boxed)),
+        callFfi: (port_) => inner.wire_handle_struct(port_,
+            _api2wire_box_autoadd_my_size(arg), _api2wire_box_my_size(boxed)),
         parseSuccessData: _wire2api_my_size,
         constMeta: kHandleStructConstMeta,
         argValues: [arg, boxed],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleStructConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleStructConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_struct",
         argNames: ["arg", "boxed"],
       );
 
-  Future<NewTypeInt> handleNewtype({required NewTypeInt arg, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_newtype(port_, _api2wire_box_autoadd_new_type_int(arg)),
+  Future<NewTypeInt> handleNewtype({required NewTypeInt arg, dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_handle_newtype(
+            port_, _api2wire_box_autoadd_new_type_int(arg)),
         parseSuccessData: _wire2api_new_type_int,
         constMeta: kHandleNewtypeConstMeta,
         argValues: [arg],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleNewtypeConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleNewtypeConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_newtype",
         argNames: ["arg"],
       );
 
-  Future<List<MySize>> handleListOfStruct({required List<MySize> l, dynamic hint}) =>
+  Future<List<MySize>> handleListOfStruct(
+          {required List<MySize> l, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_list_of_struct(port_, _api2wire_list_my_size(l)),
+        callFfi: (port_) =>
+            inner.wire_handle_list_of_struct(port_, _api2wire_list_my_size(l)),
         parseSuccessData: _wire2api_list_my_size,
         constMeta: kHandleListOfStructConstMeta,
         argValues: [l],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleListOfStructConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleListOfStructConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_list_of_struct",
         argNames: ["l"],
       );
 
-  Future<List<String>> handleStringList({required List<String> names, dynamic hint}) =>
+  Future<List<String>> handleStringList(
+          {required List<String> names, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_string_list(port_, _api2wire_StringList(names)),
+        callFfi: (port_) =>
+            inner.wire_handle_string_list(port_, _api2wire_StringList(names)),
         parseSuccessData: _wire2api_StringList,
         constMeta: kHandleStringListConstMeta,
         argValues: [names],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleStringListConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleStringListConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_string_list",
         argNames: ["names"],
       );
 
-  Future<MyTreeNode> handleComplexStruct({required MyTreeNode s, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_complex_struct(port_, _api2wire_box_autoadd_my_tree_node(s)),
+  Future<MyTreeNode> handleComplexStruct(
+          {required MyTreeNode s, dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_handle_complex_struct(
+            port_, _api2wire_box_autoadd_my_tree_node(s)),
         parseSuccessData: _wire2api_my_tree_node,
         constMeta: kHandleComplexStructConstMeta,
         argValues: [s],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleComplexStructConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleComplexStructConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_complex_struct",
         argNames: ["s"],
       );
 
-  Uint8List handleSyncReturn({required String mode, dynamic hint}) => executeSync(FlutterRustBridgeSyncTask(
+  Uint8List handleSyncReturn({required String mode, dynamic hint}) =>
+      executeSync(FlutterRustBridgeSyncTask(
         callFfi: () => inner.wire_handle_sync_return(_api2wire_String(mode)),
         constMeta: kHandleSyncReturnConstMeta,
         argValues: [mode],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleSyncReturnConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleSyncReturnConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_sync_return",
         argNames: ["mode"],
       );
 
-  Stream<String> handleStream({required String arg, dynamic hint}) => executeStream(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_stream(port_, _api2wire_String(arg)),
+  Stream<String> handleStream({required String arg, dynamic hint}) =>
+      executeStream(FlutterRustBridgeTask(
+        callFfi: (port_) =>
+            inner.wire_handle_stream(port_, _api2wire_String(arg)),
         parseSuccessData: _wire2api_String,
         constMeta: kHandleStreamConstMeta,
         argValues: [arg],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleStreamConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleStreamConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_stream",
         argNames: ["arg"],
       );
 
-  Stream<MyStreamEntry> handleStreamOfStruct({dynamic hint}) => executeStream(FlutterRustBridgeTask(
+  Stream<MyStreamEntry> handleStreamOfStruct({dynamic hint}) =>
+      executeStream(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_handle_stream_of_struct(port_),
         parseSuccessData: _wire2api_my_stream_entry,
         constMeta: kHandleStreamOfStructConstMeta,
@@ -700,7 +766,8 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleStreamOfStructConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleStreamOfStructConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_stream_of_struct",
         argNames: [],
       );
@@ -713,12 +780,14 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kReturnErrConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kReturnErrConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "return_err",
         argNames: [],
       );
 
-  Future<int> returnPanic({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+  Future<int> returnPanic({dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_return_panic(port_),
         parseSuccessData: _wire2api_i32,
         constMeta: kReturnPanicConstMeta,
@@ -726,62 +795,74 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kReturnPanicConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kReturnPanicConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "return_panic",
         argNames: [],
       );
 
-  Future<double?> handleOptionalReturn({required double left, required double right, dynamic hint}) =>
+  Future<double?> handleOptionalReturn(
+          {required double left, required double right, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_optional_return(port_, _api2wire_f64(left), _api2wire_f64(right)),
+        callFfi: (port_) => inner.wire_handle_optional_return(
+            port_, _api2wire_f64(left), _api2wire_f64(right)),
         parseSuccessData: _wire2api_opt_box_autoadd_f64,
         constMeta: kHandleOptionalReturnConstMeta,
         argValues: [left, right],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleOptionalReturnConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleOptionalReturnConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_optional_return",
         argNames: ["left", "right"],
       );
 
-  Future<Element?> handleOptionalStruct({String? document, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_optional_struct(port_, _api2wire_opt_String(document)),
+  Future<Element?> handleOptionalStruct({String? document, dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_handle_optional_struct(
+            port_, _api2wire_opt_String(document)),
         parseSuccessData: _wire2api_opt_box_autoadd_element,
         constMeta: kHandleOptionalStructConstMeta,
         argValues: [document],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleOptionalStructConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleOptionalStructConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_optional_struct",
         argNames: ["document"],
       );
 
-  Future<ExoticOptionals?> handleOptionalIncrement({ExoticOptionals? opt, dynamic hint}) =>
+  Future<ExoticOptionals?> handleOptionalIncrement(
+          {ExoticOptionals? opt, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_handle_optional_increment(port_, _api2wire_opt_box_autoadd_exotic_optionals(opt)),
+        callFfi: (port_) => inner.wire_handle_optional_increment(
+            port_, _api2wire_opt_box_autoadd_exotic_optionals(opt)),
         parseSuccessData: _wire2api_opt_box_autoadd_exotic_optionals,
         constMeta: kHandleOptionalIncrementConstMeta,
         argValues: [opt],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleOptionalIncrementConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleOptionalIncrementConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_optional_increment",
         argNames: ["opt"],
       );
 
-  Future<double> handleIncrementBoxedOptional({double? opt, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_increment_boxed_optional(port_, _api2wire_opt_box_f64(opt)),
+  Future<double> handleIncrementBoxedOptional({double? opt, dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_handle_increment_boxed_optional(
+            port_, _api2wire_opt_box_f64(opt)),
         parseSuccessData: _wire2api_f64,
         constMeta: kHandleIncrementBoxedOptionalConstMeta,
         argValues: [opt],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleIncrementBoxedOptionalConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleIncrementBoxedOptionalConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_increment_boxed_optional",
         argNames: ["opt"],
       );
@@ -811,91 +892,121 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleOptionBoxArgumentsConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleOptionBoxArgumentsConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_option_box_arguments",
-        argNames: ["i8Box", "u8Box", "i32Box", "i64Box", "f64Box", "boolbox", "structbox"],
+        argNames: [
+          "i8Box",
+          "u8Box",
+          "i32Box",
+          "i64Box",
+          "f64Box",
+          "boolbox",
+          "structbox"
+        ],
       );
 
-  Future<Weekdays?> handleReturnEnum({required String input, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_return_enum(port_, _api2wire_String(input)),
+  Future<Weekdays?> handleReturnEnum({required String input, dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) =>
+            inner.wire_handle_return_enum(port_, _api2wire_String(input)),
         parseSuccessData: _wire2api_opt_weekdays,
         constMeta: kHandleReturnEnumConstMeta,
         argValues: [input],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleReturnEnumConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleReturnEnumConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_return_enum",
         argNames: ["input"],
       );
 
-  Future<Weekdays> handleEnumParameter({required Weekdays weekday, dynamic hint}) =>
+  Future<Weekdays> handleEnumParameter(
+          {required Weekdays weekday, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_enum_parameter(port_, _api2wire_weekdays(weekday)),
+        callFfi: (port_) => inner.wire_handle_enum_parameter(
+            port_, _api2wire_weekdays(weekday)),
         parseSuccessData: _wire2api_weekdays,
         constMeta: kHandleEnumParameterConstMeta,
         argValues: [weekday],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleEnumParameterConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleEnumParameterConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_enum_parameter",
         argNames: ["weekday"],
       );
 
-  Future<void> handleCustomizedStruct({required Customized val, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_customized_struct(port_, _api2wire_box_autoadd_customized(val)),
+  Future<void> handleCustomizedStruct(
+          {required Customized val, dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_handle_customized_struct(
+            port_, _api2wire_box_autoadd_customized(val)),
         parseSuccessData: _wire2api_unit,
         constMeta: kHandleCustomizedStructConstMeta,
         argValues: [val],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleCustomizedStructConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleCustomizedStructConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_customized_struct",
         argNames: ["val"],
       );
 
-  Future<KitchenSink> handleEnumStruct({required KitchenSink val, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_enum_struct(port_, _api2wire_box_autoadd_kitchen_sink(val)),
+  Future<KitchenSink> handleEnumStruct(
+          {required KitchenSink val, dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_handle_enum_struct(
+            port_, _api2wire_box_autoadd_kitchen_sink(val)),
         parseSuccessData: _wire2api_kitchen_sink,
         constMeta: kHandleEnumStructConstMeta,
         argValues: [val],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleEnumStructConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleEnumStructConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_enum_struct",
         argNames: ["val"],
       );
 
-  Future<bool> useImportedStruct({required MyStruct myStruct, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_use_imported_struct(port_, _api2wire_box_autoadd_my_struct(myStruct)),
+  Future<bool> useImportedStruct({required MyStruct myStruct, dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_use_imported_struct(
+            port_, _api2wire_box_autoadd_my_struct(myStruct)),
         parseSuccessData: _wire2api_bool,
         constMeta: kUseImportedStructConstMeta,
         argValues: [myStruct],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kUseImportedStructConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kUseImportedStructConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "use_imported_struct",
         argNames: ["myStruct"],
       );
 
-  Future<bool> useImportedEnum({required MyEnum myEnum, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_use_imported_enum(port_, _api2wire_my_enum(myEnum)),
+  Future<bool> useImportedEnum({required MyEnum myEnum, dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) =>
+            inner.wire_use_imported_enum(port_, _api2wire_my_enum(myEnum)),
         parseSuccessData: _wire2api_bool,
         constMeta: kUseImportedEnumConstMeta,
         argValues: [myEnum],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kUseImportedEnumConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kUseImportedEnumConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "use_imported_enum",
         argNames: ["myEnum"],
       );
 
-  Future<ApplicationSettings> getAppSettings({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+  Future<ApplicationSettings> getAppSettings({dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_get_app_settings(port_),
         parseSuccessData: _wire2api_application_settings,
         constMeta: kGetAppSettingsConstMeta,
@@ -903,26 +1014,31 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kGetAppSettingsConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kGetAppSettingsConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "get_app_settings",
         argNames: [],
       );
 
-  Future<bool> isAppEmbedded({required ApplicationSettings appSettings, dynamic hint}) =>
+  Future<bool> isAppEmbedded(
+          {required ApplicationSettings appSettings, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_is_app_embedded(port_, _api2wire_box_autoadd_application_settings(appSettings)),
+        callFfi: (port_) => inner.wire_is_app_embedded(
+            port_, _api2wire_box_autoadd_application_settings(appSettings)),
         parseSuccessData: _wire2api_bool,
         constMeta: kIsAppEmbeddedConstMeta,
         argValues: [appSettings],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kIsAppEmbeddedConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kIsAppEmbeddedConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "is_app_embedded",
         argNames: ["appSettings"],
       );
 
-  Future<ApplicationMessage> getMessage({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+  Future<ApplicationMessage> getMessage({dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_get_message(port_),
         parseSuccessData: _wire2api_application_message,
         constMeta: kGetMessageConstMeta,
@@ -930,12 +1046,14 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kGetMessageConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kGetMessageConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "get_message",
         argNames: [],
       );
 
-  Future<Uint8List> getArray({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+  Future<Uint8List> getArray({dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_get_array(port_),
         parseSuccessData: _wire2api_uint_8_list,
         constMeta: kGetArrayConstMeta,
@@ -943,12 +1061,14 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kGetArrayConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kGetArrayConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "get_array",
         argNames: [],
       );
 
-  Future<List<Point>> getComplexArray({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+  Future<List<Point>> getComplexArray({dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_get_complex_array(port_),
         parseSuccessData: _wire2api_list_point,
         constMeta: kGetComplexArrayConstMeta,
@@ -956,12 +1076,14 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kGetComplexArrayConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kGetComplexArrayConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "get_complex_array",
         argNames: [],
       );
 
-  Future<int> getUsize({required int u, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+  Future<int> getUsize({required int u, dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_get_usize(port_, _api2wire_usize(u)),
         parseSuccessData: _wire2api_usize,
         constMeta: kGetUsizeConstMeta,
@@ -969,25 +1091,30 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kGetUsizeConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kGetUsizeConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "get_usize",
         argNames: ["u"],
       );
 
-  Future<UserId> nextUserId({required UserId userId, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_next_user_id(port_, _api2wire_box_autoadd_user_id(userId)),
+  Future<UserId> nextUserId({required UserId userId, dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_next_user_id(
+            port_, _api2wire_box_autoadd_user_id(userId)),
         parseSuccessData: _wire2api_user_id,
         constMeta: kNextUserIdConstMeta,
         argValues: [userId],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kNextUserIdConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kNextUserIdConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "next_user_id",
         argNames: ["userId"],
       );
 
-  Stream<Event> registerEventListener({dynamic hint}) => executeStream(FlutterRustBridgeTask(
+  Stream<Event> registerEventListener({dynamic hint}) =>
+      executeStream(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_register_event_listener(port_),
         parseSuccessData: _wire2api_event,
         constMeta: kRegisterEventListenerConstMeta,
@@ -995,12 +1122,14 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kRegisterEventListenerConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kRegisterEventListenerConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "register_event_listener",
         argNames: [],
       );
 
-  Future<void> closeEventListener({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+  Future<void> closeEventListener({dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_close_event_listener(port_),
         parseSuccessData: _wire2api_unit,
         constMeta: kCloseEventListenerConstMeta,
@@ -1008,12 +1137,14 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kCloseEventListenerConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kCloseEventListenerConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "close_event_listener",
         argNames: [],
       );
 
-  Future<void> createEvent({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+  Future<void> createEvent({dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_create_event(port_),
         parseSuccessData: _wire2api_unit,
         constMeta: kCreateEventConstMeta,
@@ -1021,7 +1152,8 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kCreateEventConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kCreateEventConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "create_event",
         argNames: [],
       );
@@ -1039,7 +1171,8 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
     return ans;
   }
 
-  ffi.Pointer<wire_uint_8_list> _api2wire_ZeroCopyBuffer_Uint8List(Uint8List raw) {
+  ffi.Pointer<wire_uint_8_list> _api2wire_ZeroCopyBuffer_Uint8List(
+      Uint8List raw) {
     return _api2wire_uint_8_list(raw);
   }
 
@@ -1051,13 +1184,15 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
     return raw;
   }
 
-  ffi.Pointer<wire_ApplicationEnv> _api2wire_box_application_env(ApplicationEnv raw) {
+  ffi.Pointer<wire_ApplicationEnv> _api2wire_box_application_env(
+      ApplicationEnv raw) {
     final ptr = inner.new_box_application_env();
     _api_fill_to_wire_application_env(raw, ptr.ref);
     return ptr;
   }
 
-  ffi.Pointer<wire_ApplicationSettings> _api2wire_box_autoadd_application_settings(ApplicationSettings raw) {
+  ffi.Pointer<wire_ApplicationSettings>
+      _api2wire_box_autoadd_application_settings(ApplicationSettings raw) {
     final ptr = inner.new_box_autoadd_application_settings();
     _api_fill_to_wire_application_settings(raw, ptr.ref);
     return ptr;
@@ -1073,13 +1208,15 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
     return inner.new_box_autoadd_bool(raw);
   }
 
-  ffi.Pointer<wire_Customized> _api2wire_box_autoadd_customized(Customized raw) {
+  ffi.Pointer<wire_Customized> _api2wire_box_autoadd_customized(
+      Customized raw) {
     final ptr = inner.new_box_autoadd_customized();
     _api_fill_to_wire_customized(raw, ptr.ref);
     return ptr;
   }
 
-  ffi.Pointer<wire_ExoticOptionals> _api2wire_box_autoadd_exotic_optionals(ExoticOptionals raw) {
+  ffi.Pointer<wire_ExoticOptionals> _api2wire_box_autoadd_exotic_optionals(
+      ExoticOptionals raw) {
     final ptr = inner.new_box_autoadd_exotic_optionals();
     _api_fill_to_wire_exotic_optionals(raw, ptr.ref);
     return ptr;
@@ -1097,7 +1234,8 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
     return inner.new_box_autoadd_i64(raw);
   }
 
-  ffi.Pointer<wire_KitchenSink> _api2wire_box_autoadd_kitchen_sink(KitchenSink raw) {
+  ffi.Pointer<wire_KitchenSink> _api2wire_box_autoadd_kitchen_sink(
+      KitchenSink raw) {
     final ptr = inner.new_box_autoadd_kitchen_sink();
     _api_fill_to_wire_kitchen_sink(raw, ptr.ref);
     return ptr;
@@ -1115,13 +1253,15 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
     return ptr;
   }
 
-  ffi.Pointer<wire_MyTreeNode> _api2wire_box_autoadd_my_tree_node(MyTreeNode raw) {
+  ffi.Pointer<wire_MyTreeNode> _api2wire_box_autoadd_my_tree_node(
+      MyTreeNode raw) {
     final ptr = inner.new_box_autoadd_my_tree_node();
     _api_fill_to_wire_my_tree_node(raw, ptr.ref);
     return ptr;
   }
 
-  ffi.Pointer<wire_NewTypeInt> _api2wire_box_autoadd_new_type_int(NewTypeInt raw) {
+  ffi.Pointer<wire_NewTypeInt> _api2wire_box_autoadd_new_type_int(
+      NewTypeInt raw) {
     final ptr = inner.new_box_autoadd_new_type_int();
     _api_fill_to_wire_new_type_int(raw, ptr.ref);
     return ptr;
@@ -1137,7 +1277,8 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
     return inner.new_box_bool(raw);
   }
 
-  ffi.Pointer<wire_ExoticOptionals> _api2wire_box_exotic_optionals(ExoticOptionals raw) {
+  ffi.Pointer<wire_ExoticOptionals> _api2wire_box_exotic_optionals(
+      ExoticOptionals raw) {
     final ptr = inner.new_box_exotic_optionals();
     _api_fill_to_wire_exotic_optionals(raw, ptr.ref);
     return ptr;
@@ -1225,7 +1366,8 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
     return ans;
   }
 
-  ffi.Pointer<wire_list_application_env_var> _api2wire_list_application_env_var(List<ApplicationEnvVar> raw) {
+  ffi.Pointer<wire_list_application_env_var> _api2wire_list_application_env_var(
+      List<ApplicationEnvVar> raw) {
     final ans = inner.new_list_application_env_var(raw.length);
     for (var i = 0; i < raw.length; ++i) {
       _api_fill_to_wire_application_env_var(raw[i], ans.ref.ptr[i]);
@@ -1233,7 +1375,8 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
     return ans;
   }
 
-  ffi.Pointer<wire_list_attribute> _api2wire_list_attribute(List<Attribute> raw) {
+  ffi.Pointer<wire_list_attribute> _api2wire_list_attribute(
+      List<Attribute> raw) {
     final ans = inner.new_list_attribute(raw.length);
     for (var i = 0; i < raw.length; ++i) {
       _api_fill_to_wire_attribute(raw[i], ans.ref.ptr[i]);
@@ -1249,7 +1392,8 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
     return ans;
   }
 
-  ffi.Pointer<wire_list_my_tree_node> _api2wire_list_my_tree_node(List<MyTreeNode> raw) {
+  ffi.Pointer<wire_list_my_tree_node> _api2wire_list_my_tree_node(
+      List<MyTreeNode> raw) {
     final ans = inner.new_list_my_tree_node(raw.length);
     for (var i = 0; i < raw.length; ++i) {
       _api_fill_to_wire_my_tree_node(raw[i], ans.ref.ptr[i]);
@@ -1257,7 +1401,8 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
     return ans;
   }
 
-  ffi.Pointer<wire_list_opt_box_autoadd_attribute> _api2wire_list_opt_box_autoadd_attribute(List<Attribute?> raw) {
+  ffi.Pointer<wire_list_opt_box_autoadd_attribute>
+      _api2wire_list_opt_box_autoadd_attribute(List<Attribute?> raw) {
     final ans = inner.new_list_opt_box_autoadd_attribute(raw.length);
     for (var i = 0; i < raw.length; ++i) {
       _api_fill_to_wire_opt_box_autoadd_attribute(raw[i], ans.ref.ptr[i]);
@@ -1273,11 +1418,13 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
     return raw == null ? ffi.nullptr : _api2wire_String(raw);
   }
 
-  ffi.Pointer<wire_uint_8_list> _api2wire_opt_ZeroCopyBuffer_Uint8List(Uint8List? raw) {
+  ffi.Pointer<wire_uint_8_list> _api2wire_opt_ZeroCopyBuffer_Uint8List(
+      Uint8List? raw) {
     return raw == null ? ffi.nullptr : _api2wire_ZeroCopyBuffer_Uint8List(raw);
   }
 
-  ffi.Pointer<wire_Attribute> _api2wire_opt_box_autoadd_attribute(Attribute? raw) {
+  ffi.Pointer<wire_Attribute> _api2wire_opt_box_autoadd_attribute(
+      Attribute? raw) {
     return raw == null ? ffi.nullptr : _api2wire_box_autoadd_attribute(raw);
   }
 
@@ -1285,8 +1432,11 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
     return raw == null ? ffi.nullptr : _api2wire_box_autoadd_bool(raw);
   }
 
-  ffi.Pointer<wire_ExoticOptionals> _api2wire_opt_box_autoadd_exotic_optionals(ExoticOptionals? raw) {
-    return raw == null ? ffi.nullptr : _api2wire_box_autoadd_exotic_optionals(raw);
+  ffi.Pointer<wire_ExoticOptionals> _api2wire_opt_box_autoadd_exotic_optionals(
+      ExoticOptionals? raw) {
+    return raw == null
+        ? ffi.nullptr
+        : _api2wire_box_autoadd_exotic_optionals(raw);
   }
 
   ffi.Pointer<ffi.Double> _api2wire_opt_box_autoadd_f64(double? raw) {
@@ -1301,7 +1451,8 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
     return raw == null ? ffi.nullptr : _api2wire_box_autoadd_i64(raw);
   }
 
-  ffi.Pointer<wire_NewTypeInt> _api2wire_opt_box_autoadd_new_type_int(NewTypeInt? raw) {
+  ffi.Pointer<wire_NewTypeInt> _api2wire_opt_box_autoadd_new_type_int(
+      NewTypeInt? raw) {
     return raw == null ? ffi.nullptr : _api2wire_box_autoadd_new_type_int(raw);
   }
 
@@ -1309,7 +1460,8 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
     return raw == null ? ffi.nullptr : _api2wire_box_bool(raw);
   }
 
-  ffi.Pointer<wire_ExoticOptionals> _api2wire_opt_box_exotic_optionals(ExoticOptionals? raw) {
+  ffi.Pointer<wire_ExoticOptionals> _api2wire_opt_box_exotic_optionals(
+      ExoticOptionals? raw) {
     return raw == null ? ffi.nullptr : _api2wire_box_exotic_optionals(raw);
   }
 
@@ -1333,11 +1485,13 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
     return raw == null ? ffi.nullptr : _api2wire_box_u8(raw);
   }
 
-  ffi.Pointer<wire_float_32_list> _api2wire_opt_float_32_list(Float32List? raw) {
+  ffi.Pointer<wire_float_32_list> _api2wire_opt_float_32_list(
+      Float32List? raw) {
     return raw == null ? ffi.nullptr : _api2wire_float_32_list(raw);
   }
 
-  ffi.Pointer<wire_float_64_list> _api2wire_opt_float_64_list(Float64List? raw) {
+  ffi.Pointer<wire_float_64_list> _api2wire_opt_float_64_list(
+      Float64List? raw) {
     return raw == null ? ffi.nullptr : _api2wire_float_64_list(raw);
   }
 
@@ -1353,12 +1507,16 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
     return raw == null ? ffi.nullptr : _api2wire_int_8_list(raw);
   }
 
-  ffi.Pointer<wire_list_attribute> _api2wire_opt_list_attribute(List<Attribute>? raw) {
+  ffi.Pointer<wire_list_attribute> _api2wire_opt_list_attribute(
+      List<Attribute>? raw) {
     return raw == null ? ffi.nullptr : _api2wire_list_attribute(raw);
   }
 
-  ffi.Pointer<wire_list_opt_box_autoadd_attribute> _api2wire_opt_list_opt_box_autoadd_attribute(List<Attribute?>? raw) {
-    return raw == null ? ffi.nullptr : _api2wire_list_opt_box_autoadd_attribute(raw);
+  ffi.Pointer<wire_list_opt_box_autoadd_attribute>
+      _api2wire_opt_list_opt_box_autoadd_attribute(List<Attribute?>? raw) {
+    return raw == null
+        ? ffi.nullptr
+        : _api2wire_list_opt_box_autoadd_attribute(raw);
   }
 
   ffi.Pointer<wire_uint_8_list> _api2wire_opt_uint_8_list(Uint8List? raw) {
@@ -1389,16 +1547,19 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
 
   // Section: api_fill_to_wire
 
-  void _api_fill_to_wire_application_env(ApplicationEnv apiObj, wire_ApplicationEnv wireObj) {
+  void _api_fill_to_wire_application_env(
+      ApplicationEnv apiObj, wire_ApplicationEnv wireObj) {
     wireObj.vars = _api2wire_list_application_env_var(apiObj.vars);
   }
 
-  void _api_fill_to_wire_application_env_var(ApplicationEnvVar apiObj, wire_ApplicationEnvVar wireObj) {
+  void _api_fill_to_wire_application_env_var(
+      ApplicationEnvVar apiObj, wire_ApplicationEnvVar wireObj) {
     wireObj.field0 = _api2wire_String(apiObj.field0);
     wireObj.field1 = _api2wire_bool(apiObj.field1);
   }
 
-  void _api_fill_to_wire_application_settings(ApplicationSettings apiObj, wire_ApplicationSettings wireObj) {
+  void _api_fill_to_wire_application_settings(
+      ApplicationSettings apiObj, wire_ApplicationSettings wireObj) {
     wireObj.name = _api2wire_String(apiObj.name);
     wireObj.version = _api2wire_String(apiObj.version);
     wireObj.mode = _api2wire_application_mode(apiObj.mode);
@@ -1410,20 +1571,24 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
     wireObj.value = _api2wire_String(apiObj.value);
   }
 
-  void _api_fill_to_wire_box_application_env(ApplicationEnv apiObj, ffi.Pointer<wire_ApplicationEnv> wireObj) {
+  void _api_fill_to_wire_box_application_env(
+      ApplicationEnv apiObj, ffi.Pointer<wire_ApplicationEnv> wireObj) {
     _api_fill_to_wire_application_env(apiObj, wireObj.ref);
   }
 
   void _api_fill_to_wire_box_autoadd_application_settings(
-      ApplicationSettings apiObj, ffi.Pointer<wire_ApplicationSettings> wireObj) {
+      ApplicationSettings apiObj,
+      ffi.Pointer<wire_ApplicationSettings> wireObj) {
     _api_fill_to_wire_application_settings(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_attribute(Attribute apiObj, ffi.Pointer<wire_Attribute> wireObj) {
+  void _api_fill_to_wire_box_autoadd_attribute(
+      Attribute apiObj, ffi.Pointer<wire_Attribute> wireObj) {
     _api_fill_to_wire_attribute(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_customized(Customized apiObj, ffi.Pointer<wire_Customized> wireObj) {
+  void _api_fill_to_wire_box_autoadd_customized(
+      Customized apiObj, ffi.Pointer<wire_Customized> wireObj) {
     _api_fill_to_wire_customized(apiObj, wireObj.ref);
   }
 
@@ -1432,48 +1597,59 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
     _api_fill_to_wire_exotic_optionals(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_kitchen_sink(KitchenSink apiObj, ffi.Pointer<wire_KitchenSink> wireObj) {
+  void _api_fill_to_wire_box_autoadd_kitchen_sink(
+      KitchenSink apiObj, ffi.Pointer<wire_KitchenSink> wireObj) {
     _api_fill_to_wire_kitchen_sink(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_my_size(MySize apiObj, ffi.Pointer<wire_MySize> wireObj) {
+  void _api_fill_to_wire_box_autoadd_my_size(
+      MySize apiObj, ffi.Pointer<wire_MySize> wireObj) {
     _api_fill_to_wire_my_size(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_my_struct(MyStruct apiObj, ffi.Pointer<wire_MyStruct> wireObj) {
+  void _api_fill_to_wire_box_autoadd_my_struct(
+      MyStruct apiObj, ffi.Pointer<wire_MyStruct> wireObj) {
     _api_fill_to_wire_my_struct(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_my_tree_node(MyTreeNode apiObj, ffi.Pointer<wire_MyTreeNode> wireObj) {
+  void _api_fill_to_wire_box_autoadd_my_tree_node(
+      MyTreeNode apiObj, ffi.Pointer<wire_MyTreeNode> wireObj) {
     _api_fill_to_wire_my_tree_node(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_new_type_int(NewTypeInt apiObj, ffi.Pointer<wire_NewTypeInt> wireObj) {
+  void _api_fill_to_wire_box_autoadd_new_type_int(
+      NewTypeInt apiObj, ffi.Pointer<wire_NewTypeInt> wireObj) {
     _api_fill_to_wire_new_type_int(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_user_id(UserId apiObj, ffi.Pointer<wire_UserId> wireObj) {
+  void _api_fill_to_wire_box_autoadd_user_id(
+      UserId apiObj, ffi.Pointer<wire_UserId> wireObj) {
     _api_fill_to_wire_user_id(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_exotic_optionals(ExoticOptionals apiObj, ffi.Pointer<wire_ExoticOptionals> wireObj) {
+  void _api_fill_to_wire_box_exotic_optionals(
+      ExoticOptionals apiObj, ffi.Pointer<wire_ExoticOptionals> wireObj) {
     _api_fill_to_wire_exotic_optionals(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_kitchen_sink(KitchenSink apiObj, ffi.Pointer<wire_KitchenSink> wireObj) {
+  void _api_fill_to_wire_box_kitchen_sink(
+      KitchenSink apiObj, ffi.Pointer<wire_KitchenSink> wireObj) {
     _api_fill_to_wire_kitchen_sink(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_my_size(MySize apiObj, ffi.Pointer<wire_MySize> wireObj) {
+  void _api_fill_to_wire_box_my_size(
+      MySize apiObj, ffi.Pointer<wire_MySize> wireObj) {
     _api_fill_to_wire_my_size(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_customized(Customized apiObj, wire_Customized wireObj) {
+  void _api_fill_to_wire_customized(
+      Customized apiObj, wire_Customized wireObj) {
     wireObj.final_field = _api2wire_String(apiObj.finalField);
     wireObj.non_final_field = _api2wire_opt_String(apiObj.nonFinalField);
   }
 
-  void _api_fill_to_wire_exotic_optionals(ExoticOptionals apiObj, wire_ExoticOptionals wireObj) {
+  void _api_fill_to_wire_exotic_optionals(
+      ExoticOptionals apiObj, wire_ExoticOptionals wireObj) {
     wireObj.int32 = _api2wire_opt_box_autoadd_i32(apiObj.int32);
     wireObj.int64 = _api2wire_opt_box_autoadd_i64(apiObj.int64);
     wireObj.float64 = _api2wire_opt_box_autoadd_f64(apiObj.float64);
@@ -1486,12 +1662,16 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
     wireObj.float32list = _api2wire_opt_float_32_list(apiObj.float32List);
     wireObj.float64list = _api2wire_opt_float_64_list(apiObj.float64List);
     wireObj.attributes = _api2wire_opt_list_attribute(apiObj.attributes);
-    wireObj.attributes_nullable = _api2wire_list_opt_box_autoadd_attribute(apiObj.attributesNullable);
-    wireObj.nullable_attributes = _api2wire_opt_list_opt_box_autoadd_attribute(apiObj.nullableAttributes);
-    wireObj.newtypeint = _api2wire_opt_box_autoadd_new_type_int(apiObj.newtypeint);
+    wireObj.attributes_nullable =
+        _api2wire_list_opt_box_autoadd_attribute(apiObj.attributesNullable);
+    wireObj.nullable_attributes =
+        _api2wire_opt_list_opt_box_autoadd_attribute(apiObj.nullableAttributes);
+    wireObj.newtypeint =
+        _api2wire_opt_box_autoadd_new_type_int(apiObj.newtypeint);
   }
 
-  void _api_fill_to_wire_kitchen_sink(KitchenSink apiObj, wire_KitchenSink wireObj) {
+  void _api_fill_to_wire_kitchen_sink(
+      KitchenSink apiObj, wire_KitchenSink wireObj) {
     if (apiObj is Empty) {
       wireObj.tag = 0;
       return;
@@ -1506,19 +1686,23 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
     if (apiObj is Nested) {
       wireObj.tag = 2;
       wireObj.kind = inner.inflate_KitchenSink_Nested();
-      wireObj.kind.ref.Nested.ref.field0 = _api2wire_box_kitchen_sink(apiObj.field0);
+      wireObj.kind.ref.Nested.ref.field0 =
+          _api2wire_box_kitchen_sink(apiObj.field0);
       wireObj.kind.ref.Nested.ref.field1 = _api2wire_i32(apiObj.field1);
     }
     if (apiObj is Optional) {
       wireObj.tag = 3;
       wireObj.kind = inner.inflate_KitchenSink_Optional();
-      wireObj.kind.ref.Optional.ref.field0 = _api2wire_opt_box_autoadd_i32(apiObj.field0);
-      wireObj.kind.ref.Optional.ref.field1 = _api2wire_opt_box_autoadd_i32(apiObj.field1);
+      wireObj.kind.ref.Optional.ref.field0 =
+          _api2wire_opt_box_autoadd_i32(apiObj.field0);
+      wireObj.kind.ref.Optional.ref.field1 =
+          _api2wire_opt_box_autoadd_i32(apiObj.field1);
     }
     if (apiObj is Buffer) {
       wireObj.tag = 4;
       wireObj.kind = inner.inflate_KitchenSink_Buffer();
-      wireObj.kind.ref.Buffer.ref.field0 = _api2wire_ZeroCopyBuffer_Uint8List(apiObj.field0);
+      wireObj.kind.ref.Buffer.ref.field0 =
+          _api2wire_ZeroCopyBuffer_Uint8List(apiObj.field0);
     }
     if (apiObj is Enums) {
       wireObj.tag = 5;
@@ -1536,31 +1720,39 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
     wireObj.content = _api2wire_bool(apiObj.content);
   }
 
-  void _api_fill_to_wire_my_tree_node(MyTreeNode apiObj, wire_MyTreeNode wireObj) {
+  void _api_fill_to_wire_my_tree_node(
+      MyTreeNode apiObj, wire_MyTreeNode wireObj) {
     wireObj.value_i32 = _api2wire_i32(apiObj.valueI32);
     wireObj.value_vec_u8 = _api2wire_uint_8_list(apiObj.valueVecU8);
     wireObj.value_boolean = _api2wire_bool(apiObj.valueBoolean);
     wireObj.children = _api2wire_list_my_tree_node(apiObj.children);
   }
 
-  void _api_fill_to_wire_new_type_int(NewTypeInt apiObj, wire_NewTypeInt wireObj) {
+  void _api_fill_to_wire_new_type_int(
+      NewTypeInt apiObj, wire_NewTypeInt wireObj) {
     wireObj.field0 = _api2wire_i64(apiObj.field0);
   }
 
-  void _api_fill_to_wire_opt_box_autoadd_attribute(Attribute? apiObj, ffi.Pointer<wire_Attribute> wireObj) {
-    if (apiObj != null) _api_fill_to_wire_box_autoadd_attribute(apiObj, wireObj);
+  void _api_fill_to_wire_opt_box_autoadd_attribute(
+      Attribute? apiObj, ffi.Pointer<wire_Attribute> wireObj) {
+    if (apiObj != null)
+      _api_fill_to_wire_box_autoadd_attribute(apiObj, wireObj);
   }
 
   void _api_fill_to_wire_opt_box_autoadd_exotic_optionals(
       ExoticOptionals? apiObj, ffi.Pointer<wire_ExoticOptionals> wireObj) {
-    if (apiObj != null) _api_fill_to_wire_box_autoadd_exotic_optionals(apiObj, wireObj);
+    if (apiObj != null)
+      _api_fill_to_wire_box_autoadd_exotic_optionals(apiObj, wireObj);
   }
 
-  void _api_fill_to_wire_opt_box_autoadd_new_type_int(NewTypeInt? apiObj, ffi.Pointer<wire_NewTypeInt> wireObj) {
-    if (apiObj != null) _api_fill_to_wire_box_autoadd_new_type_int(apiObj, wireObj);
+  void _api_fill_to_wire_opt_box_autoadd_new_type_int(
+      NewTypeInt? apiObj, ffi.Pointer<wire_NewTypeInt> wireObj) {
+    if (apiObj != null)
+      _api_fill_to_wire_box_autoadd_new_type_int(apiObj, wireObj);
   }
 
-  void _api_fill_to_wire_opt_box_exotic_optionals(ExoticOptionals? apiObj, ffi.Pointer<wire_ExoticOptionals> wireObj) {
+  void _api_fill_to_wire_opt_box_exotic_optionals(
+      ExoticOptionals? apiObj, ffi.Pointer<wire_ExoticOptionals> wireObj) {
     if (apiObj != null) _api_fill_to_wire_box_exotic_optionals(apiObj, wireObj);
   }
 
@@ -1624,7 +1816,8 @@ Uint8List _wire2api_ZeroCopyBuffer_Uint8List(dynamic raw) {
 
 ApplicationEnv _wire2api_application_env(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+  if (arr.length != 1)
+    throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
   return ApplicationEnv(
     vars: _wire2api_list_application_env_var(arr[0]),
   );
@@ -1632,7 +1825,8 @@ ApplicationEnv _wire2api_application_env(dynamic raw) {
 
 ApplicationEnvVar _wire2api_application_env_var(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+  if (arr.length != 2)
+    throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
   return ApplicationEnvVar(
     field0: _wire2api_String(arr[0]),
     field1: _wire2api_bool(arr[1]),
@@ -1663,7 +1857,8 @@ ApplicationMode _wire2api_application_mode(dynamic raw) {
 
 ApplicationSettings _wire2api_application_settings(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 4) throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
+  if (arr.length != 4)
+    throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
   return ApplicationSettings(
     name: _wire2api_String(arr[0]),
     version: _wire2api_String(arr[1]),
@@ -1674,7 +1869,8 @@ ApplicationSettings _wire2api_application_settings(dynamic raw) {
 
 Attribute _wire2api_attribute(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+  if (arr.length != 2)
+    throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
   return Attribute(
     key: _wire2api_String(arr[0]),
     value: _wire2api_String(arr[1]),
@@ -1727,7 +1923,8 @@ KitchenSink _wire2api_box_kitchen_sink(dynamic raw) {
 
 Element _wire2api_element(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 4) throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
+  if (arr.length != 4)
+    throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
   return Element(
     tag: _wire2api_opt_String(arr[0]),
     text: _wire2api_opt_String(arr[1]),
@@ -1738,7 +1935,8 @@ Element _wire2api_element(dynamic raw) {
 
 Event _wire2api_event(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+  if (arr.length != 2)
+    throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
   return Event(
     address: _wire2api_String(arr[0]),
     payload: _wire2api_String(arr[1]),
@@ -1747,7 +1945,8 @@ Event _wire2api_event(dynamic raw) {
 
 ExoticOptionals _wire2api_exotic_optionals(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 15) throw Exception('unexpected arr length: expect 15 but see ${arr.length}');
+  if (arr.length != 15)
+    throw Exception('unexpected arr length: expect 15 but see ${arr.length}');
   return ExoticOptionals(
     int32: _wire2api_opt_box_autoadd_i32(arr[0]),
     int64: _wire2api_opt_box_autoadd_i64(arr[1]),
@@ -1869,7 +2068,9 @@ List<MyTreeNode> _wire2api_list_my_tree_node(dynamic raw) {
 }
 
 List<Attribute?> _wire2api_list_opt_box_autoadd_attribute(dynamic raw) {
-  return (raw as List<dynamic>).map(_wire2api_opt_box_autoadd_attribute).toList();
+  return (raw as List<dynamic>)
+      .map(_wire2api_opt_box_autoadd_attribute)
+      .toList();
 }
 
 List<Point> _wire2api_list_point(dynamic raw) {
@@ -1878,7 +2079,8 @@ List<Point> _wire2api_list_point(dynamic raw) {
 
 MySize _wire2api_my_size(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+  if (arr.length != 2)
+    throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
   return MySize(
     width: _wire2api_i32(arr[0]),
     height: _wire2api_i32(arr[1]),
@@ -1887,7 +2089,8 @@ MySize _wire2api_my_size(dynamic raw) {
 
 MyStreamEntry _wire2api_my_stream_entry(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+  if (arr.length != 1)
+    throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
   return MyStreamEntry(
     hello: _wire2api_String(arr[0]),
   );
@@ -1895,7 +2098,8 @@ MyStreamEntry _wire2api_my_stream_entry(dynamic raw) {
 
 MyTreeNode _wire2api_my_tree_node(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 4) throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
+  if (arr.length != 4)
+    throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
   return MyTreeNode(
     valueI32: _wire2api_i32(arr[0]),
     valueVecU8: _wire2api_uint_8_list(arr[1]),
@@ -1906,7 +2110,8 @@ MyTreeNode _wire2api_my_tree_node(dynamic raw) {
 
 NewTypeInt _wire2api_new_type_int(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+  if (arr.length != 1)
+    throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
   return NewTypeInt(
     field0: _wire2api_i64(arr[0]),
   );
@@ -1994,7 +2199,8 @@ Weekdays? _wire2api_opt_weekdays(dynamic raw) {
 
 Point _wire2api_point(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+  if (arr.length != 2)
+    throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
   return Point(
     x: _wire2api_f32(arr[0]),
     y: _wire2api_f32(arr[1]),
@@ -2039,7 +2245,8 @@ void _wire2api_unit(dynamic raw) {
 
 UserId _wire2api_user_id(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+  if (arr.length != 1)
+    throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
   return UserId(
     value: _wire2api_u32(arr[0]),
   );
@@ -2051,7 +2258,8 @@ int _wire2api_usize(dynamic raw) {
 
 VecOfPrimitivePack _wire2api_vec_of_primitive_pack(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 10) throw Exception('unexpected arr length: expect 10 but see ${arr.length}');
+  if (arr.length != 10)
+    throw Exception('unexpected arr length: expect 10 but see ${arr.length}');
   return VecOfPrimitivePack(
     int8List: _wire2api_int_8_list(arr[0]),
     uint8List: _wire2api_uint_8_list(arr[1]),
@@ -2070,9 +2278,11 @@ Weekdays _wire2api_weekdays(dynamic raw) {
   return Weekdays.values[raw];
 }
 
-ZeroCopyVecOfPrimitivePack _wire2api_zero_copy_vec_of_primitive_pack(dynamic raw) {
+ZeroCopyVecOfPrimitivePack _wire2api_zero_copy_vec_of_primitive_pack(
+    dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 10) throw Exception('unexpected arr length: expect 10 but see ${arr.length}');
+  if (arr.length != 10)
+    throw Exception('unexpected arr length: expect 10 but see ${arr.length}');
   return ZeroCopyVecOfPrimitivePack(
     int8List: _wire2api_ZeroCopyBuffer_Int8List(arr[0]),
     uint8List: _wire2api_ZeroCopyBuffer_Uint8List(arr[1]),
@@ -2096,13 +2306,17 @@ ZeroCopyVecOfPrimitivePack _wire2api_zero_copy_vec_of_primitive_pack(dynamic raw
 /// generated by flutter_rust_bridge
 class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   /// Holds the symbol lookup function.
-  final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName) _lookup;
+  final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
+      _lookup;
 
   /// The symbols are looked up in [dynamicLibrary].
-  FlutterRustBridgeExampleWire(ffi.DynamicLibrary dynamicLibrary) : _lookup = dynamicLibrary.lookup;
+  FlutterRustBridgeExampleWire(ffi.DynamicLibrary dynamicLibrary)
+      : _lookup = dynamicLibrary.lookup;
 
   /// The symbols are looked up with [lookup].
-  FlutterRustBridgeExampleWire.fromLookup(ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName) lookup)
+  FlutterRustBridgeExampleWire.fromLookup(
+      ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
+          lookup)
       : _lookup = lookup;
 
   void wire_simple_adder(
@@ -2117,9 +2331,12 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_simple_adderPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32, ffi.Int32)>>('wire_simple_adder');
-  late final _wire_simple_adder = _wire_simple_adderPtr.asFunction<void Function(int, int, int)>();
+  late final _wire_simple_adderPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+              ffi.Int64, ffi.Int32, ffi.Int32)>>('wire_simple_adder');
+  late final _wire_simple_adder =
+      _wire_simple_adderPtr.asFunction<void Function(int, int, int)>();
 
   void wire_primitive_types(
     int port_,
@@ -2137,10 +2354,12 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_primitive_typesPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32, ffi.Int64, ffi.Double, ffi.Bool)>>(
-          'wire_primitive_types');
-  late final _wire_primitive_types = _wire_primitive_typesPtr.asFunction<void Function(int, int, int, double, bool)>();
+  late final _wire_primitive_typesPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Int64, ffi.Int32, ffi.Int64, ffi.Double,
+              ffi.Bool)>>('wire_primitive_types');
+  late final _wire_primitive_types = _wire_primitive_typesPtr
+      .asFunction<void Function(int, int, int, double, bool)>();
 
   void wire_primitive_u32(
     int port_,
@@ -2153,8 +2372,10 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _wire_primitive_u32Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Uint32)>>('wire_primitive_u32');
-  late final _wire_primitive_u32 = _wire_primitive_u32Ptr.asFunction<void Function(int, int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Uint32)>>(
+          'wire_primitive_u32');
+  late final _wire_primitive_u32 =
+      _wire_primitive_u32Ptr.asFunction<void Function(int, int)>();
 
   void wire_handle_string(
     int port_,
@@ -2166,10 +2387,12 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_handle_stringPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>('wire_handle_string');
-  late final _wire_handle_string =
-      _wire_handle_stringPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+  late final _wire_handle_stringPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+              ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>('wire_handle_string');
+  late final _wire_handle_string = _wire_handle_stringPtr
+      .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_handle_return_unit(
     int port_,
@@ -2180,8 +2403,10 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _wire_handle_return_unitPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_handle_return_unit');
-  late final _wire_handle_return_unit = _wire_handle_return_unitPtr.asFunction<void Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
+          'wire_handle_return_unit');
+  late final _wire_handle_return_unit =
+      _wire_handle_return_unitPtr.asFunction<void Function(int)>();
 
   void wire_handle_vec_u8(
     int port_,
@@ -2193,10 +2418,12 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_handle_vec_u8Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>('wire_handle_vec_u8');
-  late final _wire_handle_vec_u8 =
-      _wire_handle_vec_u8Ptr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+  late final _wire_handle_vec_u8Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+              ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>('wire_handle_vec_u8');
+  late final _wire_handle_vec_u8 = _wire_handle_vec_u8Ptr
+      .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_handle_vec_of_primitive(
     int port_,
@@ -2209,8 +2436,10 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _wire_handle_vec_of_primitivePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>('wire_handle_vec_of_primitive');
-  late final _wire_handle_vec_of_primitive = _wire_handle_vec_of_primitivePtr.asFunction<void Function(int, int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>(
+          'wire_handle_vec_of_primitive');
+  late final _wire_handle_vec_of_primitive =
+      _wire_handle_vec_of_primitivePtr.asFunction<void Function(int, int)>();
 
   void wire_handle_zero_copy_vec_of_primitive(
     int port_,
@@ -2223,9 +2452,11 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _wire_handle_zero_copy_vec_of_primitivePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>('wire_handle_zero_copy_vec_of_primitive');
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>(
+          'wire_handle_zero_copy_vec_of_primitive');
   late final _wire_handle_zero_copy_vec_of_primitive =
-      _wire_handle_zero_copy_vec_of_primitivePtr.asFunction<void Function(int, int)>();
+      _wire_handle_zero_copy_vec_of_primitivePtr
+          .asFunction<void Function(int, int)>();
 
   void wire_handle_struct(
     int port_,
@@ -2239,11 +2470,12 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_handle_structPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_MySize>, ffi.Pointer<wire_MySize>)>>(
-          'wire_handle_struct');
-  late final _wire_handle_struct =
-      _wire_handle_structPtr.asFunction<void Function(int, ffi.Pointer<wire_MySize>, ffi.Pointer<wire_MySize>)>();
+  late final _wire_handle_structPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Int64, ffi.Pointer<wire_MySize>,
+              ffi.Pointer<wire_MySize>)>>('wire_handle_struct');
+  late final _wire_handle_struct = _wire_handle_structPtr.asFunction<
+      void Function(int, ffi.Pointer<wire_MySize>, ffi.Pointer<wire_MySize>)>();
 
   void wire_handle_newtype(
     int port_,
@@ -2255,10 +2487,12 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_handle_newtypePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_NewTypeInt>)>>('wire_handle_newtype');
-  late final _wire_handle_newtype =
-      _wire_handle_newtypePtr.asFunction<void Function(int, ffi.Pointer<wire_NewTypeInt>)>();
+  late final _wire_handle_newtypePtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+              ffi.Int64, ffi.Pointer<wire_NewTypeInt>)>>('wire_handle_newtype');
+  late final _wire_handle_newtype = _wire_handle_newtypePtr
+      .asFunction<void Function(int, ffi.Pointer<wire_NewTypeInt>)>();
 
   void wire_handle_list_of_struct(
     int port_,
@@ -2270,11 +2504,12 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_handle_list_of_structPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_list_my_size>)>>(
-          'wire_handle_list_of_struct');
-  late final _wire_handle_list_of_struct =
-      _wire_handle_list_of_structPtr.asFunction<void Function(int, ffi.Pointer<wire_list_my_size>)>();
+  late final _wire_handle_list_of_structPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Int64,
+              ffi.Pointer<wire_list_my_size>)>>('wire_handle_list_of_struct');
+  late final _wire_handle_list_of_struct = _wire_handle_list_of_structPtr
+      .asFunction<void Function(int, ffi.Pointer<wire_list_my_size>)>();
 
   void wire_handle_string_list(
     int port_,
@@ -2286,11 +2521,12 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_handle_string_listPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_StringList>)>>(
-          'wire_handle_string_list');
-  late final _wire_handle_string_list =
-      _wire_handle_string_listPtr.asFunction<void Function(int, ffi.Pointer<wire_StringList>)>();
+  late final _wire_handle_string_listPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Int64,
+              ffi.Pointer<wire_StringList>)>>('wire_handle_string_list');
+  late final _wire_handle_string_list = _wire_handle_string_listPtr
+      .asFunction<void Function(int, ffi.Pointer<wire_StringList>)>();
 
   void wire_handle_complex_struct(
     int port_,
@@ -2302,11 +2538,12 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_handle_complex_structPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_MyTreeNode>)>>(
-          'wire_handle_complex_struct');
-  late final _wire_handle_complex_struct =
-      _wire_handle_complex_structPtr.asFunction<void Function(int, ffi.Pointer<wire_MyTreeNode>)>();
+  late final _wire_handle_complex_structPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Int64,
+              ffi.Pointer<wire_MyTreeNode>)>>('wire_handle_complex_struct');
+  late final _wire_handle_complex_struct = _wire_handle_complex_structPtr
+      .asFunction<void Function(int, ffi.Pointer<wire_MyTreeNode>)>();
 
   WireSyncReturnStruct wire_handle_sync_return(
     ffi.Pointer<wire_uint_8_list> mode,
@@ -2316,11 +2553,12 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_handle_sync_returnPtr =
-      _lookup<ffi.NativeFunction<WireSyncReturnStruct Function(ffi.Pointer<wire_uint_8_list>)>>(
-          'wire_handle_sync_return');
-  late final _wire_handle_sync_return =
-      _wire_handle_sync_returnPtr.asFunction<WireSyncReturnStruct Function(ffi.Pointer<wire_uint_8_list>)>();
+  late final _wire_handle_sync_returnPtr = _lookup<
+      ffi.NativeFunction<
+          WireSyncReturnStruct Function(
+              ffi.Pointer<wire_uint_8_list>)>>('wire_handle_sync_return');
+  late final _wire_handle_sync_return = _wire_handle_sync_returnPtr.asFunction<
+      WireSyncReturnStruct Function(ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_handle_stream(
     int port_,
@@ -2332,10 +2570,12 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_handle_streamPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>('wire_handle_stream');
-  late final _wire_handle_stream =
-      _wire_handle_streamPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+  late final _wire_handle_streamPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+              ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>('wire_handle_stream');
+  late final _wire_handle_stream = _wire_handle_streamPtr
+      .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_handle_stream_of_struct(
     int port_,
@@ -2346,8 +2586,10 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _wire_handle_stream_of_structPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_handle_stream_of_struct');
-  late final _wire_handle_stream_of_struct = _wire_handle_stream_of_structPtr.asFunction<void Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
+          'wire_handle_stream_of_struct');
+  late final _wire_handle_stream_of_struct =
+      _wire_handle_stream_of_structPtr.asFunction<void Function(int)>();
 
   void wire_return_err(
     int port_,
@@ -2357,8 +2599,11 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_return_errPtr = _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_return_err');
-  late final _wire_return_err = _wire_return_errPtr.asFunction<void Function(int)>();
+  late final _wire_return_errPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
+          'wire_return_err');
+  late final _wire_return_err =
+      _wire_return_errPtr.asFunction<void Function(int)>();
 
   void wire_return_panic(
     int port_,
@@ -2368,8 +2613,11 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_return_panicPtr = _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_return_panic');
-  late final _wire_return_panic = _wire_return_panicPtr.asFunction<void Function(int)>();
+  late final _wire_return_panicPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
+          'wire_return_panic');
+  late final _wire_return_panic =
+      _wire_return_panicPtr.asFunction<void Function(int)>();
 
   void wire_handle_optional_return(
     int port_,
@@ -2383,10 +2631,12 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_handle_optional_returnPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Double, ffi.Double)>>('wire_handle_optional_return');
-  late final _wire_handle_optional_return =
-      _wire_handle_optional_returnPtr.asFunction<void Function(int, double, double)>();
+  late final _wire_handle_optional_returnPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Int64, ffi.Double,
+              ffi.Double)>>('wire_handle_optional_return');
+  late final _wire_handle_optional_return = _wire_handle_optional_returnPtr
+      .asFunction<void Function(int, double, double)>();
 
   void wire_handle_optional_struct(
     int port_,
@@ -2398,11 +2648,12 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_handle_optional_structPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>(
-          'wire_handle_optional_struct');
-  late final _wire_handle_optional_struct =
-      _wire_handle_optional_structPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+  late final _wire_handle_optional_structPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Int64,
+              ffi.Pointer<wire_uint_8_list>)>>('wire_handle_optional_struct');
+  late final _wire_handle_optional_struct = _wire_handle_optional_structPtr
+      .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_handle_optional_increment(
     int port_,
@@ -2414,11 +2665,13 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_handle_optional_incrementPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_ExoticOptionals>)>>(
-          'wire_handle_optional_increment');
+  late final _wire_handle_optional_incrementPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Void Function(ffi.Int64, ffi.Pointer<wire_ExoticOptionals>)>>(
+      'wire_handle_optional_increment');
   late final _wire_handle_optional_increment =
-      _wire_handle_optional_incrementPtr.asFunction<void Function(int, ffi.Pointer<wire_ExoticOptionals>)>();
+      _wire_handle_optional_incrementPtr
+          .asFunction<void Function(int, ffi.Pointer<wire_ExoticOptionals>)>();
 
   void wire_handle_increment_boxed_optional(
     int port_,
@@ -2430,11 +2683,13 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_handle_increment_boxed_optionalPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<ffi.Double>)>>(
-          'wire_handle_increment_boxed_optional');
+  late final _wire_handle_increment_boxed_optionalPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Void Function(ffi.Int64, ffi.Pointer<ffi.Double>)>>(
+      'wire_handle_increment_boxed_optional');
   late final _wire_handle_increment_boxed_optional =
-      _wire_handle_increment_boxed_optionalPtr.asFunction<void Function(int, ffi.Pointer<ffi.Double>)>();
+      _wire_handle_increment_boxed_optionalPtr
+          .asFunction<void Function(int, ffi.Pointer<ffi.Double>)>();
 
   void wire_handle_option_box_arguments(
     int port_,
@@ -2459,19 +2714,28 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _wire_handle_option_box_argumentsPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-              ffi.Int64,
+          ffi.NativeFunction<
+              ffi.Void Function(
+                  ffi.Int64,
+                  ffi.Pointer<ffi.Int8>,
+                  ffi.Pointer<ffi.Uint8>,
+                  ffi.Pointer<ffi.Int32>,
+                  ffi.Pointer<ffi.Int64>,
+                  ffi.Pointer<ffi.Double>,
+                  ffi.Pointer<ffi.Bool>,
+                  ffi.Pointer<wire_ExoticOptionals>)>>(
+      'wire_handle_option_box_arguments');
+  late final _wire_handle_option_box_arguments =
+      _wire_handle_option_box_argumentsPtr.asFunction<
+          void Function(
+              int,
               ffi.Pointer<ffi.Int8>,
               ffi.Pointer<ffi.Uint8>,
               ffi.Pointer<ffi.Int32>,
               ffi.Pointer<ffi.Int64>,
               ffi.Pointer<ffi.Double>,
               ffi.Pointer<ffi.Bool>,
-              ffi.Pointer<wire_ExoticOptionals>)>>('wire_handle_option_box_arguments');
-  late final _wire_handle_option_box_arguments = _wire_handle_option_box_argumentsPtr.asFunction<
-      void Function(int, ffi.Pointer<ffi.Int8>, ffi.Pointer<ffi.Uint8>, ffi.Pointer<ffi.Int32>, ffi.Pointer<ffi.Int64>,
-          ffi.Pointer<ffi.Double>, ffi.Pointer<ffi.Bool>, ffi.Pointer<wire_ExoticOptionals>)>();
+              ffi.Pointer<wire_ExoticOptionals>)>();
 
   void wire_handle_return_enum(
     int port_,
@@ -2483,11 +2747,12 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_handle_return_enumPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>(
-          'wire_handle_return_enum');
-  late final _wire_handle_return_enum =
-      _wire_handle_return_enumPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+  late final _wire_handle_return_enumPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Int64,
+              ffi.Pointer<wire_uint_8_list>)>>('wire_handle_return_enum');
+  late final _wire_handle_return_enum = _wire_handle_return_enumPtr
+      .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_handle_enum_parameter(
     int port_,
@@ -2500,8 +2765,10 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _wire_handle_enum_parameterPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>('wire_handle_enum_parameter');
-  late final _wire_handle_enum_parameter = _wire_handle_enum_parameterPtr.asFunction<void Function(int, int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>(
+          'wire_handle_enum_parameter');
+  late final _wire_handle_enum_parameter =
+      _wire_handle_enum_parameterPtr.asFunction<void Function(int, int)>();
 
   void wire_handle_customized_struct(
     int port_,
@@ -2513,11 +2780,12 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_handle_customized_structPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_Customized>)>>(
-          'wire_handle_customized_struct');
-  late final _wire_handle_customized_struct =
-      _wire_handle_customized_structPtr.asFunction<void Function(int, ffi.Pointer<wire_Customized>)>();
+  late final _wire_handle_customized_structPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Int64,
+              ffi.Pointer<wire_Customized>)>>('wire_handle_customized_struct');
+  late final _wire_handle_customized_struct = _wire_handle_customized_structPtr
+      .asFunction<void Function(int, ffi.Pointer<wire_Customized>)>();
 
   void wire_handle_enum_struct(
     int port_,
@@ -2529,11 +2797,12 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_handle_enum_structPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_KitchenSink>)>>(
-          'wire_handle_enum_struct');
-  late final _wire_handle_enum_struct =
-      _wire_handle_enum_structPtr.asFunction<void Function(int, ffi.Pointer<wire_KitchenSink>)>();
+  late final _wire_handle_enum_structPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Int64,
+              ffi.Pointer<wire_KitchenSink>)>>('wire_handle_enum_struct');
+  late final _wire_handle_enum_struct = _wire_handle_enum_structPtr
+      .asFunction<void Function(int, ffi.Pointer<wire_KitchenSink>)>();
 
   void wire_use_imported_struct(
     int port_,
@@ -2545,10 +2814,12 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_use_imported_structPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_MyStruct>)>>('wire_use_imported_struct');
-  late final _wire_use_imported_struct =
-      _wire_use_imported_structPtr.asFunction<void Function(int, ffi.Pointer<wire_MyStruct>)>();
+  late final _wire_use_imported_structPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Int64,
+              ffi.Pointer<wire_MyStruct>)>>('wire_use_imported_struct');
+  late final _wire_use_imported_struct = _wire_use_imported_structPtr
+      .asFunction<void Function(int, ffi.Pointer<wire_MyStruct>)>();
 
   void wire_use_imported_enum(
     int port_,
@@ -2561,8 +2832,10 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _wire_use_imported_enumPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>('wire_use_imported_enum');
-  late final _wire_use_imported_enum = _wire_use_imported_enumPtr.asFunction<void Function(int, int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>(
+          'wire_use_imported_enum');
+  late final _wire_use_imported_enum =
+      _wire_use_imported_enumPtr.asFunction<void Function(int, int)>();
 
   void wire_get_app_settings(
     int port_,
@@ -2573,8 +2846,10 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _wire_get_app_settingsPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_get_app_settings');
-  late final _wire_get_app_settings = _wire_get_app_settingsPtr.asFunction<void Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
+          'wire_get_app_settings');
+  late final _wire_get_app_settings =
+      _wire_get_app_settingsPtr.asFunction<void Function(int)>();
 
   void wire_is_app_embedded(
     int port_,
@@ -2586,11 +2861,12 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_is_app_embeddedPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_ApplicationSettings>)>>(
-          'wire_is_app_embedded');
-  late final _wire_is_app_embedded =
-      _wire_is_app_embeddedPtr.asFunction<void Function(int, ffi.Pointer<wire_ApplicationSettings>)>();
+  late final _wire_is_app_embeddedPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Int64,
+              ffi.Pointer<wire_ApplicationSettings>)>>('wire_is_app_embedded');
+  late final _wire_is_app_embedded = _wire_is_app_embeddedPtr
+      .asFunction<void Function(int, ffi.Pointer<wire_ApplicationSettings>)>();
 
   void wire_get_message(
     int port_,
@@ -2600,8 +2876,11 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_get_messagePtr = _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_get_message');
-  late final _wire_get_message = _wire_get_messagePtr.asFunction<void Function(int)>();
+  late final _wire_get_messagePtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
+          'wire_get_message');
+  late final _wire_get_message =
+      _wire_get_messagePtr.asFunction<void Function(int)>();
 
   void wire_get_array(
     int port_,
@@ -2611,8 +2890,11 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_get_arrayPtr = _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_get_array');
-  late final _wire_get_array = _wire_get_arrayPtr.asFunction<void Function(int)>();
+  late final _wire_get_arrayPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
+          'wire_get_array');
+  late final _wire_get_array =
+      _wire_get_arrayPtr.asFunction<void Function(int)>();
 
   void wire_get_complex_array(
     int port_,
@@ -2623,8 +2905,10 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _wire_get_complex_arrayPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_get_complex_array');
-  late final _wire_get_complex_array = _wire_get_complex_arrayPtr.asFunction<void Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
+          'wire_get_complex_array');
+  late final _wire_get_complex_array =
+      _wire_get_complex_arrayPtr.asFunction<void Function(int)>();
 
   void wire_get_usize(
     int port_,
@@ -2637,8 +2921,10 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _wire_get_usizePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, uintptr_t)>>('wire_get_usize');
-  late final _wire_get_usize = _wire_get_usizePtr.asFunction<void Function(int, int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, uintptr_t)>>(
+          'wire_get_usize');
+  late final _wire_get_usize =
+      _wire_get_usizePtr.asFunction<void Function(int, int)>();
 
   void wire_next_user_id(
     int port_,
@@ -2650,9 +2936,12 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_next_user_idPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_UserId>)>>('wire_next_user_id');
-  late final _wire_next_user_id = _wire_next_user_idPtr.asFunction<void Function(int, ffi.Pointer<wire_UserId>)>();
+  late final _wire_next_user_idPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+              ffi.Int64, ffi.Pointer<wire_UserId>)>>('wire_next_user_id');
+  late final _wire_next_user_id = _wire_next_user_idPtr
+      .asFunction<void Function(int, ffi.Pointer<wire_UserId>)>();
 
   void wire_register_event_listener(
     int port_,
@@ -2663,8 +2952,10 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _wire_register_event_listenerPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_register_event_listener');
-  late final _wire_register_event_listener = _wire_register_event_listenerPtr.asFunction<void Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
+          'wire_register_event_listener');
+  late final _wire_register_event_listener =
+      _wire_register_event_listenerPtr.asFunction<void Function(int)>();
 
   void wire_close_event_listener(
     int port_,
@@ -2675,8 +2966,10 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _wire_close_event_listenerPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_close_event_listener');
-  late final _wire_close_event_listener = _wire_close_event_listenerPtr.asFunction<void Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
+          'wire_close_event_listener');
+  late final _wire_close_event_listener =
+      _wire_close_event_listenerPtr.asFunction<void Function(int)>();
 
   void wire_create_event(
     int port_,
@@ -2686,8 +2979,11 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_create_eventPtr = _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_create_event');
-  late final _wire_create_event = _wire_create_eventPtr.asFunction<void Function(int)>();
+  late final _wire_create_eventPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
+          'wire_create_event');
+  late final _wire_create_event =
+      _wire_create_eventPtr.asFunction<void Function(int)>();
 
   ffi.Pointer<wire_StringList> new_StringList(
     int len,
@@ -2697,37 +2993,42 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_StringListPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_StringList> Function(ffi.Int32)>>('new_StringList');
-  late final _new_StringList = _new_StringListPtr.asFunction<ffi.Pointer<wire_StringList> Function(int)>();
+  late final _new_StringListPtr = _lookup<
+          ffi.NativeFunction<ffi.Pointer<wire_StringList> Function(ffi.Int32)>>(
+      'new_StringList');
+  late final _new_StringList = _new_StringListPtr
+      .asFunction<ffi.Pointer<wire_StringList> Function(int)>();
 
   ffi.Pointer<wire_ApplicationEnv> new_box_application_env() {
     return _new_box_application_env();
   }
 
   late final _new_box_application_envPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_ApplicationEnv> Function()>>('new_box_application_env');
-  late final _new_box_application_env =
-      _new_box_application_envPtr.asFunction<ffi.Pointer<wire_ApplicationEnv> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_ApplicationEnv> Function()>>(
+          'new_box_application_env');
+  late final _new_box_application_env = _new_box_application_envPtr
+      .asFunction<ffi.Pointer<wire_ApplicationEnv> Function()>();
 
   ffi.Pointer<wire_ApplicationSettings> new_box_autoadd_application_settings() {
     return _new_box_autoadd_application_settings();
   }
 
-  late final _new_box_autoadd_application_settingsPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_ApplicationSettings> Function()>>(
-          'new_box_autoadd_application_settings');
+  late final _new_box_autoadd_application_settingsPtr = _lookup<
+          ffi.NativeFunction<ffi.Pointer<wire_ApplicationSettings> Function()>>(
+      'new_box_autoadd_application_settings');
   late final _new_box_autoadd_application_settings =
-      _new_box_autoadd_application_settingsPtr.asFunction<ffi.Pointer<wire_ApplicationSettings> Function()>();
+      _new_box_autoadd_application_settingsPtr
+          .asFunction<ffi.Pointer<wire_ApplicationSettings> Function()>();
 
   ffi.Pointer<wire_Attribute> new_box_autoadd_attribute() {
     return _new_box_autoadd_attribute();
   }
 
   late final _new_box_autoadd_attributePtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Attribute> Function()>>('new_box_autoadd_attribute');
-  late final _new_box_autoadd_attribute =
-      _new_box_autoadd_attributePtr.asFunction<ffi.Pointer<wire_Attribute> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Attribute> Function()>>(
+          'new_box_autoadd_attribute');
+  late final _new_box_autoadd_attribute = _new_box_autoadd_attributePtr
+      .asFunction<ffi.Pointer<wire_Attribute> Function()>();
 
   ffi.Pointer<ffi.Bool> new_box_autoadd_bool(
     bool value,
@@ -2738,26 +3039,31 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _new_box_autoadd_boolPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Bool> Function(ffi.Bool)>>('new_box_autoadd_bool');
-  late final _new_box_autoadd_bool = _new_box_autoadd_boolPtr.asFunction<ffi.Pointer<ffi.Bool> Function(bool)>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Bool> Function(ffi.Bool)>>(
+          'new_box_autoadd_bool');
+  late final _new_box_autoadd_bool = _new_box_autoadd_boolPtr
+      .asFunction<ffi.Pointer<ffi.Bool> Function(bool)>();
 
   ffi.Pointer<wire_Customized> new_box_autoadd_customized() {
     return _new_box_autoadd_customized();
   }
 
   late final _new_box_autoadd_customizedPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Customized> Function()>>('new_box_autoadd_customized');
-  late final _new_box_autoadd_customized =
-      _new_box_autoadd_customizedPtr.asFunction<ffi.Pointer<wire_Customized> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Customized> Function()>>(
+          'new_box_autoadd_customized');
+  late final _new_box_autoadd_customized = _new_box_autoadd_customizedPtr
+      .asFunction<ffi.Pointer<wire_Customized> Function()>();
 
   ffi.Pointer<wire_ExoticOptionals> new_box_autoadd_exotic_optionals() {
     return _new_box_autoadd_exotic_optionals();
   }
 
   late final _new_box_autoadd_exotic_optionalsPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_ExoticOptionals> Function()>>('new_box_autoadd_exotic_optionals');
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_ExoticOptionals> Function()>>(
+          'new_box_autoadd_exotic_optionals');
   late final _new_box_autoadd_exotic_optionals =
-      _new_box_autoadd_exotic_optionalsPtr.asFunction<ffi.Pointer<wire_ExoticOptionals> Function()>();
+      _new_box_autoadd_exotic_optionalsPtr
+          .asFunction<ffi.Pointer<wire_ExoticOptionals> Function()>();
 
   ffi.Pointer<ffi.Double> new_box_autoadd_f64(
     double value,
@@ -2768,8 +3074,10 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _new_box_autoadd_f64Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Double> Function(ffi.Double)>>('new_box_autoadd_f64');
-  late final _new_box_autoadd_f64 = _new_box_autoadd_f64Ptr.asFunction<ffi.Pointer<ffi.Double> Function(double)>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Double> Function(ffi.Double)>>(
+          'new_box_autoadd_f64');
+  late final _new_box_autoadd_f64 = _new_box_autoadd_f64Ptr
+      .asFunction<ffi.Pointer<ffi.Double> Function(double)>();
 
   ffi.Pointer<ffi.Int32> new_box_autoadd_i32(
     int value,
@@ -2780,8 +3088,10 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _new_box_autoadd_i32Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int32> Function(ffi.Int32)>>('new_box_autoadd_i32');
-  late final _new_box_autoadd_i32 = _new_box_autoadd_i32Ptr.asFunction<ffi.Pointer<ffi.Int32> Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int32> Function(ffi.Int32)>>(
+          'new_box_autoadd_i32');
+  late final _new_box_autoadd_i32 = _new_box_autoadd_i32Ptr
+      .asFunction<ffi.Pointer<ffi.Int32> Function(int)>();
 
   ffi.Pointer<ffi.Int64> new_box_autoadd_i64(
     int value,
@@ -2792,60 +3102,70 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _new_box_autoadd_i64Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int64> Function(ffi.Int64)>>('new_box_autoadd_i64');
-  late final _new_box_autoadd_i64 = _new_box_autoadd_i64Ptr.asFunction<ffi.Pointer<ffi.Int64> Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int64> Function(ffi.Int64)>>(
+          'new_box_autoadd_i64');
+  late final _new_box_autoadd_i64 = _new_box_autoadd_i64Ptr
+      .asFunction<ffi.Pointer<ffi.Int64> Function(int)>();
 
   ffi.Pointer<wire_KitchenSink> new_box_autoadd_kitchen_sink() {
     return _new_box_autoadd_kitchen_sink();
   }
 
   late final _new_box_autoadd_kitchen_sinkPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_KitchenSink> Function()>>('new_box_autoadd_kitchen_sink');
-  late final _new_box_autoadd_kitchen_sink =
-      _new_box_autoadd_kitchen_sinkPtr.asFunction<ffi.Pointer<wire_KitchenSink> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_KitchenSink> Function()>>(
+          'new_box_autoadd_kitchen_sink');
+  late final _new_box_autoadd_kitchen_sink = _new_box_autoadd_kitchen_sinkPtr
+      .asFunction<ffi.Pointer<wire_KitchenSink> Function()>();
 
   ffi.Pointer<wire_MySize> new_box_autoadd_my_size() {
     return _new_box_autoadd_my_size();
   }
 
   late final _new_box_autoadd_my_sizePtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_MySize> Function()>>('new_box_autoadd_my_size');
-  late final _new_box_autoadd_my_size = _new_box_autoadd_my_sizePtr.asFunction<ffi.Pointer<wire_MySize> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_MySize> Function()>>(
+          'new_box_autoadd_my_size');
+  late final _new_box_autoadd_my_size = _new_box_autoadd_my_sizePtr
+      .asFunction<ffi.Pointer<wire_MySize> Function()>();
 
   ffi.Pointer<wire_MyStruct> new_box_autoadd_my_struct() {
     return _new_box_autoadd_my_struct();
   }
 
   late final _new_box_autoadd_my_structPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_MyStruct> Function()>>('new_box_autoadd_my_struct');
-  late final _new_box_autoadd_my_struct =
-      _new_box_autoadd_my_structPtr.asFunction<ffi.Pointer<wire_MyStruct> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_MyStruct> Function()>>(
+          'new_box_autoadd_my_struct');
+  late final _new_box_autoadd_my_struct = _new_box_autoadd_my_structPtr
+      .asFunction<ffi.Pointer<wire_MyStruct> Function()>();
 
   ffi.Pointer<wire_MyTreeNode> new_box_autoadd_my_tree_node() {
     return _new_box_autoadd_my_tree_node();
   }
 
   late final _new_box_autoadd_my_tree_nodePtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_MyTreeNode> Function()>>('new_box_autoadd_my_tree_node');
-  late final _new_box_autoadd_my_tree_node =
-      _new_box_autoadd_my_tree_nodePtr.asFunction<ffi.Pointer<wire_MyTreeNode> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_MyTreeNode> Function()>>(
+          'new_box_autoadd_my_tree_node');
+  late final _new_box_autoadd_my_tree_node = _new_box_autoadd_my_tree_nodePtr
+      .asFunction<ffi.Pointer<wire_MyTreeNode> Function()>();
 
   ffi.Pointer<wire_NewTypeInt> new_box_autoadd_new_type_int() {
     return _new_box_autoadd_new_type_int();
   }
 
   late final _new_box_autoadd_new_type_intPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_NewTypeInt> Function()>>('new_box_autoadd_new_type_int');
-  late final _new_box_autoadd_new_type_int =
-      _new_box_autoadd_new_type_intPtr.asFunction<ffi.Pointer<wire_NewTypeInt> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_NewTypeInt> Function()>>(
+          'new_box_autoadd_new_type_int');
+  late final _new_box_autoadd_new_type_int = _new_box_autoadd_new_type_intPtr
+      .asFunction<ffi.Pointer<wire_NewTypeInt> Function()>();
 
   ffi.Pointer<wire_UserId> new_box_autoadd_user_id() {
     return _new_box_autoadd_user_id();
   }
 
   late final _new_box_autoadd_user_idPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_UserId> Function()>>('new_box_autoadd_user_id');
-  late final _new_box_autoadd_user_id = _new_box_autoadd_user_idPtr.asFunction<ffi.Pointer<wire_UserId> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_UserId> Function()>>(
+          'new_box_autoadd_user_id');
+  late final _new_box_autoadd_user_id = _new_box_autoadd_user_idPtr
+      .asFunction<ffi.Pointer<wire_UserId> Function()>();
 
   ffi.Pointer<ffi.Bool> new_box_bool(
     bool value,
@@ -2855,17 +3175,21 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_box_boolPtr = _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Bool> Function(ffi.Bool)>>('new_box_bool');
-  late final _new_box_bool = _new_box_boolPtr.asFunction<ffi.Pointer<ffi.Bool> Function(bool)>();
+  late final _new_box_boolPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Bool> Function(ffi.Bool)>>(
+          'new_box_bool');
+  late final _new_box_bool =
+      _new_box_boolPtr.asFunction<ffi.Pointer<ffi.Bool> Function(bool)>();
 
   ffi.Pointer<wire_ExoticOptionals> new_box_exotic_optionals() {
     return _new_box_exotic_optionals();
   }
 
   late final _new_box_exotic_optionalsPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_ExoticOptionals> Function()>>('new_box_exotic_optionals');
-  late final _new_box_exotic_optionals =
-      _new_box_exotic_optionalsPtr.asFunction<ffi.Pointer<wire_ExoticOptionals> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_ExoticOptionals> Function()>>(
+          'new_box_exotic_optionals');
+  late final _new_box_exotic_optionals = _new_box_exotic_optionalsPtr
+      .asFunction<ffi.Pointer<wire_ExoticOptionals> Function()>();
 
   ffi.Pointer<ffi.Double> new_box_f64(
     double value,
@@ -2875,8 +3199,11 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_box_f64Ptr = _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Double> Function(ffi.Double)>>('new_box_f64');
-  late final _new_box_f64 = _new_box_f64Ptr.asFunction<ffi.Pointer<ffi.Double> Function(double)>();
+  late final _new_box_f64Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Double> Function(ffi.Double)>>(
+          'new_box_f64');
+  late final _new_box_f64 =
+      _new_box_f64Ptr.asFunction<ffi.Pointer<ffi.Double> Function(double)>();
 
   ffi.Pointer<ffi.Int32> new_box_i32(
     int value,
@@ -2886,8 +3213,11 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_box_i32Ptr = _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int32> Function(ffi.Int32)>>('new_box_i32');
-  late final _new_box_i32 = _new_box_i32Ptr.asFunction<ffi.Pointer<ffi.Int32> Function(int)>();
+  late final _new_box_i32Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int32> Function(ffi.Int32)>>(
+          'new_box_i32');
+  late final _new_box_i32 =
+      _new_box_i32Ptr.asFunction<ffi.Pointer<ffi.Int32> Function(int)>();
 
   ffi.Pointer<ffi.Int64> new_box_i64(
     int value,
@@ -2897,8 +3227,11 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_box_i64Ptr = _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int64> Function(ffi.Int64)>>('new_box_i64');
-  late final _new_box_i64 = _new_box_i64Ptr.asFunction<ffi.Pointer<ffi.Int64> Function(int)>();
+  late final _new_box_i64Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int64> Function(ffi.Int64)>>(
+          'new_box_i64');
+  late final _new_box_i64 =
+      _new_box_i64Ptr.asFunction<ffi.Pointer<ffi.Int64> Function(int)>();
 
   ffi.Pointer<ffi.Int8> new_box_i8(
     int value,
@@ -2908,23 +3241,31 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_box_i8Ptr = _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int8> Function(ffi.Int8)>>('new_box_i8');
-  late final _new_box_i8 = _new_box_i8Ptr.asFunction<ffi.Pointer<ffi.Int8> Function(int)>();
+  late final _new_box_i8Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int8> Function(ffi.Int8)>>(
+          'new_box_i8');
+  late final _new_box_i8 =
+      _new_box_i8Ptr.asFunction<ffi.Pointer<ffi.Int8> Function(int)>();
 
   ffi.Pointer<wire_KitchenSink> new_box_kitchen_sink() {
     return _new_box_kitchen_sink();
   }
 
   late final _new_box_kitchen_sinkPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_KitchenSink> Function()>>('new_box_kitchen_sink');
-  late final _new_box_kitchen_sink = _new_box_kitchen_sinkPtr.asFunction<ffi.Pointer<wire_KitchenSink> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_KitchenSink> Function()>>(
+          'new_box_kitchen_sink');
+  late final _new_box_kitchen_sink = _new_box_kitchen_sinkPtr
+      .asFunction<ffi.Pointer<wire_KitchenSink> Function()>();
 
   ffi.Pointer<wire_MySize> new_box_my_size() {
     return _new_box_my_size();
   }
 
-  late final _new_box_my_sizePtr = _lookup<ffi.NativeFunction<ffi.Pointer<wire_MySize> Function()>>('new_box_my_size');
-  late final _new_box_my_size = _new_box_my_sizePtr.asFunction<ffi.Pointer<wire_MySize> Function()>();
+  late final _new_box_my_sizePtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_MySize> Function()>>(
+          'new_box_my_size');
+  late final _new_box_my_size =
+      _new_box_my_sizePtr.asFunction<ffi.Pointer<wire_MySize> Function()>();
 
   ffi.Pointer<ffi.Uint8> new_box_u8(
     int value,
@@ -2934,8 +3275,11 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_box_u8Ptr = _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Uint8> Function(ffi.Uint8)>>('new_box_u8');
-  late final _new_box_u8 = _new_box_u8Ptr.asFunction<ffi.Pointer<ffi.Uint8> Function(int)>();
+  late final _new_box_u8Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Uint8> Function(ffi.Uint8)>>(
+          'new_box_u8');
+  late final _new_box_u8 =
+      _new_box_u8Ptr.asFunction<ffi.Pointer<ffi.Uint8> Function(int)>();
 
   ffi.Pointer<wire_float_32_list> new_float_32_list(
     int len,
@@ -2945,9 +3289,12 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_float_32_listPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_float_32_list> Function(ffi.Int32)>>('new_float_32_list');
-  late final _new_float_32_list = _new_float_32_listPtr.asFunction<ffi.Pointer<wire_float_32_list> Function(int)>();
+  late final _new_float_32_listPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<wire_float_32_list> Function(
+              ffi.Int32)>>('new_float_32_list');
+  late final _new_float_32_list = _new_float_32_listPtr
+      .asFunction<ffi.Pointer<wire_float_32_list> Function(int)>();
 
   ffi.Pointer<wire_float_64_list> new_float_64_list(
     int len,
@@ -2957,9 +3304,12 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_float_64_listPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_float_64_list> Function(ffi.Int32)>>('new_float_64_list');
-  late final _new_float_64_list = _new_float_64_listPtr.asFunction<ffi.Pointer<wire_float_64_list> Function(int)>();
+  late final _new_float_64_listPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<wire_float_64_list> Function(
+              ffi.Int32)>>('new_float_64_list');
+  late final _new_float_64_list = _new_float_64_listPtr
+      .asFunction<ffi.Pointer<wire_float_64_list> Function(int)>();
 
   ffi.Pointer<wire_int_32_list> new_int_32_list(
     int len,
@@ -2969,9 +3319,12 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_int_32_listPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_int_32_list> Function(ffi.Int32)>>('new_int_32_list');
-  late final _new_int_32_list = _new_int_32_listPtr.asFunction<ffi.Pointer<wire_int_32_list> Function(int)>();
+  late final _new_int_32_listPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<wire_int_32_list> Function(
+              ffi.Int32)>>('new_int_32_list');
+  late final _new_int_32_list = _new_int_32_listPtr
+      .asFunction<ffi.Pointer<wire_int_32_list> Function(int)>();
 
   ffi.Pointer<wire_int_64_list> new_int_64_list(
     int len,
@@ -2981,9 +3334,12 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_int_64_listPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_int_64_list> Function(ffi.Int32)>>('new_int_64_list');
-  late final _new_int_64_list = _new_int_64_listPtr.asFunction<ffi.Pointer<wire_int_64_list> Function(int)>();
+  late final _new_int_64_listPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<wire_int_64_list> Function(
+              ffi.Int32)>>('new_int_64_list');
+  late final _new_int_64_list = _new_int_64_listPtr
+      .asFunction<ffi.Pointer<wire_int_64_list> Function(int)>();
 
   ffi.Pointer<wire_int_8_list> new_int_8_list(
     int len,
@@ -2993,9 +3349,11 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_int_8_listPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_int_8_list> Function(ffi.Int32)>>('new_int_8_list');
-  late final _new_int_8_list = _new_int_8_listPtr.asFunction<ffi.Pointer<wire_int_8_list> Function(int)>();
+  late final _new_int_8_listPtr = _lookup<
+          ffi.NativeFunction<ffi.Pointer<wire_int_8_list> Function(ffi.Int32)>>(
+      'new_int_8_list');
+  late final _new_int_8_list = _new_int_8_listPtr
+      .asFunction<ffi.Pointer<wire_int_8_list> Function(int)>();
 
   ffi.Pointer<wire_list_application_env_var> new_list_application_env_var(
     int len,
@@ -3005,11 +3363,12 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_list_application_env_varPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_list_application_env_var> Function(ffi.Int32)>>(
-          'new_list_application_env_var');
-  late final _new_list_application_env_var =
-      _new_list_application_env_varPtr.asFunction<ffi.Pointer<wire_list_application_env_var> Function(int)>();
+  late final _new_list_application_env_varPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<wire_list_application_env_var> Function(
+              ffi.Int32)>>('new_list_application_env_var');
+  late final _new_list_application_env_var = _new_list_application_env_varPtr
+      .asFunction<ffi.Pointer<wire_list_application_env_var> Function(int)>();
 
   ffi.Pointer<wire_list_attribute> new_list_attribute(
     int len,
@@ -3019,9 +3378,12 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_list_attributePtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_list_attribute> Function(ffi.Int32)>>('new_list_attribute');
-  late final _new_list_attribute = _new_list_attributePtr.asFunction<ffi.Pointer<wire_list_attribute> Function(int)>();
+  late final _new_list_attributePtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<wire_list_attribute> Function(
+              ffi.Int32)>>('new_list_attribute');
+  late final _new_list_attribute = _new_list_attributePtr
+      .asFunction<ffi.Pointer<wire_list_attribute> Function(int)>();
 
   ffi.Pointer<wire_list_my_size> new_list_my_size(
     int len,
@@ -3031,9 +3393,12 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_list_my_sizePtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_list_my_size> Function(ffi.Int32)>>('new_list_my_size');
-  late final _new_list_my_size = _new_list_my_sizePtr.asFunction<ffi.Pointer<wire_list_my_size> Function(int)>();
+  late final _new_list_my_sizePtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<wire_list_my_size> Function(
+              ffi.Int32)>>('new_list_my_size');
+  late final _new_list_my_size = _new_list_my_sizePtr
+      .asFunction<ffi.Pointer<wire_list_my_size> Function(int)>();
 
   ffi.Pointer<wire_list_my_tree_node> new_list_my_tree_node(
     int len,
@@ -3043,12 +3408,15 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_list_my_tree_nodePtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_list_my_tree_node> Function(ffi.Int32)>>('new_list_my_tree_node');
-  late final _new_list_my_tree_node =
-      _new_list_my_tree_nodePtr.asFunction<ffi.Pointer<wire_list_my_tree_node> Function(int)>();
+  late final _new_list_my_tree_nodePtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<wire_list_my_tree_node> Function(
+              ffi.Int32)>>('new_list_my_tree_node');
+  late final _new_list_my_tree_node = _new_list_my_tree_nodePtr
+      .asFunction<ffi.Pointer<wire_list_my_tree_node> Function(int)>();
 
-  ffi.Pointer<wire_list_opt_box_autoadd_attribute> new_list_opt_box_autoadd_attribute(
+  ffi.Pointer<wire_list_opt_box_autoadd_attribute>
+      new_list_opt_box_autoadd_attribute(
     int len,
   ) {
     return _new_list_opt_box_autoadd_attribute(
@@ -3056,11 +3424,13 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_list_opt_box_autoadd_attributePtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_list_opt_box_autoadd_attribute> Function(ffi.Int32)>>(
-          'new_list_opt_box_autoadd_attribute');
-  late final _new_list_opt_box_autoadd_attribute = _new_list_opt_box_autoadd_attributePtr
-      .asFunction<ffi.Pointer<wire_list_opt_box_autoadd_attribute> Function(int)>();
+  late final _new_list_opt_box_autoadd_attributePtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<wire_list_opt_box_autoadd_attribute> Function(
+              ffi.Int32)>>('new_list_opt_box_autoadd_attribute');
+  late final _new_list_opt_box_autoadd_attribute =
+      _new_list_opt_box_autoadd_attributePtr.asFunction<
+          ffi.Pointer<wire_list_opt_box_autoadd_attribute> Function(int)>();
 
   ffi.Pointer<wire_uint_8_list> new_uint_8_list(
     int len,
@@ -3070,54 +3440,63 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_uint_8_listPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_uint_8_list> Function(ffi.Int32)>>('new_uint_8_list');
-  late final _new_uint_8_list = _new_uint_8_listPtr.asFunction<ffi.Pointer<wire_uint_8_list> Function(int)>();
+  late final _new_uint_8_listPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<wire_uint_8_list> Function(
+              ffi.Int32)>>('new_uint_8_list');
+  late final _new_uint_8_list = _new_uint_8_listPtr
+      .asFunction<ffi.Pointer<wire_uint_8_list> Function(int)>();
 
   ffi.Pointer<KitchenSinkKind> inflate_KitchenSink_Primitives() {
     return _inflate_KitchenSink_Primitives();
   }
 
   late final _inflate_KitchenSink_PrimitivesPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>('inflate_KitchenSink_Primitives');
+      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>(
+          'inflate_KitchenSink_Primitives');
   late final _inflate_KitchenSink_Primitives =
-      _inflate_KitchenSink_PrimitivesPtr.asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
+      _inflate_KitchenSink_PrimitivesPtr
+          .asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
 
   ffi.Pointer<KitchenSinkKind> inflate_KitchenSink_Nested() {
     return _inflate_KitchenSink_Nested();
   }
 
   late final _inflate_KitchenSink_NestedPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>('inflate_KitchenSink_Nested');
-  late final _inflate_KitchenSink_Nested =
-      _inflate_KitchenSink_NestedPtr.asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>(
+          'inflate_KitchenSink_Nested');
+  late final _inflate_KitchenSink_Nested = _inflate_KitchenSink_NestedPtr
+      .asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
 
   ffi.Pointer<KitchenSinkKind> inflate_KitchenSink_Optional() {
     return _inflate_KitchenSink_Optional();
   }
 
   late final _inflate_KitchenSink_OptionalPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>('inflate_KitchenSink_Optional');
-  late final _inflate_KitchenSink_Optional =
-      _inflate_KitchenSink_OptionalPtr.asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>(
+          'inflate_KitchenSink_Optional');
+  late final _inflate_KitchenSink_Optional = _inflate_KitchenSink_OptionalPtr
+      .asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
 
   ffi.Pointer<KitchenSinkKind> inflate_KitchenSink_Buffer() {
     return _inflate_KitchenSink_Buffer();
   }
 
   late final _inflate_KitchenSink_BufferPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>('inflate_KitchenSink_Buffer');
-  late final _inflate_KitchenSink_Buffer =
-      _inflate_KitchenSink_BufferPtr.asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>(
+          'inflate_KitchenSink_Buffer');
+  late final _inflate_KitchenSink_Buffer = _inflate_KitchenSink_BufferPtr
+      .asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
 
   ffi.Pointer<KitchenSinkKind> inflate_KitchenSink_Enums() {
     return _inflate_KitchenSink_Enums();
   }
 
   late final _inflate_KitchenSink_EnumsPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>('inflate_KitchenSink_Enums');
-  late final _inflate_KitchenSink_Enums =
-      _inflate_KitchenSink_EnumsPtr.asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>(
+          'inflate_KitchenSink_Enums');
+  late final _inflate_KitchenSink_Enums = _inflate_KitchenSink_EnumsPtr
+      .asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
 
   void free_WireSyncReturnStruct(
     WireSyncReturnStruct val,
@@ -3128,9 +3507,10 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _free_WireSyncReturnStructPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(WireSyncReturnStruct)>>('free_WireSyncReturnStruct');
-  late final _free_WireSyncReturnStruct =
-      _free_WireSyncReturnStructPtr.asFunction<void Function(WireSyncReturnStruct)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(WireSyncReturnStruct)>>(
+          'free_WireSyncReturnStruct');
+  late final _free_WireSyncReturnStruct = _free_WireSyncReturnStructPtr
+      .asFunction<void Function(WireSyncReturnStruct)>();
 
   void store_dart_post_cobject(
     DartPostCObjectFnType ptr,
@@ -3141,8 +3521,10 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _store_dart_post_cobjectPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(DartPostCObjectFnType)>>('store_dart_post_cobject');
-  late final _store_dart_post_cobject = _store_dart_post_cobjectPtr.asFunction<void Function(DartPostCObjectFnType)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(DartPostCObjectFnType)>>(
+          'store_dart_post_cobject');
+  late final _store_dart_post_cobject = _store_dart_post_cobjectPtr
+      .asFunction<void Function(DartPostCObjectFnType)>();
 }
 
 class wire_uint_8_list extends ffi.Struct {
@@ -3387,5 +3769,6 @@ class wire_UserId extends ffi.Struct {
 }
 
 typedef uintptr_t = ffi.UnsignedLongLong;
-typedef DartPostCObjectFnType = ffi.Pointer<ffi.NativeFunction<ffi.Bool Function(DartPort, ffi.Pointer<ffi.Void>)>>;
+typedef DartPostCObjectFnType = ffi.Pointer<
+    ffi.NativeFunction<ffi.Bool Function(DartPort, ffi.Pointer<ffi.Void>)>>;
 typedef DartPort = ffi.Int64;

--- a/frb_example/pure_dart/dart/lib/bridge_generated.freezed.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.freezed.dart
@@ -64,12 +64,14 @@ mixin _$ApplicationMessage {
 
 /// @nodoc
 abstract class $ApplicationMessageCopyWith<$Res> {
-  factory $ApplicationMessageCopyWith(ApplicationMessage value, $Res Function(ApplicationMessage) then) =
+  factory $ApplicationMessageCopyWith(
+          ApplicationMessage value, $Res Function(ApplicationMessage) then) =
       _$ApplicationMessageCopyWithImpl<$Res>;
 }
 
 /// @nodoc
-class _$ApplicationMessageCopyWithImpl<$Res> implements $ApplicationMessageCopyWith<$Res> {
+class _$ApplicationMessageCopyWithImpl<$Res>
+    implements $ApplicationMessageCopyWith<$Res> {
   _$ApplicationMessageCopyWithImpl(this._value, this._then);
 
   final ApplicationMessage _value;
@@ -79,15 +81,18 @@ class _$ApplicationMessageCopyWithImpl<$Res> implements $ApplicationMessageCopyW
 
 /// @nodoc
 abstract class _$$DisplayMessageCopyWith<$Res> {
-  factory _$$DisplayMessageCopyWith(_$DisplayMessage value, $Res Function(_$DisplayMessage) then) =
+  factory _$$DisplayMessageCopyWith(
+          _$DisplayMessage value, $Res Function(_$DisplayMessage) then) =
       __$$DisplayMessageCopyWithImpl<$Res>;
   $Res call({String field0});
 }
 
 /// @nodoc
-class __$$DisplayMessageCopyWithImpl<$Res> extends _$ApplicationMessageCopyWithImpl<$Res>
+class __$$DisplayMessageCopyWithImpl<$Res>
+    extends _$ApplicationMessageCopyWithImpl<$Res>
     implements _$$DisplayMessageCopyWith<$Res> {
-  __$$DisplayMessageCopyWithImpl(_$DisplayMessage _value, $Res Function(_$DisplayMessage) _then)
+  __$$DisplayMessageCopyWithImpl(
+      _$DisplayMessage _value, $Res Function(_$DisplayMessage) _then)
       : super(_value, (v) => _then(v as _$DisplayMessage));
 
   @override
@@ -128,7 +133,8 @@ class _$DisplayMessage implements DisplayMessage {
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
 
   @JsonKey(ignore: true)
   @override
@@ -209,20 +215,24 @@ abstract class DisplayMessage implements ApplicationMessage {
 
   String get field0 => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
-  _$$DisplayMessageCopyWith<_$DisplayMessage> get copyWith => throw _privateConstructorUsedError;
+  _$$DisplayMessageCopyWith<_$DisplayMessage> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$RenderPixelCopyWith<$Res> {
-  factory _$$RenderPixelCopyWith(_$RenderPixel value, $Res Function(_$RenderPixel) then) =
+  factory _$$RenderPixelCopyWith(
+          _$RenderPixel value, $Res Function(_$RenderPixel) then) =
       __$$RenderPixelCopyWithImpl<$Res>;
   $Res call({int x, int y});
 }
 
 /// @nodoc
-class __$$RenderPixelCopyWithImpl<$Res> extends _$ApplicationMessageCopyWithImpl<$Res>
+class __$$RenderPixelCopyWithImpl<$Res>
+    extends _$ApplicationMessageCopyWithImpl<$Res>
     implements _$$RenderPixelCopyWith<$Res> {
-  __$$RenderPixelCopyWithImpl(_$RenderPixel _value, $Res Function(_$RenderPixel) _then)
+  __$$RenderPixelCopyWithImpl(
+      _$RenderPixel _value, $Res Function(_$RenderPixel) _then)
       : super(_value, (v) => _then(v as _$RenderPixel));
 
   @override
@@ -271,12 +281,15 @@ class _$RenderPixel implements RenderPixel {
   }
 
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, const DeepCollectionEquality().hash(x), const DeepCollectionEquality().hash(y));
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(x),
+      const DeepCollectionEquality().hash(y));
 
   @JsonKey(ignore: true)
   @override
-  _$$RenderPixelCopyWith<_$RenderPixel> get copyWith => __$$RenderPixelCopyWithImpl<_$RenderPixel>(this, _$identity);
+  _$$RenderPixelCopyWith<_$RenderPixel> get copyWith =>
+      __$$RenderPixelCopyWithImpl<_$RenderPixel>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -348,22 +361,27 @@ class _$RenderPixel implements RenderPixel {
 }
 
 abstract class RenderPixel implements ApplicationMessage {
-  const factory RenderPixel({required final int x, required final int y}) = _$RenderPixel;
+  const factory RenderPixel({required final int x, required final int y}) =
+      _$RenderPixel;
 
   int get x => throw _privateConstructorUsedError;
   int get y => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
-  _$$RenderPixelCopyWith<_$RenderPixel> get copyWith => throw _privateConstructorUsedError;
+  _$$RenderPixelCopyWith<_$RenderPixel> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$ExitCopyWith<$Res> {
-  factory _$$ExitCopyWith(_$Exit value, $Res Function(_$Exit) then) = __$$ExitCopyWithImpl<$Res>;
+  factory _$$ExitCopyWith(_$Exit value, $Res Function(_$Exit) then) =
+      __$$ExitCopyWithImpl<$Res>;
 }
 
 /// @nodoc
-class __$$ExitCopyWithImpl<$Res> extends _$ApplicationMessageCopyWithImpl<$Res> implements _$$ExitCopyWith<$Res> {
-  __$$ExitCopyWithImpl(_$Exit _value, $Res Function(_$Exit) _then) : super(_value, (v) => _then(v as _$Exit));
+class __$$ExitCopyWithImpl<$Res> extends _$ApplicationMessageCopyWithImpl<$Res>
+    implements _$$ExitCopyWith<$Res> {
+  __$$ExitCopyWithImpl(_$Exit _value, $Res Function(_$Exit) _then)
+      : super(_value, (v) => _then(v as _$Exit));
 
   @override
   _$Exit get _value => super._value as _$Exit;
@@ -381,7 +399,8 @@ class _$Exit implements Exit {
 
   @override
   bool operator ==(dynamic other) {
-    return identical(this, other) || (other.runtimeType == runtimeType && other is _$Exit);
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$Exit);
   }
 
   @override
@@ -465,7 +484,8 @@ mixin _$KitchenSink {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function() empty,
-    required TResult Function(int int32, double float64, bool boolean) primitives,
+    required TResult Function(int int32, double float64, bool boolean)
+        primitives,
     required TResult Function(KitchenSink field0, int field1) nested,
     required TResult Function(int? field0, int? field1) optional,
     required TResult Function(Uint8List field0) buffer,
@@ -528,7 +548,9 @@ mixin _$KitchenSink {
 
 /// @nodoc
 abstract class $KitchenSinkCopyWith<$Res> {
-  factory $KitchenSinkCopyWith(KitchenSink value, $Res Function(KitchenSink) then) = _$KitchenSinkCopyWithImpl<$Res>;
+  factory $KitchenSinkCopyWith(
+          KitchenSink value, $Res Function(KitchenSink) then) =
+      _$KitchenSinkCopyWithImpl<$Res>;
 }
 
 /// @nodoc
@@ -542,12 +564,15 @@ class _$KitchenSinkCopyWithImpl<$Res> implements $KitchenSinkCopyWith<$Res> {
 
 /// @nodoc
 abstract class _$$EmptyCopyWith<$Res> {
-  factory _$$EmptyCopyWith(_$Empty value, $Res Function(_$Empty) then) = __$$EmptyCopyWithImpl<$Res>;
+  factory _$$EmptyCopyWith(_$Empty value, $Res Function(_$Empty) then) =
+      __$$EmptyCopyWithImpl<$Res>;
 }
 
 /// @nodoc
-class __$$EmptyCopyWithImpl<$Res> extends _$KitchenSinkCopyWithImpl<$Res> implements _$$EmptyCopyWith<$Res> {
-  __$$EmptyCopyWithImpl(_$Empty _value, $Res Function(_$Empty) _then) : super(_value, (v) => _then(v as _$Empty));
+class __$$EmptyCopyWithImpl<$Res> extends _$KitchenSinkCopyWithImpl<$Res>
+    implements _$$EmptyCopyWith<$Res> {
+  __$$EmptyCopyWithImpl(_$Empty _value, $Res Function(_$Empty) _then)
+      : super(_value, (v) => _then(v as _$Empty));
 
   @override
   _$Empty get _value => super._value as _$Empty;
@@ -565,7 +590,8 @@ class _$Empty implements Empty {
 
   @override
   bool operator ==(dynamic other) {
-    return identical(this, other) || (other.runtimeType == runtimeType && other is _$Empty);
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$Empty);
   }
 
   @override
@@ -575,7 +601,8 @@ class _$Empty implements Empty {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function() empty,
-    required TResult Function(int int32, double float64, bool boolean) primitives,
+    required TResult Function(int int32, double float64, bool boolean)
+        primitives,
     required TResult Function(KitchenSink field0, int field1) nested,
     required TResult Function(int? field0, int? field1) optional,
     required TResult Function(Uint8List field0) buffer,
@@ -664,14 +691,17 @@ abstract class Empty implements KitchenSink {
 
 /// @nodoc
 abstract class _$$PrimitivesCopyWith<$Res> {
-  factory _$$PrimitivesCopyWith(_$Primitives value, $Res Function(_$Primitives) then) =
+  factory _$$PrimitivesCopyWith(
+          _$Primitives value, $Res Function(_$Primitives) then) =
       __$$PrimitivesCopyWithImpl<$Res>;
   $Res call({int int32, double float64, bool boolean});
 }
 
 /// @nodoc
-class __$$PrimitivesCopyWithImpl<$Res> extends _$KitchenSinkCopyWithImpl<$Res> implements _$$PrimitivesCopyWith<$Res> {
-  __$$PrimitivesCopyWithImpl(_$Primitives _value, $Res Function(_$Primitives) _then)
+class __$$PrimitivesCopyWithImpl<$Res> extends _$KitchenSinkCopyWithImpl<$Res>
+    implements _$$PrimitivesCopyWith<$Res> {
+  __$$PrimitivesCopyWithImpl(
+      _$Primitives _value, $Res Function(_$Primitives) _then)
       : super(_value, (v) => _then(v as _$Primitives));
 
   @override
@@ -703,7 +733,8 @@ class __$$PrimitivesCopyWithImpl<$Res> extends _$KitchenSinkCopyWithImpl<$Res> i
 /// @nodoc
 
 class _$Primitives implements Primitives {
-  const _$Primitives({required this.int32, required this.float64, required this.boolean});
+  const _$Primitives(
+      {required this.int32, required this.float64, required this.boolean});
 
   /// Dart field comment
   @override
@@ -729,18 +760,23 @@ class _$Primitives implements Primitives {
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, const DeepCollectionEquality().hash(int32),
-      const DeepCollectionEquality().hash(float64), const DeepCollectionEquality().hash(boolean));
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(int32),
+      const DeepCollectionEquality().hash(float64),
+      const DeepCollectionEquality().hash(boolean));
 
   @JsonKey(ignore: true)
   @override
-  _$$PrimitivesCopyWith<_$Primitives> get copyWith => __$$PrimitivesCopyWithImpl<_$Primitives>(this, _$identity);
+  _$$PrimitivesCopyWith<_$Primitives> get copyWith =>
+      __$$PrimitivesCopyWithImpl<_$Primitives>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function() empty,
-    required TResult Function(int int32, double float64, bool boolean) primitives,
+    required TResult Function(int int32, double float64, bool boolean)
+        primitives,
     required TResult Function(KitchenSink field0, int field1) nested,
     required TResult Function(int? field0, int? field1) optional,
     required TResult Function(Uint8List field0) buffer,
@@ -824,28 +860,34 @@ class _$Primitives implements Primitives {
 }
 
 abstract class Primitives implements KitchenSink {
-  const factory Primitives({required final int int32, required final double float64, required final bool boolean}) =
-      _$Primitives;
+  const factory Primitives(
+      {required final int int32,
+      required final double float64,
+      required final bool boolean}) = _$Primitives;
 
   /// Dart field comment
   int get int32 => throw _privateConstructorUsedError;
   double get float64 => throw _privateConstructorUsedError;
   bool get boolean => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
-  _$$PrimitivesCopyWith<_$Primitives> get copyWith => throw _privateConstructorUsedError;
+  _$$PrimitivesCopyWith<_$Primitives> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$NestedCopyWith<$Res> {
-  factory _$$NestedCopyWith(_$Nested value, $Res Function(_$Nested) then) = __$$NestedCopyWithImpl<$Res>;
+  factory _$$NestedCopyWith(_$Nested value, $Res Function(_$Nested) then) =
+      __$$NestedCopyWithImpl<$Res>;
   $Res call({KitchenSink field0, int field1});
 
   $KitchenSinkCopyWith<$Res> get field0;
 }
 
 /// @nodoc
-class __$$NestedCopyWithImpl<$Res> extends _$KitchenSinkCopyWithImpl<$Res> implements _$$NestedCopyWith<$Res> {
-  __$$NestedCopyWithImpl(_$Nested _value, $Res Function(_$Nested) _then) : super(_value, (v) => _then(v as _$Nested));
+class __$$NestedCopyWithImpl<$Res> extends _$KitchenSinkCopyWithImpl<$Res>
+    implements _$$NestedCopyWith<$Res> {
+  __$$NestedCopyWithImpl(_$Nested _value, $Res Function(_$Nested) _then)
+      : super(_value, (v) => _then(v as _$Nested));
 
   @override
   _$Nested get _value => super._value as _$Nested;
@@ -901,17 +943,21 @@ class _$Nested implements Nested {
 
   @override
   int get hashCode => Object.hash(
-      runtimeType, const DeepCollectionEquality().hash(field0), const DeepCollectionEquality().hash(field1));
+      runtimeType,
+      const DeepCollectionEquality().hash(field0),
+      const DeepCollectionEquality().hash(field1));
 
   @JsonKey(ignore: true)
   @override
-  _$$NestedCopyWith<_$Nested> get copyWith => __$$NestedCopyWithImpl<_$Nested>(this, _$identity);
+  _$$NestedCopyWith<_$Nested> get copyWith =>
+      __$$NestedCopyWithImpl<_$Nested>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function() empty,
-    required TResult Function(int int32, double float64, bool boolean) primitives,
+    required TResult Function(int int32, double float64, bool boolean)
+        primitives,
     required TResult Function(KitchenSink field0, int field1) nested,
     required TResult Function(int? field0, int? field1) optional,
     required TResult Function(Uint8List field0) buffer,
@@ -1000,17 +1046,21 @@ abstract class Nested implements KitchenSink {
   KitchenSink get field0 => throw _privateConstructorUsedError;
   int get field1 => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
-  _$$NestedCopyWith<_$Nested> get copyWith => throw _privateConstructorUsedError;
+  _$$NestedCopyWith<_$Nested> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$OptionalCopyWith<$Res> {
-  factory _$$OptionalCopyWith(_$Optional value, $Res Function(_$Optional) then) = __$$OptionalCopyWithImpl<$Res>;
+  factory _$$OptionalCopyWith(
+          _$Optional value, $Res Function(_$Optional) then) =
+      __$$OptionalCopyWithImpl<$Res>;
   $Res call({int? field0, int? field1});
 }
 
 /// @nodoc
-class __$$OptionalCopyWithImpl<$Res> extends _$KitchenSinkCopyWithImpl<$Res> implements _$$OptionalCopyWith<$Res> {
+class __$$OptionalCopyWithImpl<$Res> extends _$KitchenSinkCopyWithImpl<$Res>
+    implements _$$OptionalCopyWith<$Res> {
   __$$OptionalCopyWithImpl(_$Optional _value, $Res Function(_$Optional) _then)
       : super(_value, (v) => _then(v as _$Optional));
 
@@ -1062,17 +1112,21 @@ class _$Optional implements Optional {
 
   @override
   int get hashCode => Object.hash(
-      runtimeType, const DeepCollectionEquality().hash(field0), const DeepCollectionEquality().hash(field1));
+      runtimeType,
+      const DeepCollectionEquality().hash(field0),
+      const DeepCollectionEquality().hash(field1));
 
   @JsonKey(ignore: true)
   @override
-  _$$OptionalCopyWith<_$Optional> get copyWith => __$$OptionalCopyWithImpl<_$Optional>(this, _$identity);
+  _$$OptionalCopyWith<_$Optional> get copyWith =>
+      __$$OptionalCopyWithImpl<_$Optional>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function() empty,
-    required TResult Function(int int32, double float64, bool boolean) primitives,
+    required TResult Function(int int32, double float64, bool boolean)
+        primitives,
     required TResult Function(KitchenSink field0, int field1) nested,
     required TResult Function(int? field0, int? field1) optional,
     required TResult Function(Uint8List field0) buffer,
@@ -1162,18 +1216,22 @@ abstract class Optional implements KitchenSink {
   int? get field0 => throw _privateConstructorUsedError;
   int? get field1 => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
-  _$$OptionalCopyWith<_$Optional> get copyWith => throw _privateConstructorUsedError;
+  _$$OptionalCopyWith<_$Optional> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$BufferCopyWith<$Res> {
-  factory _$$BufferCopyWith(_$Buffer value, $Res Function(_$Buffer) then) = __$$BufferCopyWithImpl<$Res>;
+  factory _$$BufferCopyWith(_$Buffer value, $Res Function(_$Buffer) then) =
+      __$$BufferCopyWithImpl<$Res>;
   $Res call({Uint8List field0});
 }
 
 /// @nodoc
-class __$$BufferCopyWithImpl<$Res> extends _$KitchenSinkCopyWithImpl<$Res> implements _$$BufferCopyWith<$Res> {
-  __$$BufferCopyWithImpl(_$Buffer _value, $Res Function(_$Buffer) _then) : super(_value, (v) => _then(v as _$Buffer));
+class __$$BufferCopyWithImpl<$Res> extends _$KitchenSinkCopyWithImpl<$Res>
+    implements _$$BufferCopyWith<$Res> {
+  __$$BufferCopyWithImpl(_$Buffer _value, $Res Function(_$Buffer) _then)
+      : super(_value, (v) => _then(v as _$Buffer));
 
   @override
   _$Buffer get _value => super._value as _$Buffer;
@@ -1213,17 +1271,20 @@ class _$Buffer implements Buffer {
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
 
   @JsonKey(ignore: true)
   @override
-  _$$BufferCopyWith<_$Buffer> get copyWith => __$$BufferCopyWithImpl<_$Buffer>(this, _$identity);
+  _$$BufferCopyWith<_$Buffer> get copyWith =>
+      __$$BufferCopyWithImpl<_$Buffer>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function() empty,
-    required TResult Function(int int32, double float64, bool boolean) primitives,
+    required TResult Function(int int32, double float64, bool boolean)
+        primitives,
     required TResult Function(KitchenSink field0, int field1) nested,
     required TResult Function(int? field0, int? field1) optional,
     required TResult Function(Uint8List field0) buffer,
@@ -1311,18 +1372,22 @@ abstract class Buffer implements KitchenSink {
 
   Uint8List get field0 => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
-  _$$BufferCopyWith<_$Buffer> get copyWith => throw _privateConstructorUsedError;
+  _$$BufferCopyWith<_$Buffer> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$EnumsCopyWith<$Res> {
-  factory _$$EnumsCopyWith(_$Enums value, $Res Function(_$Enums) then) = __$$EnumsCopyWithImpl<$Res>;
+  factory _$$EnumsCopyWith(_$Enums value, $Res Function(_$Enums) then) =
+      __$$EnumsCopyWithImpl<$Res>;
   $Res call({Weekdays field0});
 }
 
 /// @nodoc
-class __$$EnumsCopyWithImpl<$Res> extends _$KitchenSinkCopyWithImpl<$Res> implements _$$EnumsCopyWith<$Res> {
-  __$$EnumsCopyWithImpl(_$Enums _value, $Res Function(_$Enums) _then) : super(_value, (v) => _then(v as _$Enums));
+class __$$EnumsCopyWithImpl<$Res> extends _$KitchenSinkCopyWithImpl<$Res>
+    implements _$$EnumsCopyWith<$Res> {
+  __$$EnumsCopyWithImpl(_$Enums _value, $Res Function(_$Enums) _then)
+      : super(_value, (v) => _then(v as _$Enums));
 
   @override
   _$Enums get _value => super._value as _$Enums;
@@ -1362,17 +1427,20 @@ class _$Enums implements Enums {
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
 
   @JsonKey(ignore: true)
   @override
-  _$$EnumsCopyWith<_$Enums> get copyWith => __$$EnumsCopyWithImpl<_$Enums>(this, _$identity);
+  _$$EnumsCopyWith<_$Enums> get copyWith =>
+      __$$EnumsCopyWithImpl<_$Enums>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function() empty,
-    required TResult Function(int int32, double float64, bool boolean) primitives,
+    required TResult Function(int int32, double float64, bool boolean)
+        primitives,
     required TResult Function(KitchenSink field0, int field1) nested,
     required TResult Function(int? field0, int? field1) optional,
     required TResult Function(Uint8List field0) buffer,
@@ -1473,7 +1541,8 @@ mixin _$UserId {
 
 /// @nodoc
 abstract class $UserIdCopyWith<$Res> {
-  factory $UserIdCopyWith(UserId value, $Res Function(UserId) then) = _$UserIdCopyWithImpl<$Res>;
+  factory $UserIdCopyWith(UserId value, $Res Function(UserId) then) =
+      _$UserIdCopyWithImpl<$Res>;
   $Res call({int value});
 }
 
@@ -1500,13 +1569,15 @@ class _$UserIdCopyWithImpl<$Res> implements $UserIdCopyWith<$Res> {
 
 /// @nodoc
 abstract class _$$_UserIdCopyWith<$Res> implements $UserIdCopyWith<$Res> {
-  factory _$$_UserIdCopyWith(_$_UserId value, $Res Function(_$_UserId) then) = __$$_UserIdCopyWithImpl<$Res>;
+  factory _$$_UserIdCopyWith(_$_UserId value, $Res Function(_$_UserId) then) =
+      __$$_UserIdCopyWithImpl<$Res>;
   @override
   $Res call({int value});
 }
 
 /// @nodoc
-class __$$_UserIdCopyWithImpl<$Res> extends _$UserIdCopyWithImpl<$Res> implements _$$_UserIdCopyWith<$Res> {
+class __$$_UserIdCopyWithImpl<$Res> extends _$UserIdCopyWithImpl<$Res>
+    implements _$$_UserIdCopyWith<$Res> {
   __$$_UserIdCopyWithImpl(_$_UserId _value, $Res Function(_$_UserId) _then)
       : super(_value, (v) => _then(v as _$_UserId));
 
@@ -1548,11 +1619,13 @@ class _$_UserId implements _UserId {
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, const DeepCollectionEquality().hash(value));
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(value));
 
   @JsonKey(ignore: true)
   @override
-  _$$_UserIdCopyWith<_$_UserId> get copyWith => __$$_UserIdCopyWithImpl<_$_UserId>(this, _$identity);
+  _$$_UserIdCopyWith<_$_UserId> get copyWith =>
+      __$$_UserIdCopyWithImpl<_$_UserId>(this, _$identity);
 }
 
 abstract class _UserId implements UserId {
@@ -1562,5 +1635,6 @@ abstract class _UserId implements UserId {
   int get value => throw _privateConstructorUsedError;
   @override
   @JsonKey(ignore: true)
-  _$$_UserIdCopyWith<_$_UserId> get copyWith => throw _privateConstructorUsedError;
+  _$$_UserIdCopyWith<_$_UserId> get copyWith =>
+      throw _privateConstructorUsedError;
 }

--- a/frb_example/pure_dart/dart/lib/bridge_generated.freezed.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.freezed.dart
@@ -64,14 +64,12 @@ mixin _$ApplicationMessage {
 
 /// @nodoc
 abstract class $ApplicationMessageCopyWith<$Res> {
-  factory $ApplicationMessageCopyWith(
-          ApplicationMessage value, $Res Function(ApplicationMessage) then) =
+  factory $ApplicationMessageCopyWith(ApplicationMessage value, $Res Function(ApplicationMessage) then) =
       _$ApplicationMessageCopyWithImpl<$Res>;
 }
 
 /// @nodoc
-class _$ApplicationMessageCopyWithImpl<$Res>
-    implements $ApplicationMessageCopyWith<$Res> {
+class _$ApplicationMessageCopyWithImpl<$Res> implements $ApplicationMessageCopyWith<$Res> {
   _$ApplicationMessageCopyWithImpl(this._value, this._then);
 
   final ApplicationMessage _value;
@@ -81,18 +79,15 @@ class _$ApplicationMessageCopyWithImpl<$Res>
 
 /// @nodoc
 abstract class _$$DisplayMessageCopyWith<$Res> {
-  factory _$$DisplayMessageCopyWith(
-          _$DisplayMessage value, $Res Function(_$DisplayMessage) then) =
+  factory _$$DisplayMessageCopyWith(_$DisplayMessage value, $Res Function(_$DisplayMessage) then) =
       __$$DisplayMessageCopyWithImpl<$Res>;
   $Res call({String field0});
 }
 
 /// @nodoc
-class __$$DisplayMessageCopyWithImpl<$Res>
-    extends _$ApplicationMessageCopyWithImpl<$Res>
+class __$$DisplayMessageCopyWithImpl<$Res> extends _$ApplicationMessageCopyWithImpl<$Res>
     implements _$$DisplayMessageCopyWith<$Res> {
-  __$$DisplayMessageCopyWithImpl(
-      _$DisplayMessage _value, $Res Function(_$DisplayMessage) _then)
+  __$$DisplayMessageCopyWithImpl(_$DisplayMessage _value, $Res Function(_$DisplayMessage) _then)
       : super(_value, (v) => _then(v as _$DisplayMessage));
 
   @override
@@ -133,8 +128,7 @@ class _$DisplayMessage implements DisplayMessage {
   }
 
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
+  int get hashCode => Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
 
   @JsonKey(ignore: true)
   @override
@@ -215,24 +209,20 @@ abstract class DisplayMessage implements ApplicationMessage {
 
   String get field0 => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
-  _$$DisplayMessageCopyWith<_$DisplayMessage> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$DisplayMessageCopyWith<_$DisplayMessage> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$RenderPixelCopyWith<$Res> {
-  factory _$$RenderPixelCopyWith(
-          _$RenderPixel value, $Res Function(_$RenderPixel) then) =
+  factory _$$RenderPixelCopyWith(_$RenderPixel value, $Res Function(_$RenderPixel) then) =
       __$$RenderPixelCopyWithImpl<$Res>;
   $Res call({int x, int y});
 }
 
 /// @nodoc
-class __$$RenderPixelCopyWithImpl<$Res>
-    extends _$ApplicationMessageCopyWithImpl<$Res>
+class __$$RenderPixelCopyWithImpl<$Res> extends _$ApplicationMessageCopyWithImpl<$Res>
     implements _$$RenderPixelCopyWith<$Res> {
-  __$$RenderPixelCopyWithImpl(
-      _$RenderPixel _value, $Res Function(_$RenderPixel) _then)
+  __$$RenderPixelCopyWithImpl(_$RenderPixel _value, $Res Function(_$RenderPixel) _then)
       : super(_value, (v) => _then(v as _$RenderPixel));
 
   @override
@@ -281,15 +271,12 @@ class _$RenderPixel implements RenderPixel {
   }
 
   @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(x),
-      const DeepCollectionEquality().hash(y));
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(x), const DeepCollectionEquality().hash(y));
 
   @JsonKey(ignore: true)
   @override
-  _$$RenderPixelCopyWith<_$RenderPixel> get copyWith =>
-      __$$RenderPixelCopyWithImpl<_$RenderPixel>(this, _$identity);
+  _$$RenderPixelCopyWith<_$RenderPixel> get copyWith => __$$RenderPixelCopyWithImpl<_$RenderPixel>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -361,27 +348,22 @@ class _$RenderPixel implements RenderPixel {
 }
 
 abstract class RenderPixel implements ApplicationMessage {
-  const factory RenderPixel({required final int x, required final int y}) =
-      _$RenderPixel;
+  const factory RenderPixel({required final int x, required final int y}) = _$RenderPixel;
 
   int get x => throw _privateConstructorUsedError;
   int get y => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
-  _$$RenderPixelCopyWith<_$RenderPixel> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$RenderPixelCopyWith<_$RenderPixel> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$ExitCopyWith<$Res> {
-  factory _$$ExitCopyWith(_$Exit value, $Res Function(_$Exit) then) =
-      __$$ExitCopyWithImpl<$Res>;
+  factory _$$ExitCopyWith(_$Exit value, $Res Function(_$Exit) then) = __$$ExitCopyWithImpl<$Res>;
 }
 
 /// @nodoc
-class __$$ExitCopyWithImpl<$Res> extends _$ApplicationMessageCopyWithImpl<$Res>
-    implements _$$ExitCopyWith<$Res> {
-  __$$ExitCopyWithImpl(_$Exit _value, $Res Function(_$Exit) _then)
-      : super(_value, (v) => _then(v as _$Exit));
+class __$$ExitCopyWithImpl<$Res> extends _$ApplicationMessageCopyWithImpl<$Res> implements _$$ExitCopyWith<$Res> {
+  __$$ExitCopyWithImpl(_$Exit _value, $Res Function(_$Exit) _then) : super(_value, (v) => _then(v as _$Exit));
 
   @override
   _$Exit get _value => super._value as _$Exit;
@@ -399,8 +381,7 @@ class _$Exit implements Exit {
 
   @override
   bool operator ==(dynamic other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType && other is _$Exit);
+    return identical(this, other) || (other.runtimeType == runtimeType && other is _$Exit);
   }
 
   @override
@@ -484,8 +465,7 @@ mixin _$KitchenSink {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function() empty,
-    required TResult Function(int int32, double float64, bool boolean)
-        primitives,
+    required TResult Function(int int32, double float64, bool boolean) primitives,
     required TResult Function(KitchenSink field0, int field1) nested,
     required TResult Function(int? field0, int? field1) optional,
     required TResult Function(Uint8List field0) buffer,
@@ -548,9 +528,7 @@ mixin _$KitchenSink {
 
 /// @nodoc
 abstract class $KitchenSinkCopyWith<$Res> {
-  factory $KitchenSinkCopyWith(
-          KitchenSink value, $Res Function(KitchenSink) then) =
-      _$KitchenSinkCopyWithImpl<$Res>;
+  factory $KitchenSinkCopyWith(KitchenSink value, $Res Function(KitchenSink) then) = _$KitchenSinkCopyWithImpl<$Res>;
 }
 
 /// @nodoc
@@ -564,15 +542,12 @@ class _$KitchenSinkCopyWithImpl<$Res> implements $KitchenSinkCopyWith<$Res> {
 
 /// @nodoc
 abstract class _$$EmptyCopyWith<$Res> {
-  factory _$$EmptyCopyWith(_$Empty value, $Res Function(_$Empty) then) =
-      __$$EmptyCopyWithImpl<$Res>;
+  factory _$$EmptyCopyWith(_$Empty value, $Res Function(_$Empty) then) = __$$EmptyCopyWithImpl<$Res>;
 }
 
 /// @nodoc
-class __$$EmptyCopyWithImpl<$Res> extends _$KitchenSinkCopyWithImpl<$Res>
-    implements _$$EmptyCopyWith<$Res> {
-  __$$EmptyCopyWithImpl(_$Empty _value, $Res Function(_$Empty) _then)
-      : super(_value, (v) => _then(v as _$Empty));
+class __$$EmptyCopyWithImpl<$Res> extends _$KitchenSinkCopyWithImpl<$Res> implements _$$EmptyCopyWith<$Res> {
+  __$$EmptyCopyWithImpl(_$Empty _value, $Res Function(_$Empty) _then) : super(_value, (v) => _then(v as _$Empty));
 
   @override
   _$Empty get _value => super._value as _$Empty;
@@ -590,8 +565,7 @@ class _$Empty implements Empty {
 
   @override
   bool operator ==(dynamic other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType && other is _$Empty);
+    return identical(this, other) || (other.runtimeType == runtimeType && other is _$Empty);
   }
 
   @override
@@ -601,8 +575,7 @@ class _$Empty implements Empty {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function() empty,
-    required TResult Function(int int32, double float64, bool boolean)
-        primitives,
+    required TResult Function(int int32, double float64, bool boolean) primitives,
     required TResult Function(KitchenSink field0, int field1) nested,
     required TResult Function(int? field0, int? field1) optional,
     required TResult Function(Uint8List field0) buffer,
@@ -691,17 +664,14 @@ abstract class Empty implements KitchenSink {
 
 /// @nodoc
 abstract class _$$PrimitivesCopyWith<$Res> {
-  factory _$$PrimitivesCopyWith(
-          _$Primitives value, $Res Function(_$Primitives) then) =
+  factory _$$PrimitivesCopyWith(_$Primitives value, $Res Function(_$Primitives) then) =
       __$$PrimitivesCopyWithImpl<$Res>;
   $Res call({int int32, double float64, bool boolean});
 }
 
 /// @nodoc
-class __$$PrimitivesCopyWithImpl<$Res> extends _$KitchenSinkCopyWithImpl<$Res>
-    implements _$$PrimitivesCopyWith<$Res> {
-  __$$PrimitivesCopyWithImpl(
-      _$Primitives _value, $Res Function(_$Primitives) _then)
+class __$$PrimitivesCopyWithImpl<$Res> extends _$KitchenSinkCopyWithImpl<$Res> implements _$$PrimitivesCopyWith<$Res> {
+  __$$PrimitivesCopyWithImpl(_$Primitives _value, $Res Function(_$Primitives) _then)
       : super(_value, (v) => _then(v as _$Primitives));
 
   @override
@@ -733,8 +703,7 @@ class __$$PrimitivesCopyWithImpl<$Res> extends _$KitchenSinkCopyWithImpl<$Res>
 /// @nodoc
 
 class _$Primitives implements Primitives {
-  const _$Primitives(
-      {required this.int32, required this.float64, required this.boolean});
+  const _$Primitives({required this.int32, required this.float64, required this.boolean});
 
   /// Dart field comment
   @override
@@ -760,23 +729,18 @@ class _$Primitives implements Primitives {
   }
 
   @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(int32),
-      const DeepCollectionEquality().hash(float64),
-      const DeepCollectionEquality().hash(boolean));
+  int get hashCode => Object.hash(runtimeType, const DeepCollectionEquality().hash(int32),
+      const DeepCollectionEquality().hash(float64), const DeepCollectionEquality().hash(boolean));
 
   @JsonKey(ignore: true)
   @override
-  _$$PrimitivesCopyWith<_$Primitives> get copyWith =>
-      __$$PrimitivesCopyWithImpl<_$Primitives>(this, _$identity);
+  _$$PrimitivesCopyWith<_$Primitives> get copyWith => __$$PrimitivesCopyWithImpl<_$Primitives>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function() empty,
-    required TResult Function(int int32, double float64, bool boolean)
-        primitives,
+    required TResult Function(int int32, double float64, bool boolean) primitives,
     required TResult Function(KitchenSink field0, int field1) nested,
     required TResult Function(int? field0, int? field1) optional,
     required TResult Function(Uint8List field0) buffer,
@@ -860,34 +824,28 @@ class _$Primitives implements Primitives {
 }
 
 abstract class Primitives implements KitchenSink {
-  const factory Primitives(
-      {required final int int32,
-      required final double float64,
-      required final bool boolean}) = _$Primitives;
+  const factory Primitives({required final int int32, required final double float64, required final bool boolean}) =
+      _$Primitives;
 
   /// Dart field comment
   int get int32 => throw _privateConstructorUsedError;
   double get float64 => throw _privateConstructorUsedError;
   bool get boolean => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
-  _$$PrimitivesCopyWith<_$Primitives> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$PrimitivesCopyWith<_$Primitives> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$NestedCopyWith<$Res> {
-  factory _$$NestedCopyWith(_$Nested value, $Res Function(_$Nested) then) =
-      __$$NestedCopyWithImpl<$Res>;
+  factory _$$NestedCopyWith(_$Nested value, $Res Function(_$Nested) then) = __$$NestedCopyWithImpl<$Res>;
   $Res call({KitchenSink field0, int field1});
 
   $KitchenSinkCopyWith<$Res> get field0;
 }
 
 /// @nodoc
-class __$$NestedCopyWithImpl<$Res> extends _$KitchenSinkCopyWithImpl<$Res>
-    implements _$$NestedCopyWith<$Res> {
-  __$$NestedCopyWithImpl(_$Nested _value, $Res Function(_$Nested) _then)
-      : super(_value, (v) => _then(v as _$Nested));
+class __$$NestedCopyWithImpl<$Res> extends _$KitchenSinkCopyWithImpl<$Res> implements _$$NestedCopyWith<$Res> {
+  __$$NestedCopyWithImpl(_$Nested _value, $Res Function(_$Nested) _then) : super(_value, (v) => _then(v as _$Nested));
 
   @override
   _$Nested get _value => super._value as _$Nested;
@@ -943,21 +901,17 @@ class _$Nested implements Nested {
 
   @override
   int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(field0),
-      const DeepCollectionEquality().hash(field1));
+      runtimeType, const DeepCollectionEquality().hash(field0), const DeepCollectionEquality().hash(field1));
 
   @JsonKey(ignore: true)
   @override
-  _$$NestedCopyWith<_$Nested> get copyWith =>
-      __$$NestedCopyWithImpl<_$Nested>(this, _$identity);
+  _$$NestedCopyWith<_$Nested> get copyWith => __$$NestedCopyWithImpl<_$Nested>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function() empty,
-    required TResult Function(int int32, double float64, bool boolean)
-        primitives,
+    required TResult Function(int int32, double float64, bool boolean) primitives,
     required TResult Function(KitchenSink field0, int field1) nested,
     required TResult Function(int? field0, int? field1) optional,
     required TResult Function(Uint8List field0) buffer,
@@ -1046,21 +1000,17 @@ abstract class Nested implements KitchenSink {
   KitchenSink get field0 => throw _privateConstructorUsedError;
   int get field1 => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
-  _$$NestedCopyWith<_$Nested> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$NestedCopyWith<_$Nested> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$OptionalCopyWith<$Res> {
-  factory _$$OptionalCopyWith(
-          _$Optional value, $Res Function(_$Optional) then) =
-      __$$OptionalCopyWithImpl<$Res>;
+  factory _$$OptionalCopyWith(_$Optional value, $Res Function(_$Optional) then) = __$$OptionalCopyWithImpl<$Res>;
   $Res call({int? field0, int? field1});
 }
 
 /// @nodoc
-class __$$OptionalCopyWithImpl<$Res> extends _$KitchenSinkCopyWithImpl<$Res>
-    implements _$$OptionalCopyWith<$Res> {
+class __$$OptionalCopyWithImpl<$Res> extends _$KitchenSinkCopyWithImpl<$Res> implements _$$OptionalCopyWith<$Res> {
   __$$OptionalCopyWithImpl(_$Optional _value, $Res Function(_$Optional) _then)
       : super(_value, (v) => _then(v as _$Optional));
 
@@ -1112,21 +1062,17 @@ class _$Optional implements Optional {
 
   @override
   int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(field0),
-      const DeepCollectionEquality().hash(field1));
+      runtimeType, const DeepCollectionEquality().hash(field0), const DeepCollectionEquality().hash(field1));
 
   @JsonKey(ignore: true)
   @override
-  _$$OptionalCopyWith<_$Optional> get copyWith =>
-      __$$OptionalCopyWithImpl<_$Optional>(this, _$identity);
+  _$$OptionalCopyWith<_$Optional> get copyWith => __$$OptionalCopyWithImpl<_$Optional>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function() empty,
-    required TResult Function(int int32, double float64, bool boolean)
-        primitives,
+    required TResult Function(int int32, double float64, bool boolean) primitives,
     required TResult Function(KitchenSink field0, int field1) nested,
     required TResult Function(int? field0, int? field1) optional,
     required TResult Function(Uint8List field0) buffer,
@@ -1216,22 +1162,18 @@ abstract class Optional implements KitchenSink {
   int? get field0 => throw _privateConstructorUsedError;
   int? get field1 => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
-  _$$OptionalCopyWith<_$Optional> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$OptionalCopyWith<_$Optional> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$BufferCopyWith<$Res> {
-  factory _$$BufferCopyWith(_$Buffer value, $Res Function(_$Buffer) then) =
-      __$$BufferCopyWithImpl<$Res>;
+  factory _$$BufferCopyWith(_$Buffer value, $Res Function(_$Buffer) then) = __$$BufferCopyWithImpl<$Res>;
   $Res call({Uint8List field0});
 }
 
 /// @nodoc
-class __$$BufferCopyWithImpl<$Res> extends _$KitchenSinkCopyWithImpl<$Res>
-    implements _$$BufferCopyWith<$Res> {
-  __$$BufferCopyWithImpl(_$Buffer _value, $Res Function(_$Buffer) _then)
-      : super(_value, (v) => _then(v as _$Buffer));
+class __$$BufferCopyWithImpl<$Res> extends _$KitchenSinkCopyWithImpl<$Res> implements _$$BufferCopyWith<$Res> {
+  __$$BufferCopyWithImpl(_$Buffer _value, $Res Function(_$Buffer) _then) : super(_value, (v) => _then(v as _$Buffer));
 
   @override
   _$Buffer get _value => super._value as _$Buffer;
@@ -1271,20 +1213,17 @@ class _$Buffer implements Buffer {
   }
 
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
+  int get hashCode => Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
 
   @JsonKey(ignore: true)
   @override
-  _$$BufferCopyWith<_$Buffer> get copyWith =>
-      __$$BufferCopyWithImpl<_$Buffer>(this, _$identity);
+  _$$BufferCopyWith<_$Buffer> get copyWith => __$$BufferCopyWithImpl<_$Buffer>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function() empty,
-    required TResult Function(int int32, double float64, bool boolean)
-        primitives,
+    required TResult Function(int int32, double float64, bool boolean) primitives,
     required TResult Function(KitchenSink field0, int field1) nested,
     required TResult Function(int? field0, int? field1) optional,
     required TResult Function(Uint8List field0) buffer,
@@ -1372,22 +1311,18 @@ abstract class Buffer implements KitchenSink {
 
   Uint8List get field0 => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
-  _$$BufferCopyWith<_$Buffer> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$BufferCopyWith<_$Buffer> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$EnumsCopyWith<$Res> {
-  factory _$$EnumsCopyWith(_$Enums value, $Res Function(_$Enums) then) =
-      __$$EnumsCopyWithImpl<$Res>;
+  factory _$$EnumsCopyWith(_$Enums value, $Res Function(_$Enums) then) = __$$EnumsCopyWithImpl<$Res>;
   $Res call({Weekdays field0});
 }
 
 /// @nodoc
-class __$$EnumsCopyWithImpl<$Res> extends _$KitchenSinkCopyWithImpl<$Res>
-    implements _$$EnumsCopyWith<$Res> {
-  __$$EnumsCopyWithImpl(_$Enums _value, $Res Function(_$Enums) _then)
-      : super(_value, (v) => _then(v as _$Enums));
+class __$$EnumsCopyWithImpl<$Res> extends _$KitchenSinkCopyWithImpl<$Res> implements _$$EnumsCopyWith<$Res> {
+  __$$EnumsCopyWithImpl(_$Enums _value, $Res Function(_$Enums) _then) : super(_value, (v) => _then(v as _$Enums));
 
   @override
   _$Enums get _value => super._value as _$Enums;
@@ -1427,20 +1362,17 @@ class _$Enums implements Enums {
   }
 
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
+  int get hashCode => Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
 
   @JsonKey(ignore: true)
   @override
-  _$$EnumsCopyWith<_$Enums> get copyWith =>
-      __$$EnumsCopyWithImpl<_$Enums>(this, _$identity);
+  _$$EnumsCopyWith<_$Enums> get copyWith => __$$EnumsCopyWithImpl<_$Enums>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function() empty,
-    required TResult Function(int int32, double float64, bool boolean)
-        primitives,
+    required TResult Function(int int32, double float64, bool boolean) primitives,
     required TResult Function(KitchenSink field0, int field1) nested,
     required TResult Function(int? field0, int? field1) optional,
     required TResult Function(Uint8List field0) buffer,
@@ -1541,8 +1473,7 @@ mixin _$UserId {
 
 /// @nodoc
 abstract class $UserIdCopyWith<$Res> {
-  factory $UserIdCopyWith(UserId value, $Res Function(UserId) then) =
-      _$UserIdCopyWithImpl<$Res>;
+  factory $UserIdCopyWith(UserId value, $Res Function(UserId) then) = _$UserIdCopyWithImpl<$Res>;
   $Res call({int value});
 }
 
@@ -1569,15 +1500,13 @@ class _$UserIdCopyWithImpl<$Res> implements $UserIdCopyWith<$Res> {
 
 /// @nodoc
 abstract class _$$_UserIdCopyWith<$Res> implements $UserIdCopyWith<$Res> {
-  factory _$$_UserIdCopyWith(_$_UserId value, $Res Function(_$_UserId) then) =
-      __$$_UserIdCopyWithImpl<$Res>;
+  factory _$$_UserIdCopyWith(_$_UserId value, $Res Function(_$_UserId) then) = __$$_UserIdCopyWithImpl<$Res>;
   @override
   $Res call({int value});
 }
 
 /// @nodoc
-class __$$_UserIdCopyWithImpl<$Res> extends _$UserIdCopyWithImpl<$Res>
-    implements _$$_UserIdCopyWith<$Res> {
+class __$$_UserIdCopyWithImpl<$Res> extends _$UserIdCopyWithImpl<$Res> implements _$$_UserIdCopyWith<$Res> {
   __$$_UserIdCopyWithImpl(_$_UserId _value, $Res Function(_$_UserId) _then)
       : super(_value, (v) => _then(v as _$_UserId));
 
@@ -1619,13 +1548,11 @@ class _$_UserId implements _UserId {
   }
 
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, const DeepCollectionEquality().hash(value));
+  int get hashCode => Object.hash(runtimeType, const DeepCollectionEquality().hash(value));
 
   @JsonKey(ignore: true)
   @override
-  _$$_UserIdCopyWith<_$_UserId> get copyWith =>
-      __$$_UserIdCopyWithImpl<_$_UserId>(this, _$identity);
+  _$$_UserIdCopyWith<_$_UserId> get copyWith => __$$_UserIdCopyWithImpl<_$_UserId>(this, _$identity);
 }
 
 abstract class _UserId implements UserId {
@@ -1635,6 +1562,5 @@ abstract class _UserId implements UserId {
   int get value => throw _privateConstructorUsedError;
   @override
   @JsonKey(ignore: true)
-  _$$_UserIdCopyWith<_$_UserId> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$_UserIdCopyWith<_$_UserId> get copyWith => throw _privateConstructorUsedError;
 }

--- a/frb_example/with_flutter/lib/bridge_generated.dart
+++ b/frb_example/with_flutter/lib/bridge_generated.dart
@@ -29,33 +29,45 @@ abstract class FlutterRustBridgeExample {
 
   FlutterRustBridgeTaskConstMeta get kReturningStructsWithBoxedFieldsConstMeta;
 
-  Future<int> offTopicMemoryTestInputArray({required Uint8List input, dynamic hint});
+  Future<int> offTopicMemoryTestInputArray(
+      {required Uint8List input, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kOffTopicMemoryTestInputArrayConstMeta;
 
-  Future<Uint8List> offTopicMemoryTestOutputZeroCopyBuffer({required int len, dynamic hint});
+  Future<Uint8List> offTopicMemoryTestOutputZeroCopyBuffer(
+      {required int len, dynamic hint});
 
-  FlutterRustBridgeTaskConstMeta get kOffTopicMemoryTestOutputZeroCopyBufferConstMeta;
+  FlutterRustBridgeTaskConstMeta
+      get kOffTopicMemoryTestOutputZeroCopyBufferConstMeta;
 
-  Future<Uint8List> offTopicMemoryTestOutputVecU8({required int len, dynamic hint});
+  Future<Uint8List> offTopicMemoryTestOutputVecU8(
+      {required int len, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kOffTopicMemoryTestOutputVecU8ConstMeta;
 
-  Future<int> offTopicMemoryTestInputVecOfObject({required List<Size> input, dynamic hint});
+  Future<int> offTopicMemoryTestInputVecOfObject(
+      {required List<Size> input, dynamic hint});
 
-  FlutterRustBridgeTaskConstMeta get kOffTopicMemoryTestInputVecOfObjectConstMeta;
+  FlutterRustBridgeTaskConstMeta
+      get kOffTopicMemoryTestInputVecOfObjectConstMeta;
 
-  Future<List<Size>> offTopicMemoryTestOutputVecOfObject({required int len, dynamic hint});
+  Future<List<Size>> offTopicMemoryTestOutputVecOfObject(
+      {required int len, dynamic hint});
 
-  FlutterRustBridgeTaskConstMeta get kOffTopicMemoryTestOutputVecOfObjectConstMeta;
+  FlutterRustBridgeTaskConstMeta
+      get kOffTopicMemoryTestOutputVecOfObjectConstMeta;
 
-  Future<int> offTopicMemoryTestInputComplexStruct({required TreeNode input, dynamic hint});
+  Future<int> offTopicMemoryTestInputComplexStruct(
+      {required TreeNode input, dynamic hint});
 
-  FlutterRustBridgeTaskConstMeta get kOffTopicMemoryTestInputComplexStructConstMeta;
+  FlutterRustBridgeTaskConstMeta
+      get kOffTopicMemoryTestInputComplexStructConstMeta;
 
-  Future<TreeNode> offTopicMemoryTestOutputComplexStruct({required int len, dynamic hint});
+  Future<TreeNode> offTopicMemoryTestOutputComplexStruct(
+      {required int len, dynamic hint});
 
-  FlutterRustBridgeTaskConstMeta get kOffTopicMemoryTestOutputComplexStructConstMeta;
+  FlutterRustBridgeTaskConstMeta
+      get kOffTopicMemoryTestOutputComplexStructConstMeta;
 
   Future<int> offTopicDeliberatelyReturnError({dynamic hint});
 
@@ -104,12 +116,14 @@ class TreeNode {
   });
 }
 
-class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBridgeExampleWire>
+class FlutterRustBridgeExampleImpl
+    extends FlutterRustBridgeBase<FlutterRustBridgeExampleWire>
     implements FlutterRustBridgeExample {
   factory FlutterRustBridgeExampleImpl(ffi.DynamicLibrary dylib) =>
       FlutterRustBridgeExampleImpl.raw(FlutterRustBridgeExampleWire(dylib));
 
-  FlutterRustBridgeExampleImpl.raw(FlutterRustBridgeExampleWire inner) : super(inner);
+  FlutterRustBridgeExampleImpl.raw(FlutterRustBridgeExampleWire inner)
+      : super(inner);
 
   Future<Uint8List> drawMandelbrot(
           {required Size imageSize,
@@ -118,163 +132,206 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
           required int numThreads,
           dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_draw_mandelbrot(port_, _api2wire_box_autoadd_size(imageSize),
-            _api2wire_box_autoadd_point(zoomPoint), _api2wire_f64(scale), _api2wire_i32(numThreads)),
+        callFfi: (port_) => inner.wire_draw_mandelbrot(
+            port_,
+            _api2wire_box_autoadd_size(imageSize),
+            _api2wire_box_autoadd_point(zoomPoint),
+            _api2wire_f64(scale),
+            _api2wire_i32(numThreads)),
         parseSuccessData: _wire2api_ZeroCopyBuffer_Uint8List,
         constMeta: kDrawMandelbrotConstMeta,
         argValues: [imageSize, zoomPoint, scale, numThreads],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kDrawMandelbrotConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kDrawMandelbrotConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "draw_mandelbrot",
         argNames: ["imageSize", "zoomPoint", "scale", "numThreads"],
       );
 
-  Future<String> passingComplexStructs({required TreeNode root, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_passing_complex_structs(port_, _api2wire_box_autoadd_tree_node(root)),
+  Future<String> passingComplexStructs(
+          {required TreeNode root, dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_passing_complex_structs(
+            port_, _api2wire_box_autoadd_tree_node(root)),
         parseSuccessData: _wire2api_String,
         constMeta: kPassingComplexStructsConstMeta,
         argValues: [root],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kPassingComplexStructsConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kPassingComplexStructsConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "passing_complex_structs",
         argNames: ["root"],
       );
 
-  Future<BoxedPoint> returningStructsWithBoxedFields({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_returning_structs_with_boxed_fields(port_),
+  Future<BoxedPoint> returningStructsWithBoxedFields({dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) =>
+            inner.wire_returning_structs_with_boxed_fields(port_),
         parseSuccessData: _wire2api_boxed_point,
         constMeta: kReturningStructsWithBoxedFieldsConstMeta,
         argValues: [],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kReturningStructsWithBoxedFieldsConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "returning_structs_with_boxed_fields",
-        argNames: [],
-      );
+  FlutterRustBridgeTaskConstMeta
+      get kReturningStructsWithBoxedFieldsConstMeta =>
+          const FlutterRustBridgeTaskConstMeta(
+            debugName: "returning_structs_with_boxed_fields",
+            argNames: [],
+          );
 
-  Future<int> offTopicMemoryTestInputArray({required Uint8List input, dynamic hint}) =>
+  Future<int> offTopicMemoryTestInputArray(
+          {required Uint8List input, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_off_topic_memory_test_input_array(port_, _api2wire_uint_8_list(input)),
+        callFfi: (port_) => inner.wire_off_topic_memory_test_input_array(
+            port_, _api2wire_uint_8_list(input)),
         parseSuccessData: _wire2api_i32,
         constMeta: kOffTopicMemoryTestInputArrayConstMeta,
         argValues: [input],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kOffTopicMemoryTestInputArrayConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kOffTopicMemoryTestInputArrayConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "off_topic_memory_test_input_array",
         argNames: ["input"],
       );
 
-  Future<Uint8List> offTopicMemoryTestOutputZeroCopyBuffer({required int len, dynamic hint}) =>
+  Future<Uint8List> offTopicMemoryTestOutputZeroCopyBuffer(
+          {required int len, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_off_topic_memory_test_output_zero_copy_buffer(port_, _api2wire_i32(len)),
+        callFfi: (port_) =>
+            inner.wire_off_topic_memory_test_output_zero_copy_buffer(
+                port_, _api2wire_i32(len)),
         parseSuccessData: _wire2api_ZeroCopyBuffer_Uint8List,
         constMeta: kOffTopicMemoryTestOutputZeroCopyBufferConstMeta,
         argValues: [len],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kOffTopicMemoryTestOutputZeroCopyBufferConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
-        debugName: "off_topic_memory_test_output_zero_copy_buffer",
-        argNames: ["len"],
-      );
+  FlutterRustBridgeTaskConstMeta
+      get kOffTopicMemoryTestOutputZeroCopyBufferConstMeta =>
+          const FlutterRustBridgeTaskConstMeta(
+            debugName: "off_topic_memory_test_output_zero_copy_buffer",
+            argNames: ["len"],
+          );
 
-  Future<Uint8List> offTopicMemoryTestOutputVecU8({required int len, dynamic hint}) =>
+  Future<Uint8List> offTopicMemoryTestOutputVecU8(
+          {required int len, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_off_topic_memory_test_output_vec_u8(port_, _api2wire_i32(len)),
+        callFfi: (port_) => inner.wire_off_topic_memory_test_output_vec_u8(
+            port_, _api2wire_i32(len)),
         parseSuccessData: _wire2api_uint_8_list,
         constMeta: kOffTopicMemoryTestOutputVecU8ConstMeta,
         argValues: [len],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kOffTopicMemoryTestOutputVecU8ConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kOffTopicMemoryTestOutputVecU8ConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "off_topic_memory_test_output_vec_u8",
         argNames: ["len"],
       );
 
-  Future<int> offTopicMemoryTestInputVecOfObject({required List<Size> input, dynamic hint}) =>
+  Future<int> offTopicMemoryTestInputVecOfObject(
+          {required List<Size> input, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_off_topic_memory_test_input_vec_of_object(port_, _api2wire_list_size(input)),
+        callFfi: (port_) =>
+            inner.wire_off_topic_memory_test_input_vec_of_object(
+                port_, _api2wire_list_size(input)),
         parseSuccessData: _wire2api_i32,
         constMeta: kOffTopicMemoryTestInputVecOfObjectConstMeta,
         argValues: [input],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kOffTopicMemoryTestInputVecOfObjectConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
-        debugName: "off_topic_memory_test_input_vec_of_object",
-        argNames: ["input"],
-      );
+  FlutterRustBridgeTaskConstMeta
+      get kOffTopicMemoryTestInputVecOfObjectConstMeta =>
+          const FlutterRustBridgeTaskConstMeta(
+            debugName: "off_topic_memory_test_input_vec_of_object",
+            argNames: ["input"],
+          );
 
-  Future<List<Size>> offTopicMemoryTestOutputVecOfObject({required int len, dynamic hint}) =>
+  Future<List<Size>> offTopicMemoryTestOutputVecOfObject(
+          {required int len, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_off_topic_memory_test_output_vec_of_object(port_, _api2wire_i32(len)),
+        callFfi: (port_) =>
+            inner.wire_off_topic_memory_test_output_vec_of_object(
+                port_, _api2wire_i32(len)),
         parseSuccessData: _wire2api_list_size,
         constMeta: kOffTopicMemoryTestOutputVecOfObjectConstMeta,
         argValues: [len],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kOffTopicMemoryTestOutputVecOfObjectConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
-        debugName: "off_topic_memory_test_output_vec_of_object",
-        argNames: ["len"],
-      );
+  FlutterRustBridgeTaskConstMeta
+      get kOffTopicMemoryTestOutputVecOfObjectConstMeta =>
+          const FlutterRustBridgeTaskConstMeta(
+            debugName: "off_topic_memory_test_output_vec_of_object",
+            argNames: ["len"],
+          );
 
-  Future<int> offTopicMemoryTestInputComplexStruct({required TreeNode input, dynamic hint}) =>
+  Future<int> offTopicMemoryTestInputComplexStruct(
+          {required TreeNode input, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) =>
-            inner.wire_off_topic_memory_test_input_complex_struct(port_, _api2wire_box_autoadd_tree_node(input)),
+            inner.wire_off_topic_memory_test_input_complex_struct(
+                port_, _api2wire_box_autoadd_tree_node(input)),
         parseSuccessData: _wire2api_i32,
         constMeta: kOffTopicMemoryTestInputComplexStructConstMeta,
         argValues: [input],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kOffTopicMemoryTestInputComplexStructConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
-        debugName: "off_topic_memory_test_input_complex_struct",
-        argNames: ["input"],
-      );
+  FlutterRustBridgeTaskConstMeta
+      get kOffTopicMemoryTestInputComplexStructConstMeta =>
+          const FlutterRustBridgeTaskConstMeta(
+            debugName: "off_topic_memory_test_input_complex_struct",
+            argNames: ["input"],
+          );
 
-  Future<TreeNode> offTopicMemoryTestOutputComplexStruct({required int len, dynamic hint}) =>
+  Future<TreeNode> offTopicMemoryTestOutputComplexStruct(
+          {required int len, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_off_topic_memory_test_output_complex_struct(port_, _api2wire_i32(len)),
+        callFfi: (port_) =>
+            inner.wire_off_topic_memory_test_output_complex_struct(
+                port_, _api2wire_i32(len)),
         parseSuccessData: _wire2api_tree_node,
         constMeta: kOffTopicMemoryTestOutputComplexStructConstMeta,
         argValues: [len],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kOffTopicMemoryTestOutputComplexStructConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
-        debugName: "off_topic_memory_test_output_complex_struct",
-        argNames: ["len"],
-      );
+  FlutterRustBridgeTaskConstMeta
+      get kOffTopicMemoryTestOutputComplexStructConstMeta =>
+          const FlutterRustBridgeTaskConstMeta(
+            debugName: "off_topic_memory_test_output_complex_struct",
+            argNames: ["len"],
+          );
 
-  Future<int> offTopicDeliberatelyReturnError({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_off_topic_deliberately_return_error(port_),
+  Future<int> offTopicDeliberatelyReturnError({dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) =>
+            inner.wire_off_topic_deliberately_return_error(port_),
         parseSuccessData: _wire2api_i32,
         constMeta: kOffTopicDeliberatelyReturnErrorConstMeta,
         argValues: [],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kOffTopicDeliberatelyReturnErrorConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "off_topic_deliberately_return_error",
-        argNames: [],
-      );
+  FlutterRustBridgeTaskConstMeta
+      get kOffTopicDeliberatelyReturnErrorConstMeta =>
+          const FlutterRustBridgeTaskConstMeta(
+            debugName: "off_topic_deliberately_return_error",
+            argNames: [],
+          );
 
-  Future<int> offTopicDeliberatelyPanic({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+  Future<int> offTopicDeliberatelyPanic({dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_off_topic_deliberately_panic(port_),
         parseSuccessData: _wire2api_i32,
         constMeta: kOffTopicDeliberatelyPanicConstMeta,
@@ -282,7 +339,8 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kOffTopicDeliberatelyPanicConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kOffTopicDeliberatelyPanicConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "off_topic_deliberately_panic",
         argNames: [],
       );
@@ -326,7 +384,8 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
     return ans;
   }
 
-  ffi.Pointer<wire_list_tree_node> _api2wire_list_tree_node(List<TreeNode> raw) {
+  ffi.Pointer<wire_list_tree_node> _api2wire_list_tree_node(
+      List<TreeNode> raw) {
     final ans = inner.new_list_tree_node(raw.length);
     for (var i = 0; i < raw.length; ++i) {
       _api_fill_to_wire_tree_node(raw[i], ans.ref.ptr[i]);
@@ -346,15 +405,18 @@ class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBrid
 
   // Section: api_fill_to_wire
 
-  void _api_fill_to_wire_box_autoadd_point(Point apiObj, ffi.Pointer<wire_Point> wireObj) {
+  void _api_fill_to_wire_box_autoadd_point(
+      Point apiObj, ffi.Pointer<wire_Point> wireObj) {
     _api_fill_to_wire_point(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_size(Size apiObj, ffi.Pointer<wire_Size> wireObj) {
+  void _api_fill_to_wire_box_autoadd_size(
+      Size apiObj, ffi.Pointer<wire_Size> wireObj) {
     _api_fill_to_wire_size(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_tree_node(TreeNode apiObj, ffi.Pointer<wire_TreeNode> wireObj) {
+  void _api_fill_to_wire_box_autoadd_tree_node(
+      TreeNode apiObj, ffi.Pointer<wire_TreeNode> wireObj) {
     _api_fill_to_wire_tree_node(apiObj, wireObj.ref);
   }
 
@@ -389,7 +451,8 @@ Point _wire2api_box_point(dynamic raw) {
 
 BoxedPoint _wire2api_boxed_point(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+  if (arr.length != 1)
+    throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
   return BoxedPoint(
     point: _wire2api_box_point(arr[0]),
   );
@@ -413,7 +476,8 @@ List<TreeNode> _wire2api_list_tree_node(dynamic raw) {
 
 Point _wire2api_point(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+  if (arr.length != 2)
+    throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
   return Point(
     x: _wire2api_f64(arr[0]),
     y: _wire2api_f64(arr[1]),
@@ -422,7 +486,8 @@ Point _wire2api_point(dynamic raw) {
 
 Size _wire2api_size(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+  if (arr.length != 2)
+    throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
   return Size(
     width: _wire2api_i32(arr[0]),
     height: _wire2api_i32(arr[1]),
@@ -431,7 +496,8 @@ Size _wire2api_size(dynamic raw) {
 
 TreeNode _wire2api_tree_node(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+  if (arr.length != 2)
+    throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
   return TreeNode(
     name: _wire2api_String(arr[0]),
     children: _wire2api_list_tree_node(arr[1]),
@@ -455,13 +521,17 @@ Uint8List _wire2api_uint_8_list(dynamic raw) {
 /// generated by flutter_rust_bridge
 class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   /// Holds the symbol lookup function.
-  final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName) _lookup;
+  final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
+      _lookup;
 
   /// The symbols are looked up in [dynamicLibrary].
-  FlutterRustBridgeExampleWire(ffi.DynamicLibrary dynamicLibrary) : _lookup = dynamicLibrary.lookup;
+  FlutterRustBridgeExampleWire(ffi.DynamicLibrary dynamicLibrary)
+      : _lookup = dynamicLibrary.lookup;
 
   /// The symbols are looked up with [lookup].
-  FlutterRustBridgeExampleWire.fromLookup(ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName) lookup)
+  FlutterRustBridgeExampleWire.fromLookup(
+      ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
+          lookup)
       : _lookup = lookup;
 
   void wire_draw_mandelbrot(
@@ -482,10 +552,15 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
 
   late final _wire_draw_mandelbrotPtr = _lookup<
       ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64, ffi.Pointer<wire_Size>, ffi.Pointer<wire_Point>, ffi.Double,
+          ffi.Void Function(
+              ffi.Int64,
+              ffi.Pointer<wire_Size>,
+              ffi.Pointer<wire_Point>,
+              ffi.Double,
               ffi.Int32)>>('wire_draw_mandelbrot');
-  late final _wire_draw_mandelbrot = _wire_draw_mandelbrotPtr
-      .asFunction<void Function(int, ffi.Pointer<wire_Size>, ffi.Pointer<wire_Point>, double, int)>();
+  late final _wire_draw_mandelbrot = _wire_draw_mandelbrotPtr.asFunction<
+      void Function(
+          int, ffi.Pointer<wire_Size>, ffi.Pointer<wire_Point>, double, int)>();
 
   void wire_passing_complex_structs(
     int port_,
@@ -497,11 +572,12 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_passing_complex_structsPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_TreeNode>)>>(
-          'wire_passing_complex_structs');
-  late final _wire_passing_complex_structs =
-      _wire_passing_complex_structsPtr.asFunction<void Function(int, ffi.Pointer<wire_TreeNode>)>();
+  late final _wire_passing_complex_structsPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Int64,
+              ffi.Pointer<wire_TreeNode>)>>('wire_passing_complex_structs');
+  late final _wire_passing_complex_structs = _wire_passing_complex_structsPtr
+      .asFunction<void Function(int, ffi.Pointer<wire_TreeNode>)>();
 
   void wire_returning_structs_with_boxed_fields(
     int port_,
@@ -512,9 +588,11 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _wire_returning_structs_with_boxed_fieldsPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_returning_structs_with_boxed_fields');
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
+          'wire_returning_structs_with_boxed_fields');
   late final _wire_returning_structs_with_boxed_fields =
-      _wire_returning_structs_with_boxed_fieldsPtr.asFunction<void Function(int)>();
+      _wire_returning_structs_with_boxed_fieldsPtr
+          .asFunction<void Function(int)>();
 
   void wire_off_topic_memory_test_input_array(
     int port_,
@@ -526,11 +604,13 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_off_topic_memory_test_input_arrayPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>(
-          'wire_off_topic_memory_test_input_array');
+  late final _wire_off_topic_memory_test_input_arrayPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>(
+      'wire_off_topic_memory_test_input_array');
   late final _wire_off_topic_memory_test_input_array =
-      _wire_off_topic_memory_test_input_arrayPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+      _wire_off_topic_memory_test_input_arrayPtr
+          .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_off_topic_memory_test_output_zero_copy_buffer(
     int port_,
@@ -546,7 +626,8 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>(
           'wire_off_topic_memory_test_output_zero_copy_buffer');
   late final _wire_off_topic_memory_test_output_zero_copy_buffer =
-      _wire_off_topic_memory_test_output_zero_copy_bufferPtr.asFunction<void Function(int, int)>();
+      _wire_off_topic_memory_test_output_zero_copy_bufferPtr
+          .asFunction<void Function(int, int)>();
 
   void wire_off_topic_memory_test_output_vec_u8(
     int port_,
@@ -559,9 +640,11 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _wire_off_topic_memory_test_output_vec_u8Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>('wire_off_topic_memory_test_output_vec_u8');
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>(
+          'wire_off_topic_memory_test_output_vec_u8');
   late final _wire_off_topic_memory_test_output_vec_u8 =
-      _wire_off_topic_memory_test_output_vec_u8Ptr.asFunction<void Function(int, int)>();
+      _wire_off_topic_memory_test_output_vec_u8Ptr
+          .asFunction<void Function(int, int)>();
 
   void wire_off_topic_memory_test_input_vec_of_object(
     int port_,
@@ -573,11 +656,13 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_off_topic_memory_test_input_vec_of_objectPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_list_size>)>>(
-          'wire_off_topic_memory_test_input_vec_of_object');
+  late final _wire_off_topic_memory_test_input_vec_of_objectPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Void Function(ffi.Int64, ffi.Pointer<wire_list_size>)>>(
+      'wire_off_topic_memory_test_input_vec_of_object');
   late final _wire_off_topic_memory_test_input_vec_of_object =
-      _wire_off_topic_memory_test_input_vec_of_objectPtr.asFunction<void Function(int, ffi.Pointer<wire_list_size>)>();
+      _wire_off_topic_memory_test_input_vec_of_objectPtr
+          .asFunction<void Function(int, ffi.Pointer<wire_list_size>)>();
 
   void wire_off_topic_memory_test_output_vec_of_object(
     int port_,
@@ -593,7 +678,8 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>(
           'wire_off_topic_memory_test_output_vec_of_object');
   late final _wire_off_topic_memory_test_output_vec_of_object =
-      _wire_off_topic_memory_test_output_vec_of_objectPtr.asFunction<void Function(int, int)>();
+      _wire_off_topic_memory_test_output_vec_of_objectPtr
+          .asFunction<void Function(int, int)>();
 
   void wire_off_topic_memory_test_input_complex_struct(
     int port_,
@@ -605,11 +691,13 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_off_topic_memory_test_input_complex_structPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_TreeNode>)>>(
-          'wire_off_topic_memory_test_input_complex_struct');
+  late final _wire_off_topic_memory_test_input_complex_structPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Void Function(ffi.Int64, ffi.Pointer<wire_TreeNode>)>>(
+      'wire_off_topic_memory_test_input_complex_struct');
   late final _wire_off_topic_memory_test_input_complex_struct =
-      _wire_off_topic_memory_test_input_complex_structPtr.asFunction<void Function(int, ffi.Pointer<wire_TreeNode>)>();
+      _wire_off_topic_memory_test_input_complex_structPtr
+          .asFunction<void Function(int, ffi.Pointer<wire_TreeNode>)>();
 
   void wire_off_topic_memory_test_output_complex_struct(
     int port_,
@@ -625,7 +713,8 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>(
           'wire_off_topic_memory_test_output_complex_struct');
   late final _wire_off_topic_memory_test_output_complex_struct =
-      _wire_off_topic_memory_test_output_complex_structPtr.asFunction<void Function(int, int)>();
+      _wire_off_topic_memory_test_output_complex_structPtr
+          .asFunction<void Function(int, int)>();
 
   void wire_off_topic_deliberately_return_error(
     int port_,
@@ -636,9 +725,11 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _wire_off_topic_deliberately_return_errorPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_off_topic_deliberately_return_error');
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
+          'wire_off_topic_deliberately_return_error');
   late final _wire_off_topic_deliberately_return_error =
-      _wire_off_topic_deliberately_return_errorPtr.asFunction<void Function(int)>();
+      _wire_off_topic_deliberately_return_errorPtr
+          .asFunction<void Function(int)>();
 
   void wire_off_topic_deliberately_panic(
     int port_,
@@ -649,7 +740,8 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _wire_off_topic_deliberately_panicPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_off_topic_deliberately_panic');
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
+          'wire_off_topic_deliberately_panic');
   late final _wire_off_topic_deliberately_panic =
       _wire_off_topic_deliberately_panicPtr.asFunction<void Function(int)>();
 
@@ -658,25 +750,30 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _new_box_autoadd_pointPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Point> Function()>>('new_box_autoadd_point');
-  late final _new_box_autoadd_point = _new_box_autoadd_pointPtr.asFunction<ffi.Pointer<wire_Point> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Point> Function()>>(
+          'new_box_autoadd_point');
+  late final _new_box_autoadd_point = _new_box_autoadd_pointPtr
+      .asFunction<ffi.Pointer<wire_Point> Function()>();
 
   ffi.Pointer<wire_Size> new_box_autoadd_size() {
     return _new_box_autoadd_size();
   }
 
   late final _new_box_autoadd_sizePtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Size> Function()>>('new_box_autoadd_size');
-  late final _new_box_autoadd_size = _new_box_autoadd_sizePtr.asFunction<ffi.Pointer<wire_Size> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Size> Function()>>(
+          'new_box_autoadd_size');
+  late final _new_box_autoadd_size =
+      _new_box_autoadd_sizePtr.asFunction<ffi.Pointer<wire_Size> Function()>();
 
   ffi.Pointer<wire_TreeNode> new_box_autoadd_tree_node() {
     return _new_box_autoadd_tree_node();
   }
 
   late final _new_box_autoadd_tree_nodePtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_TreeNode> Function()>>('new_box_autoadd_tree_node');
-  late final _new_box_autoadd_tree_node =
-      _new_box_autoadd_tree_nodePtr.asFunction<ffi.Pointer<wire_TreeNode> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_TreeNode> Function()>>(
+          'new_box_autoadd_tree_node');
+  late final _new_box_autoadd_tree_node = _new_box_autoadd_tree_nodePtr
+      .asFunction<ffi.Pointer<wire_TreeNode> Function()>();
 
   ffi.Pointer<wire_list_size> new_list_size(
     int len,
@@ -686,9 +783,11 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_list_sizePtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_list_size> Function(ffi.Int32)>>('new_list_size');
-  late final _new_list_size = _new_list_sizePtr.asFunction<ffi.Pointer<wire_list_size> Function(int)>();
+  late final _new_list_sizePtr = _lookup<
+          ffi.NativeFunction<ffi.Pointer<wire_list_size> Function(ffi.Int32)>>(
+      'new_list_size');
+  late final _new_list_size =
+      _new_list_sizePtr.asFunction<ffi.Pointer<wire_list_size> Function(int)>();
 
   ffi.Pointer<wire_list_tree_node> new_list_tree_node(
     int len,
@@ -698,9 +797,12 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_list_tree_nodePtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_list_tree_node> Function(ffi.Int32)>>('new_list_tree_node');
-  late final _new_list_tree_node = _new_list_tree_nodePtr.asFunction<ffi.Pointer<wire_list_tree_node> Function(int)>();
+  late final _new_list_tree_nodePtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<wire_list_tree_node> Function(
+              ffi.Int32)>>('new_list_tree_node');
+  late final _new_list_tree_node = _new_list_tree_nodePtr
+      .asFunction<ffi.Pointer<wire_list_tree_node> Function(int)>();
 
   ffi.Pointer<wire_uint_8_list> new_uint_8_list(
     int len,
@@ -710,9 +812,12 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_uint_8_listPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_uint_8_list> Function(ffi.Int32)>>('new_uint_8_list');
-  late final _new_uint_8_list = _new_uint_8_listPtr.asFunction<ffi.Pointer<wire_uint_8_list> Function(int)>();
+  late final _new_uint_8_listPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<wire_uint_8_list> Function(
+              ffi.Int32)>>('new_uint_8_list');
+  late final _new_uint_8_list = _new_uint_8_listPtr
+      .asFunction<ffi.Pointer<wire_uint_8_list> Function(int)>();
 
   void free_WireSyncReturnStruct(
     WireSyncReturnStruct val,
@@ -723,9 +828,10 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _free_WireSyncReturnStructPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(WireSyncReturnStruct)>>('free_WireSyncReturnStruct');
-  late final _free_WireSyncReturnStruct =
-      _free_WireSyncReturnStructPtr.asFunction<void Function(WireSyncReturnStruct)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(WireSyncReturnStruct)>>(
+          'free_WireSyncReturnStruct');
+  late final _free_WireSyncReturnStruct = _free_WireSyncReturnStructPtr
+      .asFunction<void Function(WireSyncReturnStruct)>();
 
   void store_dart_post_cobject(
     DartPostCObjectFnType ptr,
@@ -736,8 +842,10 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _store_dart_post_cobjectPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(DartPostCObjectFnType)>>('store_dart_post_cobject');
-  late final _store_dart_post_cobject = _store_dart_post_cobjectPtr.asFunction<void Function(DartPostCObjectFnType)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(DartPostCObjectFnType)>>(
+          'store_dart_post_cobject');
+  late final _store_dart_post_cobject = _store_dart_post_cobjectPtr
+      .asFunction<void Function(DartPostCObjectFnType)>();
 }
 
 class wire_Size extends ffi.Struct {
@@ -783,5 +891,6 @@ class wire_list_size extends ffi.Struct {
   external int len;
 }
 
-typedef DartPostCObjectFnType = ffi.Pointer<ffi.NativeFunction<ffi.Bool Function(DartPort, ffi.Pointer<ffi.Void>)>>;
+typedef DartPostCObjectFnType = ffi.Pointer<
+    ffi.NativeFunction<ffi.Bool Function(DartPort, ffi.Pointer<ffi.Void>)>>;
 typedef DartPort = ffi.Int64;

--- a/frb_example/with_flutter/lib/bridge_generated.dart
+++ b/frb_example/with_flutter/lib/bridge_generated.dart
@@ -783,5 +783,5 @@ class wire_list_size extends ffi.Struct {
   external int len;
 }
 
-typedef DartPostCObjectFnType = ffi.Pointer<ffi.NativeFunction<ffi.Uint8 Function(DartPort, ffi.Pointer<ffi.Void>)>>;
+typedef DartPostCObjectFnType = ffi.Pointer<ffi.NativeFunction<ffi.Bool Function(DartPort, ffi.Pointer<ffi.Void>)>>;
 typedef DartPort = ffi.Int64;

--- a/frb_example/with_flutter/lib/bridge_generated.dart
+++ b/frb_example/with_flutter/lib/bridge_generated.dart
@@ -29,45 +29,33 @@ abstract class FlutterRustBridgeExample {
 
   FlutterRustBridgeTaskConstMeta get kReturningStructsWithBoxedFieldsConstMeta;
 
-  Future<int> offTopicMemoryTestInputArray(
-      {required Uint8List input, dynamic hint});
+  Future<int> offTopicMemoryTestInputArray({required Uint8List input, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kOffTopicMemoryTestInputArrayConstMeta;
 
-  Future<Uint8List> offTopicMemoryTestOutputZeroCopyBuffer(
-      {required int len, dynamic hint});
+  Future<Uint8List> offTopicMemoryTestOutputZeroCopyBuffer({required int len, dynamic hint});
 
-  FlutterRustBridgeTaskConstMeta
-      get kOffTopicMemoryTestOutputZeroCopyBufferConstMeta;
+  FlutterRustBridgeTaskConstMeta get kOffTopicMemoryTestOutputZeroCopyBufferConstMeta;
 
-  Future<Uint8List> offTopicMemoryTestOutputVecU8(
-      {required int len, dynamic hint});
+  Future<Uint8List> offTopicMemoryTestOutputVecU8({required int len, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kOffTopicMemoryTestOutputVecU8ConstMeta;
 
-  Future<int> offTopicMemoryTestInputVecOfObject(
-      {required List<Size> input, dynamic hint});
+  Future<int> offTopicMemoryTestInputVecOfObject({required List<Size> input, dynamic hint});
 
-  FlutterRustBridgeTaskConstMeta
-      get kOffTopicMemoryTestInputVecOfObjectConstMeta;
+  FlutterRustBridgeTaskConstMeta get kOffTopicMemoryTestInputVecOfObjectConstMeta;
 
-  Future<List<Size>> offTopicMemoryTestOutputVecOfObject(
-      {required int len, dynamic hint});
+  Future<List<Size>> offTopicMemoryTestOutputVecOfObject({required int len, dynamic hint});
 
-  FlutterRustBridgeTaskConstMeta
-      get kOffTopicMemoryTestOutputVecOfObjectConstMeta;
+  FlutterRustBridgeTaskConstMeta get kOffTopicMemoryTestOutputVecOfObjectConstMeta;
 
-  Future<int> offTopicMemoryTestInputComplexStruct(
-      {required TreeNode input, dynamic hint});
+  Future<int> offTopicMemoryTestInputComplexStruct({required TreeNode input, dynamic hint});
 
-  FlutterRustBridgeTaskConstMeta
-      get kOffTopicMemoryTestInputComplexStructConstMeta;
+  FlutterRustBridgeTaskConstMeta get kOffTopicMemoryTestInputComplexStructConstMeta;
 
-  Future<TreeNode> offTopicMemoryTestOutputComplexStruct(
-      {required int len, dynamic hint});
+  Future<TreeNode> offTopicMemoryTestOutputComplexStruct({required int len, dynamic hint});
 
-  FlutterRustBridgeTaskConstMeta
-      get kOffTopicMemoryTestOutputComplexStructConstMeta;
+  FlutterRustBridgeTaskConstMeta get kOffTopicMemoryTestOutputComplexStructConstMeta;
 
   Future<int> offTopicDeliberatelyReturnError({dynamic hint});
 
@@ -116,14 +104,12 @@ class TreeNode {
   });
 }
 
-class FlutterRustBridgeExampleImpl
-    extends FlutterRustBridgeBase<FlutterRustBridgeExampleWire>
+class FlutterRustBridgeExampleImpl extends FlutterRustBridgeBase<FlutterRustBridgeExampleWire>
     implements FlutterRustBridgeExample {
   factory FlutterRustBridgeExampleImpl(ffi.DynamicLibrary dylib) =>
       FlutterRustBridgeExampleImpl.raw(FlutterRustBridgeExampleWire(dylib));
 
-  FlutterRustBridgeExampleImpl.raw(FlutterRustBridgeExampleWire inner)
-      : super(inner);
+  FlutterRustBridgeExampleImpl.raw(FlutterRustBridgeExampleWire inner) : super(inner);
 
   Future<Uint8List> drawMandelbrot(
           {required Size imageSize,
@@ -132,206 +118,163 @@ class FlutterRustBridgeExampleImpl
           required int numThreads,
           dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_draw_mandelbrot(
-            port_,
-            _api2wire_box_autoadd_size(imageSize),
-            _api2wire_box_autoadd_point(zoomPoint),
-            _api2wire_f64(scale),
-            _api2wire_i32(numThreads)),
+        callFfi: (port_) => inner.wire_draw_mandelbrot(port_, _api2wire_box_autoadd_size(imageSize),
+            _api2wire_box_autoadd_point(zoomPoint), _api2wire_f64(scale), _api2wire_i32(numThreads)),
         parseSuccessData: _wire2api_ZeroCopyBuffer_Uint8List,
         constMeta: kDrawMandelbrotConstMeta,
         argValues: [imageSize, zoomPoint, scale, numThreads],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kDrawMandelbrotConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kDrawMandelbrotConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "draw_mandelbrot",
         argNames: ["imageSize", "zoomPoint", "scale", "numThreads"],
       );
 
-  Future<String> passingComplexStructs(
-          {required TreeNode root, dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_passing_complex_structs(
-            port_, _api2wire_box_autoadd_tree_node(root)),
+  Future<String> passingComplexStructs({required TreeNode root, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_passing_complex_structs(port_, _api2wire_box_autoadd_tree_node(root)),
         parseSuccessData: _wire2api_String,
         constMeta: kPassingComplexStructsConstMeta,
         argValues: [root],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kPassingComplexStructsConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kPassingComplexStructsConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "passing_complex_structs",
         argNames: ["root"],
       );
 
-  Future<BoxedPoint> returningStructsWithBoxedFields({dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_returning_structs_with_boxed_fields(port_),
+  Future<BoxedPoint> returningStructsWithBoxedFields({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_returning_structs_with_boxed_fields(port_),
         parseSuccessData: _wire2api_boxed_point,
         constMeta: kReturningStructsWithBoxedFieldsConstMeta,
         argValues: [],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta
-      get kReturningStructsWithBoxedFieldsConstMeta =>
-          const FlutterRustBridgeTaskConstMeta(
-            debugName: "returning_structs_with_boxed_fields",
-            argNames: [],
-          );
+  FlutterRustBridgeTaskConstMeta get kReturningStructsWithBoxedFieldsConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "returning_structs_with_boxed_fields",
+        argNames: [],
+      );
 
-  Future<int> offTopicMemoryTestInputArray(
-          {required Uint8List input, dynamic hint}) =>
+  Future<int> offTopicMemoryTestInputArray({required Uint8List input, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_off_topic_memory_test_input_array(
-            port_, _api2wire_uint_8_list(input)),
+        callFfi: (port_) => inner.wire_off_topic_memory_test_input_array(port_, _api2wire_uint_8_list(input)),
         parseSuccessData: _wire2api_i32,
         constMeta: kOffTopicMemoryTestInputArrayConstMeta,
         argValues: [input],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kOffTopicMemoryTestInputArrayConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kOffTopicMemoryTestInputArrayConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "off_topic_memory_test_input_array",
         argNames: ["input"],
       );
 
-  Future<Uint8List> offTopicMemoryTestOutputZeroCopyBuffer(
-          {required int len, dynamic hint}) =>
+  Future<Uint8List> offTopicMemoryTestOutputZeroCopyBuffer({required int len, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_off_topic_memory_test_output_zero_copy_buffer(
-                port_, _api2wire_i32(len)),
+        callFfi: (port_) => inner.wire_off_topic_memory_test_output_zero_copy_buffer(port_, _api2wire_i32(len)),
         parseSuccessData: _wire2api_ZeroCopyBuffer_Uint8List,
         constMeta: kOffTopicMemoryTestOutputZeroCopyBufferConstMeta,
         argValues: [len],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta
-      get kOffTopicMemoryTestOutputZeroCopyBufferConstMeta =>
-          const FlutterRustBridgeTaskConstMeta(
-            debugName: "off_topic_memory_test_output_zero_copy_buffer",
-            argNames: ["len"],
-          );
+  FlutterRustBridgeTaskConstMeta get kOffTopicMemoryTestOutputZeroCopyBufferConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
+        debugName: "off_topic_memory_test_output_zero_copy_buffer",
+        argNames: ["len"],
+      );
 
-  Future<Uint8List> offTopicMemoryTestOutputVecU8(
-          {required int len, dynamic hint}) =>
+  Future<Uint8List> offTopicMemoryTestOutputVecU8({required int len, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_off_topic_memory_test_output_vec_u8(
-            port_, _api2wire_i32(len)),
+        callFfi: (port_) => inner.wire_off_topic_memory_test_output_vec_u8(port_, _api2wire_i32(len)),
         parseSuccessData: _wire2api_uint_8_list,
         constMeta: kOffTopicMemoryTestOutputVecU8ConstMeta,
         argValues: [len],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kOffTopicMemoryTestOutputVecU8ConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kOffTopicMemoryTestOutputVecU8ConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "off_topic_memory_test_output_vec_u8",
         argNames: ["len"],
       );
 
-  Future<int> offTopicMemoryTestInputVecOfObject(
-          {required List<Size> input, dynamic hint}) =>
+  Future<int> offTopicMemoryTestInputVecOfObject({required List<Size> input, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_off_topic_memory_test_input_vec_of_object(
-                port_, _api2wire_list_size(input)),
+        callFfi: (port_) => inner.wire_off_topic_memory_test_input_vec_of_object(port_, _api2wire_list_size(input)),
         parseSuccessData: _wire2api_i32,
         constMeta: kOffTopicMemoryTestInputVecOfObjectConstMeta,
         argValues: [input],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta
-      get kOffTopicMemoryTestInputVecOfObjectConstMeta =>
-          const FlutterRustBridgeTaskConstMeta(
-            debugName: "off_topic_memory_test_input_vec_of_object",
-            argNames: ["input"],
-          );
+  FlutterRustBridgeTaskConstMeta get kOffTopicMemoryTestInputVecOfObjectConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
+        debugName: "off_topic_memory_test_input_vec_of_object",
+        argNames: ["input"],
+      );
 
-  Future<List<Size>> offTopicMemoryTestOutputVecOfObject(
-          {required int len, dynamic hint}) =>
+  Future<List<Size>> offTopicMemoryTestOutputVecOfObject({required int len, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_off_topic_memory_test_output_vec_of_object(
-                port_, _api2wire_i32(len)),
+        callFfi: (port_) => inner.wire_off_topic_memory_test_output_vec_of_object(port_, _api2wire_i32(len)),
         parseSuccessData: _wire2api_list_size,
         constMeta: kOffTopicMemoryTestOutputVecOfObjectConstMeta,
         argValues: [len],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta
-      get kOffTopicMemoryTestOutputVecOfObjectConstMeta =>
-          const FlutterRustBridgeTaskConstMeta(
-            debugName: "off_topic_memory_test_output_vec_of_object",
-            argNames: ["len"],
-          );
+  FlutterRustBridgeTaskConstMeta get kOffTopicMemoryTestOutputVecOfObjectConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
+        debugName: "off_topic_memory_test_output_vec_of_object",
+        argNames: ["len"],
+      );
 
-  Future<int> offTopicMemoryTestInputComplexStruct(
-          {required TreeNode input, dynamic hint}) =>
+  Future<int> offTopicMemoryTestInputComplexStruct({required TreeNode input, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) =>
-            inner.wire_off_topic_memory_test_input_complex_struct(
-                port_, _api2wire_box_autoadd_tree_node(input)),
+            inner.wire_off_topic_memory_test_input_complex_struct(port_, _api2wire_box_autoadd_tree_node(input)),
         parseSuccessData: _wire2api_i32,
         constMeta: kOffTopicMemoryTestInputComplexStructConstMeta,
         argValues: [input],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta
-      get kOffTopicMemoryTestInputComplexStructConstMeta =>
-          const FlutterRustBridgeTaskConstMeta(
-            debugName: "off_topic_memory_test_input_complex_struct",
-            argNames: ["input"],
-          );
+  FlutterRustBridgeTaskConstMeta get kOffTopicMemoryTestInputComplexStructConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
+        debugName: "off_topic_memory_test_input_complex_struct",
+        argNames: ["input"],
+      );
 
-  Future<TreeNode> offTopicMemoryTestOutputComplexStruct(
-          {required int len, dynamic hint}) =>
+  Future<TreeNode> offTopicMemoryTestOutputComplexStruct({required int len, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_off_topic_memory_test_output_complex_struct(
-                port_, _api2wire_i32(len)),
+        callFfi: (port_) => inner.wire_off_topic_memory_test_output_complex_struct(port_, _api2wire_i32(len)),
         parseSuccessData: _wire2api_tree_node,
         constMeta: kOffTopicMemoryTestOutputComplexStructConstMeta,
         argValues: [len],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta
-      get kOffTopicMemoryTestOutputComplexStructConstMeta =>
-          const FlutterRustBridgeTaskConstMeta(
-            debugName: "off_topic_memory_test_output_complex_struct",
-            argNames: ["len"],
-          );
+  FlutterRustBridgeTaskConstMeta get kOffTopicMemoryTestOutputComplexStructConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
+        debugName: "off_topic_memory_test_output_complex_struct",
+        argNames: ["len"],
+      );
 
-  Future<int> offTopicDeliberatelyReturnError({dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_off_topic_deliberately_return_error(port_),
+  Future<int> offTopicDeliberatelyReturnError({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_off_topic_deliberately_return_error(port_),
         parseSuccessData: _wire2api_i32,
         constMeta: kOffTopicDeliberatelyReturnErrorConstMeta,
         argValues: [],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta
-      get kOffTopicDeliberatelyReturnErrorConstMeta =>
-          const FlutterRustBridgeTaskConstMeta(
-            debugName: "off_topic_deliberately_return_error",
-            argNames: [],
-          );
+  FlutterRustBridgeTaskConstMeta get kOffTopicDeliberatelyReturnErrorConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "off_topic_deliberately_return_error",
+        argNames: [],
+      );
 
-  Future<int> offTopicDeliberatelyPanic({dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
+  Future<int> offTopicDeliberatelyPanic({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_off_topic_deliberately_panic(port_),
         parseSuccessData: _wire2api_i32,
         constMeta: kOffTopicDeliberatelyPanicConstMeta,
@@ -339,8 +282,7 @@ class FlutterRustBridgeExampleImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kOffTopicDeliberatelyPanicConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kOffTopicDeliberatelyPanicConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "off_topic_deliberately_panic",
         argNames: [],
       );
@@ -384,8 +326,7 @@ class FlutterRustBridgeExampleImpl
     return ans;
   }
 
-  ffi.Pointer<wire_list_tree_node> _api2wire_list_tree_node(
-      List<TreeNode> raw) {
+  ffi.Pointer<wire_list_tree_node> _api2wire_list_tree_node(List<TreeNode> raw) {
     final ans = inner.new_list_tree_node(raw.length);
     for (var i = 0; i < raw.length; ++i) {
       _api_fill_to_wire_tree_node(raw[i], ans.ref.ptr[i]);
@@ -405,18 +346,15 @@ class FlutterRustBridgeExampleImpl
 
   // Section: api_fill_to_wire
 
-  void _api_fill_to_wire_box_autoadd_point(
-      Point apiObj, ffi.Pointer<wire_Point> wireObj) {
+  void _api_fill_to_wire_box_autoadd_point(Point apiObj, ffi.Pointer<wire_Point> wireObj) {
     _api_fill_to_wire_point(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_size(
-      Size apiObj, ffi.Pointer<wire_Size> wireObj) {
+  void _api_fill_to_wire_box_autoadd_size(Size apiObj, ffi.Pointer<wire_Size> wireObj) {
     _api_fill_to_wire_size(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_tree_node(
-      TreeNode apiObj, ffi.Pointer<wire_TreeNode> wireObj) {
+  void _api_fill_to_wire_box_autoadd_tree_node(TreeNode apiObj, ffi.Pointer<wire_TreeNode> wireObj) {
     _api_fill_to_wire_tree_node(apiObj, wireObj.ref);
   }
 
@@ -451,8 +389,7 @@ Point _wire2api_box_point(dynamic raw) {
 
 BoxedPoint _wire2api_boxed_point(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 1)
-    throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+  if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
   return BoxedPoint(
     point: _wire2api_box_point(arr[0]),
   );
@@ -476,8 +413,7 @@ List<TreeNode> _wire2api_list_tree_node(dynamic raw) {
 
 Point _wire2api_point(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 2)
-    throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+  if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
   return Point(
     x: _wire2api_f64(arr[0]),
     y: _wire2api_f64(arr[1]),
@@ -486,8 +422,7 @@ Point _wire2api_point(dynamic raw) {
 
 Size _wire2api_size(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 2)
-    throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+  if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
   return Size(
     width: _wire2api_i32(arr[0]),
     height: _wire2api_i32(arr[1]),
@@ -496,8 +431,7 @@ Size _wire2api_size(dynamic raw) {
 
 TreeNode _wire2api_tree_node(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 2)
-    throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+  if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
   return TreeNode(
     name: _wire2api_String(arr[0]),
     children: _wire2api_list_tree_node(arr[1]),
@@ -521,17 +455,13 @@ Uint8List _wire2api_uint_8_list(dynamic raw) {
 /// generated by flutter_rust_bridge
 class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   /// Holds the symbol lookup function.
-  final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
-      _lookup;
+  final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName) _lookup;
 
   /// The symbols are looked up in [dynamicLibrary].
-  FlutterRustBridgeExampleWire(ffi.DynamicLibrary dynamicLibrary)
-      : _lookup = dynamicLibrary.lookup;
+  FlutterRustBridgeExampleWire(ffi.DynamicLibrary dynamicLibrary) : _lookup = dynamicLibrary.lookup;
 
   /// The symbols are looked up with [lookup].
-  FlutterRustBridgeExampleWire.fromLookup(
-      ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
-          lookup)
+  FlutterRustBridgeExampleWire.fromLookup(ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName) lookup)
       : _lookup = lookup;
 
   void wire_draw_mandelbrot(
@@ -552,15 +482,10 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
 
   late final _wire_draw_mandelbrotPtr = _lookup<
       ffi.NativeFunction<
-          ffi.Void Function(
-              ffi.Int64,
-              ffi.Pointer<wire_Size>,
-              ffi.Pointer<wire_Point>,
-              ffi.Double,
+          ffi.Void Function(ffi.Int64, ffi.Pointer<wire_Size>, ffi.Pointer<wire_Point>, ffi.Double,
               ffi.Int32)>>('wire_draw_mandelbrot');
-  late final _wire_draw_mandelbrot = _wire_draw_mandelbrotPtr.asFunction<
-      void Function(
-          int, ffi.Pointer<wire_Size>, ffi.Pointer<wire_Point>, double, int)>();
+  late final _wire_draw_mandelbrot = _wire_draw_mandelbrotPtr
+      .asFunction<void Function(int, ffi.Pointer<wire_Size>, ffi.Pointer<wire_Point>, double, int)>();
 
   void wire_passing_complex_structs(
     int port_,
@@ -572,12 +497,11 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_passing_complex_structsPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64,
-              ffi.Pointer<wire_TreeNode>)>>('wire_passing_complex_structs');
-  late final _wire_passing_complex_structs = _wire_passing_complex_structsPtr
-      .asFunction<void Function(int, ffi.Pointer<wire_TreeNode>)>();
+  late final _wire_passing_complex_structsPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_TreeNode>)>>(
+          'wire_passing_complex_structs');
+  late final _wire_passing_complex_structs =
+      _wire_passing_complex_structsPtr.asFunction<void Function(int, ffi.Pointer<wire_TreeNode>)>();
 
   void wire_returning_structs_with_boxed_fields(
     int port_,
@@ -588,11 +512,9 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _wire_returning_structs_with_boxed_fieldsPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
-          'wire_returning_structs_with_boxed_fields');
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_returning_structs_with_boxed_fields');
   late final _wire_returning_structs_with_boxed_fields =
-      _wire_returning_structs_with_boxed_fieldsPtr
-          .asFunction<void Function(int)>();
+      _wire_returning_structs_with_boxed_fieldsPtr.asFunction<void Function(int)>();
 
   void wire_off_topic_memory_test_input_array(
     int port_,
@@ -604,13 +526,11 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_off_topic_memory_test_input_arrayPtr = _lookup<
-          ffi.NativeFunction<
-              ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>(
-      'wire_off_topic_memory_test_input_array');
+  late final _wire_off_topic_memory_test_input_arrayPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>(
+          'wire_off_topic_memory_test_input_array');
   late final _wire_off_topic_memory_test_input_array =
-      _wire_off_topic_memory_test_input_arrayPtr
-          .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+      _wire_off_topic_memory_test_input_arrayPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_off_topic_memory_test_output_zero_copy_buffer(
     int port_,
@@ -626,8 +546,7 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>(
           'wire_off_topic_memory_test_output_zero_copy_buffer');
   late final _wire_off_topic_memory_test_output_zero_copy_buffer =
-      _wire_off_topic_memory_test_output_zero_copy_bufferPtr
-          .asFunction<void Function(int, int)>();
+      _wire_off_topic_memory_test_output_zero_copy_bufferPtr.asFunction<void Function(int, int)>();
 
   void wire_off_topic_memory_test_output_vec_u8(
     int port_,
@@ -640,11 +559,9 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _wire_off_topic_memory_test_output_vec_u8Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>(
-          'wire_off_topic_memory_test_output_vec_u8');
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>('wire_off_topic_memory_test_output_vec_u8');
   late final _wire_off_topic_memory_test_output_vec_u8 =
-      _wire_off_topic_memory_test_output_vec_u8Ptr
-          .asFunction<void Function(int, int)>();
+      _wire_off_topic_memory_test_output_vec_u8Ptr.asFunction<void Function(int, int)>();
 
   void wire_off_topic_memory_test_input_vec_of_object(
     int port_,
@@ -656,13 +573,11 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_off_topic_memory_test_input_vec_of_objectPtr = _lookup<
-          ffi.NativeFunction<
-              ffi.Void Function(ffi.Int64, ffi.Pointer<wire_list_size>)>>(
-      'wire_off_topic_memory_test_input_vec_of_object');
+  late final _wire_off_topic_memory_test_input_vec_of_objectPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_list_size>)>>(
+          'wire_off_topic_memory_test_input_vec_of_object');
   late final _wire_off_topic_memory_test_input_vec_of_object =
-      _wire_off_topic_memory_test_input_vec_of_objectPtr
-          .asFunction<void Function(int, ffi.Pointer<wire_list_size>)>();
+      _wire_off_topic_memory_test_input_vec_of_objectPtr.asFunction<void Function(int, ffi.Pointer<wire_list_size>)>();
 
   void wire_off_topic_memory_test_output_vec_of_object(
     int port_,
@@ -678,8 +593,7 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>(
           'wire_off_topic_memory_test_output_vec_of_object');
   late final _wire_off_topic_memory_test_output_vec_of_object =
-      _wire_off_topic_memory_test_output_vec_of_objectPtr
-          .asFunction<void Function(int, int)>();
+      _wire_off_topic_memory_test_output_vec_of_objectPtr.asFunction<void Function(int, int)>();
 
   void wire_off_topic_memory_test_input_complex_struct(
     int port_,
@@ -691,13 +605,11 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_off_topic_memory_test_input_complex_structPtr = _lookup<
-          ffi.NativeFunction<
-              ffi.Void Function(ffi.Int64, ffi.Pointer<wire_TreeNode>)>>(
-      'wire_off_topic_memory_test_input_complex_struct');
+  late final _wire_off_topic_memory_test_input_complex_structPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_TreeNode>)>>(
+          'wire_off_topic_memory_test_input_complex_struct');
   late final _wire_off_topic_memory_test_input_complex_struct =
-      _wire_off_topic_memory_test_input_complex_structPtr
-          .asFunction<void Function(int, ffi.Pointer<wire_TreeNode>)>();
+      _wire_off_topic_memory_test_input_complex_structPtr.asFunction<void Function(int, ffi.Pointer<wire_TreeNode>)>();
 
   void wire_off_topic_memory_test_output_complex_struct(
     int port_,
@@ -713,8 +625,7 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>(
           'wire_off_topic_memory_test_output_complex_struct');
   late final _wire_off_topic_memory_test_output_complex_struct =
-      _wire_off_topic_memory_test_output_complex_structPtr
-          .asFunction<void Function(int, int)>();
+      _wire_off_topic_memory_test_output_complex_structPtr.asFunction<void Function(int, int)>();
 
   void wire_off_topic_deliberately_return_error(
     int port_,
@@ -725,11 +636,9 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _wire_off_topic_deliberately_return_errorPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
-          'wire_off_topic_deliberately_return_error');
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_off_topic_deliberately_return_error');
   late final _wire_off_topic_deliberately_return_error =
-      _wire_off_topic_deliberately_return_errorPtr
-          .asFunction<void Function(int)>();
+      _wire_off_topic_deliberately_return_errorPtr.asFunction<void Function(int)>();
 
   void wire_off_topic_deliberately_panic(
     int port_,
@@ -740,8 +649,7 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _wire_off_topic_deliberately_panicPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
-          'wire_off_topic_deliberately_panic');
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_off_topic_deliberately_panic');
   late final _wire_off_topic_deliberately_panic =
       _wire_off_topic_deliberately_panicPtr.asFunction<void Function(int)>();
 
@@ -750,30 +658,25 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _new_box_autoadd_pointPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Point> Function()>>(
-          'new_box_autoadd_point');
-  late final _new_box_autoadd_point = _new_box_autoadd_pointPtr
-      .asFunction<ffi.Pointer<wire_Point> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Point> Function()>>('new_box_autoadd_point');
+  late final _new_box_autoadd_point = _new_box_autoadd_pointPtr.asFunction<ffi.Pointer<wire_Point> Function()>();
 
   ffi.Pointer<wire_Size> new_box_autoadd_size() {
     return _new_box_autoadd_size();
   }
 
   late final _new_box_autoadd_sizePtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Size> Function()>>(
-          'new_box_autoadd_size');
-  late final _new_box_autoadd_size =
-      _new_box_autoadd_sizePtr.asFunction<ffi.Pointer<wire_Size> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Size> Function()>>('new_box_autoadd_size');
+  late final _new_box_autoadd_size = _new_box_autoadd_sizePtr.asFunction<ffi.Pointer<wire_Size> Function()>();
 
   ffi.Pointer<wire_TreeNode> new_box_autoadd_tree_node() {
     return _new_box_autoadd_tree_node();
   }
 
   late final _new_box_autoadd_tree_nodePtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_TreeNode> Function()>>(
-          'new_box_autoadd_tree_node');
-  late final _new_box_autoadd_tree_node = _new_box_autoadd_tree_nodePtr
-      .asFunction<ffi.Pointer<wire_TreeNode> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_TreeNode> Function()>>('new_box_autoadd_tree_node');
+  late final _new_box_autoadd_tree_node =
+      _new_box_autoadd_tree_nodePtr.asFunction<ffi.Pointer<wire_TreeNode> Function()>();
 
   ffi.Pointer<wire_list_size> new_list_size(
     int len,
@@ -783,11 +686,9 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_list_sizePtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<wire_list_size> Function(ffi.Int32)>>(
-      'new_list_size');
-  late final _new_list_size =
-      _new_list_sizePtr.asFunction<ffi.Pointer<wire_list_size> Function(int)>();
+  late final _new_list_sizePtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_list_size> Function(ffi.Int32)>>('new_list_size');
+  late final _new_list_size = _new_list_sizePtr.asFunction<ffi.Pointer<wire_list_size> Function(int)>();
 
   ffi.Pointer<wire_list_tree_node> new_list_tree_node(
     int len,
@@ -797,12 +698,9 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_list_tree_nodePtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<wire_list_tree_node> Function(
-              ffi.Int32)>>('new_list_tree_node');
-  late final _new_list_tree_node = _new_list_tree_nodePtr
-      .asFunction<ffi.Pointer<wire_list_tree_node> Function(int)>();
+  late final _new_list_tree_nodePtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_list_tree_node> Function(ffi.Int32)>>('new_list_tree_node');
+  late final _new_list_tree_node = _new_list_tree_nodePtr.asFunction<ffi.Pointer<wire_list_tree_node> Function(int)>();
 
   ffi.Pointer<wire_uint_8_list> new_uint_8_list(
     int len,
@@ -812,12 +710,9 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _new_uint_8_listPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<wire_uint_8_list> Function(
-              ffi.Int32)>>('new_uint_8_list');
-  late final _new_uint_8_list = _new_uint_8_listPtr
-      .asFunction<ffi.Pointer<wire_uint_8_list> Function(int)>();
+  late final _new_uint_8_listPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_uint_8_list> Function(ffi.Int32)>>('new_uint_8_list');
+  late final _new_uint_8_list = _new_uint_8_listPtr.asFunction<ffi.Pointer<wire_uint_8_list> Function(int)>();
 
   void free_WireSyncReturnStruct(
     WireSyncReturnStruct val,
@@ -828,10 +723,9 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _free_WireSyncReturnStructPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(WireSyncReturnStruct)>>(
-          'free_WireSyncReturnStruct');
-  late final _free_WireSyncReturnStruct = _free_WireSyncReturnStructPtr
-      .asFunction<void Function(WireSyncReturnStruct)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(WireSyncReturnStruct)>>('free_WireSyncReturnStruct');
+  late final _free_WireSyncReturnStruct =
+      _free_WireSyncReturnStructPtr.asFunction<void Function(WireSyncReturnStruct)>();
 
   void store_dart_post_cobject(
     DartPostCObjectFnType ptr,
@@ -842,10 +736,8 @@ class FlutterRustBridgeExampleWire implements FlutterRustBridgeWireBase {
   }
 
   late final _store_dart_post_cobjectPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(DartPostCObjectFnType)>>(
-          'store_dart_post_cobject');
-  late final _store_dart_post_cobject = _store_dart_post_cobjectPtr
-      .asFunction<void Function(DartPostCObjectFnType)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(DartPostCObjectFnType)>>('store_dart_post_cobject');
+  late final _store_dart_post_cobject = _store_dart_post_cobjectPtr.asFunction<void Function(DartPostCObjectFnType)>();
 }
 
 class wire_Size extends ffi.Struct {
@@ -891,6 +783,5 @@ class wire_list_size extends ffi.Struct {
   external int len;
 }
 
-typedef DartPostCObjectFnType = ffi.Pointer<
-    ffi.NativeFunction<ffi.Bool Function(DartPort, ffi.Pointer<ffi.Void>)>>;
+typedef DartPostCObjectFnType = ffi.Pointer<ffi.NativeFunction<ffi.Bool Function(DartPort, ffi.Pointer<ffi.Void>)>>;
 typedef DartPort = ffi.Int64;


### PR DESCRIPTION
Based on [this comment](https://github.com/fzyzcjy/flutter_rust_bridge/issues/478#issuecomment-1168648564).

This fixes the syntax error and allows my project to build with `ffigen` >= 6.0. I haven't tested thoroughly and I don't fully understand what's going on, so I'm relying on CI to validate it. If CI doesn't pass then I'll dig into it more.

This is a breaking change, as I expect this PR to cause `flutter_rust_bridge` to break with `ffigen` < 6.0. `ffigen` can be upgraded by running `dart pub global activate ffigen`.

Resolves #478 and resolves #512.