### PR TITLE
fix "Skipping unresolvable module" by align latest

### DIFF
--- a/frb_codegen/src/source_graph.rs
+++ b/frb_codegen/src/source_graph.rs
@@ -7,7 +7,12 @@
         - Imports that start with two colons (use ::a::b) - these are also silently ignored
 */
 
-use std::{collections::HashMap, fmt::Debug, fs, path::PathBuf};
+use std::{
+    collections::HashMap,
+    fmt::Debug,
+    fs,
+    path::{Path, PathBuf},
+};
 
 use cargo_metadata::MetadataCommand;
 use log::{debug, warn};
@@ -284,7 +289,7 @@ impl Module {
                         None => {
                             fn get_module_file_path(
                                 module_name: String,
-                                parent_module_file_path: &PathBuf,
+                                parent_module_file_path: &Path,
                             ) -> Result<PathBuf, Vec<PathBuf>> {
                                 let folder_path = parent_module_file_path.parent().unwrap();
                                 let file_path = folder_path.join(&module_name).with_extension("rs");
@@ -350,7 +355,7 @@ impl Module {
                                             .map(|it| it.to_string_lossy().to_string())
                                             .fold(String::new(), |mut a, b| {
                                                 a.push_str(&b);
-                                                a.push_str(",");
+                                                a.push(',');
                                                 a
                                             })
                                     );

--- a/frb_example/pure_dart/dart/lib/bridge_generated.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.dart
@@ -247,9 +247,13 @@ abstract class FlutterRustBridgeExampleSingleBlockTest {
 
   FlutterRustBridgeTaskConstMeta get kMultiplyByTenConstMeta;
 
-  Future<String> callBothModuleSystem({dynamic hint});
+  Future<OldSimpleStruct> callOldModuleSystem({dynamic hint});
 
-  FlutterRustBridgeTaskConstMeta get kCallBothModuleSystemConstMeta;
+  FlutterRustBridgeTaskConstMeta get kCallOldModuleSystemConstMeta;
+
+  Future<NewSimpleStruct> callNewModuleSystem({dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kCallNewModuleSystemConstMeta;
 
   Future<int> sumMethodSumWith(
       {required SumWith that, required int y, required int z, dynamic hint});
@@ -596,6 +600,14 @@ class MyTreeNode {
   });
 }
 
+class NewSimpleStruct {
+  final int field;
+
+  NewSimpleStruct({
+    required this.field,
+  });
+}
+
 class NewTypeInt {
   final int field0;
 
@@ -619,6 +631,14 @@ class Numbers {
 
   Numbers({
     required this.field0,
+  });
+}
+
+class OldSimpleStruct {
+  final int field;
+
+  OldSimpleStruct({
+    required this.field,
   });
 }
 
@@ -1568,18 +1588,33 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
         argNames: ["measure"],
       );
 
-  Future<String> callBothModuleSystem({dynamic hint}) =>
+  Future<OldSimpleStruct> callOldModuleSystem({dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_call_both_module_system(port_),
-        parseSuccessData: _wire2api_String,
-        constMeta: kCallBothModuleSystemConstMeta,
+        callFfi: (port_) => inner.wire_call_old_module_system(port_),
+        parseSuccessData: _wire2api_old_simple_struct,
+        constMeta: kCallOldModuleSystemConstMeta,
         argValues: [],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kCallBothModuleSystemConstMeta =>
+  FlutterRustBridgeTaskConstMeta get kCallOldModuleSystemConstMeta =>
       const FlutterRustBridgeTaskConstMeta(
-        debugName: "call_both_module_system",
+        debugName: "call_old_module_system",
+        argNames: [],
+      );
+
+  Future<NewSimpleStruct> callNewModuleSystem({dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_call_new_module_system(port_),
+        parseSuccessData: _wire2api_new_simple_struct,
+        constMeta: kCallNewModuleSystemConstMeta,
+        argValues: [],
+        hint: hint,
+      ));
+
+  FlutterRustBridgeTaskConstMeta get kCallNewModuleSystemConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
+        debugName: "call_new_module_system",
         argNames: [],
       );
 
@@ -2918,6 +2953,15 @@ MyTreeNode _wire2api_my_tree_node(dynamic raw) {
   );
 }
 
+NewSimpleStruct _wire2api_new_simple_struct(dynamic raw) {
+  final arr = raw as List<dynamic>;
+  if (arr.length != 1)
+    throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+  return NewSimpleStruct(
+    field: _wire2api_i32(arr[0]),
+  );
+}
+
 NewTypeInt _wire2api_new_type_int(dynamic raw) {
   final arr = raw as List<dynamic>;
   if (arr.length != 1)
@@ -2933,6 +2977,15 @@ Numbers _wire2api_numbers(dynamic raw) {
     throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
   return Numbers(
     field0: _wire2api_int_32_list(arr[0]),
+  );
+}
+
+OldSimpleStruct _wire2api_old_simple_struct(dynamic raw) {
+  final arr = raw as List<dynamic>;
+  if (arr.length != 1)
+    throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+  return OldSimpleStruct(
+    field: _wire2api_i32(arr[0]),
   );
 }
 
@@ -4019,19 +4072,33 @@ class FlutterRustBridgeExampleSingleBlockTestWire
   late final _wire_multiply_by_ten = _wire_multiply_by_tenPtr
       .asFunction<void Function(int, ffi.Pointer<wire_Measure>)>();
 
-  void wire_call_both_module_system(
+  void wire_call_old_module_system(
     int port_,
   ) {
-    return _wire_call_both_module_system(
+    return _wire_call_old_module_system(
       port_,
     );
   }
 
-  late final _wire_call_both_module_systemPtr =
+  late final _wire_call_old_module_systemPtr =
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
-          'wire_call_both_module_system');
-  late final _wire_call_both_module_system =
-      _wire_call_both_module_systemPtr.asFunction<void Function(int)>();
+          'wire_call_old_module_system');
+  late final _wire_call_old_module_system =
+      _wire_call_old_module_systemPtr.asFunction<void Function(int)>();
+
+  void wire_call_new_module_system(
+    int port_,
+  ) {
+    return _wire_call_new_module_system(
+      port_,
+    );
+  }
+
+  late final _wire_call_new_module_systemPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
+          'wire_call_new_module_system');
+  late final _wire_call_new_module_system =
+      _wire_call_new_module_systemPtr.asFunction<void Function(int)>();
 
   void wire_sum__method__SumWith(
     int port_,

--- a/frb_example/pure_dart/dart/lib/bridge_generated.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.dart
@@ -28,7 +28,11 @@ abstract class FlutterRustBridgeExampleSingleBlockTest {
   /// Newlines are preserved.
   ///
   Future<int> primitiveTypes(
-      {required int myI32, required int myI64, required double myF64, required bool myBool, dynamic hint});
+      {required int myI32,
+      required int myI64,
+      required double myF64,
+      required bool myBool,
+      dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kPrimitiveTypesConstMeta;
 
@@ -48,15 +52,18 @@ abstract class FlutterRustBridgeExampleSingleBlockTest {
 
   FlutterRustBridgeTaskConstMeta get kHandleVecU8ConstMeta;
 
-  Future<VecOfPrimitivePack> handleVecOfPrimitive({required int n, dynamic hint});
+  Future<VecOfPrimitivePack> handleVecOfPrimitive(
+      {required int n, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleVecOfPrimitiveConstMeta;
 
-  Future<ZeroCopyVecOfPrimitivePack> handleZeroCopyVecOfPrimitive({required int n, dynamic hint});
+  Future<ZeroCopyVecOfPrimitivePack> handleZeroCopyVecOfPrimitive(
+      {required int n, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleZeroCopyVecOfPrimitiveConstMeta;
 
-  Future<MySize> handleStruct({required MySize arg, required MySize boxed, dynamic hint});
+  Future<MySize> handleStruct(
+      {required MySize arg, required MySize boxed, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleStructConstMeta;
 
@@ -64,11 +71,13 @@ abstract class FlutterRustBridgeExampleSingleBlockTest {
 
   FlutterRustBridgeTaskConstMeta get kHandleNewtypeConstMeta;
 
-  Future<List<MySize>> handleListOfStruct({required List<MySize> l, dynamic hint});
+  Future<List<MySize>> handleListOfStruct(
+      {required List<MySize> l, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleListOfStructConstMeta;
 
-  Future<List<String>> handleStringList({required List<String> names, dynamic hint});
+  Future<List<String>> handleStringList(
+      {required List<String> names, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleStringListConstMeta;
 
@@ -96,7 +105,8 @@ abstract class FlutterRustBridgeExampleSingleBlockTest {
 
   FlutterRustBridgeTaskConstMeta get kReturnPanicConstMeta;
 
-  Future<double?> handleOptionalReturn({required double left, required double right, dynamic hint});
+  Future<double?> handleOptionalReturn(
+      {required double left, required double right, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleOptionalReturnConstMeta;
 
@@ -104,7 +114,8 @@ abstract class FlutterRustBridgeExampleSingleBlockTest {
 
   FlutterRustBridgeTaskConstMeta get kHandleOptionalStructConstMeta;
 
-  Future<ExoticOptionals?> handleOptionalIncrement({ExoticOptionals? opt, dynamic hint});
+  Future<ExoticOptionals?> handleOptionalIncrement(
+      {ExoticOptionals? opt, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleOptionalIncrementConstMeta;
 
@@ -132,7 +143,8 @@ abstract class FlutterRustBridgeExampleSingleBlockTest {
 
   FlutterRustBridgeTaskConstMeta get kHandleReturnEnumConstMeta;
 
-  Future<Weekdays> handleEnumParameter({required Weekdays weekday, dynamic hint});
+  Future<Weekdays> handleEnumParameter(
+      {required Weekdays weekday, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleEnumParameterConstMeta;
 
@@ -140,7 +152,8 @@ abstract class FlutterRustBridgeExampleSingleBlockTest {
 
   FlutterRustBridgeTaskConstMeta get kHandleCustomizedStructConstMeta;
 
-  Future<KitchenSink> handleEnumStruct({required KitchenSink val, dynamic hint});
+  Future<KitchenSink> handleEnumStruct(
+      {required KitchenSink val, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleEnumStructConstMeta;
 
@@ -156,7 +169,8 @@ abstract class FlutterRustBridgeExampleSingleBlockTest {
 
   FlutterRustBridgeTaskConstMeta get kGetAppSettingsConstMeta;
 
-  Future<bool> isAppEmbedded({required ApplicationSettings appSettings, dynamic hint});
+  Future<bool> isAppEmbedded(
+      {required ApplicationSettings appSettings, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kIsAppEmbeddedConstMeta;
 
@@ -164,11 +178,13 @@ abstract class FlutterRustBridgeExampleSingleBlockTest {
 
   FlutterRustBridgeTaskConstMeta get kGetMessageConstMeta;
 
-  Future<Numbers> repeatNumber({required int num, required int times, dynamic hint});
+  Future<Numbers> repeatNumber(
+      {required int num, required int times, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kRepeatNumberConstMeta;
 
-  Future<Sequences> repeatSequence({required int seq, required int times, dynamic hint});
+  Future<Sequences> repeatSequence(
+      {required int seq, required int times, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kRepeatSequenceConstMeta;
 
@@ -208,15 +224,18 @@ abstract class FlutterRustBridgeExampleSingleBlockTest {
 
   FlutterRustBridgeTaskConstMeta get kCreateEventConstMeta;
 
-  Stream<Log> handleStreamSinkAt1({required int key, required int max, dynamic hint});
+  Stream<Log> handleStreamSinkAt1(
+      {required int key, required int max, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleStreamSinkAt1ConstMeta;
 
-  Stream<Log> handleStreamSinkAt2({required int key, required int max, dynamic hint});
+  Stream<Log> handleStreamSinkAt2(
+      {required int key, required int max, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleStreamSinkAt2ConstMeta;
 
-  Stream<Log> handleStreamSinkAt3({required int key, required int max, dynamic hint});
+  Stream<Log> handleStreamSinkAt3(
+      {required int key, required int max, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleStreamSinkAt3ConstMeta;
 
@@ -228,39 +247,57 @@ abstract class FlutterRustBridgeExampleSingleBlockTest {
 
   FlutterRustBridgeTaskConstMeta get kMultiplyByTenConstMeta;
 
-  Future<int> sumMethodSumWith({required SumWith that, required int y, required int z, dynamic hint});
+  Future<String> callBothModuleSystem({dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kCallBothModuleSystemConstMeta;
+
+  Future<int> sumMethodSumWith(
+      {required SumWith that, required int y, required int z, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kSumMethodSumWithConstMeta;
 
-  Future<ConcatenateWith> newStaticMethodConcatenateWith({required String a, dynamic hint});
+  Future<ConcatenateWith> newStaticMethodConcatenateWith(
+      {required String a, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kNewStaticMethodConcatenateWithConstMeta;
 
-  Future<String> concatenateMethodConcatenateWith({required ConcatenateWith that, required String b, dynamic hint});
+  Future<String> concatenateMethodConcatenateWith(
+      {required ConcatenateWith that, required String b, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kConcatenateMethodConcatenateWithConstMeta;
 
-  Future<String> concatenateStaticStaticMethodConcatenateWith({required String a, required String b, dynamic hint});
+  Future<String> concatenateStaticStaticMethodConcatenateWith(
+      {required String a, required String b, dynamic hint});
 
-  FlutterRustBridgeTaskConstMeta get kConcatenateStaticStaticMethodConcatenateWithConstMeta;
+  FlutterRustBridgeTaskConstMeta
+      get kConcatenateStaticStaticMethodConcatenateWithConstMeta;
 
   Stream<Log2> handleSomeStreamSinkMethodConcatenateWith(
-      {required ConcatenateWith that, required int key, required int max, dynamic hint});
+      {required ConcatenateWith that,
+      required int key,
+      required int max,
+      dynamic hint});
 
-  FlutterRustBridgeTaskConstMeta get kHandleSomeStreamSinkMethodConcatenateWithConstMeta;
+  FlutterRustBridgeTaskConstMeta
+      get kHandleSomeStreamSinkMethodConcatenateWithConstMeta;
 
-  Stream<int> handleSomeStreamSinkAt1MethodConcatenateWith({required ConcatenateWith that, dynamic hint});
+  Stream<int> handleSomeStreamSinkAt1MethodConcatenateWith(
+      {required ConcatenateWith that, dynamic hint});
 
-  FlutterRustBridgeTaskConstMeta get kHandleSomeStreamSinkAt1MethodConcatenateWithConstMeta;
+  FlutterRustBridgeTaskConstMeta
+      get kHandleSomeStreamSinkAt1MethodConcatenateWithConstMeta;
 
   Stream<Log2> handleSomeStaticStreamSinkStaticMethodConcatenateWith(
       {required int key, required int max, dynamic hint});
 
-  FlutterRustBridgeTaskConstMeta get kHandleSomeStaticStreamSinkStaticMethodConcatenateWithConstMeta;
+  FlutterRustBridgeTaskConstMeta
+      get kHandleSomeStaticStreamSinkStaticMethodConcatenateWithConstMeta;
 
-  Stream<int> handleSomeStaticStreamSinkSingleArgStaticMethodConcatenateWith({dynamic hint});
+  Stream<int> handleSomeStaticStreamSinkSingleArgStaticMethodConcatenateWith(
+      {dynamic hint});
 
-  FlutterRustBridgeTaskConstMeta get kHandleSomeStaticStreamSinkSingleArgStaticMethodConcatenateWithConstMeta;
+  FlutterRustBridgeTaskConstMeta
+      get kHandleSomeStaticStreamSinkSingleArgStaticMethodConcatenateWithConstMeta;
 }
 
 class ApplicationEnv {
@@ -332,10 +369,13 @@ class ConcatenateWith {
   });
 
   static Future<ConcatenateWith> newConcatenateWith(
-          {required FlutterRustBridgeExampleSingleBlockTest bridge, required String a, dynamic hint}) =>
+          {required FlutterRustBridgeExampleSingleBlockTest bridge,
+          required String a,
+          dynamic hint}) =>
       bridge.newStaticMethodConcatenateWith(a: a, hint: hint);
 
-  Future<String> concatenate({required String b, dynamic hint}) => bridge.concatenateMethodConcatenateWith(
+  Future<String> concatenate({required String b, dynamic hint}) =>
+      bridge.concatenateMethodConcatenateWith(
         that: this,
         b: b,
       );
@@ -345,16 +385,19 @@ class ConcatenateWith {
           required String a,
           required String b,
           dynamic hint}) =>
-      bridge.concatenateStaticStaticMethodConcatenateWith(a: a, b: b, hint: hint);
+      bridge.concatenateStaticStaticMethodConcatenateWith(
+          a: a, b: b, hint: hint);
 
-  Stream<Log2> handleSomeStreamSink({required int key, required int max, dynamic hint}) =>
+  Stream<Log2> handleSomeStreamSink(
+          {required int key, required int max, dynamic hint}) =>
       bridge.handleSomeStreamSinkMethodConcatenateWith(
         that: this,
         key: key,
         max: max,
       );
 
-  Stream<int> handleSomeStreamSinkAt1({dynamic hint}) => bridge.handleSomeStreamSinkAt1MethodConcatenateWith(
+  Stream<int> handleSomeStreamSinkAt1({dynamic hint}) =>
+      bridge.handleSomeStreamSinkAt1MethodConcatenateWith(
         that: this,
       );
 
@@ -363,11 +406,14 @@ class ConcatenateWith {
           required int key,
           required int max,
           dynamic hint}) =>
-      bridge.handleSomeStaticStreamSinkStaticMethodConcatenateWith(key: key, max: max, hint: hint);
+      bridge.handleSomeStaticStreamSinkStaticMethodConcatenateWith(
+          key: key, max: max, hint: hint);
 
   static Stream<int> handleSomeStaticStreamSinkSingleArg(
-          {required FlutterRustBridgeExampleSingleBlockTest bridge, dynamic hint}) =>
-      bridge.handleSomeStaticStreamSinkSingleArgStaticMethodConcatenateWith(hint: hint);
+          {required FlutterRustBridgeExampleSingleBlockTest bridge,
+          dynamic hint}) =>
+      bridge.handleSomeStaticStreamSinkSingleArgStaticMethodConcatenateWith(
+          hint: hint);
 }
 
 class Customized {
@@ -611,7 +657,8 @@ class SumWith {
     required this.x,
   });
 
-  Future<int> sum({required int y, required int z, dynamic hint}) => bridge.sumMethodSumWith(
+  Future<int> sum({required int y, required int z, dynamic hint}) =>
+      bridge.sumMethodSumWith(
         that: this,
         y: y,
         z: z,
@@ -695,67 +742,90 @@ class ZeroCopyVecOfPrimitivePack {
 class FlutterRustBridgeExampleSingleBlockTestImpl
     extends FlutterRustBridgeBase<FlutterRustBridgeExampleSingleBlockTestWire>
     implements FlutterRustBridgeExampleSingleBlockTest {
-  factory FlutterRustBridgeExampleSingleBlockTestImpl(ffi.DynamicLibrary dylib) =>
-      FlutterRustBridgeExampleSingleBlockTestImpl.raw(FlutterRustBridgeExampleSingleBlockTestWire(dylib));
+  factory FlutterRustBridgeExampleSingleBlockTestImpl(
+          ffi.DynamicLibrary dylib) =>
+      FlutterRustBridgeExampleSingleBlockTestImpl.raw(
+          FlutterRustBridgeExampleSingleBlockTestWire(dylib));
 
-  FlutterRustBridgeExampleSingleBlockTestImpl.raw(FlutterRustBridgeExampleSingleBlockTestWire inner) : super(inner);
+  FlutterRustBridgeExampleSingleBlockTestImpl.raw(
+      FlutterRustBridgeExampleSingleBlockTestWire inner)
+      : super(inner);
 
-  Future<int> simpleAdder({required int a, required int b, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_simple_adder(port_, _api2wire_i32(a), _api2wire_i32(b)),
+  Future<int> simpleAdder({required int a, required int b, dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) =>
+            inner.wire_simple_adder(port_, _api2wire_i32(a), _api2wire_i32(b)),
         parseSuccessData: _wire2api_i32,
         constMeta: kSimpleAdderConstMeta,
         argValues: [a, b],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kSimpleAdderConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kSimpleAdderConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "simple_adder",
         argNames: ["a", "b"],
       );
 
   Future<int> primitiveTypes(
-          {required int myI32, required int myI64, required double myF64, required bool myBool, dynamic hint}) =>
+          {required int myI32,
+          required int myI64,
+          required double myF64,
+          required bool myBool,
+          dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_primitive_types(port_, _api2wire_i32(myI32), _api2wire_i64(myI64), _api2wire_f64(myF64), myBool),
+        callFfi: (port_) => inner.wire_primitive_types(
+            port_,
+            _api2wire_i32(myI32),
+            _api2wire_i64(myI64),
+            _api2wire_f64(myF64),
+            myBool),
         parseSuccessData: _wire2api_i32,
         constMeta: kPrimitiveTypesConstMeta,
         argValues: [myI32, myI64, myF64, myBool],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kPrimitiveTypesConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kPrimitiveTypesConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "primitive_types",
         argNames: ["myI32", "myI64", "myF64", "myBool"],
       );
 
-  Future<int> primitiveU32({required int myU32, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_primitive_u32(port_, _api2wire_u32(myU32)),
+  Future<int> primitiveU32({required int myU32, dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) =>
+            inner.wire_primitive_u32(port_, _api2wire_u32(myU32)),
         parseSuccessData: _wire2api_u32,
         constMeta: kPrimitiveU32ConstMeta,
         argValues: [myU32],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kPrimitiveU32ConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kPrimitiveU32ConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "primitive_u32",
         argNames: ["myU32"],
       );
 
-  Future<String> handleString({required String s, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_string(port_, _api2wire_String(s)),
+  Future<String> handleString({required String s, dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) =>
+            inner.wire_handle_string(port_, _api2wire_String(s)),
         parseSuccessData: _wire2api_String,
         constMeta: kHandleStringConstMeta,
         argValues: [s],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleStringConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleStringConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_string",
         argNames: ["s"],
       );
 
-  Future<void> handleReturnUnit({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+  Future<void> handleReturnUnit({dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_handle_return_unit(port_),
         parseSuccessData: _wire2api_unit,
         constMeta: kHandleReturnUnitConstMeta,
@@ -763,147 +833,178 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleReturnUnitConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleReturnUnitConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_return_unit",
         argNames: [],
       );
 
-  Future<Uint8List> handleVecU8({required Uint8List v, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_vec_u8(port_, _api2wire_uint_8_list(v)),
+  Future<Uint8List> handleVecU8({required Uint8List v, dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) =>
+            inner.wire_handle_vec_u8(port_, _api2wire_uint_8_list(v)),
         parseSuccessData: _wire2api_uint_8_list,
         constMeta: kHandleVecU8ConstMeta,
         argValues: [v],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleVecU8ConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleVecU8ConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_vec_u8",
         argNames: ["v"],
       );
 
-  Future<VecOfPrimitivePack> handleVecOfPrimitive({required int n, dynamic hint}) =>
+  Future<VecOfPrimitivePack> handleVecOfPrimitive(
+          {required int n, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_vec_of_primitive(port_, _api2wire_i32(n)),
+        callFfi: (port_) =>
+            inner.wire_handle_vec_of_primitive(port_, _api2wire_i32(n)),
         parseSuccessData: _wire2api_vec_of_primitive_pack,
         constMeta: kHandleVecOfPrimitiveConstMeta,
         argValues: [n],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleVecOfPrimitiveConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleVecOfPrimitiveConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_vec_of_primitive",
         argNames: ["n"],
       );
 
-  Future<ZeroCopyVecOfPrimitivePack> handleZeroCopyVecOfPrimitive({required int n, dynamic hint}) =>
+  Future<ZeroCopyVecOfPrimitivePack> handleZeroCopyVecOfPrimitive(
+          {required int n, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_zero_copy_vec_of_primitive(port_, _api2wire_i32(n)),
+        callFfi: (port_) => inner.wire_handle_zero_copy_vec_of_primitive(
+            port_, _api2wire_i32(n)),
         parseSuccessData: _wire2api_zero_copy_vec_of_primitive_pack,
         constMeta: kHandleZeroCopyVecOfPrimitiveConstMeta,
         argValues: [n],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleZeroCopyVecOfPrimitiveConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleZeroCopyVecOfPrimitiveConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_zero_copy_vec_of_primitive",
         argNames: ["n"],
       );
 
-  Future<MySize> handleStruct({required MySize arg, required MySize boxed, dynamic hint}) =>
+  Future<MySize> handleStruct(
+          {required MySize arg, required MySize boxed, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_handle_struct(port_, _api2wire_box_autoadd_my_size(arg), _api2wire_box_my_size(boxed)),
+        callFfi: (port_) => inner.wire_handle_struct(port_,
+            _api2wire_box_autoadd_my_size(arg), _api2wire_box_my_size(boxed)),
         parseSuccessData: _wire2api_my_size,
         constMeta: kHandleStructConstMeta,
         argValues: [arg, boxed],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleStructConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleStructConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_struct",
         argNames: ["arg", "boxed"],
       );
 
-  Future<NewTypeInt> handleNewtype({required NewTypeInt arg, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_newtype(port_, _api2wire_box_autoadd_new_type_int(arg)),
+  Future<NewTypeInt> handleNewtype({required NewTypeInt arg, dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_handle_newtype(
+            port_, _api2wire_box_autoadd_new_type_int(arg)),
         parseSuccessData: _wire2api_new_type_int,
         constMeta: kHandleNewtypeConstMeta,
         argValues: [arg],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleNewtypeConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleNewtypeConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_newtype",
         argNames: ["arg"],
       );
 
-  Future<List<MySize>> handleListOfStruct({required List<MySize> l, dynamic hint}) =>
+  Future<List<MySize>> handleListOfStruct(
+          {required List<MySize> l, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_list_of_struct(port_, _api2wire_list_my_size(l)),
+        callFfi: (port_) =>
+            inner.wire_handle_list_of_struct(port_, _api2wire_list_my_size(l)),
         parseSuccessData: _wire2api_list_my_size,
         constMeta: kHandleListOfStructConstMeta,
         argValues: [l],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleListOfStructConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleListOfStructConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_list_of_struct",
         argNames: ["l"],
       );
 
-  Future<List<String>> handleStringList({required List<String> names, dynamic hint}) =>
+  Future<List<String>> handleStringList(
+          {required List<String> names, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_string_list(port_, _api2wire_StringList(names)),
+        callFfi: (port_) =>
+            inner.wire_handle_string_list(port_, _api2wire_StringList(names)),
         parseSuccessData: _wire2api_StringList,
         constMeta: kHandleStringListConstMeta,
         argValues: [names],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleStringListConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleStringListConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_string_list",
         argNames: ["names"],
       );
 
-  Future<MyTreeNode> handleComplexStruct({required MyTreeNode s, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_complex_struct(port_, _api2wire_box_autoadd_my_tree_node(s)),
+  Future<MyTreeNode> handleComplexStruct(
+          {required MyTreeNode s, dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_handle_complex_struct(
+            port_, _api2wire_box_autoadd_my_tree_node(s)),
         parseSuccessData: _wire2api_my_tree_node,
         constMeta: kHandleComplexStructConstMeta,
         argValues: [s],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleComplexStructConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleComplexStructConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_complex_struct",
         argNames: ["s"],
       );
 
-  Uint8List handleSyncReturn({required String mode, dynamic hint}) => executeSync(FlutterRustBridgeSyncTask(
+  Uint8List handleSyncReturn({required String mode, dynamic hint}) =>
+      executeSync(FlutterRustBridgeSyncTask(
         callFfi: () => inner.wire_handle_sync_return(_api2wire_String(mode)),
         constMeta: kHandleSyncReturnConstMeta,
         argValues: [mode],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleSyncReturnConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleSyncReturnConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_sync_return",
         argNames: ["mode"],
       );
 
-  Stream<String> handleStream({required String arg, dynamic hint}) => executeStream(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_stream(port_, _api2wire_String(arg)),
+  Stream<String> handleStream({required String arg, dynamic hint}) =>
+      executeStream(FlutterRustBridgeTask(
+        callFfi: (port_) =>
+            inner.wire_handle_stream(port_, _api2wire_String(arg)),
         parseSuccessData: _wire2api_String,
         constMeta: kHandleStreamConstMeta,
         argValues: [arg],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleStreamConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleStreamConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_stream",
         argNames: ["arg"],
       );
 
-  Stream<MyStreamEntry> handleStreamOfStruct({dynamic hint}) => executeStream(FlutterRustBridgeTask(
+  Stream<MyStreamEntry> handleStreamOfStruct({dynamic hint}) =>
+      executeStream(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_handle_stream_of_struct(port_),
         parseSuccessData: _wire2api_my_stream_entry,
         constMeta: kHandleStreamOfStructConstMeta,
@@ -911,7 +1012,8 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleStreamOfStructConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleStreamOfStructConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_stream_of_struct",
         argNames: [],
       );
@@ -924,12 +1026,14 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kReturnErrConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kReturnErrConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "return_err",
         argNames: [],
       );
 
-  Future<int> returnPanic({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+  Future<int> returnPanic({dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_return_panic(port_),
         parseSuccessData: _wire2api_i32,
         constMeta: kReturnPanicConstMeta,
@@ -937,62 +1041,74 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kReturnPanicConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kReturnPanicConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "return_panic",
         argNames: [],
       );
 
-  Future<double?> handleOptionalReturn({required double left, required double right, dynamic hint}) =>
+  Future<double?> handleOptionalReturn(
+          {required double left, required double right, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_optional_return(port_, _api2wire_f64(left), _api2wire_f64(right)),
+        callFfi: (port_) => inner.wire_handle_optional_return(
+            port_, _api2wire_f64(left), _api2wire_f64(right)),
         parseSuccessData: _wire2api_opt_box_autoadd_f64,
         constMeta: kHandleOptionalReturnConstMeta,
         argValues: [left, right],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleOptionalReturnConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleOptionalReturnConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_optional_return",
         argNames: ["left", "right"],
       );
 
-  Future<Element?> handleOptionalStruct({String? document, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_optional_struct(port_, _api2wire_opt_String(document)),
+  Future<Element?> handleOptionalStruct({String? document, dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_handle_optional_struct(
+            port_, _api2wire_opt_String(document)),
         parseSuccessData: _wire2api_opt_box_autoadd_element,
         constMeta: kHandleOptionalStructConstMeta,
         argValues: [document],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleOptionalStructConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleOptionalStructConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_optional_struct",
         argNames: ["document"],
       );
 
-  Future<ExoticOptionals?> handleOptionalIncrement({ExoticOptionals? opt, dynamic hint}) =>
+  Future<ExoticOptionals?> handleOptionalIncrement(
+          {ExoticOptionals? opt, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_handle_optional_increment(port_, _api2wire_opt_box_autoadd_exotic_optionals(opt)),
+        callFfi: (port_) => inner.wire_handle_optional_increment(
+            port_, _api2wire_opt_box_autoadd_exotic_optionals(opt)),
         parseSuccessData: _wire2api_opt_box_autoadd_exotic_optionals,
         constMeta: kHandleOptionalIncrementConstMeta,
         argValues: [opt],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleOptionalIncrementConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleOptionalIncrementConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_optional_increment",
         argNames: ["opt"],
       );
 
-  Future<double> handleIncrementBoxedOptional({double? opt, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_increment_boxed_optional(port_, _api2wire_opt_box_f64(opt)),
+  Future<double> handleIncrementBoxedOptional({double? opt, dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_handle_increment_boxed_optional(
+            port_, _api2wire_opt_box_f64(opt)),
         parseSuccessData: _wire2api_f64,
         constMeta: kHandleIncrementBoxedOptionalConstMeta,
         argValues: [opt],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleIncrementBoxedOptionalConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleIncrementBoxedOptionalConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_increment_boxed_optional",
         argNames: ["opt"],
       );
@@ -1022,104 +1138,137 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleOptionBoxArgumentsConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleOptionBoxArgumentsConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_option_box_arguments",
-        argNames: ["i8Box", "u8Box", "i32Box", "i64Box", "f64Box", "boolbox", "structbox"],
+        argNames: [
+          "i8Box",
+          "u8Box",
+          "i32Box",
+          "i64Box",
+          "f64Box",
+          "boolbox",
+          "structbox"
+        ],
       );
 
-  Future<Uint8List> printNote({required Note note, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_print_note(port_, _api2wire_box_autoadd_note(note)),
+  Future<Uint8List> printNote({required Note note, dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) =>
+            inner.wire_print_note(port_, _api2wire_box_autoadd_note(note)),
         parseSuccessData: _wire2api_ZeroCopyBuffer_Uint8List,
         constMeta: kPrintNoteConstMeta,
         argValues: [note],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kPrintNoteConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kPrintNoteConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "print_note",
         argNames: ["note"],
       );
 
-  Future<Weekdays?> handleReturnEnum({required String input, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_return_enum(port_, _api2wire_String(input)),
+  Future<Weekdays?> handleReturnEnum({required String input, dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) =>
+            inner.wire_handle_return_enum(port_, _api2wire_String(input)),
         parseSuccessData: _wire2api_opt_weekdays,
         constMeta: kHandleReturnEnumConstMeta,
         argValues: [input],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleReturnEnumConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleReturnEnumConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_return_enum",
         argNames: ["input"],
       );
 
-  Future<Weekdays> handleEnumParameter({required Weekdays weekday, dynamic hint}) =>
+  Future<Weekdays> handleEnumParameter(
+          {required Weekdays weekday, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_enum_parameter(port_, _api2wire_weekdays(weekday)),
+        callFfi: (port_) => inner.wire_handle_enum_parameter(
+            port_, _api2wire_weekdays(weekday)),
         parseSuccessData: _wire2api_weekdays,
         constMeta: kHandleEnumParameterConstMeta,
         argValues: [weekday],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleEnumParameterConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleEnumParameterConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_enum_parameter",
         argNames: ["weekday"],
       );
 
-  Future<void> handleCustomizedStruct({required Customized val, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_customized_struct(port_, _api2wire_box_autoadd_customized(val)),
+  Future<void> handleCustomizedStruct(
+          {required Customized val, dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_handle_customized_struct(
+            port_, _api2wire_box_autoadd_customized(val)),
         parseSuccessData: _wire2api_unit,
         constMeta: kHandleCustomizedStructConstMeta,
         argValues: [val],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleCustomizedStructConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleCustomizedStructConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_customized_struct",
         argNames: ["val"],
       );
 
-  Future<KitchenSink> handleEnumStruct({required KitchenSink val, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_enum_struct(port_, _api2wire_box_autoadd_kitchen_sink(val)),
+  Future<KitchenSink> handleEnumStruct(
+          {required KitchenSink val, dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_handle_enum_struct(
+            port_, _api2wire_box_autoadd_kitchen_sink(val)),
         parseSuccessData: _wire2api_kitchen_sink,
         constMeta: kHandleEnumStructConstMeta,
         argValues: [val],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleEnumStructConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleEnumStructConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_enum_struct",
         argNames: ["val"],
       );
 
-  Future<bool> useImportedStruct({required MyStruct myStruct, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_use_imported_struct(port_, _api2wire_box_autoadd_my_struct(myStruct)),
+  Future<bool> useImportedStruct({required MyStruct myStruct, dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_use_imported_struct(
+            port_, _api2wire_box_autoadd_my_struct(myStruct)),
         parseSuccessData: _wire2api_bool,
         constMeta: kUseImportedStructConstMeta,
         argValues: [myStruct],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kUseImportedStructConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kUseImportedStructConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "use_imported_struct",
         argNames: ["myStruct"],
       );
 
-  Future<bool> useImportedEnum({required MyEnum myEnum, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_use_imported_enum(port_, _api2wire_my_enum(myEnum)),
+  Future<bool> useImportedEnum({required MyEnum myEnum, dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) =>
+            inner.wire_use_imported_enum(port_, _api2wire_my_enum(myEnum)),
         parseSuccessData: _wire2api_bool,
         constMeta: kUseImportedEnumConstMeta,
         argValues: [myEnum],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kUseImportedEnumConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kUseImportedEnumConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "use_imported_enum",
         argNames: ["myEnum"],
       );
 
-  Future<ApplicationSettings> getAppSettings({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+  Future<ApplicationSettings> getAppSettings({dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_get_app_settings(port_),
         parseSuccessData: _wire2api_application_settings,
         constMeta: kGetAppSettingsConstMeta,
@@ -1127,26 +1276,31 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kGetAppSettingsConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kGetAppSettingsConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "get_app_settings",
         argNames: [],
       );
 
-  Future<bool> isAppEmbedded({required ApplicationSettings appSettings, dynamic hint}) =>
+  Future<bool> isAppEmbedded(
+          {required ApplicationSettings appSettings, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_is_app_embedded(port_, _api2wire_box_autoadd_application_settings(appSettings)),
+        callFfi: (port_) => inner.wire_is_app_embedded(
+            port_, _api2wire_box_autoadd_application_settings(appSettings)),
         parseSuccessData: _wire2api_bool,
         constMeta: kIsAppEmbeddedConstMeta,
         argValues: [appSettings],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kIsAppEmbeddedConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kIsAppEmbeddedConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "is_app_embedded",
         argNames: ["appSettings"],
       );
 
-  Future<ApplicationMessage> getMessage({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+  Future<ApplicationMessage> getMessage({dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_get_message(port_),
         parseSuccessData: _wire2api_application_message,
         constMeta: kGetMessageConstMeta,
@@ -1154,66 +1308,80 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kGetMessageConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kGetMessageConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "get_message",
         argNames: [],
       );
 
-  Future<Numbers> repeatNumber({required int num, required int times, dynamic hint}) =>
+  Future<Numbers> repeatNumber(
+          {required int num, required int times, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_repeat_number(port_, _api2wire_i32(num), _api2wire_usize(times)),
+        callFfi: (port_) => inner.wire_repeat_number(
+            port_, _api2wire_i32(num), _api2wire_usize(times)),
         parseSuccessData: _wire2api_numbers,
         constMeta: kRepeatNumberConstMeta,
         argValues: [num, times],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kRepeatNumberConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kRepeatNumberConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "repeat_number",
         argNames: ["num", "times"],
       );
 
-  Future<Sequences> repeatSequence({required int seq, required int times, dynamic hint}) =>
+  Future<Sequences> repeatSequence(
+          {required int seq, required int times, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_repeat_sequence(port_, _api2wire_i32(seq), _api2wire_usize(times)),
+        callFfi: (port_) => inner.wire_repeat_sequence(
+            port_, _api2wire_i32(seq), _api2wire_usize(times)),
         parseSuccessData: _wire2api_sequences,
         constMeta: kRepeatSequenceConstMeta,
         argValues: [seq, times],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kRepeatSequenceConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kRepeatSequenceConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "repeat_sequence",
         argNames: ["seq", "times"],
       );
 
-  Future<int?> firstNumber({required Numbers nums, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_first_number(port_, _api2wire_box_autoadd_numbers(nums)),
+  Future<int?> firstNumber({required Numbers nums, dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) =>
+            inner.wire_first_number(port_, _api2wire_box_autoadd_numbers(nums)),
         parseSuccessData: _wire2api_opt_box_autoadd_i32,
         constMeta: kFirstNumberConstMeta,
         argValues: [nums],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kFirstNumberConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kFirstNumberConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "first_number",
         argNames: ["nums"],
       );
 
-  Future<int?> firstSequence({required Sequences seqs, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_first_sequence(port_, _api2wire_box_autoadd_sequences(seqs)),
+  Future<int?> firstSequence({required Sequences seqs, dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_first_sequence(
+            port_, _api2wire_box_autoadd_sequences(seqs)),
         parseSuccessData: _wire2api_opt_box_autoadd_i32,
         constMeta: kFirstSequenceConstMeta,
         argValues: [seqs],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kFirstSequenceConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kFirstSequenceConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "first_sequence",
         argNames: ["seqs"],
       );
 
-  Future<Uint8List> getArray({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+  Future<Uint8List> getArray({dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_get_array(port_),
         parseSuccessData: _wire2api_uint_8_list,
         constMeta: kGetArrayConstMeta,
@@ -1221,12 +1389,14 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kGetArrayConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kGetArrayConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "get_array",
         argNames: [],
       );
 
-  Future<List<Point>> getComplexArray({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+  Future<List<Point>> getComplexArray({dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_get_complex_array(port_),
         parseSuccessData: _wire2api_list_point,
         constMeta: kGetComplexArrayConstMeta,
@@ -1234,12 +1404,14 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kGetComplexArrayConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kGetComplexArrayConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "get_complex_array",
         argNames: [],
       );
 
-  Future<int> getUsize({required int u, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+  Future<int> getUsize({required int u, dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_get_usize(port_, _api2wire_usize(u)),
         parseSuccessData: _wire2api_usize,
         constMeta: kGetUsizeConstMeta,
@@ -1247,25 +1419,30 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kGetUsizeConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kGetUsizeConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "get_usize",
         argNames: ["u"],
       );
 
-  Future<UserId> nextUserId({required UserId userId, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_next_user_id(port_, _api2wire_box_autoadd_user_id(userId)),
+  Future<UserId> nextUserId({required UserId userId, dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_next_user_id(
+            port_, _api2wire_box_autoadd_user_id(userId)),
         parseSuccessData: _wire2api_user_id,
         constMeta: kNextUserIdConstMeta,
         argValues: [userId],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kNextUserIdConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kNextUserIdConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "next_user_id",
         argNames: ["userId"],
       );
 
-  Stream<Event> registerEventListener({dynamic hint}) => executeStream(FlutterRustBridgeTask(
+  Stream<Event> registerEventListener({dynamic hint}) =>
+      executeStream(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_register_event_listener(port_),
         parseSuccessData: _wire2api_event,
         constMeta: kRegisterEventListenerConstMeta,
@@ -1273,12 +1450,14 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kRegisterEventListenerConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kRegisterEventListenerConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "register_event_listener",
         argNames: [],
       );
 
-  Future<void> closeEventListener({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+  Future<void> closeEventListener({dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_close_event_listener(port_),
         parseSuccessData: _wire2api_unit,
         constMeta: kCloseEventListenerConstMeta,
@@ -1286,12 +1465,14 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kCloseEventListenerConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kCloseEventListenerConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "close_event_listener",
         argNames: [],
       );
 
-  Future<void> createEvent({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+  Future<void> createEvent({dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_create_event(port_),
         parseSuccessData: _wire2api_unit,
         constMeta: kCreateEventConstMeta,
@@ -1299,54 +1480,65 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kCreateEventConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kCreateEventConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "create_event",
         argNames: [],
       );
 
-  Stream<Log> handleStreamSinkAt1({required int key, required int max, dynamic hint}) =>
+  Stream<Log> handleStreamSinkAt1(
+          {required int key, required int max, dynamic hint}) =>
       executeStream(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_stream_sink_at_1(port_, _api2wire_u32(key), _api2wire_u32(max)),
+        callFfi: (port_) => inner.wire_handle_stream_sink_at_1(
+            port_, _api2wire_u32(key), _api2wire_u32(max)),
         parseSuccessData: _wire2api_log,
         constMeta: kHandleStreamSinkAt1ConstMeta,
         argValues: [key, max],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleStreamSinkAt1ConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleStreamSinkAt1ConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_stream_sink_at_1",
         argNames: ["key", "max"],
       );
 
-  Stream<Log> handleStreamSinkAt2({required int key, required int max, dynamic hint}) =>
+  Stream<Log> handleStreamSinkAt2(
+          {required int key, required int max, dynamic hint}) =>
       executeStream(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_stream_sink_at_2(port_, _api2wire_u32(key), _api2wire_u32(max)),
+        callFfi: (port_) => inner.wire_handle_stream_sink_at_2(
+            port_, _api2wire_u32(key), _api2wire_u32(max)),
         parseSuccessData: _wire2api_log,
         constMeta: kHandleStreamSinkAt2ConstMeta,
         argValues: [key, max],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleStreamSinkAt2ConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleStreamSinkAt2ConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_stream_sink_at_2",
         argNames: ["key", "max"],
       );
 
-  Stream<Log> handleStreamSinkAt3({required int key, required int max, dynamic hint}) =>
+  Stream<Log> handleStreamSinkAt3(
+          {required int key, required int max, dynamic hint}) =>
       executeStream(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_stream_sink_at_3(port_, _api2wire_u32(key), _api2wire_u32(max)),
+        callFfi: (port_) => inner.wire_handle_stream_sink_at_3(
+            port_, _api2wire_u32(key), _api2wire_u32(max)),
         parseSuccessData: _wire2api_log,
         constMeta: kHandleStreamSinkAt3ConstMeta,
         argValues: [key, max],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleStreamSinkAt3ConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleStreamSinkAt3ConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_stream_sink_at_3",
         argNames: ["key", "max"],
       );
 
-  Future<SumWith> getSumStruct({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+  Future<SumWith> getSumStruct({dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_get_sum_struct(port_),
         parseSuccessData: (d) => _wire2api_sum_with(this, d),
         constMeta: kGetSumStructConstMeta,
@@ -1354,148 +1546,207 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kGetSumStructConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kGetSumStructConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "get_sum_struct",
         argNames: [],
       );
 
-  Future<Measure?> multiplyByTen({required Measure measure, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_multiply_by_ten(port_, _api2wire_box_autoadd_measure(measure)),
+  Future<Measure?> multiplyByTen({required Measure measure, dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_multiply_by_ten(
+            port_, _api2wire_box_autoadd_measure(measure)),
         parseSuccessData: _wire2api_opt_measure,
         constMeta: kMultiplyByTenConstMeta,
         argValues: [measure],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kMultiplyByTenConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kMultiplyByTenConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "multiply_by_ten",
         argNames: ["measure"],
       );
 
-  Future<int> sumMethodSumWith({required SumWith that, required int y, required int z, dynamic hint}) =>
+  Future<String> callBothModuleSystem({dynamic hint}) =>
+      executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_call_both_module_system(port_),
+        parseSuccessData: _wire2api_String,
+        constMeta: kCallBothModuleSystemConstMeta,
+        argValues: [],
+        hint: hint,
+      ));
+
+  FlutterRustBridgeTaskConstMeta get kCallBothModuleSystemConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
+        debugName: "call_both_module_system",
+        argNames: [],
+      );
+
+  Future<int> sumMethodSumWith(
+          {required SumWith that,
+          required int y,
+          required int z,
+          dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_sum__method__SumWith(
-            port_, _api2wire_box_autoadd_sum_with(that), _api2wire_u32(y), _api2wire_u32(z)),
+            port_,
+            _api2wire_box_autoadd_sum_with(that),
+            _api2wire_u32(y),
+            _api2wire_u32(z)),
         parseSuccessData: _wire2api_u32,
         constMeta: kSumMethodSumWithConstMeta,
         argValues: [that, y, z],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kSumMethodSumWithConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kSumMethodSumWithConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "sum__method__SumWith",
         argNames: ["that", "y", "z"],
       );
 
-  Future<ConcatenateWith> newStaticMethodConcatenateWith({required String a, dynamic hint}) =>
+  Future<ConcatenateWith> newStaticMethodConcatenateWith(
+          {required String a, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_new__static_method__ConcatenateWith(port_, _api2wire_String(a)),
+        callFfi: (port_) => inner.wire_new__static_method__ConcatenateWith(
+            port_, _api2wire_String(a)),
         parseSuccessData: (d) => _wire2api_concatenate_with(this, d),
         constMeta: kNewStaticMethodConcatenateWithConstMeta,
         argValues: [a],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kNewStaticMethodConcatenateWithConstMeta => const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kNewStaticMethodConcatenateWithConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
         debugName: "new__static_method__ConcatenateWith",
         argNames: ["a"],
       );
 
-  Future<String> concatenateMethodConcatenateWith({required ConcatenateWith that, required String b, dynamic hint}) =>
+  Future<String> concatenateMethodConcatenateWith(
+          {required ConcatenateWith that, required String b, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_concatenate__method__ConcatenateWith(
-            port_, _api2wire_box_autoadd_concatenate_with(that), _api2wire_String(b)),
+            port_,
+            _api2wire_box_autoadd_concatenate_with(that),
+            _api2wire_String(b)),
         parseSuccessData: _wire2api_String,
         constMeta: kConcatenateMethodConcatenateWithConstMeta,
         argValues: [that, b],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kConcatenateMethodConcatenateWithConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "concatenate__method__ConcatenateWith",
-        argNames: ["that", "b"],
-      );
+  FlutterRustBridgeTaskConstMeta
+      get kConcatenateMethodConcatenateWithConstMeta =>
+          const FlutterRustBridgeTaskConstMeta(
+            debugName: "concatenate__method__ConcatenateWith",
+            argNames: ["that", "b"],
+          );
 
-  Future<String> concatenateStaticStaticMethodConcatenateWith({required String a, required String b, dynamic hint}) =>
+  Future<String> concatenateStaticStaticMethodConcatenateWith(
+          {required String a, required String b, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_concatenate_static__static_method__ConcatenateWith(
-            port_, _api2wire_String(a), _api2wire_String(b)),
+        callFfi: (port_) =>
+            inner.wire_concatenate_static__static_method__ConcatenateWith(
+                port_, _api2wire_String(a), _api2wire_String(b)),
         parseSuccessData: _wire2api_String,
         constMeta: kConcatenateStaticStaticMethodConcatenateWithConstMeta,
         argValues: [a, b],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kConcatenateStaticStaticMethodConcatenateWithConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
-        debugName: "concatenate_static__static_method__ConcatenateWith",
-        argNames: ["a", "b"],
-      );
+  FlutterRustBridgeTaskConstMeta
+      get kConcatenateStaticStaticMethodConcatenateWithConstMeta =>
+          const FlutterRustBridgeTaskConstMeta(
+            debugName: "concatenate_static__static_method__ConcatenateWith",
+            argNames: ["a", "b"],
+          );
 
   Stream<Log2> handleSomeStreamSinkMethodConcatenateWith(
-          {required ConcatenateWith that, required int key, required int max, dynamic hint}) =>
+          {required ConcatenateWith that,
+          required int key,
+          required int max,
+          dynamic hint}) =>
       executeStream(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_some_stream_sink__method__ConcatenateWith(
-            port_, _api2wire_box_autoadd_concatenate_with(that), _api2wire_u32(key), _api2wire_u32(max)),
+        callFfi: (port_) =>
+            inner.wire_handle_some_stream_sink__method__ConcatenateWith(
+                port_,
+                _api2wire_box_autoadd_concatenate_with(that),
+                _api2wire_u32(key),
+                _api2wire_u32(max)),
         parseSuccessData: _wire2api_log_2,
         constMeta: kHandleSomeStreamSinkMethodConcatenateWithConstMeta,
         argValues: [that, key, max],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleSomeStreamSinkMethodConcatenateWithConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
-        debugName: "handle_some_stream_sink__method__ConcatenateWith",
-        argNames: ["that", "key", "max"],
-      );
+  FlutterRustBridgeTaskConstMeta
+      get kHandleSomeStreamSinkMethodConcatenateWithConstMeta =>
+          const FlutterRustBridgeTaskConstMeta(
+            debugName: "handle_some_stream_sink__method__ConcatenateWith",
+            argNames: ["that", "key", "max"],
+          );
 
-  Stream<int> handleSomeStreamSinkAt1MethodConcatenateWith({required ConcatenateWith that, dynamic hint}) =>
+  Stream<int> handleSomeStreamSinkAt1MethodConcatenateWith(
+          {required ConcatenateWith that, dynamic hint}) =>
       executeStream(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_some_stream_sink_at_1__method__ConcatenateWith(
-            port_, _api2wire_box_autoadd_concatenate_with(that)),
+        callFfi: (port_) =>
+            inner.wire_handle_some_stream_sink_at_1__method__ConcatenateWith(
+                port_, _api2wire_box_autoadd_concatenate_with(that)),
         parseSuccessData: _wire2api_u32,
         constMeta: kHandleSomeStreamSinkAt1MethodConcatenateWithConstMeta,
         argValues: [that],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleSomeStreamSinkAt1MethodConcatenateWithConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
-        debugName: "handle_some_stream_sink_at_1__method__ConcatenateWith",
-        argNames: ["that"],
-      );
+  FlutterRustBridgeTaskConstMeta
+      get kHandleSomeStreamSinkAt1MethodConcatenateWithConstMeta =>
+          const FlutterRustBridgeTaskConstMeta(
+            debugName: "handle_some_stream_sink_at_1__method__ConcatenateWith",
+            argNames: ["that"],
+          );
 
   Stream<Log2> handleSomeStaticStreamSinkStaticMethodConcatenateWith(
           {required int key, required int max, dynamic hint}) =>
       executeStream(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_some_static_stream_sink__static_method__ConcatenateWith(
-            port_, _api2wire_u32(key), _api2wire_u32(max)),
+        callFfi: (port_) => inner
+            .wire_handle_some_static_stream_sink__static_method__ConcatenateWith(
+                port_, _api2wire_u32(key), _api2wire_u32(max)),
         parseSuccessData: _wire2api_log_2,
-        constMeta: kHandleSomeStaticStreamSinkStaticMethodConcatenateWithConstMeta,
+        constMeta:
+            kHandleSomeStaticStreamSinkStaticMethodConcatenateWithConstMeta,
         argValues: [key, max],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleSomeStaticStreamSinkStaticMethodConcatenateWithConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
-        debugName: "handle_some_static_stream_sink__static_method__ConcatenateWith",
-        argNames: ["key", "max"],
-      );
+  FlutterRustBridgeTaskConstMeta
+      get kHandleSomeStaticStreamSinkStaticMethodConcatenateWithConstMeta =>
+          const FlutterRustBridgeTaskConstMeta(
+            debugName:
+                "handle_some_static_stream_sink__static_method__ConcatenateWith",
+            argNames: ["key", "max"],
+          );
 
-  Stream<int> handleSomeStaticStreamSinkSingleArgStaticMethodConcatenateWith({dynamic hint}) =>
+  Stream<int> handleSomeStaticStreamSinkSingleArgStaticMethodConcatenateWith(
+          {dynamic hint}) =>
       executeStream(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_some_static_stream_sink_single_arg__static_method__ConcatenateWith(port_),
+        callFfi: (port_) => inner
+            .wire_handle_some_static_stream_sink_single_arg__static_method__ConcatenateWith(
+                port_),
         parseSuccessData: _wire2api_u32,
-        constMeta: kHandleSomeStaticStreamSinkSingleArgStaticMethodConcatenateWithConstMeta,
+        constMeta:
+            kHandleSomeStaticStreamSinkSingleArgStaticMethodConcatenateWithConstMeta,
         argValues: [],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleSomeStaticStreamSinkSingleArgStaticMethodConcatenateWithConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
-        debugName: "handle_some_static_stream_sink_single_arg__static_method__ConcatenateWith",
-        argNames: [],
-      );
+  FlutterRustBridgeTaskConstMeta
+      get kHandleSomeStaticStreamSinkSingleArgStaticMethodConcatenateWithConstMeta =>
+          const FlutterRustBridgeTaskConstMeta(
+            debugName:
+                "handle_some_static_stream_sink_single_arg__static_method__ConcatenateWith",
+            argNames: [],
+          );
 
   // Section: api2wire
   ffi.Pointer<wire_uint_8_list> _api2wire_String(String raw) {
@@ -1510,7 +1761,8 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     return ans;
   }
 
-  ffi.Pointer<wire_uint_8_list> _api2wire_ZeroCopyBuffer_Uint8List(Uint8List raw) {
+  ffi.Pointer<wire_uint_8_list> _api2wire_ZeroCopyBuffer_Uint8List(
+      Uint8List raw) {
     return _api2wire_uint_8_list(raw);
   }
 
@@ -1522,13 +1774,15 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     return raw;
   }
 
-  ffi.Pointer<wire_ApplicationEnv> _api2wire_box_application_env(ApplicationEnv raw) {
+  ffi.Pointer<wire_ApplicationEnv> _api2wire_box_application_env(
+      ApplicationEnv raw) {
     final ptr = inner.new_box_application_env_0();
     _api_fill_to_wire_application_env(raw, ptr.ref);
     return ptr;
   }
 
-  ffi.Pointer<wire_ApplicationSettings> _api2wire_box_autoadd_application_settings(ApplicationSettings raw) {
+  ffi.Pointer<wire_ApplicationSettings>
+      _api2wire_box_autoadd_application_settings(ApplicationSettings raw) {
     final ptr = inner.new_box_autoadd_application_settings_0();
     _api_fill_to_wire_application_settings(raw, ptr.ref);
     return ptr;
@@ -1544,19 +1798,22 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     return inner.new_box_autoadd_bool_0(_api2wire_bool(raw));
   }
 
-  ffi.Pointer<wire_ConcatenateWith> _api2wire_box_autoadd_concatenate_with(ConcatenateWith raw) {
+  ffi.Pointer<wire_ConcatenateWith> _api2wire_box_autoadd_concatenate_with(
+      ConcatenateWith raw) {
     final ptr = inner.new_box_autoadd_concatenate_with_0();
     _api_fill_to_wire_concatenate_with(raw, ptr.ref);
     return ptr;
   }
 
-  ffi.Pointer<wire_Customized> _api2wire_box_autoadd_customized(Customized raw) {
+  ffi.Pointer<wire_Customized> _api2wire_box_autoadd_customized(
+      Customized raw) {
     final ptr = inner.new_box_autoadd_customized_0();
     _api_fill_to_wire_customized(raw, ptr.ref);
     return ptr;
   }
 
-  ffi.Pointer<wire_ExoticOptionals> _api2wire_box_autoadd_exotic_optionals(ExoticOptionals raw) {
+  ffi.Pointer<wire_ExoticOptionals> _api2wire_box_autoadd_exotic_optionals(
+      ExoticOptionals raw) {
     final ptr = inner.new_box_autoadd_exotic_optionals_0();
     _api_fill_to_wire_exotic_optionals(raw, ptr.ref);
     return ptr;
@@ -1574,7 +1831,8 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     return inner.new_box_autoadd_i64_0(_api2wire_i64(raw));
   }
 
-  ffi.Pointer<wire_KitchenSink> _api2wire_box_autoadd_kitchen_sink(KitchenSink raw) {
+  ffi.Pointer<wire_KitchenSink> _api2wire_box_autoadd_kitchen_sink(
+      KitchenSink raw) {
     final ptr = inner.new_box_autoadd_kitchen_sink_0();
     _api_fill_to_wire_kitchen_sink(raw, ptr.ref);
     return ptr;
@@ -1598,13 +1856,15 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     return ptr;
   }
 
-  ffi.Pointer<wire_MyTreeNode> _api2wire_box_autoadd_my_tree_node(MyTreeNode raw) {
+  ffi.Pointer<wire_MyTreeNode> _api2wire_box_autoadd_my_tree_node(
+      MyTreeNode raw) {
     final ptr = inner.new_box_autoadd_my_tree_node_0();
     _api_fill_to_wire_my_tree_node(raw, ptr.ref);
     return ptr;
   }
 
-  ffi.Pointer<wire_NewTypeInt> _api2wire_box_autoadd_new_type_int(NewTypeInt raw) {
+  ffi.Pointer<wire_NewTypeInt> _api2wire_box_autoadd_new_type_int(
+      NewTypeInt raw) {
     final ptr = inner.new_box_autoadd_new_type_int_0();
     _api_fill_to_wire_new_type_int(raw, ptr.ref);
     return ptr;
@@ -1650,7 +1910,8 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     return ptr;
   }
 
-  ffi.Pointer<wire_ExoticOptionals> _api2wire_box_exotic_optionals(ExoticOptionals raw) {
+  ffi.Pointer<wire_ExoticOptionals> _api2wire_box_exotic_optionals(
+      ExoticOptionals raw) {
     final ptr = inner.new_box_exotic_optionals_0();
     _api_fill_to_wire_exotic_optionals(raw, ptr.ref);
     return ptr;
@@ -1748,7 +2009,8 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     return ans;
   }
 
-  ffi.Pointer<wire_list_application_env_var> _api2wire_list_application_env_var(List<ApplicationEnvVar> raw) {
+  ffi.Pointer<wire_list_application_env_var> _api2wire_list_application_env_var(
+      List<ApplicationEnvVar> raw) {
     final ans = inner.new_list_application_env_var_0(raw.length);
     for (var i = 0; i < raw.length; ++i) {
       _api_fill_to_wire_application_env_var(raw[i], ans.ref.ptr[i]);
@@ -1756,7 +2018,8 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     return ans;
   }
 
-  ffi.Pointer<wire_list_attribute> _api2wire_list_attribute(List<Attribute> raw) {
+  ffi.Pointer<wire_list_attribute> _api2wire_list_attribute(
+      List<Attribute> raw) {
     final ans = inner.new_list_attribute_0(raw.length);
     for (var i = 0; i < raw.length; ++i) {
       _api_fill_to_wire_attribute(raw[i], ans.ref.ptr[i]);
@@ -1772,7 +2035,8 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     return ans;
   }
 
-  ffi.Pointer<wire_list_my_tree_node> _api2wire_list_my_tree_node(List<MyTreeNode> raw) {
+  ffi.Pointer<wire_list_my_tree_node> _api2wire_list_my_tree_node(
+      List<MyTreeNode> raw) {
     final ans = inner.new_list_my_tree_node_0(raw.length);
     for (var i = 0; i < raw.length; ++i) {
       _api_fill_to_wire_my_tree_node(raw[i], ans.ref.ptr[i]);
@@ -1780,7 +2044,8 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     return ans;
   }
 
-  ffi.Pointer<wire_list_opt_box_autoadd_attribute> _api2wire_list_opt_box_autoadd_attribute(List<Attribute?> raw) {
+  ffi.Pointer<wire_list_opt_box_autoadd_attribute>
+      _api2wire_list_opt_box_autoadd_attribute(List<Attribute?> raw) {
     final ans = inner.new_list_opt_box_autoadd_attribute_0(raw.length);
     for (var i = 0; i < raw.length; ++i) {
       _api_fill_to_wire_opt_box_autoadd_attribute(raw[i], ans.ref.ptr[i]);
@@ -1796,11 +2061,13 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     return raw == null ? ffi.nullptr : _api2wire_String(raw);
   }
 
-  ffi.Pointer<wire_uint_8_list> _api2wire_opt_ZeroCopyBuffer_Uint8List(Uint8List? raw) {
+  ffi.Pointer<wire_uint_8_list> _api2wire_opt_ZeroCopyBuffer_Uint8List(
+      Uint8List? raw) {
     return raw == null ? ffi.nullptr : _api2wire_ZeroCopyBuffer_Uint8List(raw);
   }
 
-  ffi.Pointer<wire_Attribute> _api2wire_opt_box_autoadd_attribute(Attribute? raw) {
+  ffi.Pointer<wire_Attribute> _api2wire_opt_box_autoadd_attribute(
+      Attribute? raw) {
     return raw == null ? ffi.nullptr : _api2wire_box_autoadd_attribute(raw);
   }
 
@@ -1808,8 +2075,11 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     return raw == null ? ffi.nullptr : _api2wire_box_autoadd_bool(raw);
   }
 
-  ffi.Pointer<wire_ExoticOptionals> _api2wire_opt_box_autoadd_exotic_optionals(ExoticOptionals? raw) {
-    return raw == null ? ffi.nullptr : _api2wire_box_autoadd_exotic_optionals(raw);
+  ffi.Pointer<wire_ExoticOptionals> _api2wire_opt_box_autoadd_exotic_optionals(
+      ExoticOptionals? raw) {
+    return raw == null
+        ? ffi.nullptr
+        : _api2wire_box_autoadd_exotic_optionals(raw);
   }
 
   ffi.Pointer<ffi.Double> _api2wire_opt_box_autoadd_f64(double? raw) {
@@ -1824,7 +2094,8 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     return raw == null ? ffi.nullptr : _api2wire_box_autoadd_i64(raw);
   }
 
-  ffi.Pointer<wire_NewTypeInt> _api2wire_opt_box_autoadd_new_type_int(NewTypeInt? raw) {
+  ffi.Pointer<wire_NewTypeInt> _api2wire_opt_box_autoadd_new_type_int(
+      NewTypeInt? raw) {
     return raw == null ? ffi.nullptr : _api2wire_box_autoadd_new_type_int(raw);
   }
 
@@ -1832,7 +2103,8 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     return raw == null ? ffi.nullptr : _api2wire_box_bool(raw);
   }
 
-  ffi.Pointer<wire_ExoticOptionals> _api2wire_opt_box_exotic_optionals(ExoticOptionals? raw) {
+  ffi.Pointer<wire_ExoticOptionals> _api2wire_opt_box_exotic_optionals(
+      ExoticOptionals? raw) {
     return raw == null ? ffi.nullptr : _api2wire_box_exotic_optionals(raw);
   }
 
@@ -1856,11 +2128,13 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     return raw == null ? ffi.nullptr : _api2wire_box_u8(raw);
   }
 
-  ffi.Pointer<wire_float_32_list> _api2wire_opt_float_32_list(Float32List? raw) {
+  ffi.Pointer<wire_float_32_list> _api2wire_opt_float_32_list(
+      Float32List? raw) {
     return raw == null ? ffi.nullptr : _api2wire_float_32_list(raw);
   }
 
-  ffi.Pointer<wire_float_64_list> _api2wire_opt_float_64_list(Float64List? raw) {
+  ffi.Pointer<wire_float_64_list> _api2wire_opt_float_64_list(
+      Float64List? raw) {
     return raw == null ? ffi.nullptr : _api2wire_float_64_list(raw);
   }
 
@@ -1876,12 +2150,16 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     return raw == null ? ffi.nullptr : _api2wire_int_8_list(raw);
   }
 
-  ffi.Pointer<wire_list_attribute> _api2wire_opt_list_attribute(List<Attribute>? raw) {
+  ffi.Pointer<wire_list_attribute> _api2wire_opt_list_attribute(
+      List<Attribute>? raw) {
     return raw == null ? ffi.nullptr : _api2wire_list_attribute(raw);
   }
 
-  ffi.Pointer<wire_list_opt_box_autoadd_attribute> _api2wire_opt_list_opt_box_autoadd_attribute(List<Attribute?>? raw) {
-    return raw == null ? ffi.nullptr : _api2wire_list_opt_box_autoadd_attribute(raw);
+  ffi.Pointer<wire_list_opt_box_autoadd_attribute>
+      _api2wire_opt_list_opt_box_autoadd_attribute(List<Attribute?>? raw) {
+    return raw == null
+        ? ffi.nullptr
+        : _api2wire_list_opt_box_autoadd_attribute(raw);
   }
 
   ffi.Pointer<wire_uint_8_list> _api2wire_opt_uint_8_list(Uint8List? raw) {
@@ -1912,16 +2190,19 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
 
   // Section: api_fill_to_wire
 
-  void _api_fill_to_wire_application_env(ApplicationEnv apiObj, wire_ApplicationEnv wireObj) {
+  void _api_fill_to_wire_application_env(
+      ApplicationEnv apiObj, wire_ApplicationEnv wireObj) {
     wireObj.vars = _api2wire_list_application_env_var(apiObj.vars);
   }
 
-  void _api_fill_to_wire_application_env_var(ApplicationEnvVar apiObj, wire_ApplicationEnvVar wireObj) {
+  void _api_fill_to_wire_application_env_var(
+      ApplicationEnvVar apiObj, wire_ApplicationEnvVar wireObj) {
     wireObj.field0 = _api2wire_String(apiObj.field0);
     wireObj.field1 = _api2wire_bool(apiObj.field1);
   }
 
-  void _api_fill_to_wire_application_settings(ApplicationSettings apiObj, wire_ApplicationSettings wireObj) {
+  void _api_fill_to_wire_application_settings(
+      ApplicationSettings apiObj, wire_ApplicationSettings wireObj) {
     wireObj.name = _api2wire_String(apiObj.name);
     wireObj.version = _api2wire_String(apiObj.version);
     wireObj.mode = _api2wire_application_mode(apiObj.mode);
@@ -1933,16 +2214,19 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     wireObj.value = _api2wire_String(apiObj.value);
   }
 
-  void _api_fill_to_wire_box_application_env(ApplicationEnv apiObj, ffi.Pointer<wire_ApplicationEnv> wireObj) {
+  void _api_fill_to_wire_box_application_env(
+      ApplicationEnv apiObj, ffi.Pointer<wire_ApplicationEnv> wireObj) {
     _api_fill_to_wire_application_env(apiObj, wireObj.ref);
   }
 
   void _api_fill_to_wire_box_autoadd_application_settings(
-      ApplicationSettings apiObj, ffi.Pointer<wire_ApplicationSettings> wireObj) {
+      ApplicationSettings apiObj,
+      ffi.Pointer<wire_ApplicationSettings> wireObj) {
     _api_fill_to_wire_application_settings(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_attribute(Attribute apiObj, ffi.Pointer<wire_Attribute> wireObj) {
+  void _api_fill_to_wire_box_autoadd_attribute(
+      Attribute apiObj, ffi.Pointer<wire_Attribute> wireObj) {
     _api_fill_to_wire_attribute(apiObj, wireObj.ref);
   }
 
@@ -1951,7 +2235,8 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     _api_fill_to_wire_concatenate_with(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_customized(Customized apiObj, ffi.Pointer<wire_Customized> wireObj) {
+  void _api_fill_to_wire_box_autoadd_customized(
+      Customized apiObj, ffi.Pointer<wire_Customized> wireObj) {
     _api_fill_to_wire_customized(apiObj, wireObj.ref);
   }
 
@@ -1960,75 +2245,93 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     _api_fill_to_wire_exotic_optionals(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_kitchen_sink(KitchenSink apiObj, ffi.Pointer<wire_KitchenSink> wireObj) {
+  void _api_fill_to_wire_box_autoadd_kitchen_sink(
+      KitchenSink apiObj, ffi.Pointer<wire_KitchenSink> wireObj) {
     _api_fill_to_wire_kitchen_sink(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_measure(Measure apiObj, ffi.Pointer<wire_Measure> wireObj) {
+  void _api_fill_to_wire_box_autoadd_measure(
+      Measure apiObj, ffi.Pointer<wire_Measure> wireObj) {
     _api_fill_to_wire_measure(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_my_size(MySize apiObj, ffi.Pointer<wire_MySize> wireObj) {
+  void _api_fill_to_wire_box_autoadd_my_size(
+      MySize apiObj, ffi.Pointer<wire_MySize> wireObj) {
     _api_fill_to_wire_my_size(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_my_struct(MyStruct apiObj, ffi.Pointer<wire_MyStruct> wireObj) {
+  void _api_fill_to_wire_box_autoadd_my_struct(
+      MyStruct apiObj, ffi.Pointer<wire_MyStruct> wireObj) {
     _api_fill_to_wire_my_struct(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_my_tree_node(MyTreeNode apiObj, ffi.Pointer<wire_MyTreeNode> wireObj) {
+  void _api_fill_to_wire_box_autoadd_my_tree_node(
+      MyTreeNode apiObj, ffi.Pointer<wire_MyTreeNode> wireObj) {
     _api_fill_to_wire_my_tree_node(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_new_type_int(NewTypeInt apiObj, ffi.Pointer<wire_NewTypeInt> wireObj) {
+  void _api_fill_to_wire_box_autoadd_new_type_int(
+      NewTypeInt apiObj, ffi.Pointer<wire_NewTypeInt> wireObj) {
     _api_fill_to_wire_new_type_int(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_note(Note apiObj, ffi.Pointer<wire_Note> wireObj) {
+  void _api_fill_to_wire_box_autoadd_note(
+      Note apiObj, ffi.Pointer<wire_Note> wireObj) {
     _api_fill_to_wire_note(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_numbers(Numbers apiObj, ffi.Pointer<wire_Numbers> wireObj) {
+  void _api_fill_to_wire_box_autoadd_numbers(
+      Numbers apiObj, ffi.Pointer<wire_Numbers> wireObj) {
     _api_fill_to_wire_numbers(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_sequences(Sequences apiObj, ffi.Pointer<wire_Sequences> wireObj) {
+  void _api_fill_to_wire_box_autoadd_sequences(
+      Sequences apiObj, ffi.Pointer<wire_Sequences> wireObj) {
     _api_fill_to_wire_sequences(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_sum_with(SumWith apiObj, ffi.Pointer<wire_SumWith> wireObj) {
+  void _api_fill_to_wire_box_autoadd_sum_with(
+      SumWith apiObj, ffi.Pointer<wire_SumWith> wireObj) {
     _api_fill_to_wire_sum_with(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_user_id(UserId apiObj, ffi.Pointer<wire_UserId> wireObj) {
+  void _api_fill_to_wire_box_autoadd_user_id(
+      UserId apiObj, ffi.Pointer<wire_UserId> wireObj) {
     _api_fill_to_wire_user_id(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_distance(Distance apiObj, ffi.Pointer<wire_Distance> wireObj) {
+  void _api_fill_to_wire_box_distance(
+      Distance apiObj, ffi.Pointer<wire_Distance> wireObj) {
     _api_fill_to_wire_distance(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_exotic_optionals(ExoticOptionals apiObj, ffi.Pointer<wire_ExoticOptionals> wireObj) {
+  void _api_fill_to_wire_box_exotic_optionals(
+      ExoticOptionals apiObj, ffi.Pointer<wire_ExoticOptionals> wireObj) {
     _api_fill_to_wire_exotic_optionals(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_kitchen_sink(KitchenSink apiObj, ffi.Pointer<wire_KitchenSink> wireObj) {
+  void _api_fill_to_wire_box_kitchen_sink(
+      KitchenSink apiObj, ffi.Pointer<wire_KitchenSink> wireObj) {
     _api_fill_to_wire_kitchen_sink(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_my_size(MySize apiObj, ffi.Pointer<wire_MySize> wireObj) {
+  void _api_fill_to_wire_box_my_size(
+      MySize apiObj, ffi.Pointer<wire_MySize> wireObj) {
     _api_fill_to_wire_my_size(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_speed(Speed apiObj, ffi.Pointer<wire_Speed> wireObj) {
+  void _api_fill_to_wire_box_speed(
+      Speed apiObj, ffi.Pointer<wire_Speed> wireObj) {
     _api_fill_to_wire_speed(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_concatenate_with(ConcatenateWith apiObj, wire_ConcatenateWith wireObj) {
+  void _api_fill_to_wire_concatenate_with(
+      ConcatenateWith apiObj, wire_ConcatenateWith wireObj) {
     wireObj.a = _api2wire_String(apiObj.a);
   }
 
-  void _api_fill_to_wire_customized(Customized apiObj, wire_Customized wireObj) {
+  void _api_fill_to_wire_customized(
+      Customized apiObj, wire_Customized wireObj) {
     wireObj.final_field = _api2wire_String(apiObj.finalField);
     wireObj.non_final_field = _api2wire_opt_String(apiObj.nonFinalField);
   }
@@ -2045,7 +2348,8 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     }
   }
 
-  void _api_fill_to_wire_exotic_optionals(ExoticOptionals apiObj, wire_ExoticOptionals wireObj) {
+  void _api_fill_to_wire_exotic_optionals(
+      ExoticOptionals apiObj, wire_ExoticOptionals wireObj) {
     wireObj.int32 = _api2wire_opt_box_autoadd_i32(apiObj.int32);
     wireObj.int64 = _api2wire_opt_box_autoadd_i64(apiObj.int64);
     wireObj.float64 = _api2wire_opt_box_autoadd_f64(apiObj.float64);
@@ -2058,12 +2362,16 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     wireObj.float32list = _api2wire_opt_float_32_list(apiObj.float32List);
     wireObj.float64list = _api2wire_opt_float_64_list(apiObj.float64List);
     wireObj.attributes = _api2wire_opt_list_attribute(apiObj.attributes);
-    wireObj.attributes_nullable = _api2wire_list_opt_box_autoadd_attribute(apiObj.attributesNullable);
-    wireObj.nullable_attributes = _api2wire_opt_list_opt_box_autoadd_attribute(apiObj.nullableAttributes);
-    wireObj.newtypeint = _api2wire_opt_box_autoadd_new_type_int(apiObj.newtypeint);
+    wireObj.attributes_nullable =
+        _api2wire_list_opt_box_autoadd_attribute(apiObj.attributesNullable);
+    wireObj.nullable_attributes =
+        _api2wire_opt_list_opt_box_autoadd_attribute(apiObj.nullableAttributes);
+    wireObj.newtypeint =
+        _api2wire_opt_box_autoadd_new_type_int(apiObj.newtypeint);
   }
 
-  void _api_fill_to_wire_kitchen_sink(KitchenSink apiObj, wire_KitchenSink wireObj) {
+  void _api_fill_to_wire_kitchen_sink(
+      KitchenSink apiObj, wire_KitchenSink wireObj) {
     if (apiObj is KitchenSink_Empty) {
       wireObj.tag = 0;
       return;
@@ -2078,19 +2386,23 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     if (apiObj is KitchenSink_Nested) {
       wireObj.tag = 2;
       wireObj.kind = inner.inflate_KitchenSink_Nested();
-      wireObj.kind.ref.Nested.ref.field0 = _api2wire_box_kitchen_sink(apiObj.field0);
+      wireObj.kind.ref.Nested.ref.field0 =
+          _api2wire_box_kitchen_sink(apiObj.field0);
       wireObj.kind.ref.Nested.ref.field1 = _api2wire_i32(apiObj.field1);
     }
     if (apiObj is KitchenSink_Optional) {
       wireObj.tag = 3;
       wireObj.kind = inner.inflate_KitchenSink_Optional();
-      wireObj.kind.ref.Optional.ref.field0 = _api2wire_opt_box_autoadd_i32(apiObj.field0);
-      wireObj.kind.ref.Optional.ref.field1 = _api2wire_opt_box_autoadd_i32(apiObj.field1);
+      wireObj.kind.ref.Optional.ref.field0 =
+          _api2wire_opt_box_autoadd_i32(apiObj.field0);
+      wireObj.kind.ref.Optional.ref.field1 =
+          _api2wire_opt_box_autoadd_i32(apiObj.field1);
     }
     if (apiObj is KitchenSink_Buffer) {
       wireObj.tag = 4;
       wireObj.kind = inner.inflate_KitchenSink_Buffer();
-      wireObj.kind.ref.Buffer.ref.field0 = _api2wire_ZeroCopyBuffer_Uint8List(apiObj.field0);
+      wireObj.kind.ref.Buffer.ref.field0 =
+          _api2wire_ZeroCopyBuffer_Uint8List(apiObj.field0);
     }
     if (apiObj is KitchenSink_Enums) {
       wireObj.tag = 5;
@@ -2108,7 +2420,8 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     if (apiObj is Measure_Distance) {
       wireObj.tag = 1;
       wireObj.kind = inner.inflate_Measure_Distance();
-      wireObj.kind.ref.Distance.ref.field0 = _api2wire_box_distance(apiObj.field0);
+      wireObj.kind.ref.Distance.ref.field0 =
+          _api2wire_box_distance(apiObj.field0);
     }
   }
 
@@ -2121,14 +2434,16 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     wireObj.content = _api2wire_bool(apiObj.content);
   }
 
-  void _api_fill_to_wire_my_tree_node(MyTreeNode apiObj, wire_MyTreeNode wireObj) {
+  void _api_fill_to_wire_my_tree_node(
+      MyTreeNode apiObj, wire_MyTreeNode wireObj) {
     wireObj.value_i32 = _api2wire_i32(apiObj.valueI32);
     wireObj.value_vec_u8 = _api2wire_uint_8_list(apiObj.valueVecU8);
     wireObj.value_boolean = _api2wire_bool(apiObj.valueBoolean);
     wireObj.children = _api2wire_list_my_tree_node(apiObj.children);
   }
 
-  void _api_fill_to_wire_new_type_int(NewTypeInt apiObj, wire_NewTypeInt wireObj) {
+  void _api_fill_to_wire_new_type_int(
+      NewTypeInt apiObj, wire_NewTypeInt wireObj) {
     wireObj.field0 = _api2wire_i64(apiObj.field0);
   }
 
@@ -2141,20 +2456,26 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     wireObj.field0 = _api2wire_int_32_list(apiObj.field0);
   }
 
-  void _api_fill_to_wire_opt_box_autoadd_attribute(Attribute? apiObj, ffi.Pointer<wire_Attribute> wireObj) {
-    if (apiObj != null) _api_fill_to_wire_box_autoadd_attribute(apiObj, wireObj);
+  void _api_fill_to_wire_opt_box_autoadd_attribute(
+      Attribute? apiObj, ffi.Pointer<wire_Attribute> wireObj) {
+    if (apiObj != null)
+      _api_fill_to_wire_box_autoadd_attribute(apiObj, wireObj);
   }
 
   void _api_fill_to_wire_opt_box_autoadd_exotic_optionals(
       ExoticOptionals? apiObj, ffi.Pointer<wire_ExoticOptionals> wireObj) {
-    if (apiObj != null) _api_fill_to_wire_box_autoadd_exotic_optionals(apiObj, wireObj);
+    if (apiObj != null)
+      _api_fill_to_wire_box_autoadd_exotic_optionals(apiObj, wireObj);
   }
 
-  void _api_fill_to_wire_opt_box_autoadd_new_type_int(NewTypeInt? apiObj, ffi.Pointer<wire_NewTypeInt> wireObj) {
-    if (apiObj != null) _api_fill_to_wire_box_autoadd_new_type_int(apiObj, wireObj);
+  void _api_fill_to_wire_opt_box_autoadd_new_type_int(
+      NewTypeInt? apiObj, ffi.Pointer<wire_NewTypeInt> wireObj) {
+    if (apiObj != null)
+      _api_fill_to_wire_box_autoadd_new_type_int(apiObj, wireObj);
   }
 
-  void _api_fill_to_wire_opt_box_exotic_optionals(ExoticOptionals? apiObj, ffi.Pointer<wire_ExoticOptionals> wireObj) {
+  void _api_fill_to_wire_opt_box_exotic_optionals(
+      ExoticOptionals? apiObj, ffi.Pointer<wire_ExoticOptionals> wireObj) {
     if (apiObj != null) _api_fill_to_wire_box_exotic_optionals(apiObj, wireObj);
   }
 
@@ -2238,7 +2559,8 @@ Uint8List _wire2api_ZeroCopyBuffer_Uint8List(dynamic raw) {
 
 ApplicationEnv _wire2api_application_env(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+  if (arr.length != 1)
+    throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
   return ApplicationEnv(
     vars: _wire2api_list_application_env_var(arr[0]),
   );
@@ -2246,7 +2568,8 @@ ApplicationEnv _wire2api_application_env(dynamic raw) {
 
 ApplicationEnvVar _wire2api_application_env_var(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+  if (arr.length != 2)
+    throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
   return ApplicationEnvVar(
     field0: _wire2api_String(arr[0]),
     field1: _wire2api_bool(arr[1]),
@@ -2277,7 +2600,8 @@ ApplicationMode _wire2api_application_mode(dynamic raw) {
 
 ApplicationSettings _wire2api_application_settings(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 4) throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
+  if (arr.length != 4)
+    throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
   return ApplicationSettings(
     name: _wire2api_String(arr[0]),
     version: _wire2api_String(arr[1]),
@@ -2288,7 +2612,8 @@ ApplicationSettings _wire2api_application_settings(dynamic raw) {
 
 Attribute _wire2api_attribute(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+  if (arr.length != 2)
+    throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
   return Attribute(
     key: _wire2api_String(arr[0]),
     value: _wire2api_String(arr[1]),
@@ -2347,9 +2672,11 @@ Speed _wire2api_box_speed(dynamic raw) {
   return _wire2api_speed(raw);
 }
 
-ConcatenateWith _wire2api_concatenate_with(FlutterRustBridgeExampleSingleBlockTest bridge, dynamic raw) {
+ConcatenateWith _wire2api_concatenate_with(
+    FlutterRustBridgeExampleSingleBlockTest bridge, dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+  if (arr.length != 1)
+    throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
   return ConcatenateWith(
     bridge: bridge,
     a: _wire2api_String(arr[0]),
@@ -2371,7 +2698,8 @@ Distance _wire2api_distance(dynamic raw) {
 
 Element _wire2api_element(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 4) throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
+  if (arr.length != 4)
+    throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
   return Element(
     tag: _wire2api_opt_String(arr[0]),
     text: _wire2api_opt_String(arr[1]),
@@ -2382,7 +2710,8 @@ Element _wire2api_element(dynamic raw) {
 
 Event _wire2api_event(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+  if (arr.length != 2)
+    throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
   return Event(
     address: _wire2api_String(arr[0]),
     payload: _wire2api_String(arr[1]),
@@ -2391,7 +2720,8 @@ Event _wire2api_event(dynamic raw) {
 
 ExoticOptionals _wire2api_exotic_optionals(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 15) throw Exception('unexpected arr length: expect 15 but see ${arr.length}');
+  if (arr.length != 15)
+    throw Exception('unexpected arr length: expect 15 but see ${arr.length}');
   return ExoticOptionals(
     int32: _wire2api_opt_box_autoadd_i32(arr[0]),
     int64: _wire2api_opt_box_autoadd_i64(arr[1]),
@@ -2513,7 +2843,9 @@ List<MyTreeNode> _wire2api_list_my_tree_node(dynamic raw) {
 }
 
 List<Attribute?> _wire2api_list_opt_box_autoadd_attribute(dynamic raw) {
-  return (raw as List<dynamic>).map(_wire2api_opt_box_autoadd_attribute).toList();
+  return (raw as List<dynamic>)
+      .map(_wire2api_opt_box_autoadd_attribute)
+      .toList();
 }
 
 List<Point> _wire2api_list_point(dynamic raw) {
@@ -2522,7 +2854,8 @@ List<Point> _wire2api_list_point(dynamic raw) {
 
 Log _wire2api_log(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+  if (arr.length != 2)
+    throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
   return Log(
     key: _wire2api_u32(arr[0]),
     value: _wire2api_u32(arr[1]),
@@ -2531,7 +2864,8 @@ Log _wire2api_log(dynamic raw) {
 
 Log2 _wire2api_log_2(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+  if (arr.length != 2)
+    throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
   return Log2(
     key: _wire2api_u32(arr[0]),
     value: _wire2api_String(arr[1]),
@@ -2555,7 +2889,8 @@ Measure _wire2api_measure(dynamic raw) {
 
 MySize _wire2api_my_size(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+  if (arr.length != 2)
+    throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
   return MySize(
     width: _wire2api_i32(arr[0]),
     height: _wire2api_i32(arr[1]),
@@ -2564,7 +2899,8 @@ MySize _wire2api_my_size(dynamic raw) {
 
 MyStreamEntry _wire2api_my_stream_entry(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+  if (arr.length != 1)
+    throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
   return MyStreamEntry(
     hello: _wire2api_String(arr[0]),
   );
@@ -2572,7 +2908,8 @@ MyStreamEntry _wire2api_my_stream_entry(dynamic raw) {
 
 MyTreeNode _wire2api_my_tree_node(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 4) throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
+  if (arr.length != 4)
+    throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
   return MyTreeNode(
     valueI32: _wire2api_i32(arr[0]),
     valueVecU8: _wire2api_uint_8_list(arr[1]),
@@ -2583,7 +2920,8 @@ MyTreeNode _wire2api_my_tree_node(dynamic raw) {
 
 NewTypeInt _wire2api_new_type_int(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+  if (arr.length != 1)
+    throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
   return NewTypeInt(
     field0: _wire2api_i64(arr[0]),
   );
@@ -2591,7 +2929,8 @@ NewTypeInt _wire2api_new_type_int(dynamic raw) {
 
 Numbers _wire2api_numbers(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+  if (arr.length != 1)
+    throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
   return Numbers(
     field0: _wire2api_int_32_list(arr[0]),
   );
@@ -2683,7 +3022,8 @@ Weekdays? _wire2api_opt_weekdays(dynamic raw) {
 
 Point _wire2api_point(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+  if (arr.length != 2)
+    throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
   return Point(
     x: _wire2api_f32(arr[0]),
     y: _wire2api_f32(arr[1]),
@@ -2692,7 +3032,8 @@ Point _wire2api_point(dynamic raw) {
 
 Sequences _wire2api_sequences(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+  if (arr.length != 1)
+    throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
   return Sequences(
     field0: _wire2api_int_32_list(arr[0]),
   );
@@ -2711,9 +3052,11 @@ Speed _wire2api_speed(dynamic raw) {
   }
 }
 
-SumWith _wire2api_sum_with(FlutterRustBridgeExampleSingleBlockTest bridge, dynamic raw) {
+SumWith _wire2api_sum_with(
+    FlutterRustBridgeExampleSingleBlockTest bridge, dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+  if (arr.length != 1)
+    throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
   return SumWith(
     bridge: bridge,
     x: _wire2api_u32(arr[0]),
@@ -2758,7 +3101,8 @@ void _wire2api_unit(dynamic raw) {
 
 UserId _wire2api_user_id(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+  if (arr.length != 1)
+    throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
   return UserId(
     value: _wire2api_u32(arr[0]),
   );
@@ -2770,7 +3114,8 @@ int _wire2api_usize(dynamic raw) {
 
 VecOfPrimitivePack _wire2api_vec_of_primitive_pack(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 10) throw Exception('unexpected arr length: expect 10 but see ${arr.length}');
+  if (arr.length != 10)
+    throw Exception('unexpected arr length: expect 10 but see ${arr.length}');
   return VecOfPrimitivePack(
     int8List: _wire2api_int_8_list(arr[0]),
     uint8List: _wire2api_uint_8_list(arr[1]),
@@ -2789,9 +3134,11 @@ Weekdays _wire2api_weekdays(dynamic raw) {
   return Weekdays.values[raw];
 }
 
-ZeroCopyVecOfPrimitivePack _wire2api_zero_copy_vec_of_primitive_pack(dynamic raw) {
+ZeroCopyVecOfPrimitivePack _wire2api_zero_copy_vec_of_primitive_pack(
+    dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 10) throw Exception('unexpected arr length: expect 10 but see ${arr.length}');
+  if (arr.length != 10)
+    throw Exception('unexpected arr length: expect 10 but see ${arr.length}');
   return ZeroCopyVecOfPrimitivePack(
     int8List: _wire2api_ZeroCopyBuffer_Int8List(arr[0]),
     uint8List: _wire2api_ZeroCopyBuffer_Uint8List(arr[1]),
@@ -2813,16 +3160,20 @@ ZeroCopyVecOfPrimitivePack _wire2api_zero_copy_vec_of_primitive_pack(dynamic raw
 // Generated by `package:ffigen`.
 
 /// generated by flutter_rust_bridge
-class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWireBase {
+class FlutterRustBridgeExampleSingleBlockTestWire
+    implements FlutterRustBridgeWireBase {
   /// Holds the symbol lookup function.
-  final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName) _lookup;
+  final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
+      _lookup;
 
   /// The symbols are looked up in [dynamicLibrary].
-  FlutterRustBridgeExampleSingleBlockTestWire(ffi.DynamicLibrary dynamicLibrary) : _lookup = dynamicLibrary.lookup;
+  FlutterRustBridgeExampleSingleBlockTestWire(ffi.DynamicLibrary dynamicLibrary)
+      : _lookup = dynamicLibrary.lookup;
 
   /// The symbols are looked up with [lookup].
   FlutterRustBridgeExampleSingleBlockTestWire.fromLookup(
-      ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName) lookup)
+      ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
+          lookup)
       : _lookup = lookup;
 
   void wire_simple_adder(
@@ -2837,9 +3188,12 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_simple_adderPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32, ffi.Int32)>>('wire_simple_adder');
-  late final _wire_simple_adder = _wire_simple_adderPtr.asFunction<void Function(int, int, int)>();
+  late final _wire_simple_adderPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+              ffi.Int64, ffi.Int32, ffi.Int32)>>('wire_simple_adder');
+  late final _wire_simple_adder =
+      _wire_simple_adderPtr.asFunction<void Function(int, int, int)>();
 
   void wire_primitive_types(
     int port_,
@@ -2857,10 +3211,12 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_primitive_typesPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32, ffi.Int64, ffi.Double, ffi.Bool)>>(
-          'wire_primitive_types');
-  late final _wire_primitive_types = _wire_primitive_typesPtr.asFunction<void Function(int, int, int, double, bool)>();
+  late final _wire_primitive_typesPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Int64, ffi.Int32, ffi.Int64, ffi.Double,
+              ffi.Bool)>>('wire_primitive_types');
+  late final _wire_primitive_types = _wire_primitive_typesPtr
+      .asFunction<void Function(int, int, int, double, bool)>();
 
   void wire_primitive_u32(
     int port_,
@@ -2873,8 +3229,10 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   }
 
   late final _wire_primitive_u32Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Uint32)>>('wire_primitive_u32');
-  late final _wire_primitive_u32 = _wire_primitive_u32Ptr.asFunction<void Function(int, int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Uint32)>>(
+          'wire_primitive_u32');
+  late final _wire_primitive_u32 =
+      _wire_primitive_u32Ptr.asFunction<void Function(int, int)>();
 
   void wire_handle_string(
     int port_,
@@ -2886,10 +3244,12 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_handle_stringPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>('wire_handle_string');
-  late final _wire_handle_string =
-      _wire_handle_stringPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+  late final _wire_handle_stringPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+              ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>('wire_handle_string');
+  late final _wire_handle_string = _wire_handle_stringPtr
+      .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_handle_return_unit(
     int port_,
@@ -2900,8 +3260,10 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   }
 
   late final _wire_handle_return_unitPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_handle_return_unit');
-  late final _wire_handle_return_unit = _wire_handle_return_unitPtr.asFunction<void Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
+          'wire_handle_return_unit');
+  late final _wire_handle_return_unit =
+      _wire_handle_return_unitPtr.asFunction<void Function(int)>();
 
   void wire_handle_vec_u8(
     int port_,
@@ -2913,10 +3275,12 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_handle_vec_u8Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>('wire_handle_vec_u8');
-  late final _wire_handle_vec_u8 =
-      _wire_handle_vec_u8Ptr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+  late final _wire_handle_vec_u8Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+              ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>('wire_handle_vec_u8');
+  late final _wire_handle_vec_u8 = _wire_handle_vec_u8Ptr
+      .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_handle_vec_of_primitive(
     int port_,
@@ -2929,8 +3293,10 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   }
 
   late final _wire_handle_vec_of_primitivePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>('wire_handle_vec_of_primitive');
-  late final _wire_handle_vec_of_primitive = _wire_handle_vec_of_primitivePtr.asFunction<void Function(int, int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>(
+          'wire_handle_vec_of_primitive');
+  late final _wire_handle_vec_of_primitive =
+      _wire_handle_vec_of_primitivePtr.asFunction<void Function(int, int)>();
 
   void wire_handle_zero_copy_vec_of_primitive(
     int port_,
@@ -2943,9 +3309,11 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   }
 
   late final _wire_handle_zero_copy_vec_of_primitivePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>('wire_handle_zero_copy_vec_of_primitive');
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>(
+          'wire_handle_zero_copy_vec_of_primitive');
   late final _wire_handle_zero_copy_vec_of_primitive =
-      _wire_handle_zero_copy_vec_of_primitivePtr.asFunction<void Function(int, int)>();
+      _wire_handle_zero_copy_vec_of_primitivePtr
+          .asFunction<void Function(int, int)>();
 
   void wire_handle_struct(
     int port_,
@@ -2959,11 +3327,12 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_handle_structPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_MySize>, ffi.Pointer<wire_MySize>)>>(
-          'wire_handle_struct');
-  late final _wire_handle_struct =
-      _wire_handle_structPtr.asFunction<void Function(int, ffi.Pointer<wire_MySize>, ffi.Pointer<wire_MySize>)>();
+  late final _wire_handle_structPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Int64, ffi.Pointer<wire_MySize>,
+              ffi.Pointer<wire_MySize>)>>('wire_handle_struct');
+  late final _wire_handle_struct = _wire_handle_structPtr.asFunction<
+      void Function(int, ffi.Pointer<wire_MySize>, ffi.Pointer<wire_MySize>)>();
 
   void wire_handle_newtype(
     int port_,
@@ -2975,10 +3344,12 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_handle_newtypePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_NewTypeInt>)>>('wire_handle_newtype');
-  late final _wire_handle_newtype =
-      _wire_handle_newtypePtr.asFunction<void Function(int, ffi.Pointer<wire_NewTypeInt>)>();
+  late final _wire_handle_newtypePtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+              ffi.Int64, ffi.Pointer<wire_NewTypeInt>)>>('wire_handle_newtype');
+  late final _wire_handle_newtype = _wire_handle_newtypePtr
+      .asFunction<void Function(int, ffi.Pointer<wire_NewTypeInt>)>();
 
   void wire_handle_list_of_struct(
     int port_,
@@ -2990,11 +3361,12 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_handle_list_of_structPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_list_my_size>)>>(
-          'wire_handle_list_of_struct');
-  late final _wire_handle_list_of_struct =
-      _wire_handle_list_of_structPtr.asFunction<void Function(int, ffi.Pointer<wire_list_my_size>)>();
+  late final _wire_handle_list_of_structPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Int64,
+              ffi.Pointer<wire_list_my_size>)>>('wire_handle_list_of_struct');
+  late final _wire_handle_list_of_struct = _wire_handle_list_of_structPtr
+      .asFunction<void Function(int, ffi.Pointer<wire_list_my_size>)>();
 
   void wire_handle_string_list(
     int port_,
@@ -3006,11 +3378,12 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_handle_string_listPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_StringList>)>>(
-          'wire_handle_string_list');
-  late final _wire_handle_string_list =
-      _wire_handle_string_listPtr.asFunction<void Function(int, ffi.Pointer<wire_StringList>)>();
+  late final _wire_handle_string_listPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Int64,
+              ffi.Pointer<wire_StringList>)>>('wire_handle_string_list');
+  late final _wire_handle_string_list = _wire_handle_string_listPtr
+      .asFunction<void Function(int, ffi.Pointer<wire_StringList>)>();
 
   void wire_handle_complex_struct(
     int port_,
@@ -3022,11 +3395,12 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_handle_complex_structPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_MyTreeNode>)>>(
-          'wire_handle_complex_struct');
-  late final _wire_handle_complex_struct =
-      _wire_handle_complex_structPtr.asFunction<void Function(int, ffi.Pointer<wire_MyTreeNode>)>();
+  late final _wire_handle_complex_structPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Int64,
+              ffi.Pointer<wire_MyTreeNode>)>>('wire_handle_complex_struct');
+  late final _wire_handle_complex_struct = _wire_handle_complex_structPtr
+      .asFunction<void Function(int, ffi.Pointer<wire_MyTreeNode>)>();
 
   WireSyncReturnStruct wire_handle_sync_return(
     ffi.Pointer<wire_uint_8_list> mode,
@@ -3036,11 +3410,12 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_handle_sync_returnPtr =
-      _lookup<ffi.NativeFunction<WireSyncReturnStruct Function(ffi.Pointer<wire_uint_8_list>)>>(
-          'wire_handle_sync_return');
-  late final _wire_handle_sync_return =
-      _wire_handle_sync_returnPtr.asFunction<WireSyncReturnStruct Function(ffi.Pointer<wire_uint_8_list>)>();
+  late final _wire_handle_sync_returnPtr = _lookup<
+      ffi.NativeFunction<
+          WireSyncReturnStruct Function(
+              ffi.Pointer<wire_uint_8_list>)>>('wire_handle_sync_return');
+  late final _wire_handle_sync_return = _wire_handle_sync_returnPtr.asFunction<
+      WireSyncReturnStruct Function(ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_handle_stream(
     int port_,
@@ -3052,10 +3427,12 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_handle_streamPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>('wire_handle_stream');
-  late final _wire_handle_stream =
-      _wire_handle_streamPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+  late final _wire_handle_streamPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+              ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>('wire_handle_stream');
+  late final _wire_handle_stream = _wire_handle_streamPtr
+      .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_handle_stream_of_struct(
     int port_,
@@ -3066,8 +3443,10 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   }
 
   late final _wire_handle_stream_of_structPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_handle_stream_of_struct');
-  late final _wire_handle_stream_of_struct = _wire_handle_stream_of_structPtr.asFunction<void Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
+          'wire_handle_stream_of_struct');
+  late final _wire_handle_stream_of_struct =
+      _wire_handle_stream_of_structPtr.asFunction<void Function(int)>();
 
   void wire_return_err(
     int port_,
@@ -3077,8 +3456,11 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_return_errPtr = _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_return_err');
-  late final _wire_return_err = _wire_return_errPtr.asFunction<void Function(int)>();
+  late final _wire_return_errPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
+          'wire_return_err');
+  late final _wire_return_err =
+      _wire_return_errPtr.asFunction<void Function(int)>();
 
   void wire_return_panic(
     int port_,
@@ -3088,8 +3470,11 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_return_panicPtr = _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_return_panic');
-  late final _wire_return_panic = _wire_return_panicPtr.asFunction<void Function(int)>();
+  late final _wire_return_panicPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
+          'wire_return_panic');
+  late final _wire_return_panic =
+      _wire_return_panicPtr.asFunction<void Function(int)>();
 
   void wire_handle_optional_return(
     int port_,
@@ -3103,10 +3488,12 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_handle_optional_returnPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Double, ffi.Double)>>('wire_handle_optional_return');
-  late final _wire_handle_optional_return =
-      _wire_handle_optional_returnPtr.asFunction<void Function(int, double, double)>();
+  late final _wire_handle_optional_returnPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Int64, ffi.Double,
+              ffi.Double)>>('wire_handle_optional_return');
+  late final _wire_handle_optional_return = _wire_handle_optional_returnPtr
+      .asFunction<void Function(int, double, double)>();
 
   void wire_handle_optional_struct(
     int port_,
@@ -3118,11 +3505,12 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_handle_optional_structPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>(
-          'wire_handle_optional_struct');
-  late final _wire_handle_optional_struct =
-      _wire_handle_optional_structPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+  late final _wire_handle_optional_structPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Int64,
+              ffi.Pointer<wire_uint_8_list>)>>('wire_handle_optional_struct');
+  late final _wire_handle_optional_struct = _wire_handle_optional_structPtr
+      .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_handle_optional_increment(
     int port_,
@@ -3134,11 +3522,13 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_handle_optional_incrementPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_ExoticOptionals>)>>(
-          'wire_handle_optional_increment');
+  late final _wire_handle_optional_incrementPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Void Function(ffi.Int64, ffi.Pointer<wire_ExoticOptionals>)>>(
+      'wire_handle_optional_increment');
   late final _wire_handle_optional_increment =
-      _wire_handle_optional_incrementPtr.asFunction<void Function(int, ffi.Pointer<wire_ExoticOptionals>)>();
+      _wire_handle_optional_incrementPtr
+          .asFunction<void Function(int, ffi.Pointer<wire_ExoticOptionals>)>();
 
   void wire_handle_increment_boxed_optional(
     int port_,
@@ -3150,11 +3540,13 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_handle_increment_boxed_optionalPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<ffi.Double>)>>(
-          'wire_handle_increment_boxed_optional');
+  late final _wire_handle_increment_boxed_optionalPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Void Function(ffi.Int64, ffi.Pointer<ffi.Double>)>>(
+      'wire_handle_increment_boxed_optional');
   late final _wire_handle_increment_boxed_optional =
-      _wire_handle_increment_boxed_optionalPtr.asFunction<void Function(int, ffi.Pointer<ffi.Double>)>();
+      _wire_handle_increment_boxed_optionalPtr
+          .asFunction<void Function(int, ffi.Pointer<ffi.Double>)>();
 
   void wire_handle_option_box_arguments(
     int port_,
@@ -3179,19 +3571,28 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   }
 
   late final _wire_handle_option_box_argumentsPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-              ffi.Int64,
+          ffi.NativeFunction<
+              ffi.Void Function(
+                  ffi.Int64,
+                  ffi.Pointer<ffi.Int8>,
+                  ffi.Pointer<ffi.Uint8>,
+                  ffi.Pointer<ffi.Int32>,
+                  ffi.Pointer<ffi.Int64>,
+                  ffi.Pointer<ffi.Double>,
+                  ffi.Pointer<ffi.Bool>,
+                  ffi.Pointer<wire_ExoticOptionals>)>>(
+      'wire_handle_option_box_arguments');
+  late final _wire_handle_option_box_arguments =
+      _wire_handle_option_box_argumentsPtr.asFunction<
+          void Function(
+              int,
               ffi.Pointer<ffi.Int8>,
               ffi.Pointer<ffi.Uint8>,
               ffi.Pointer<ffi.Int32>,
               ffi.Pointer<ffi.Int64>,
               ffi.Pointer<ffi.Double>,
               ffi.Pointer<ffi.Bool>,
-              ffi.Pointer<wire_ExoticOptionals>)>>('wire_handle_option_box_arguments');
-  late final _wire_handle_option_box_arguments = _wire_handle_option_box_argumentsPtr.asFunction<
-      void Function(int, ffi.Pointer<ffi.Int8>, ffi.Pointer<ffi.Uint8>, ffi.Pointer<ffi.Int32>, ffi.Pointer<ffi.Int64>,
-          ffi.Pointer<ffi.Double>, ffi.Pointer<ffi.Bool>, ffi.Pointer<wire_ExoticOptionals>)>();
+              ffi.Pointer<wire_ExoticOptionals>)>();
 
   void wire_print_note(
     int port_,
@@ -3203,9 +3604,12 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_print_notePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_Note>)>>('wire_print_note');
-  late final _wire_print_note = _wire_print_notePtr.asFunction<void Function(int, ffi.Pointer<wire_Note>)>();
+  late final _wire_print_notePtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+              ffi.Int64, ffi.Pointer<wire_Note>)>>('wire_print_note');
+  late final _wire_print_note = _wire_print_notePtr
+      .asFunction<void Function(int, ffi.Pointer<wire_Note>)>();
 
   void wire_handle_return_enum(
     int port_,
@@ -3217,11 +3621,12 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_handle_return_enumPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>(
-          'wire_handle_return_enum');
-  late final _wire_handle_return_enum =
-      _wire_handle_return_enumPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+  late final _wire_handle_return_enumPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Int64,
+              ffi.Pointer<wire_uint_8_list>)>>('wire_handle_return_enum');
+  late final _wire_handle_return_enum = _wire_handle_return_enumPtr
+      .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_handle_enum_parameter(
     int port_,
@@ -3234,8 +3639,10 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   }
 
   late final _wire_handle_enum_parameterPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>('wire_handle_enum_parameter');
-  late final _wire_handle_enum_parameter = _wire_handle_enum_parameterPtr.asFunction<void Function(int, int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>(
+          'wire_handle_enum_parameter');
+  late final _wire_handle_enum_parameter =
+      _wire_handle_enum_parameterPtr.asFunction<void Function(int, int)>();
 
   void wire_handle_customized_struct(
     int port_,
@@ -3247,11 +3654,12 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_handle_customized_structPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_Customized>)>>(
-          'wire_handle_customized_struct');
-  late final _wire_handle_customized_struct =
-      _wire_handle_customized_structPtr.asFunction<void Function(int, ffi.Pointer<wire_Customized>)>();
+  late final _wire_handle_customized_structPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Int64,
+              ffi.Pointer<wire_Customized>)>>('wire_handle_customized_struct');
+  late final _wire_handle_customized_struct = _wire_handle_customized_structPtr
+      .asFunction<void Function(int, ffi.Pointer<wire_Customized>)>();
 
   void wire_handle_enum_struct(
     int port_,
@@ -3263,11 +3671,12 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_handle_enum_structPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_KitchenSink>)>>(
-          'wire_handle_enum_struct');
-  late final _wire_handle_enum_struct =
-      _wire_handle_enum_structPtr.asFunction<void Function(int, ffi.Pointer<wire_KitchenSink>)>();
+  late final _wire_handle_enum_structPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Int64,
+              ffi.Pointer<wire_KitchenSink>)>>('wire_handle_enum_struct');
+  late final _wire_handle_enum_struct = _wire_handle_enum_structPtr
+      .asFunction<void Function(int, ffi.Pointer<wire_KitchenSink>)>();
 
   void wire_use_imported_struct(
     int port_,
@@ -3279,10 +3688,12 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_use_imported_structPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_MyStruct>)>>('wire_use_imported_struct');
-  late final _wire_use_imported_struct =
-      _wire_use_imported_structPtr.asFunction<void Function(int, ffi.Pointer<wire_MyStruct>)>();
+  late final _wire_use_imported_structPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Int64,
+              ffi.Pointer<wire_MyStruct>)>>('wire_use_imported_struct');
+  late final _wire_use_imported_struct = _wire_use_imported_structPtr
+      .asFunction<void Function(int, ffi.Pointer<wire_MyStruct>)>();
 
   void wire_use_imported_enum(
     int port_,
@@ -3295,8 +3706,10 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   }
 
   late final _wire_use_imported_enumPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>('wire_use_imported_enum');
-  late final _wire_use_imported_enum = _wire_use_imported_enumPtr.asFunction<void Function(int, int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>(
+          'wire_use_imported_enum');
+  late final _wire_use_imported_enum =
+      _wire_use_imported_enumPtr.asFunction<void Function(int, int)>();
 
   void wire_get_app_settings(
     int port_,
@@ -3307,8 +3720,10 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   }
 
   late final _wire_get_app_settingsPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_get_app_settings');
-  late final _wire_get_app_settings = _wire_get_app_settingsPtr.asFunction<void Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
+          'wire_get_app_settings');
+  late final _wire_get_app_settings =
+      _wire_get_app_settingsPtr.asFunction<void Function(int)>();
 
   void wire_is_app_embedded(
     int port_,
@@ -3320,11 +3735,12 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_is_app_embeddedPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_ApplicationSettings>)>>(
-          'wire_is_app_embedded');
-  late final _wire_is_app_embedded =
-      _wire_is_app_embeddedPtr.asFunction<void Function(int, ffi.Pointer<wire_ApplicationSettings>)>();
+  late final _wire_is_app_embeddedPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Int64,
+              ffi.Pointer<wire_ApplicationSettings>)>>('wire_is_app_embedded');
+  late final _wire_is_app_embedded = _wire_is_app_embeddedPtr
+      .asFunction<void Function(int, ffi.Pointer<wire_ApplicationSettings>)>();
 
   void wire_get_message(
     int port_,
@@ -3334,8 +3750,11 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_get_messagePtr = _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_get_message');
-  late final _wire_get_message = _wire_get_messagePtr.asFunction<void Function(int)>();
+  late final _wire_get_messagePtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
+          'wire_get_message');
+  late final _wire_get_message =
+      _wire_get_messagePtr.asFunction<void Function(int)>();
 
   void wire_repeat_number(
     int port_,
@@ -3349,9 +3768,12 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_repeat_numberPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32, uintptr_t)>>('wire_repeat_number');
-  late final _wire_repeat_number = _wire_repeat_numberPtr.asFunction<void Function(int, int, int)>();
+  late final _wire_repeat_numberPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+              ffi.Int64, ffi.Int32, uintptr_t)>>('wire_repeat_number');
+  late final _wire_repeat_number =
+      _wire_repeat_numberPtr.asFunction<void Function(int, int, int)>();
 
   void wire_repeat_sequence(
     int port_,
@@ -3365,9 +3787,12 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_repeat_sequencePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32, uintptr_t)>>('wire_repeat_sequence');
-  late final _wire_repeat_sequence = _wire_repeat_sequencePtr.asFunction<void Function(int, int, int)>();
+  late final _wire_repeat_sequencePtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+              ffi.Int64, ffi.Int32, uintptr_t)>>('wire_repeat_sequence');
+  late final _wire_repeat_sequence =
+      _wire_repeat_sequencePtr.asFunction<void Function(int, int, int)>();
 
   void wire_first_number(
     int port_,
@@ -3379,9 +3804,12 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_first_numberPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_Numbers>)>>('wire_first_number');
-  late final _wire_first_number = _wire_first_numberPtr.asFunction<void Function(int, ffi.Pointer<wire_Numbers>)>();
+  late final _wire_first_numberPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+              ffi.Int64, ffi.Pointer<wire_Numbers>)>>('wire_first_number');
+  late final _wire_first_number = _wire_first_numberPtr
+      .asFunction<void Function(int, ffi.Pointer<wire_Numbers>)>();
 
   void wire_first_sequence(
     int port_,
@@ -3393,10 +3821,12 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_first_sequencePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_Sequences>)>>('wire_first_sequence');
-  late final _wire_first_sequence =
-      _wire_first_sequencePtr.asFunction<void Function(int, ffi.Pointer<wire_Sequences>)>();
+  late final _wire_first_sequencePtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+              ffi.Int64, ffi.Pointer<wire_Sequences>)>>('wire_first_sequence');
+  late final _wire_first_sequence = _wire_first_sequencePtr
+      .asFunction<void Function(int, ffi.Pointer<wire_Sequences>)>();
 
   void wire_get_array(
     int port_,
@@ -3406,8 +3836,11 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_get_arrayPtr = _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_get_array');
-  late final _wire_get_array = _wire_get_arrayPtr.asFunction<void Function(int)>();
+  late final _wire_get_arrayPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
+          'wire_get_array');
+  late final _wire_get_array =
+      _wire_get_arrayPtr.asFunction<void Function(int)>();
 
   void wire_get_complex_array(
     int port_,
@@ -3418,8 +3851,10 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   }
 
   late final _wire_get_complex_arrayPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_get_complex_array');
-  late final _wire_get_complex_array = _wire_get_complex_arrayPtr.asFunction<void Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
+          'wire_get_complex_array');
+  late final _wire_get_complex_array =
+      _wire_get_complex_arrayPtr.asFunction<void Function(int)>();
 
   void wire_get_usize(
     int port_,
@@ -3432,8 +3867,10 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   }
 
   late final _wire_get_usizePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, uintptr_t)>>('wire_get_usize');
-  late final _wire_get_usize = _wire_get_usizePtr.asFunction<void Function(int, int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, uintptr_t)>>(
+          'wire_get_usize');
+  late final _wire_get_usize =
+      _wire_get_usizePtr.asFunction<void Function(int, int)>();
 
   void wire_next_user_id(
     int port_,
@@ -3445,9 +3882,12 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_next_user_idPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_UserId>)>>('wire_next_user_id');
-  late final _wire_next_user_id = _wire_next_user_idPtr.asFunction<void Function(int, ffi.Pointer<wire_UserId>)>();
+  late final _wire_next_user_idPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+              ffi.Int64, ffi.Pointer<wire_UserId>)>>('wire_next_user_id');
+  late final _wire_next_user_id = _wire_next_user_idPtr
+      .asFunction<void Function(int, ffi.Pointer<wire_UserId>)>();
 
   void wire_register_event_listener(
     int port_,
@@ -3458,8 +3898,10 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   }
 
   late final _wire_register_event_listenerPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_register_event_listener');
-  late final _wire_register_event_listener = _wire_register_event_listenerPtr.asFunction<void Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
+          'wire_register_event_listener');
+  late final _wire_register_event_listener =
+      _wire_register_event_listenerPtr.asFunction<void Function(int)>();
 
   void wire_close_event_listener(
     int port_,
@@ -3470,8 +3912,10 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   }
 
   late final _wire_close_event_listenerPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_close_event_listener');
-  late final _wire_close_event_listener = _wire_close_event_listenerPtr.asFunction<void Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
+          'wire_close_event_listener');
+  late final _wire_close_event_listener =
+      _wire_close_event_listenerPtr.asFunction<void Function(int)>();
 
   void wire_create_event(
     int port_,
@@ -3481,8 +3925,11 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_create_eventPtr = _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_create_event');
-  late final _wire_create_event = _wire_create_eventPtr.asFunction<void Function(int)>();
+  late final _wire_create_eventPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
+          'wire_create_event');
+  late final _wire_create_event =
+      _wire_create_eventPtr.asFunction<void Function(int)>();
 
   void wire_handle_stream_sink_at_1(
     int port_,
@@ -3496,10 +3943,12 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_handle_stream_sink_at_1Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Uint32, ffi.Uint32)>>('wire_handle_stream_sink_at_1');
-  late final _wire_handle_stream_sink_at_1 =
-      _wire_handle_stream_sink_at_1Ptr.asFunction<void Function(int, int, int)>();
+  late final _wire_handle_stream_sink_at_1Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Int64, ffi.Uint32,
+              ffi.Uint32)>>('wire_handle_stream_sink_at_1');
+  late final _wire_handle_stream_sink_at_1 = _wire_handle_stream_sink_at_1Ptr
+      .asFunction<void Function(int, int, int)>();
 
   void wire_handle_stream_sink_at_2(
     int port_,
@@ -3513,10 +3962,12 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_handle_stream_sink_at_2Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Uint32, ffi.Uint32)>>('wire_handle_stream_sink_at_2');
-  late final _wire_handle_stream_sink_at_2 =
-      _wire_handle_stream_sink_at_2Ptr.asFunction<void Function(int, int, int)>();
+  late final _wire_handle_stream_sink_at_2Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Int64, ffi.Uint32,
+              ffi.Uint32)>>('wire_handle_stream_sink_at_2');
+  late final _wire_handle_stream_sink_at_2 = _wire_handle_stream_sink_at_2Ptr
+      .asFunction<void Function(int, int, int)>();
 
   void wire_handle_stream_sink_at_3(
     int port_,
@@ -3530,10 +3981,12 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_handle_stream_sink_at_3Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Uint32, ffi.Uint32)>>('wire_handle_stream_sink_at_3');
-  late final _wire_handle_stream_sink_at_3 =
-      _wire_handle_stream_sink_at_3Ptr.asFunction<void Function(int, int, int)>();
+  late final _wire_handle_stream_sink_at_3Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Int64, ffi.Uint32,
+              ffi.Uint32)>>('wire_handle_stream_sink_at_3');
+  late final _wire_handle_stream_sink_at_3 = _wire_handle_stream_sink_at_3Ptr
+      .asFunction<void Function(int, int, int)>();
 
   void wire_get_sum_struct(
     int port_,
@@ -3543,8 +3996,11 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_get_sum_structPtr = _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_get_sum_struct');
-  late final _wire_get_sum_struct = _wire_get_sum_structPtr.asFunction<void Function(int)>();
+  late final _wire_get_sum_structPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
+          'wire_get_sum_struct');
+  late final _wire_get_sum_struct =
+      _wire_get_sum_structPtr.asFunction<void Function(int)>();
 
   void wire_multiply_by_ten(
     int port_,
@@ -3556,10 +4012,26 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_multiply_by_tenPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_Measure>)>>('wire_multiply_by_ten');
-  late final _wire_multiply_by_ten =
-      _wire_multiply_by_tenPtr.asFunction<void Function(int, ffi.Pointer<wire_Measure>)>();
+  late final _wire_multiply_by_tenPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+              ffi.Int64, ffi.Pointer<wire_Measure>)>>('wire_multiply_by_ten');
+  late final _wire_multiply_by_ten = _wire_multiply_by_tenPtr
+      .asFunction<void Function(int, ffi.Pointer<wire_Measure>)>();
+
+  void wire_call_both_module_system(
+    int port_,
+  ) {
+    return _wire_call_both_module_system(
+      port_,
+    );
+  }
+
+  late final _wire_call_both_module_systemPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
+          'wire_call_both_module_system');
+  late final _wire_call_both_module_system =
+      _wire_call_both_module_systemPtr.asFunction<void Function(int)>();
 
   void wire_sum__method__SumWith(
     int port_,
@@ -3575,11 +4047,12 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_sum__method__SumWithPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_SumWith>, ffi.Uint32, ffi.Uint32)>>(
-          'wire_sum__method__SumWith');
-  late final _wire_sum__method__SumWith =
-      _wire_sum__method__SumWithPtr.asFunction<void Function(int, ffi.Pointer<wire_SumWith>, int, int)>();
+  late final _wire_sum__method__SumWithPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Int64, ffi.Pointer<wire_SumWith>, ffi.Uint32,
+              ffi.Uint32)>>('wire_sum__method__SumWith');
+  late final _wire_sum__method__SumWith = _wire_sum__method__SumWithPtr
+      .asFunction<void Function(int, ffi.Pointer<wire_SumWith>, int, int)>();
 
   void wire_new__static_method__ConcatenateWith(
     int port_,
@@ -3591,11 +4064,13 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_new__static_method__ConcatenateWithPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>(
-          'wire_new__static_method__ConcatenateWith');
+  late final _wire_new__static_method__ConcatenateWithPtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>(
+      'wire_new__static_method__ConcatenateWith');
   late final _wire_new__static_method__ConcatenateWith =
-      _wire_new__static_method__ConcatenateWithPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+      _wire_new__static_method__ConcatenateWithPtr
+          .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_concatenate__method__ConcatenateWith(
     int port_,
@@ -3610,11 +4085,14 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   }
 
   late final _wire_concatenate__method__ConcatenateWithPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64, ffi.Pointer<wire_ConcatenateWith>,
-              ffi.Pointer<wire_uint_8_list>)>>('wire_concatenate__method__ConcatenateWith');
-  late final _wire_concatenate__method__ConcatenateWith = _wire_concatenate__method__ConcatenateWithPtr
-      .asFunction<void Function(int, ffi.Pointer<wire_ConcatenateWith>, ffi.Pointer<wire_uint_8_list>)>();
+          ffi.NativeFunction<
+              ffi.Void Function(ffi.Int64, ffi.Pointer<wire_ConcatenateWith>,
+                  ffi.Pointer<wire_uint_8_list>)>>(
+      'wire_concatenate__method__ConcatenateWith');
+  late final _wire_concatenate__method__ConcatenateWith =
+      _wire_concatenate__method__ConcatenateWithPtr.asFunction<
+          void Function(int, ffi.Pointer<wire_ConcatenateWith>,
+              ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_concatenate_static__static_method__ConcatenateWith(
     int port_,
@@ -3628,13 +4106,16 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_concatenate_static__static_method__ConcatenateWithPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>,
-              ffi.Pointer<wire_uint_8_list>)>>('wire_concatenate_static__static_method__ConcatenateWith');
+  late final _wire_concatenate_static__static_method__ConcatenateWithPtr =
+      _lookup<
+              ffi.NativeFunction<
+                  ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>,
+                      ffi.Pointer<wire_uint_8_list>)>>(
+          'wire_concatenate_static__static_method__ConcatenateWith');
   late final _wire_concatenate_static__static_method__ConcatenateWith =
-      _wire_concatenate_static__static_method__ConcatenateWithPtr
-          .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>, ffi.Pointer<wire_uint_8_list>)>();
+      _wire_concatenate_static__static_method__ConcatenateWithPtr.asFunction<
+          void Function(int, ffi.Pointer<wire_uint_8_list>,
+              ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_handle_some_stream_sink__method__ConcatenateWith(
     int port_,
@@ -3650,12 +4131,18 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _wire_handle_some_stream_sink__method__ConcatenateWithPtr = _lookup<
-          ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_ConcatenateWith>, ffi.Uint32, ffi.Uint32)>>(
-      'wire_handle_some_stream_sink__method__ConcatenateWith');
+  late final _wire_handle_some_stream_sink__method__ConcatenateWithPtr =
+      _lookup<
+              ffi.NativeFunction<
+                  ffi.Void Function(
+                      ffi.Int64,
+                      ffi.Pointer<wire_ConcatenateWith>,
+                      ffi.Uint32,
+                      ffi.Uint32)>>(
+          'wire_handle_some_stream_sink__method__ConcatenateWith');
   late final _wire_handle_some_stream_sink__method__ConcatenateWith =
-      _wire_handle_some_stream_sink__method__ConcatenateWithPtr
-          .asFunction<void Function(int, ffi.Pointer<wire_ConcatenateWith>, int, int)>();
+      _wire_handle_some_stream_sink__method__ConcatenateWithPtr.asFunction<
+          void Function(int, ffi.Pointer<wire_ConcatenateWith>, int, int)>();
 
   void wire_handle_some_stream_sink_at_1__method__ConcatenateWith(
     int port_,
@@ -3668,7 +4155,10 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   }
 
   late final _wire_handle_some_stream_sink_at_1__method__ConcatenateWithPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_ConcatenateWith>)>>(
+      _lookup<
+              ffi.NativeFunction<
+                  ffi.Void Function(
+                      ffi.Int64, ffi.Pointer<wire_ConcatenateWith>)>>(
           'wire_handle_some_stream_sink_at_1__method__ConcatenateWith');
   late final _wire_handle_some_stream_sink_at_1__method__ConcatenateWith =
       _wire_handle_some_stream_sink_at_1__method__ConcatenateWithPtr
@@ -3687,13 +4177,16 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   }
 
   late final _wire_handle_some_static_stream_sink__static_method__ConcatenateWithPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Uint32, ffi.Uint32)>>(
+      _lookup<
+              ffi.NativeFunction<
+                  ffi.Void Function(ffi.Int64, ffi.Uint32, ffi.Uint32)>>(
           'wire_handle_some_static_stream_sink__static_method__ConcatenateWith');
   late final _wire_handle_some_static_stream_sink__static_method__ConcatenateWith =
       _wire_handle_some_static_stream_sink__static_method__ConcatenateWithPtr
           .asFunction<void Function(int, int, int)>();
 
-  void wire_handle_some_static_stream_sink_single_arg__static_method__ConcatenateWith(
+  void
+      wire_handle_some_static_stream_sink_single_arg__static_method__ConcatenateWith(
     int port_,
   ) {
     return _wire_handle_some_static_stream_sink_single_arg__static_method__ConcatenateWith(
@@ -3716,37 +4209,43 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _new_StringList_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_StringList> Function(ffi.Int32)>>('new_StringList_0');
-  late final _new_StringList_0 = _new_StringList_0Ptr.asFunction<ffi.Pointer<wire_StringList> Function(int)>();
+  late final _new_StringList_0Ptr = _lookup<
+          ffi.NativeFunction<ffi.Pointer<wire_StringList> Function(ffi.Int32)>>(
+      'new_StringList_0');
+  late final _new_StringList_0 = _new_StringList_0Ptr
+      .asFunction<ffi.Pointer<wire_StringList> Function(int)>();
 
   ffi.Pointer<wire_ApplicationEnv> new_box_application_env_0() {
     return _new_box_application_env_0();
   }
 
   late final _new_box_application_env_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_ApplicationEnv> Function()>>('new_box_application_env_0');
-  late final _new_box_application_env_0 =
-      _new_box_application_env_0Ptr.asFunction<ffi.Pointer<wire_ApplicationEnv> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_ApplicationEnv> Function()>>(
+          'new_box_application_env_0');
+  late final _new_box_application_env_0 = _new_box_application_env_0Ptr
+      .asFunction<ffi.Pointer<wire_ApplicationEnv> Function()>();
 
-  ffi.Pointer<wire_ApplicationSettings> new_box_autoadd_application_settings_0() {
+  ffi.Pointer<wire_ApplicationSettings>
+      new_box_autoadd_application_settings_0() {
     return _new_box_autoadd_application_settings_0();
   }
 
-  late final _new_box_autoadd_application_settings_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_ApplicationSettings> Function()>>(
-          'new_box_autoadd_application_settings_0');
+  late final _new_box_autoadd_application_settings_0Ptr = _lookup<
+          ffi.NativeFunction<ffi.Pointer<wire_ApplicationSettings> Function()>>(
+      'new_box_autoadd_application_settings_0');
   late final _new_box_autoadd_application_settings_0 =
-      _new_box_autoadd_application_settings_0Ptr.asFunction<ffi.Pointer<wire_ApplicationSettings> Function()>();
+      _new_box_autoadd_application_settings_0Ptr
+          .asFunction<ffi.Pointer<wire_ApplicationSettings> Function()>();
 
   ffi.Pointer<wire_Attribute> new_box_autoadd_attribute_0() {
     return _new_box_autoadd_attribute_0();
   }
 
   late final _new_box_autoadd_attribute_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Attribute> Function()>>('new_box_autoadd_attribute_0');
-  late final _new_box_autoadd_attribute_0 =
-      _new_box_autoadd_attribute_0Ptr.asFunction<ffi.Pointer<wire_Attribute> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Attribute> Function()>>(
+          'new_box_autoadd_attribute_0');
+  late final _new_box_autoadd_attribute_0 = _new_box_autoadd_attribute_0Ptr
+      .asFunction<ffi.Pointer<wire_Attribute> Function()>();
 
   ffi.Pointer<ffi.Bool> new_box_autoadd_bool_0(
     bool value,
@@ -3757,35 +4256,42 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   }
 
   late final _new_box_autoadd_bool_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Bool> Function(ffi.Bool)>>('new_box_autoadd_bool_0');
-  late final _new_box_autoadd_bool_0 = _new_box_autoadd_bool_0Ptr.asFunction<ffi.Pointer<ffi.Bool> Function(bool)>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Bool> Function(ffi.Bool)>>(
+          'new_box_autoadd_bool_0');
+  late final _new_box_autoadd_bool_0 = _new_box_autoadd_bool_0Ptr
+      .asFunction<ffi.Pointer<ffi.Bool> Function(bool)>();
 
   ffi.Pointer<wire_ConcatenateWith> new_box_autoadd_concatenate_with_0() {
     return _new_box_autoadd_concatenate_with_0();
   }
 
   late final _new_box_autoadd_concatenate_with_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_ConcatenateWith> Function()>>('new_box_autoadd_concatenate_with_0');
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_ConcatenateWith> Function()>>(
+          'new_box_autoadd_concatenate_with_0');
   late final _new_box_autoadd_concatenate_with_0 =
-      _new_box_autoadd_concatenate_with_0Ptr.asFunction<ffi.Pointer<wire_ConcatenateWith> Function()>();
+      _new_box_autoadd_concatenate_with_0Ptr
+          .asFunction<ffi.Pointer<wire_ConcatenateWith> Function()>();
 
   ffi.Pointer<wire_Customized> new_box_autoadd_customized_0() {
     return _new_box_autoadd_customized_0();
   }
 
   late final _new_box_autoadd_customized_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Customized> Function()>>('new_box_autoadd_customized_0');
-  late final _new_box_autoadd_customized_0 =
-      _new_box_autoadd_customized_0Ptr.asFunction<ffi.Pointer<wire_Customized> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Customized> Function()>>(
+          'new_box_autoadd_customized_0');
+  late final _new_box_autoadd_customized_0 = _new_box_autoadd_customized_0Ptr
+      .asFunction<ffi.Pointer<wire_Customized> Function()>();
 
   ffi.Pointer<wire_ExoticOptionals> new_box_autoadd_exotic_optionals_0() {
     return _new_box_autoadd_exotic_optionals_0();
   }
 
   late final _new_box_autoadd_exotic_optionals_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_ExoticOptionals> Function()>>('new_box_autoadd_exotic_optionals_0');
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_ExoticOptionals> Function()>>(
+          'new_box_autoadd_exotic_optionals_0');
   late final _new_box_autoadd_exotic_optionals_0 =
-      _new_box_autoadd_exotic_optionals_0Ptr.asFunction<ffi.Pointer<wire_ExoticOptionals> Function()>();
+      _new_box_autoadd_exotic_optionals_0Ptr
+          .asFunction<ffi.Pointer<wire_ExoticOptionals> Function()>();
 
   ffi.Pointer<ffi.Double> new_box_autoadd_f64_0(
     double value,
@@ -3796,8 +4302,10 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   }
 
   late final _new_box_autoadd_f64_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Double> Function(ffi.Double)>>('new_box_autoadd_f64_0');
-  late final _new_box_autoadd_f64_0 = _new_box_autoadd_f64_0Ptr.asFunction<ffi.Pointer<ffi.Double> Function(double)>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Double> Function(ffi.Double)>>(
+          'new_box_autoadd_f64_0');
+  late final _new_box_autoadd_f64_0 = _new_box_autoadd_f64_0Ptr
+      .asFunction<ffi.Pointer<ffi.Double> Function(double)>();
 
   ffi.Pointer<ffi.Int32> new_box_autoadd_i32_0(
     int value,
@@ -3808,8 +4316,10 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   }
 
   late final _new_box_autoadd_i32_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int32> Function(ffi.Int32)>>('new_box_autoadd_i32_0');
-  late final _new_box_autoadd_i32_0 = _new_box_autoadd_i32_0Ptr.asFunction<ffi.Pointer<ffi.Int32> Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int32> Function(ffi.Int32)>>(
+          'new_box_autoadd_i32_0');
+  late final _new_box_autoadd_i32_0 = _new_box_autoadd_i32_0Ptr
+      .asFunction<ffi.Pointer<ffi.Int32> Function(int)>();
 
   ffi.Pointer<ffi.Int64> new_box_autoadd_i64_0(
     int value,
@@ -3820,106 +4330,123 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   }
 
   late final _new_box_autoadd_i64_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int64> Function(ffi.Int64)>>('new_box_autoadd_i64_0');
-  late final _new_box_autoadd_i64_0 = _new_box_autoadd_i64_0Ptr.asFunction<ffi.Pointer<ffi.Int64> Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int64> Function(ffi.Int64)>>(
+          'new_box_autoadd_i64_0');
+  late final _new_box_autoadd_i64_0 = _new_box_autoadd_i64_0Ptr
+      .asFunction<ffi.Pointer<ffi.Int64> Function(int)>();
 
   ffi.Pointer<wire_KitchenSink> new_box_autoadd_kitchen_sink_0() {
     return _new_box_autoadd_kitchen_sink_0();
   }
 
   late final _new_box_autoadd_kitchen_sink_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_KitchenSink> Function()>>('new_box_autoadd_kitchen_sink_0');
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_KitchenSink> Function()>>(
+          'new_box_autoadd_kitchen_sink_0');
   late final _new_box_autoadd_kitchen_sink_0 =
-      _new_box_autoadd_kitchen_sink_0Ptr.asFunction<ffi.Pointer<wire_KitchenSink> Function()>();
+      _new_box_autoadd_kitchen_sink_0Ptr
+          .asFunction<ffi.Pointer<wire_KitchenSink> Function()>();
 
   ffi.Pointer<wire_Measure> new_box_autoadd_measure_0() {
     return _new_box_autoadd_measure_0();
   }
 
   late final _new_box_autoadd_measure_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Measure> Function()>>('new_box_autoadd_measure_0');
-  late final _new_box_autoadd_measure_0 =
-      _new_box_autoadd_measure_0Ptr.asFunction<ffi.Pointer<wire_Measure> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Measure> Function()>>(
+          'new_box_autoadd_measure_0');
+  late final _new_box_autoadd_measure_0 = _new_box_autoadd_measure_0Ptr
+      .asFunction<ffi.Pointer<wire_Measure> Function()>();
 
   ffi.Pointer<wire_MySize> new_box_autoadd_my_size_0() {
     return _new_box_autoadd_my_size_0();
   }
 
   late final _new_box_autoadd_my_size_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_MySize> Function()>>('new_box_autoadd_my_size_0');
-  late final _new_box_autoadd_my_size_0 =
-      _new_box_autoadd_my_size_0Ptr.asFunction<ffi.Pointer<wire_MySize> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_MySize> Function()>>(
+          'new_box_autoadd_my_size_0');
+  late final _new_box_autoadd_my_size_0 = _new_box_autoadd_my_size_0Ptr
+      .asFunction<ffi.Pointer<wire_MySize> Function()>();
 
   ffi.Pointer<wire_MyStruct> new_box_autoadd_my_struct_0() {
     return _new_box_autoadd_my_struct_0();
   }
 
   late final _new_box_autoadd_my_struct_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_MyStruct> Function()>>('new_box_autoadd_my_struct_0');
-  late final _new_box_autoadd_my_struct_0 =
-      _new_box_autoadd_my_struct_0Ptr.asFunction<ffi.Pointer<wire_MyStruct> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_MyStruct> Function()>>(
+          'new_box_autoadd_my_struct_0');
+  late final _new_box_autoadd_my_struct_0 = _new_box_autoadd_my_struct_0Ptr
+      .asFunction<ffi.Pointer<wire_MyStruct> Function()>();
 
   ffi.Pointer<wire_MyTreeNode> new_box_autoadd_my_tree_node_0() {
     return _new_box_autoadd_my_tree_node_0();
   }
 
   late final _new_box_autoadd_my_tree_node_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_MyTreeNode> Function()>>('new_box_autoadd_my_tree_node_0');
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_MyTreeNode> Function()>>(
+          'new_box_autoadd_my_tree_node_0');
   late final _new_box_autoadd_my_tree_node_0 =
-      _new_box_autoadd_my_tree_node_0Ptr.asFunction<ffi.Pointer<wire_MyTreeNode> Function()>();
+      _new_box_autoadd_my_tree_node_0Ptr
+          .asFunction<ffi.Pointer<wire_MyTreeNode> Function()>();
 
   ffi.Pointer<wire_NewTypeInt> new_box_autoadd_new_type_int_0() {
     return _new_box_autoadd_new_type_int_0();
   }
 
   late final _new_box_autoadd_new_type_int_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_NewTypeInt> Function()>>('new_box_autoadd_new_type_int_0');
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_NewTypeInt> Function()>>(
+          'new_box_autoadd_new_type_int_0');
   late final _new_box_autoadd_new_type_int_0 =
-      _new_box_autoadd_new_type_int_0Ptr.asFunction<ffi.Pointer<wire_NewTypeInt> Function()>();
+      _new_box_autoadd_new_type_int_0Ptr
+          .asFunction<ffi.Pointer<wire_NewTypeInt> Function()>();
 
   ffi.Pointer<wire_Note> new_box_autoadd_note_0() {
     return _new_box_autoadd_note_0();
   }
 
   late final _new_box_autoadd_note_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Note> Function()>>('new_box_autoadd_note_0');
-  late final _new_box_autoadd_note_0 = _new_box_autoadd_note_0Ptr.asFunction<ffi.Pointer<wire_Note> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Note> Function()>>(
+          'new_box_autoadd_note_0');
+  late final _new_box_autoadd_note_0 = _new_box_autoadd_note_0Ptr
+      .asFunction<ffi.Pointer<wire_Note> Function()>();
 
   ffi.Pointer<wire_Numbers> new_box_autoadd_numbers_0() {
     return _new_box_autoadd_numbers_0();
   }
 
   late final _new_box_autoadd_numbers_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Numbers> Function()>>('new_box_autoadd_numbers_0');
-  late final _new_box_autoadd_numbers_0 =
-      _new_box_autoadd_numbers_0Ptr.asFunction<ffi.Pointer<wire_Numbers> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Numbers> Function()>>(
+          'new_box_autoadd_numbers_0');
+  late final _new_box_autoadd_numbers_0 = _new_box_autoadd_numbers_0Ptr
+      .asFunction<ffi.Pointer<wire_Numbers> Function()>();
 
   ffi.Pointer<wire_Sequences> new_box_autoadd_sequences_0() {
     return _new_box_autoadd_sequences_0();
   }
 
   late final _new_box_autoadd_sequences_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Sequences> Function()>>('new_box_autoadd_sequences_0');
-  late final _new_box_autoadd_sequences_0 =
-      _new_box_autoadd_sequences_0Ptr.asFunction<ffi.Pointer<wire_Sequences> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Sequences> Function()>>(
+          'new_box_autoadd_sequences_0');
+  late final _new_box_autoadd_sequences_0 = _new_box_autoadd_sequences_0Ptr
+      .asFunction<ffi.Pointer<wire_Sequences> Function()>();
 
   ffi.Pointer<wire_SumWith> new_box_autoadd_sum_with_0() {
     return _new_box_autoadd_sum_with_0();
   }
 
   late final _new_box_autoadd_sum_with_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_SumWith> Function()>>('new_box_autoadd_sum_with_0');
-  late final _new_box_autoadd_sum_with_0 =
-      _new_box_autoadd_sum_with_0Ptr.asFunction<ffi.Pointer<wire_SumWith> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_SumWith> Function()>>(
+          'new_box_autoadd_sum_with_0');
+  late final _new_box_autoadd_sum_with_0 = _new_box_autoadd_sum_with_0Ptr
+      .asFunction<ffi.Pointer<wire_SumWith> Function()>();
 
   ffi.Pointer<wire_UserId> new_box_autoadd_user_id_0() {
     return _new_box_autoadd_user_id_0();
   }
 
   late final _new_box_autoadd_user_id_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_UserId> Function()>>('new_box_autoadd_user_id_0');
-  late final _new_box_autoadd_user_id_0 =
-      _new_box_autoadd_user_id_0Ptr.asFunction<ffi.Pointer<wire_UserId> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_UserId> Function()>>(
+          'new_box_autoadd_user_id_0');
+  late final _new_box_autoadd_user_id_0 = _new_box_autoadd_user_id_0Ptr
+      .asFunction<ffi.Pointer<wire_UserId> Function()>();
 
   ffi.Pointer<ffi.Bool> new_box_bool_0(
     bool value,
@@ -3930,25 +4457,30 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   }
 
   late final _new_box_bool_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Bool> Function(ffi.Bool)>>('new_box_bool_0');
-  late final _new_box_bool_0 = _new_box_bool_0Ptr.asFunction<ffi.Pointer<ffi.Bool> Function(bool)>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Bool> Function(ffi.Bool)>>(
+          'new_box_bool_0');
+  late final _new_box_bool_0 =
+      _new_box_bool_0Ptr.asFunction<ffi.Pointer<ffi.Bool> Function(bool)>();
 
   ffi.Pointer<wire_Distance> new_box_distance_0() {
     return _new_box_distance_0();
   }
 
   late final _new_box_distance_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Distance> Function()>>('new_box_distance_0');
-  late final _new_box_distance_0 = _new_box_distance_0Ptr.asFunction<ffi.Pointer<wire_Distance> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Distance> Function()>>(
+          'new_box_distance_0');
+  late final _new_box_distance_0 = _new_box_distance_0Ptr
+      .asFunction<ffi.Pointer<wire_Distance> Function()>();
 
   ffi.Pointer<wire_ExoticOptionals> new_box_exotic_optionals_0() {
     return _new_box_exotic_optionals_0();
   }
 
   late final _new_box_exotic_optionals_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_ExoticOptionals> Function()>>('new_box_exotic_optionals_0');
-  late final _new_box_exotic_optionals_0 =
-      _new_box_exotic_optionals_0Ptr.asFunction<ffi.Pointer<wire_ExoticOptionals> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_ExoticOptionals> Function()>>(
+          'new_box_exotic_optionals_0');
+  late final _new_box_exotic_optionals_0 = _new_box_exotic_optionals_0Ptr
+      .asFunction<ffi.Pointer<wire_ExoticOptionals> Function()>();
 
   ffi.Pointer<ffi.Double> new_box_f64_0(
     double value,
@@ -3959,8 +4491,10 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   }
 
   late final _new_box_f64_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Double> Function(ffi.Double)>>('new_box_f64_0');
-  late final _new_box_f64_0 = _new_box_f64_0Ptr.asFunction<ffi.Pointer<ffi.Double> Function(double)>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Double> Function(ffi.Double)>>(
+          'new_box_f64_0');
+  late final _new_box_f64_0 =
+      _new_box_f64_0Ptr.asFunction<ffi.Pointer<ffi.Double> Function(double)>();
 
   ffi.Pointer<ffi.Int32> new_box_i32_0(
     int value,
@@ -3971,8 +4505,10 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   }
 
   late final _new_box_i32_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int32> Function(ffi.Int32)>>('new_box_i32_0');
-  late final _new_box_i32_0 = _new_box_i32_0Ptr.asFunction<ffi.Pointer<ffi.Int32> Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int32> Function(ffi.Int32)>>(
+          'new_box_i32_0');
+  late final _new_box_i32_0 =
+      _new_box_i32_0Ptr.asFunction<ffi.Pointer<ffi.Int32> Function(int)>();
 
   ffi.Pointer<ffi.Int64> new_box_i64_0(
     int value,
@@ -3983,8 +4519,10 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   }
 
   late final _new_box_i64_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int64> Function(ffi.Int64)>>('new_box_i64_0');
-  late final _new_box_i64_0 = _new_box_i64_0Ptr.asFunction<ffi.Pointer<ffi.Int64> Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int64> Function(ffi.Int64)>>(
+          'new_box_i64_0');
+  late final _new_box_i64_0 =
+      _new_box_i64_0Ptr.asFunction<ffi.Pointer<ffi.Int64> Function(int)>();
 
   ffi.Pointer<ffi.Int8> new_box_i8_0(
     int value,
@@ -3994,32 +4532,41 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _new_box_i8_0Ptr = _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int8> Function(ffi.Int8)>>('new_box_i8_0');
-  late final _new_box_i8_0 = _new_box_i8_0Ptr.asFunction<ffi.Pointer<ffi.Int8> Function(int)>();
+  late final _new_box_i8_0Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int8> Function(ffi.Int8)>>(
+          'new_box_i8_0');
+  late final _new_box_i8_0 =
+      _new_box_i8_0Ptr.asFunction<ffi.Pointer<ffi.Int8> Function(int)>();
 
   ffi.Pointer<wire_KitchenSink> new_box_kitchen_sink_0() {
     return _new_box_kitchen_sink_0();
   }
 
   late final _new_box_kitchen_sink_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_KitchenSink> Function()>>('new_box_kitchen_sink_0');
-  late final _new_box_kitchen_sink_0 =
-      _new_box_kitchen_sink_0Ptr.asFunction<ffi.Pointer<wire_KitchenSink> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_KitchenSink> Function()>>(
+          'new_box_kitchen_sink_0');
+  late final _new_box_kitchen_sink_0 = _new_box_kitchen_sink_0Ptr
+      .asFunction<ffi.Pointer<wire_KitchenSink> Function()>();
 
   ffi.Pointer<wire_MySize> new_box_my_size_0() {
     return _new_box_my_size_0();
   }
 
   late final _new_box_my_size_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_MySize> Function()>>('new_box_my_size_0');
-  late final _new_box_my_size_0 = _new_box_my_size_0Ptr.asFunction<ffi.Pointer<wire_MySize> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_MySize> Function()>>(
+          'new_box_my_size_0');
+  late final _new_box_my_size_0 =
+      _new_box_my_size_0Ptr.asFunction<ffi.Pointer<wire_MySize> Function()>();
 
   ffi.Pointer<wire_Speed> new_box_speed_0() {
     return _new_box_speed_0();
   }
 
-  late final _new_box_speed_0Ptr = _lookup<ffi.NativeFunction<ffi.Pointer<wire_Speed> Function()>>('new_box_speed_0');
-  late final _new_box_speed_0 = _new_box_speed_0Ptr.asFunction<ffi.Pointer<wire_Speed> Function()>();
+  late final _new_box_speed_0Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Speed> Function()>>(
+          'new_box_speed_0');
+  late final _new_box_speed_0 =
+      _new_box_speed_0Ptr.asFunction<ffi.Pointer<wire_Speed> Function()>();
 
   ffi.Pointer<ffi.Uint8> new_box_u8_0(
     int value,
@@ -4029,8 +4576,11 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _new_box_u8_0Ptr = _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Uint8> Function(ffi.Uint8)>>('new_box_u8_0');
-  late final _new_box_u8_0 = _new_box_u8_0Ptr.asFunction<ffi.Pointer<ffi.Uint8> Function(int)>();
+  late final _new_box_u8_0Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Uint8> Function(ffi.Uint8)>>(
+          'new_box_u8_0');
+  late final _new_box_u8_0 =
+      _new_box_u8_0Ptr.asFunction<ffi.Pointer<ffi.Uint8> Function(int)>();
 
   ffi.Pointer<ffi.Int32> new_box_weekdays_0(
     int value,
@@ -4041,8 +4591,10 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   }
 
   late final _new_box_weekdays_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int32> Function(ffi.Int32)>>('new_box_weekdays_0');
-  late final _new_box_weekdays_0 = _new_box_weekdays_0Ptr.asFunction<ffi.Pointer<ffi.Int32> Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int32> Function(ffi.Int32)>>(
+          'new_box_weekdays_0');
+  late final _new_box_weekdays_0 =
+      _new_box_weekdays_0Ptr.asFunction<ffi.Pointer<ffi.Int32> Function(int)>();
 
   ffi.Pointer<wire_float_32_list> new_float_32_list_0(
     int len,
@@ -4052,9 +4604,12 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _new_float_32_list_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_float_32_list> Function(ffi.Int32)>>('new_float_32_list_0');
-  late final _new_float_32_list_0 = _new_float_32_list_0Ptr.asFunction<ffi.Pointer<wire_float_32_list> Function(int)>();
+  late final _new_float_32_list_0Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<wire_float_32_list> Function(
+              ffi.Int32)>>('new_float_32_list_0');
+  late final _new_float_32_list_0 = _new_float_32_list_0Ptr
+      .asFunction<ffi.Pointer<wire_float_32_list> Function(int)>();
 
   ffi.Pointer<wire_float_64_list> new_float_64_list_0(
     int len,
@@ -4064,9 +4619,12 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _new_float_64_list_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_float_64_list> Function(ffi.Int32)>>('new_float_64_list_0');
-  late final _new_float_64_list_0 = _new_float_64_list_0Ptr.asFunction<ffi.Pointer<wire_float_64_list> Function(int)>();
+  late final _new_float_64_list_0Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<wire_float_64_list> Function(
+              ffi.Int32)>>('new_float_64_list_0');
+  late final _new_float_64_list_0 = _new_float_64_list_0Ptr
+      .asFunction<ffi.Pointer<wire_float_64_list> Function(int)>();
 
   ffi.Pointer<wire_int_32_list> new_int_32_list_0(
     int len,
@@ -4076,9 +4634,12 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _new_int_32_list_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_int_32_list> Function(ffi.Int32)>>('new_int_32_list_0');
-  late final _new_int_32_list_0 = _new_int_32_list_0Ptr.asFunction<ffi.Pointer<wire_int_32_list> Function(int)>();
+  late final _new_int_32_list_0Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<wire_int_32_list> Function(
+              ffi.Int32)>>('new_int_32_list_0');
+  late final _new_int_32_list_0 = _new_int_32_list_0Ptr
+      .asFunction<ffi.Pointer<wire_int_32_list> Function(int)>();
 
   ffi.Pointer<wire_int_64_list> new_int_64_list_0(
     int len,
@@ -4088,9 +4649,12 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _new_int_64_list_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_int_64_list> Function(ffi.Int32)>>('new_int_64_list_0');
-  late final _new_int_64_list_0 = _new_int_64_list_0Ptr.asFunction<ffi.Pointer<wire_int_64_list> Function(int)>();
+  late final _new_int_64_list_0Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<wire_int_64_list> Function(
+              ffi.Int32)>>('new_int_64_list_0');
+  late final _new_int_64_list_0 = _new_int_64_list_0Ptr
+      .asFunction<ffi.Pointer<wire_int_64_list> Function(int)>();
 
   ffi.Pointer<wire_int_8_list> new_int_8_list_0(
     int len,
@@ -4100,9 +4664,11 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _new_int_8_list_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_int_8_list> Function(ffi.Int32)>>('new_int_8_list_0');
-  late final _new_int_8_list_0 = _new_int_8_list_0Ptr.asFunction<ffi.Pointer<wire_int_8_list> Function(int)>();
+  late final _new_int_8_list_0Ptr = _lookup<
+          ffi.NativeFunction<ffi.Pointer<wire_int_8_list> Function(ffi.Int32)>>(
+      'new_int_8_list_0');
+  late final _new_int_8_list_0 = _new_int_8_list_0Ptr
+      .asFunction<ffi.Pointer<wire_int_8_list> Function(int)>();
 
   ffi.Pointer<wire_list_application_env_var> new_list_application_env_var_0(
     int len,
@@ -4112,11 +4678,13 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _new_list_application_env_var_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_list_application_env_var> Function(ffi.Int32)>>(
-          'new_list_application_env_var_0');
+  late final _new_list_application_env_var_0Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<wire_list_application_env_var> Function(
+              ffi.Int32)>>('new_list_application_env_var_0');
   late final _new_list_application_env_var_0 =
-      _new_list_application_env_var_0Ptr.asFunction<ffi.Pointer<wire_list_application_env_var> Function(int)>();
+      _new_list_application_env_var_0Ptr.asFunction<
+          ffi.Pointer<wire_list_application_env_var> Function(int)>();
 
   ffi.Pointer<wire_list_attribute> new_list_attribute_0(
     int len,
@@ -4126,10 +4694,12 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _new_list_attribute_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_list_attribute> Function(ffi.Int32)>>('new_list_attribute_0');
-  late final _new_list_attribute_0 =
-      _new_list_attribute_0Ptr.asFunction<ffi.Pointer<wire_list_attribute> Function(int)>();
+  late final _new_list_attribute_0Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<wire_list_attribute> Function(
+              ffi.Int32)>>('new_list_attribute_0');
+  late final _new_list_attribute_0 = _new_list_attribute_0Ptr
+      .asFunction<ffi.Pointer<wire_list_attribute> Function(int)>();
 
   ffi.Pointer<wire_list_my_size> new_list_my_size_0(
     int len,
@@ -4139,9 +4709,12 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _new_list_my_size_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_list_my_size> Function(ffi.Int32)>>('new_list_my_size_0');
-  late final _new_list_my_size_0 = _new_list_my_size_0Ptr.asFunction<ffi.Pointer<wire_list_my_size> Function(int)>();
+  late final _new_list_my_size_0Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<wire_list_my_size> Function(
+              ffi.Int32)>>('new_list_my_size_0');
+  late final _new_list_my_size_0 = _new_list_my_size_0Ptr
+      .asFunction<ffi.Pointer<wire_list_my_size> Function(int)>();
 
   ffi.Pointer<wire_list_my_tree_node> new_list_my_tree_node_0(
     int len,
@@ -4151,12 +4724,15 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _new_list_my_tree_node_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_list_my_tree_node> Function(ffi.Int32)>>('new_list_my_tree_node_0');
-  late final _new_list_my_tree_node_0 =
-      _new_list_my_tree_node_0Ptr.asFunction<ffi.Pointer<wire_list_my_tree_node> Function(int)>();
+  late final _new_list_my_tree_node_0Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<wire_list_my_tree_node> Function(
+              ffi.Int32)>>('new_list_my_tree_node_0');
+  late final _new_list_my_tree_node_0 = _new_list_my_tree_node_0Ptr
+      .asFunction<ffi.Pointer<wire_list_my_tree_node> Function(int)>();
 
-  ffi.Pointer<wire_list_opt_box_autoadd_attribute> new_list_opt_box_autoadd_attribute_0(
+  ffi.Pointer<wire_list_opt_box_autoadd_attribute>
+      new_list_opt_box_autoadd_attribute_0(
     int len,
   ) {
     return _new_list_opt_box_autoadd_attribute_0(
@@ -4164,11 +4740,13 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _new_list_opt_box_autoadd_attribute_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_list_opt_box_autoadd_attribute> Function(ffi.Int32)>>(
-          'new_list_opt_box_autoadd_attribute_0');
-  late final _new_list_opt_box_autoadd_attribute_0 = _new_list_opt_box_autoadd_attribute_0Ptr
-      .asFunction<ffi.Pointer<wire_list_opt_box_autoadd_attribute> Function(int)>();
+  late final _new_list_opt_box_autoadd_attribute_0Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<wire_list_opt_box_autoadd_attribute> Function(
+              ffi.Int32)>>('new_list_opt_box_autoadd_attribute_0');
+  late final _new_list_opt_box_autoadd_attribute_0 =
+      _new_list_opt_box_autoadd_attribute_0Ptr.asFunction<
+          ffi.Pointer<wire_list_opt_box_autoadd_attribute> Function(int)>();
 
   ffi.Pointer<wire_uint_8_list> new_uint_8_list_0(
     int len,
@@ -4178,86 +4756,103 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
     );
   }
 
-  late final _new_uint_8_list_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_uint_8_list> Function(ffi.Int32)>>('new_uint_8_list_0');
-  late final _new_uint_8_list_0 = _new_uint_8_list_0Ptr.asFunction<ffi.Pointer<wire_uint_8_list> Function(int)>();
+  late final _new_uint_8_list_0Ptr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<wire_uint_8_list> Function(
+              ffi.Int32)>>('new_uint_8_list_0');
+  late final _new_uint_8_list_0 = _new_uint_8_list_0Ptr
+      .asFunction<ffi.Pointer<wire_uint_8_list> Function(int)>();
 
   ffi.Pointer<DistanceKind> inflate_Distance_Map() {
     return _inflate_Distance_Map();
   }
 
   late final _inflate_Distance_MapPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<DistanceKind> Function()>>('inflate_Distance_Map');
-  late final _inflate_Distance_Map = _inflate_Distance_MapPtr.asFunction<ffi.Pointer<DistanceKind> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<DistanceKind> Function()>>(
+          'inflate_Distance_Map');
+  late final _inflate_Distance_Map = _inflate_Distance_MapPtr
+      .asFunction<ffi.Pointer<DistanceKind> Function()>();
 
   ffi.Pointer<KitchenSinkKind> inflate_KitchenSink_Primitives() {
     return _inflate_KitchenSink_Primitives();
   }
 
   late final _inflate_KitchenSink_PrimitivesPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>('inflate_KitchenSink_Primitives');
+      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>(
+          'inflate_KitchenSink_Primitives');
   late final _inflate_KitchenSink_Primitives =
-      _inflate_KitchenSink_PrimitivesPtr.asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
+      _inflate_KitchenSink_PrimitivesPtr
+          .asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
 
   ffi.Pointer<KitchenSinkKind> inflate_KitchenSink_Nested() {
     return _inflate_KitchenSink_Nested();
   }
 
   late final _inflate_KitchenSink_NestedPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>('inflate_KitchenSink_Nested');
-  late final _inflate_KitchenSink_Nested =
-      _inflate_KitchenSink_NestedPtr.asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>(
+          'inflate_KitchenSink_Nested');
+  late final _inflate_KitchenSink_Nested = _inflate_KitchenSink_NestedPtr
+      .asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
 
   ffi.Pointer<KitchenSinkKind> inflate_KitchenSink_Optional() {
     return _inflate_KitchenSink_Optional();
   }
 
   late final _inflate_KitchenSink_OptionalPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>('inflate_KitchenSink_Optional');
-  late final _inflate_KitchenSink_Optional =
-      _inflate_KitchenSink_OptionalPtr.asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>(
+          'inflate_KitchenSink_Optional');
+  late final _inflate_KitchenSink_Optional = _inflate_KitchenSink_OptionalPtr
+      .asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
 
   ffi.Pointer<KitchenSinkKind> inflate_KitchenSink_Buffer() {
     return _inflate_KitchenSink_Buffer();
   }
 
   late final _inflate_KitchenSink_BufferPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>('inflate_KitchenSink_Buffer');
-  late final _inflate_KitchenSink_Buffer =
-      _inflate_KitchenSink_BufferPtr.asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>(
+          'inflate_KitchenSink_Buffer');
+  late final _inflate_KitchenSink_Buffer = _inflate_KitchenSink_BufferPtr
+      .asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
 
   ffi.Pointer<KitchenSinkKind> inflate_KitchenSink_Enums() {
     return _inflate_KitchenSink_Enums();
   }
 
   late final _inflate_KitchenSink_EnumsPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>('inflate_KitchenSink_Enums');
-  late final _inflate_KitchenSink_Enums =
-      _inflate_KitchenSink_EnumsPtr.asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>(
+          'inflate_KitchenSink_Enums');
+  late final _inflate_KitchenSink_Enums = _inflate_KitchenSink_EnumsPtr
+      .asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
 
   ffi.Pointer<MeasureKind> inflate_Measure_Speed() {
     return _inflate_Measure_Speed();
   }
 
   late final _inflate_Measure_SpeedPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<MeasureKind> Function()>>('inflate_Measure_Speed');
-  late final _inflate_Measure_Speed = _inflate_Measure_SpeedPtr.asFunction<ffi.Pointer<MeasureKind> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<MeasureKind> Function()>>(
+          'inflate_Measure_Speed');
+  late final _inflate_Measure_Speed = _inflate_Measure_SpeedPtr
+      .asFunction<ffi.Pointer<MeasureKind> Function()>();
 
   ffi.Pointer<MeasureKind> inflate_Measure_Distance() {
     return _inflate_Measure_Distance();
   }
 
   late final _inflate_Measure_DistancePtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<MeasureKind> Function()>>('inflate_Measure_Distance');
-  late final _inflate_Measure_Distance = _inflate_Measure_DistancePtr.asFunction<ffi.Pointer<MeasureKind> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<MeasureKind> Function()>>(
+          'inflate_Measure_Distance');
+  late final _inflate_Measure_Distance = _inflate_Measure_DistancePtr
+      .asFunction<ffi.Pointer<MeasureKind> Function()>();
 
   ffi.Pointer<SpeedKind> inflate_Speed_GPS() {
     return _inflate_Speed_GPS();
   }
 
   late final _inflate_Speed_GPSPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<SpeedKind> Function()>>('inflate_Speed_GPS');
-  late final _inflate_Speed_GPS = _inflate_Speed_GPSPtr.asFunction<ffi.Pointer<SpeedKind> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<SpeedKind> Function()>>(
+          'inflate_Speed_GPS');
+  late final _inflate_Speed_GPS =
+      _inflate_Speed_GPSPtr.asFunction<ffi.Pointer<SpeedKind> Function()>();
 
   void free_WireSyncReturnStruct(
     WireSyncReturnStruct val,
@@ -4268,9 +4863,10 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   }
 
   late final _free_WireSyncReturnStructPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(WireSyncReturnStruct)>>('free_WireSyncReturnStruct');
-  late final _free_WireSyncReturnStruct =
-      _free_WireSyncReturnStructPtr.asFunction<void Function(WireSyncReturnStruct)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(WireSyncReturnStruct)>>(
+          'free_WireSyncReturnStruct');
+  late final _free_WireSyncReturnStruct = _free_WireSyncReturnStructPtr
+      .asFunction<void Function(WireSyncReturnStruct)>();
 
   void store_dart_post_cobject(
     DartPostCObjectFnType ptr,
@@ -4281,8 +4877,10 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   }
 
   late final _store_dart_post_cobjectPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(DartPostCObjectFnType)>>('store_dart_post_cobject');
-  late final _store_dart_post_cobject = _store_dart_post_cobjectPtr.asFunction<void Function(DartPostCObjectFnType)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(DartPostCObjectFnType)>>(
+          'store_dart_post_cobject');
+  late final _store_dart_post_cobject = _store_dart_post_cobjectPtr
+      .asFunction<void Function(DartPostCObjectFnType)>();
 }
 
 class wire_uint_8_list extends ffi.Struct {
@@ -4610,6 +5208,7 @@ class wire_ConcatenateWith extends ffi.Struct {
   external ffi.Pointer<wire_uint_8_list> a;
 }
 
-typedef uintptr_t = ffi.UnsignedLong;
-typedef DartPostCObjectFnType = ffi.Pointer<ffi.NativeFunction<ffi.Bool Function(DartPort, ffi.Pointer<ffi.Void>)>>;
+typedef uintptr_t = ffi.UnsignedLongLong;
+typedef DartPostCObjectFnType = ffi.Pointer<
+    ffi.NativeFunction<ffi.Bool Function(DartPort, ffi.Pointer<ffi.Void>)>>;
 typedef DartPort = ffi.Int64;

--- a/frb_example/pure_dart/dart/lib/bridge_generated.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.dart
@@ -28,11 +28,7 @@ abstract class FlutterRustBridgeExampleSingleBlockTest {
   /// Newlines are preserved.
   ///
   Future<int> primitiveTypes(
-      {required int myI32,
-      required int myI64,
-      required double myF64,
-      required bool myBool,
-      dynamic hint});
+      {required int myI32, required int myI64, required double myF64, required bool myBool, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kPrimitiveTypesConstMeta;
 
@@ -52,18 +48,15 @@ abstract class FlutterRustBridgeExampleSingleBlockTest {
 
   FlutterRustBridgeTaskConstMeta get kHandleVecU8ConstMeta;
 
-  Future<VecOfPrimitivePack> handleVecOfPrimitive(
-      {required int n, dynamic hint});
+  Future<VecOfPrimitivePack> handleVecOfPrimitive({required int n, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleVecOfPrimitiveConstMeta;
 
-  Future<ZeroCopyVecOfPrimitivePack> handleZeroCopyVecOfPrimitive(
-      {required int n, dynamic hint});
+  Future<ZeroCopyVecOfPrimitivePack> handleZeroCopyVecOfPrimitive({required int n, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleZeroCopyVecOfPrimitiveConstMeta;
 
-  Future<MySize> handleStruct(
-      {required MySize arg, required MySize boxed, dynamic hint});
+  Future<MySize> handleStruct({required MySize arg, required MySize boxed, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleStructConstMeta;
 
@@ -71,13 +64,11 @@ abstract class FlutterRustBridgeExampleSingleBlockTest {
 
   FlutterRustBridgeTaskConstMeta get kHandleNewtypeConstMeta;
 
-  Future<List<MySize>> handleListOfStruct(
-      {required List<MySize> l, dynamic hint});
+  Future<List<MySize>> handleListOfStruct({required List<MySize> l, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleListOfStructConstMeta;
 
-  Future<List<String>> handleStringList(
-      {required List<String> names, dynamic hint});
+  Future<List<String>> handleStringList({required List<String> names, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleStringListConstMeta;
 
@@ -105,8 +96,7 @@ abstract class FlutterRustBridgeExampleSingleBlockTest {
 
   FlutterRustBridgeTaskConstMeta get kReturnPanicConstMeta;
 
-  Future<double?> handleOptionalReturn(
-      {required double left, required double right, dynamic hint});
+  Future<double?> handleOptionalReturn({required double left, required double right, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleOptionalReturnConstMeta;
 
@@ -114,8 +104,7 @@ abstract class FlutterRustBridgeExampleSingleBlockTest {
 
   FlutterRustBridgeTaskConstMeta get kHandleOptionalStructConstMeta;
 
-  Future<ExoticOptionals?> handleOptionalIncrement(
-      {ExoticOptionals? opt, dynamic hint});
+  Future<ExoticOptionals?> handleOptionalIncrement({ExoticOptionals? opt, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleOptionalIncrementConstMeta;
 
@@ -143,8 +132,7 @@ abstract class FlutterRustBridgeExampleSingleBlockTest {
 
   FlutterRustBridgeTaskConstMeta get kHandleReturnEnumConstMeta;
 
-  Future<Weekdays> handleEnumParameter(
-      {required Weekdays weekday, dynamic hint});
+  Future<Weekdays> handleEnumParameter({required Weekdays weekday, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleEnumParameterConstMeta;
 
@@ -152,8 +140,7 @@ abstract class FlutterRustBridgeExampleSingleBlockTest {
 
   FlutterRustBridgeTaskConstMeta get kHandleCustomizedStructConstMeta;
 
-  Future<KitchenSink> handleEnumStruct(
-      {required KitchenSink val, dynamic hint});
+  Future<KitchenSink> handleEnumStruct({required KitchenSink val, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleEnumStructConstMeta;
 
@@ -169,8 +156,7 @@ abstract class FlutterRustBridgeExampleSingleBlockTest {
 
   FlutterRustBridgeTaskConstMeta get kGetAppSettingsConstMeta;
 
-  Future<bool> isAppEmbedded(
-      {required ApplicationSettings appSettings, dynamic hint});
+  Future<bool> isAppEmbedded({required ApplicationSettings appSettings, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kIsAppEmbeddedConstMeta;
 
@@ -178,13 +164,11 @@ abstract class FlutterRustBridgeExampleSingleBlockTest {
 
   FlutterRustBridgeTaskConstMeta get kGetMessageConstMeta;
 
-  Future<Numbers> repeatNumber(
-      {required int num, required int times, dynamic hint});
+  Future<Numbers> repeatNumber({required int num, required int times, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kRepeatNumberConstMeta;
 
-  Future<Sequences> repeatSequence(
-      {required int seq, required int times, dynamic hint});
+  Future<Sequences> repeatSequence({required int seq, required int times, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kRepeatSequenceConstMeta;
 
@@ -224,18 +208,15 @@ abstract class FlutterRustBridgeExampleSingleBlockTest {
 
   FlutterRustBridgeTaskConstMeta get kCreateEventConstMeta;
 
-  Stream<Log> handleStreamSinkAt1(
-      {required int key, required int max, dynamic hint});
+  Stream<Log> handleStreamSinkAt1({required int key, required int max, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleStreamSinkAt1ConstMeta;
 
-  Stream<Log> handleStreamSinkAt2(
-      {required int key, required int max, dynamic hint});
+  Stream<Log> handleStreamSinkAt2({required int key, required int max, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleStreamSinkAt2ConstMeta;
 
-  Stream<Log> handleStreamSinkAt3(
-      {required int key, required int max, dynamic hint});
+  Stream<Log> handleStreamSinkAt3({required int key, required int max, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleStreamSinkAt3ConstMeta;
 
@@ -255,53 +236,39 @@ abstract class FlutterRustBridgeExampleSingleBlockTest {
 
   FlutterRustBridgeTaskConstMeta get kCallNewModuleSystemConstMeta;
 
-  Future<int> sumMethodSumWith(
-      {required SumWith that, required int y, required int z, dynamic hint});
+  Future<int> sumMethodSumWith({required SumWith that, required int y, required int z, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kSumMethodSumWithConstMeta;
 
-  Future<ConcatenateWith> newStaticMethodConcatenateWith(
-      {required String a, dynamic hint});
+  Future<ConcatenateWith> newStaticMethodConcatenateWith({required String a, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kNewStaticMethodConcatenateWithConstMeta;
 
-  Future<String> concatenateMethodConcatenateWith(
-      {required ConcatenateWith that, required String b, dynamic hint});
+  Future<String> concatenateMethodConcatenateWith({required ConcatenateWith that, required String b, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kConcatenateMethodConcatenateWithConstMeta;
 
-  Future<String> concatenateStaticStaticMethodConcatenateWith(
-      {required String a, required String b, dynamic hint});
+  Future<String> concatenateStaticStaticMethodConcatenateWith({required String a, required String b, dynamic hint});
 
-  FlutterRustBridgeTaskConstMeta
-      get kConcatenateStaticStaticMethodConcatenateWithConstMeta;
+  FlutterRustBridgeTaskConstMeta get kConcatenateStaticStaticMethodConcatenateWithConstMeta;
 
   Stream<Log2> handleSomeStreamSinkMethodConcatenateWith(
-      {required ConcatenateWith that,
-      required int key,
-      required int max,
-      dynamic hint});
+      {required ConcatenateWith that, required int key, required int max, dynamic hint});
 
-  FlutterRustBridgeTaskConstMeta
-      get kHandleSomeStreamSinkMethodConcatenateWithConstMeta;
+  FlutterRustBridgeTaskConstMeta get kHandleSomeStreamSinkMethodConcatenateWithConstMeta;
 
-  Stream<int> handleSomeStreamSinkAt1MethodConcatenateWith(
-      {required ConcatenateWith that, dynamic hint});
+  Stream<int> handleSomeStreamSinkAt1MethodConcatenateWith({required ConcatenateWith that, dynamic hint});
 
-  FlutterRustBridgeTaskConstMeta
-      get kHandleSomeStreamSinkAt1MethodConcatenateWithConstMeta;
+  FlutterRustBridgeTaskConstMeta get kHandleSomeStreamSinkAt1MethodConcatenateWithConstMeta;
 
   Stream<Log2> handleSomeStaticStreamSinkStaticMethodConcatenateWith(
       {required int key, required int max, dynamic hint});
 
-  FlutterRustBridgeTaskConstMeta
-      get kHandleSomeStaticStreamSinkStaticMethodConcatenateWithConstMeta;
+  FlutterRustBridgeTaskConstMeta get kHandleSomeStaticStreamSinkStaticMethodConcatenateWithConstMeta;
 
-  Stream<int> handleSomeStaticStreamSinkSingleArgStaticMethodConcatenateWith(
-      {dynamic hint});
+  Stream<int> handleSomeStaticStreamSinkSingleArgStaticMethodConcatenateWith({dynamic hint});
 
-  FlutterRustBridgeTaskConstMeta
-      get kHandleSomeStaticStreamSinkSingleArgStaticMethodConcatenateWithConstMeta;
+  FlutterRustBridgeTaskConstMeta get kHandleSomeStaticStreamSinkSingleArgStaticMethodConcatenateWithConstMeta;
 }
 
 class ApplicationEnv {
@@ -373,13 +340,10 @@ class ConcatenateWith {
   });
 
   static Future<ConcatenateWith> newConcatenateWith(
-          {required FlutterRustBridgeExampleSingleBlockTest bridge,
-          required String a,
-          dynamic hint}) =>
+          {required FlutterRustBridgeExampleSingleBlockTest bridge, required String a, dynamic hint}) =>
       bridge.newStaticMethodConcatenateWith(a: a, hint: hint);
 
-  Future<String> concatenate({required String b, dynamic hint}) =>
-      bridge.concatenateMethodConcatenateWith(
+  Future<String> concatenate({required String b, dynamic hint}) => bridge.concatenateMethodConcatenateWith(
         that: this,
         b: b,
       );
@@ -389,19 +353,16 @@ class ConcatenateWith {
           required String a,
           required String b,
           dynamic hint}) =>
-      bridge.concatenateStaticStaticMethodConcatenateWith(
-          a: a, b: b, hint: hint);
+      bridge.concatenateStaticStaticMethodConcatenateWith(a: a, b: b, hint: hint);
 
-  Stream<Log2> handleSomeStreamSink(
-          {required int key, required int max, dynamic hint}) =>
+  Stream<Log2> handleSomeStreamSink({required int key, required int max, dynamic hint}) =>
       bridge.handleSomeStreamSinkMethodConcatenateWith(
         that: this,
         key: key,
         max: max,
       );
 
-  Stream<int> handleSomeStreamSinkAt1({dynamic hint}) =>
-      bridge.handleSomeStreamSinkAt1MethodConcatenateWith(
+  Stream<int> handleSomeStreamSinkAt1({dynamic hint}) => bridge.handleSomeStreamSinkAt1MethodConcatenateWith(
         that: this,
       );
 
@@ -410,14 +371,11 @@ class ConcatenateWith {
           required int key,
           required int max,
           dynamic hint}) =>
-      bridge.handleSomeStaticStreamSinkStaticMethodConcatenateWith(
-          key: key, max: max, hint: hint);
+      bridge.handleSomeStaticStreamSinkStaticMethodConcatenateWith(key: key, max: max, hint: hint);
 
   static Stream<int> handleSomeStaticStreamSinkSingleArg(
-          {required FlutterRustBridgeExampleSingleBlockTest bridge,
-          dynamic hint}) =>
-      bridge.handleSomeStaticStreamSinkSingleArgStaticMethodConcatenateWith(
-          hint: hint);
+          {required FlutterRustBridgeExampleSingleBlockTest bridge, dynamic hint}) =>
+      bridge.handleSomeStaticStreamSinkSingleArgStaticMethodConcatenateWith(hint: hint);
 }
 
 class Customized {
@@ -677,8 +635,7 @@ class SumWith {
     required this.x,
   });
 
-  Future<int> sum({required int y, required int z, dynamic hint}) =>
-      bridge.sumMethodSumWith(
+  Future<int> sum({required int y, required int z, dynamic hint}) => bridge.sumMethodSumWith(
         that: this,
         y: y,
         z: z,
@@ -762,90 +719,67 @@ class ZeroCopyVecOfPrimitivePack {
 class FlutterRustBridgeExampleSingleBlockTestImpl
     extends FlutterRustBridgeBase<FlutterRustBridgeExampleSingleBlockTestWire>
     implements FlutterRustBridgeExampleSingleBlockTest {
-  factory FlutterRustBridgeExampleSingleBlockTestImpl(
-          ffi.DynamicLibrary dylib) =>
-      FlutterRustBridgeExampleSingleBlockTestImpl.raw(
-          FlutterRustBridgeExampleSingleBlockTestWire(dylib));
+  factory FlutterRustBridgeExampleSingleBlockTestImpl(ffi.DynamicLibrary dylib) =>
+      FlutterRustBridgeExampleSingleBlockTestImpl.raw(FlutterRustBridgeExampleSingleBlockTestWire(dylib));
 
-  FlutterRustBridgeExampleSingleBlockTestImpl.raw(
-      FlutterRustBridgeExampleSingleBlockTestWire inner)
-      : super(inner);
+  FlutterRustBridgeExampleSingleBlockTestImpl.raw(FlutterRustBridgeExampleSingleBlockTestWire inner) : super(inner);
 
-  Future<int> simpleAdder({required int a, required int b, dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_simple_adder(port_, _api2wire_i32(a), _api2wire_i32(b)),
+  Future<int> simpleAdder({required int a, required int b, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_simple_adder(port_, _api2wire_i32(a), _api2wire_i32(b)),
         parseSuccessData: _wire2api_i32,
         constMeta: kSimpleAdderConstMeta,
         argValues: [a, b],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kSimpleAdderConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kSimpleAdderConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "simple_adder",
         argNames: ["a", "b"],
       );
 
   Future<int> primitiveTypes(
-          {required int myI32,
-          required int myI64,
-          required double myF64,
-          required bool myBool,
-          dynamic hint}) =>
+          {required int myI32, required int myI64, required double myF64, required bool myBool, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_primitive_types(
-            port_,
-            _api2wire_i32(myI32),
-            _api2wire_i64(myI64),
-            _api2wire_f64(myF64),
-            myBool),
+        callFfi: (port_) =>
+            inner.wire_primitive_types(port_, _api2wire_i32(myI32), _api2wire_i64(myI64), _api2wire_f64(myF64), myBool),
         parseSuccessData: _wire2api_i32,
         constMeta: kPrimitiveTypesConstMeta,
         argValues: [myI32, myI64, myF64, myBool],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kPrimitiveTypesConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kPrimitiveTypesConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "primitive_types",
         argNames: ["myI32", "myI64", "myF64", "myBool"],
       );
 
-  Future<int> primitiveU32({required int myU32, dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_primitive_u32(port_, _api2wire_u32(myU32)),
+  Future<int> primitiveU32({required int myU32, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_primitive_u32(port_, _api2wire_u32(myU32)),
         parseSuccessData: _wire2api_u32,
         constMeta: kPrimitiveU32ConstMeta,
         argValues: [myU32],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kPrimitiveU32ConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kPrimitiveU32ConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "primitive_u32",
         argNames: ["myU32"],
       );
 
-  Future<String> handleString({required String s, dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_handle_string(port_, _api2wire_String(s)),
+  Future<String> handleString({required String s, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_handle_string(port_, _api2wire_String(s)),
         parseSuccessData: _wire2api_String,
         constMeta: kHandleStringConstMeta,
         argValues: [s],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleStringConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleStringConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_string",
         argNames: ["s"],
       );
 
-  Future<void> handleReturnUnit({dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
+  Future<void> handleReturnUnit({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_handle_return_unit(port_),
         parseSuccessData: _wire2api_unit,
         constMeta: kHandleReturnUnitConstMeta,
@@ -853,178 +787,147 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleReturnUnitConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleReturnUnitConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_return_unit",
         argNames: [],
       );
 
-  Future<Uint8List> handleVecU8({required Uint8List v, dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_handle_vec_u8(port_, _api2wire_uint_8_list(v)),
+  Future<Uint8List> handleVecU8({required Uint8List v, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_handle_vec_u8(port_, _api2wire_uint_8_list(v)),
         parseSuccessData: _wire2api_uint_8_list,
         constMeta: kHandleVecU8ConstMeta,
         argValues: [v],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleVecU8ConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleVecU8ConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_vec_u8",
         argNames: ["v"],
       );
 
-  Future<VecOfPrimitivePack> handleVecOfPrimitive(
-          {required int n, dynamic hint}) =>
+  Future<VecOfPrimitivePack> handleVecOfPrimitive({required int n, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_handle_vec_of_primitive(port_, _api2wire_i32(n)),
+        callFfi: (port_) => inner.wire_handle_vec_of_primitive(port_, _api2wire_i32(n)),
         parseSuccessData: _wire2api_vec_of_primitive_pack,
         constMeta: kHandleVecOfPrimitiveConstMeta,
         argValues: [n],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleVecOfPrimitiveConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleVecOfPrimitiveConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_vec_of_primitive",
         argNames: ["n"],
       );
 
-  Future<ZeroCopyVecOfPrimitivePack> handleZeroCopyVecOfPrimitive(
-          {required int n, dynamic hint}) =>
+  Future<ZeroCopyVecOfPrimitivePack> handleZeroCopyVecOfPrimitive({required int n, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_zero_copy_vec_of_primitive(
-            port_, _api2wire_i32(n)),
+        callFfi: (port_) => inner.wire_handle_zero_copy_vec_of_primitive(port_, _api2wire_i32(n)),
         parseSuccessData: _wire2api_zero_copy_vec_of_primitive_pack,
         constMeta: kHandleZeroCopyVecOfPrimitiveConstMeta,
         argValues: [n],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleZeroCopyVecOfPrimitiveConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleZeroCopyVecOfPrimitiveConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_zero_copy_vec_of_primitive",
         argNames: ["n"],
       );
 
-  Future<MySize> handleStruct(
-          {required MySize arg, required MySize boxed, dynamic hint}) =>
+  Future<MySize> handleStruct({required MySize arg, required MySize boxed, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_struct(port_,
-            _api2wire_box_autoadd_my_size(arg), _api2wire_box_my_size(boxed)),
+        callFfi: (port_) =>
+            inner.wire_handle_struct(port_, _api2wire_box_autoadd_my_size(arg), _api2wire_box_my_size(boxed)),
         parseSuccessData: _wire2api_my_size,
         constMeta: kHandleStructConstMeta,
         argValues: [arg, boxed],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleStructConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleStructConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_struct",
         argNames: ["arg", "boxed"],
       );
 
-  Future<NewTypeInt> handleNewtype({required NewTypeInt arg, dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_newtype(
-            port_, _api2wire_box_autoadd_new_type_int(arg)),
+  Future<NewTypeInt> handleNewtype({required NewTypeInt arg, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_handle_newtype(port_, _api2wire_box_autoadd_new_type_int(arg)),
         parseSuccessData: _wire2api_new_type_int,
         constMeta: kHandleNewtypeConstMeta,
         argValues: [arg],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleNewtypeConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleNewtypeConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_newtype",
         argNames: ["arg"],
       );
 
-  Future<List<MySize>> handleListOfStruct(
-          {required List<MySize> l, dynamic hint}) =>
+  Future<List<MySize>> handleListOfStruct({required List<MySize> l, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_handle_list_of_struct(port_, _api2wire_list_my_size(l)),
+        callFfi: (port_) => inner.wire_handle_list_of_struct(port_, _api2wire_list_my_size(l)),
         parseSuccessData: _wire2api_list_my_size,
         constMeta: kHandleListOfStructConstMeta,
         argValues: [l],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleListOfStructConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleListOfStructConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_list_of_struct",
         argNames: ["l"],
       );
 
-  Future<List<String>> handleStringList(
-          {required List<String> names, dynamic hint}) =>
+  Future<List<String>> handleStringList({required List<String> names, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_handle_string_list(port_, _api2wire_StringList(names)),
+        callFfi: (port_) => inner.wire_handle_string_list(port_, _api2wire_StringList(names)),
         parseSuccessData: _wire2api_StringList,
         constMeta: kHandleStringListConstMeta,
         argValues: [names],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleStringListConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleStringListConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_string_list",
         argNames: ["names"],
       );
 
-  Future<MyTreeNode> handleComplexStruct(
-          {required MyTreeNode s, dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_complex_struct(
-            port_, _api2wire_box_autoadd_my_tree_node(s)),
+  Future<MyTreeNode> handleComplexStruct({required MyTreeNode s, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_handle_complex_struct(port_, _api2wire_box_autoadd_my_tree_node(s)),
         parseSuccessData: _wire2api_my_tree_node,
         constMeta: kHandleComplexStructConstMeta,
         argValues: [s],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleComplexStructConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleComplexStructConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_complex_struct",
         argNames: ["s"],
       );
 
-  Uint8List handleSyncReturn({required String mode, dynamic hint}) =>
-      executeSync(FlutterRustBridgeSyncTask(
+  Uint8List handleSyncReturn({required String mode, dynamic hint}) => executeSync(FlutterRustBridgeSyncTask(
         callFfi: () => inner.wire_handle_sync_return(_api2wire_String(mode)),
         constMeta: kHandleSyncReturnConstMeta,
         argValues: [mode],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleSyncReturnConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleSyncReturnConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_sync_return",
         argNames: ["mode"],
       );
 
-  Stream<String> handleStream({required String arg, dynamic hint}) =>
-      executeStream(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_handle_stream(port_, _api2wire_String(arg)),
+  Stream<String> handleStream({required String arg, dynamic hint}) => executeStream(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_handle_stream(port_, _api2wire_String(arg)),
         parseSuccessData: _wire2api_String,
         constMeta: kHandleStreamConstMeta,
         argValues: [arg],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleStreamConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleStreamConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_stream",
         argNames: ["arg"],
       );
 
-  Stream<MyStreamEntry> handleStreamOfStruct({dynamic hint}) =>
-      executeStream(FlutterRustBridgeTask(
+  Stream<MyStreamEntry> handleStreamOfStruct({dynamic hint}) => executeStream(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_handle_stream_of_struct(port_),
         parseSuccessData: _wire2api_my_stream_entry,
         constMeta: kHandleStreamOfStructConstMeta,
@@ -1032,8 +935,7 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleStreamOfStructConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleStreamOfStructConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_stream_of_struct",
         argNames: [],
       );
@@ -1046,14 +948,12 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kReturnErrConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kReturnErrConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "return_err",
         argNames: [],
       );
 
-  Future<int> returnPanic({dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
+  Future<int> returnPanic({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_return_panic(port_),
         parseSuccessData: _wire2api_i32,
         constMeta: kReturnPanicConstMeta,
@@ -1061,74 +961,62 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kReturnPanicConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kReturnPanicConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "return_panic",
         argNames: [],
       );
 
-  Future<double?> handleOptionalReturn(
-          {required double left, required double right, dynamic hint}) =>
+  Future<double?> handleOptionalReturn({required double left, required double right, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_optional_return(
-            port_, _api2wire_f64(left), _api2wire_f64(right)),
+        callFfi: (port_) => inner.wire_handle_optional_return(port_, _api2wire_f64(left), _api2wire_f64(right)),
         parseSuccessData: _wire2api_opt_box_autoadd_f64,
         constMeta: kHandleOptionalReturnConstMeta,
         argValues: [left, right],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleOptionalReturnConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleOptionalReturnConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_optional_return",
         argNames: ["left", "right"],
       );
 
-  Future<Element?> handleOptionalStruct({String? document, dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_optional_struct(
-            port_, _api2wire_opt_String(document)),
+  Future<Element?> handleOptionalStruct({String? document, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_handle_optional_struct(port_, _api2wire_opt_String(document)),
         parseSuccessData: _wire2api_opt_box_autoadd_element,
         constMeta: kHandleOptionalStructConstMeta,
         argValues: [document],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleOptionalStructConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleOptionalStructConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_optional_struct",
         argNames: ["document"],
       );
 
-  Future<ExoticOptionals?> handleOptionalIncrement(
-          {ExoticOptionals? opt, dynamic hint}) =>
+  Future<ExoticOptionals?> handleOptionalIncrement({ExoticOptionals? opt, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_optional_increment(
-            port_, _api2wire_opt_box_autoadd_exotic_optionals(opt)),
+        callFfi: (port_) =>
+            inner.wire_handle_optional_increment(port_, _api2wire_opt_box_autoadd_exotic_optionals(opt)),
         parseSuccessData: _wire2api_opt_box_autoadd_exotic_optionals,
         constMeta: kHandleOptionalIncrementConstMeta,
         argValues: [opt],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleOptionalIncrementConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleOptionalIncrementConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_optional_increment",
         argNames: ["opt"],
       );
 
-  Future<double> handleIncrementBoxedOptional({double? opt, dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_increment_boxed_optional(
-            port_, _api2wire_opt_box_f64(opt)),
+  Future<double> handleIncrementBoxedOptional({double? opt, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_handle_increment_boxed_optional(port_, _api2wire_opt_box_f64(opt)),
         parseSuccessData: _wire2api_f64,
         constMeta: kHandleIncrementBoxedOptionalConstMeta,
         argValues: [opt],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleIncrementBoxedOptionalConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleIncrementBoxedOptionalConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_increment_boxed_optional",
         argNames: ["opt"],
       );
@@ -1158,137 +1046,104 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleOptionBoxArgumentsConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleOptionBoxArgumentsConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_option_box_arguments",
-        argNames: [
-          "i8Box",
-          "u8Box",
-          "i32Box",
-          "i64Box",
-          "f64Box",
-          "boolbox",
-          "structbox"
-        ],
+        argNames: ["i8Box", "u8Box", "i32Box", "i64Box", "f64Box", "boolbox", "structbox"],
       );
 
-  Future<Uint8List> printNote({required Note note, dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_print_note(port_, _api2wire_box_autoadd_note(note)),
+  Future<Uint8List> printNote({required Note note, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_print_note(port_, _api2wire_box_autoadd_note(note)),
         parseSuccessData: _wire2api_ZeroCopyBuffer_Uint8List,
         constMeta: kPrintNoteConstMeta,
         argValues: [note],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kPrintNoteConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kPrintNoteConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "print_note",
         argNames: ["note"],
       );
 
-  Future<Weekdays?> handleReturnEnum({required String input, dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_handle_return_enum(port_, _api2wire_String(input)),
+  Future<Weekdays?> handleReturnEnum({required String input, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_handle_return_enum(port_, _api2wire_String(input)),
         parseSuccessData: _wire2api_opt_weekdays,
         constMeta: kHandleReturnEnumConstMeta,
         argValues: [input],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleReturnEnumConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleReturnEnumConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_return_enum",
         argNames: ["input"],
       );
 
-  Future<Weekdays> handleEnumParameter(
-          {required Weekdays weekday, dynamic hint}) =>
+  Future<Weekdays> handleEnumParameter({required Weekdays weekday, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_enum_parameter(
-            port_, _api2wire_weekdays(weekday)),
+        callFfi: (port_) => inner.wire_handle_enum_parameter(port_, _api2wire_weekdays(weekday)),
         parseSuccessData: _wire2api_weekdays,
         constMeta: kHandleEnumParameterConstMeta,
         argValues: [weekday],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleEnumParameterConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleEnumParameterConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_enum_parameter",
         argNames: ["weekday"],
       );
 
-  Future<void> handleCustomizedStruct(
-          {required Customized val, dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_customized_struct(
-            port_, _api2wire_box_autoadd_customized(val)),
+  Future<void> handleCustomizedStruct({required Customized val, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_handle_customized_struct(port_, _api2wire_box_autoadd_customized(val)),
         parseSuccessData: _wire2api_unit,
         constMeta: kHandleCustomizedStructConstMeta,
         argValues: [val],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleCustomizedStructConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleCustomizedStructConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_customized_struct",
         argNames: ["val"],
       );
 
-  Future<KitchenSink> handleEnumStruct(
-          {required KitchenSink val, dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_enum_struct(
-            port_, _api2wire_box_autoadd_kitchen_sink(val)),
+  Future<KitchenSink> handleEnumStruct({required KitchenSink val, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_handle_enum_struct(port_, _api2wire_box_autoadd_kitchen_sink(val)),
         parseSuccessData: _wire2api_kitchen_sink,
         constMeta: kHandleEnumStructConstMeta,
         argValues: [val],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleEnumStructConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleEnumStructConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_enum_struct",
         argNames: ["val"],
       );
 
-  Future<bool> useImportedStruct({required MyStruct myStruct, dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_use_imported_struct(
-            port_, _api2wire_box_autoadd_my_struct(myStruct)),
+  Future<bool> useImportedStruct({required MyStruct myStruct, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_use_imported_struct(port_, _api2wire_box_autoadd_my_struct(myStruct)),
         parseSuccessData: _wire2api_bool,
         constMeta: kUseImportedStructConstMeta,
         argValues: [myStruct],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kUseImportedStructConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kUseImportedStructConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "use_imported_struct",
         argNames: ["myStruct"],
       );
 
-  Future<bool> useImportedEnum({required MyEnum myEnum, dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_use_imported_enum(port_, _api2wire_my_enum(myEnum)),
+  Future<bool> useImportedEnum({required MyEnum myEnum, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_use_imported_enum(port_, _api2wire_my_enum(myEnum)),
         parseSuccessData: _wire2api_bool,
         constMeta: kUseImportedEnumConstMeta,
         argValues: [myEnum],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kUseImportedEnumConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kUseImportedEnumConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "use_imported_enum",
         argNames: ["myEnum"],
       );
 
-  Future<ApplicationSettings> getAppSettings({dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
+  Future<ApplicationSettings> getAppSettings({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_get_app_settings(port_),
         parseSuccessData: _wire2api_application_settings,
         constMeta: kGetAppSettingsConstMeta,
@@ -1296,31 +1151,26 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kGetAppSettingsConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kGetAppSettingsConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "get_app_settings",
         argNames: [],
       );
 
-  Future<bool> isAppEmbedded(
-          {required ApplicationSettings appSettings, dynamic hint}) =>
+  Future<bool> isAppEmbedded({required ApplicationSettings appSettings, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_is_app_embedded(
-            port_, _api2wire_box_autoadd_application_settings(appSettings)),
+        callFfi: (port_) => inner.wire_is_app_embedded(port_, _api2wire_box_autoadd_application_settings(appSettings)),
         parseSuccessData: _wire2api_bool,
         constMeta: kIsAppEmbeddedConstMeta,
         argValues: [appSettings],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kIsAppEmbeddedConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kIsAppEmbeddedConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "is_app_embedded",
         argNames: ["appSettings"],
       );
 
-  Future<ApplicationMessage> getMessage({dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
+  Future<ApplicationMessage> getMessage({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_get_message(port_),
         parseSuccessData: _wire2api_application_message,
         constMeta: kGetMessageConstMeta,
@@ -1328,80 +1178,66 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kGetMessageConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kGetMessageConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "get_message",
         argNames: [],
       );
 
-  Future<Numbers> repeatNumber(
-          {required int num, required int times, dynamic hint}) =>
+  Future<Numbers> repeatNumber({required int num, required int times, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_repeat_number(
-            port_, _api2wire_i32(num), _api2wire_usize(times)),
+        callFfi: (port_) => inner.wire_repeat_number(port_, _api2wire_i32(num), _api2wire_usize(times)),
         parseSuccessData: _wire2api_numbers,
         constMeta: kRepeatNumberConstMeta,
         argValues: [num, times],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kRepeatNumberConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kRepeatNumberConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "repeat_number",
         argNames: ["num", "times"],
       );
 
-  Future<Sequences> repeatSequence(
-          {required int seq, required int times, dynamic hint}) =>
+  Future<Sequences> repeatSequence({required int seq, required int times, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_repeat_sequence(
-            port_, _api2wire_i32(seq), _api2wire_usize(times)),
+        callFfi: (port_) => inner.wire_repeat_sequence(port_, _api2wire_i32(seq), _api2wire_usize(times)),
         parseSuccessData: _wire2api_sequences,
         constMeta: kRepeatSequenceConstMeta,
         argValues: [seq, times],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kRepeatSequenceConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kRepeatSequenceConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "repeat_sequence",
         argNames: ["seq", "times"],
       );
 
-  Future<int?> firstNumber({required Numbers nums, dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_first_number(port_, _api2wire_box_autoadd_numbers(nums)),
+  Future<int?> firstNumber({required Numbers nums, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_first_number(port_, _api2wire_box_autoadd_numbers(nums)),
         parseSuccessData: _wire2api_opt_box_autoadd_i32,
         constMeta: kFirstNumberConstMeta,
         argValues: [nums],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kFirstNumberConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kFirstNumberConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "first_number",
         argNames: ["nums"],
       );
 
-  Future<int?> firstSequence({required Sequences seqs, dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_first_sequence(
-            port_, _api2wire_box_autoadd_sequences(seqs)),
+  Future<int?> firstSequence({required Sequences seqs, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_first_sequence(port_, _api2wire_box_autoadd_sequences(seqs)),
         parseSuccessData: _wire2api_opt_box_autoadd_i32,
         constMeta: kFirstSequenceConstMeta,
         argValues: [seqs],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kFirstSequenceConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kFirstSequenceConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "first_sequence",
         argNames: ["seqs"],
       );
 
-  Future<Uint8List> getArray({dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
+  Future<Uint8List> getArray({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_get_array(port_),
         parseSuccessData: _wire2api_uint_8_list,
         constMeta: kGetArrayConstMeta,
@@ -1409,14 +1245,12 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kGetArrayConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kGetArrayConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "get_array",
         argNames: [],
       );
 
-  Future<List<Point>> getComplexArray({dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
+  Future<List<Point>> getComplexArray({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_get_complex_array(port_),
         parseSuccessData: _wire2api_list_point,
         constMeta: kGetComplexArrayConstMeta,
@@ -1424,14 +1258,12 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kGetComplexArrayConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kGetComplexArrayConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "get_complex_array",
         argNames: [],
       );
 
-  Future<int> getUsize({required int u, dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
+  Future<int> getUsize({required int u, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_get_usize(port_, _api2wire_usize(u)),
         parseSuccessData: _wire2api_usize,
         constMeta: kGetUsizeConstMeta,
@@ -1439,30 +1271,25 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kGetUsizeConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kGetUsizeConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "get_usize",
         argNames: ["u"],
       );
 
-  Future<UserId> nextUserId({required UserId userId, dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_next_user_id(
-            port_, _api2wire_box_autoadd_user_id(userId)),
+  Future<UserId> nextUserId({required UserId userId, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_next_user_id(port_, _api2wire_box_autoadd_user_id(userId)),
         parseSuccessData: _wire2api_user_id,
         constMeta: kNextUserIdConstMeta,
         argValues: [userId],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kNextUserIdConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kNextUserIdConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "next_user_id",
         argNames: ["userId"],
       );
 
-  Stream<Event> registerEventListener({dynamic hint}) =>
-      executeStream(FlutterRustBridgeTask(
+  Stream<Event> registerEventListener({dynamic hint}) => executeStream(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_register_event_listener(port_),
         parseSuccessData: _wire2api_event,
         constMeta: kRegisterEventListenerConstMeta,
@@ -1470,14 +1297,12 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kRegisterEventListenerConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kRegisterEventListenerConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "register_event_listener",
         argNames: [],
       );
 
-  Future<void> closeEventListener({dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
+  Future<void> closeEventListener({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_close_event_listener(port_),
         parseSuccessData: _wire2api_unit,
         constMeta: kCloseEventListenerConstMeta,
@@ -1485,14 +1310,12 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kCloseEventListenerConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kCloseEventListenerConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "close_event_listener",
         argNames: [],
       );
 
-  Future<void> createEvent({dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
+  Future<void> createEvent({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_create_event(port_),
         parseSuccessData: _wire2api_unit,
         constMeta: kCreateEventConstMeta,
@@ -1500,65 +1323,54 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kCreateEventConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kCreateEventConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "create_event",
         argNames: [],
       );
 
-  Stream<Log> handleStreamSinkAt1(
-          {required int key, required int max, dynamic hint}) =>
+  Stream<Log> handleStreamSinkAt1({required int key, required int max, dynamic hint}) =>
       executeStream(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_stream_sink_at_1(
-            port_, _api2wire_u32(key), _api2wire_u32(max)),
+        callFfi: (port_) => inner.wire_handle_stream_sink_at_1(port_, _api2wire_u32(key), _api2wire_u32(max)),
         parseSuccessData: _wire2api_log,
         constMeta: kHandleStreamSinkAt1ConstMeta,
         argValues: [key, max],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleStreamSinkAt1ConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleStreamSinkAt1ConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_stream_sink_at_1",
         argNames: ["key", "max"],
       );
 
-  Stream<Log> handleStreamSinkAt2(
-          {required int key, required int max, dynamic hint}) =>
+  Stream<Log> handleStreamSinkAt2({required int key, required int max, dynamic hint}) =>
       executeStream(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_stream_sink_at_2(
-            port_, _api2wire_u32(key), _api2wire_u32(max)),
+        callFfi: (port_) => inner.wire_handle_stream_sink_at_2(port_, _api2wire_u32(key), _api2wire_u32(max)),
         parseSuccessData: _wire2api_log,
         constMeta: kHandleStreamSinkAt2ConstMeta,
         argValues: [key, max],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleStreamSinkAt2ConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleStreamSinkAt2ConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_stream_sink_at_2",
         argNames: ["key", "max"],
       );
 
-  Stream<Log> handleStreamSinkAt3(
-          {required int key, required int max, dynamic hint}) =>
+  Stream<Log> handleStreamSinkAt3({required int key, required int max, dynamic hint}) =>
       executeStream(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_handle_stream_sink_at_3(
-            port_, _api2wire_u32(key), _api2wire_u32(max)),
+        callFfi: (port_) => inner.wire_handle_stream_sink_at_3(port_, _api2wire_u32(key), _api2wire_u32(max)),
         parseSuccessData: _wire2api_log,
         constMeta: kHandleStreamSinkAt3ConstMeta,
         argValues: [key, max],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kHandleStreamSinkAt3ConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kHandleStreamSinkAt3ConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_stream_sink_at_3",
         argNames: ["key", "max"],
       );
 
-  Future<SumWith> getSumStruct({dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
+  Future<SumWith> getSumStruct({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_get_sum_struct(port_),
         parseSuccessData: (d) => _wire2api_sum_with(this, d),
         constMeta: kGetSumStructConstMeta,
@@ -1566,30 +1378,25 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kGetSumStructConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kGetSumStructConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "get_sum_struct",
         argNames: [],
       );
 
-  Future<Measure?> multiplyByTen({required Measure measure, dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_multiply_by_ten(
-            port_, _api2wire_box_autoadd_measure(measure)),
+  Future<Measure?> multiplyByTen({required Measure measure, dynamic hint}) => executeNormal(FlutterRustBridgeTask(
+        callFfi: (port_) => inner.wire_multiply_by_ten(port_, _api2wire_box_autoadd_measure(measure)),
         parseSuccessData: _wire2api_opt_measure,
         constMeta: kMultiplyByTenConstMeta,
         argValues: [measure],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kMultiplyByTenConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kMultiplyByTenConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "multiply_by_ten",
         argNames: ["measure"],
       );
 
-  Future<OldSimpleStruct> callOldModuleSystem({dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
+  Future<OldSimpleStruct> callOldModuleSystem({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_call_old_module_system(port_),
         parseSuccessData: _wire2api_old_simple_struct,
         constMeta: kCallOldModuleSystemConstMeta,
@@ -1597,14 +1404,12 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kCallOldModuleSystemConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kCallOldModuleSystemConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "call_old_module_system",
         argNames: [],
       );
 
-  Future<NewSimpleStruct> callNewModuleSystem({dynamic hint}) =>
-      executeNormal(FlutterRustBridgeTask(
+  Future<NewSimpleStruct> callNewModuleSystem({dynamic hint}) => executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_call_new_module_system(port_),
         parseSuccessData: _wire2api_new_simple_struct,
         constMeta: kCallNewModuleSystemConstMeta,
@@ -1612,176 +1417,135 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kCallNewModuleSystemConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kCallNewModuleSystemConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "call_new_module_system",
         argNames: [],
       );
 
-  Future<int> sumMethodSumWith(
-          {required SumWith that,
-          required int y,
-          required int z,
-          dynamic hint}) =>
+  Future<int> sumMethodSumWith({required SumWith that, required int y, required int z, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_sum__method__SumWith(
-            port_,
-            _api2wire_box_autoadd_sum_with(that),
-            _api2wire_u32(y),
-            _api2wire_u32(z)),
+            port_, _api2wire_box_autoadd_sum_with(that), _api2wire_u32(y), _api2wire_u32(z)),
         parseSuccessData: _wire2api_u32,
         constMeta: kSumMethodSumWithConstMeta,
         argValues: [that, y, z],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kSumMethodSumWithConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kSumMethodSumWithConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "sum__method__SumWith",
         argNames: ["that", "y", "z"],
       );
 
-  Future<ConcatenateWith> newStaticMethodConcatenateWith(
-          {required String a, dynamic hint}) =>
+  Future<ConcatenateWith> newStaticMethodConcatenateWith({required String a, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_new__static_method__ConcatenateWith(
-            port_, _api2wire_String(a)),
+        callFfi: (port_) => inner.wire_new__static_method__ConcatenateWith(port_, _api2wire_String(a)),
         parseSuccessData: (d) => _wire2api_concatenate_with(this, d),
         constMeta: kNewStaticMethodConcatenateWithConstMeta,
         argValues: [a],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta get kNewStaticMethodConcatenateWithConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
+  FlutterRustBridgeTaskConstMeta get kNewStaticMethodConcatenateWithConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "new__static_method__ConcatenateWith",
         argNames: ["a"],
       );
 
-  Future<String> concatenateMethodConcatenateWith(
-          {required ConcatenateWith that, required String b, dynamic hint}) =>
+  Future<String> concatenateMethodConcatenateWith({required ConcatenateWith that, required String b, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_concatenate__method__ConcatenateWith(
-            port_,
-            _api2wire_box_autoadd_concatenate_with(that),
-            _api2wire_String(b)),
+            port_, _api2wire_box_autoadd_concatenate_with(that), _api2wire_String(b)),
         parseSuccessData: _wire2api_String,
         constMeta: kConcatenateMethodConcatenateWithConstMeta,
         argValues: [that, b],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta
-      get kConcatenateMethodConcatenateWithConstMeta =>
-          const FlutterRustBridgeTaskConstMeta(
-            debugName: "concatenate__method__ConcatenateWith",
-            argNames: ["that", "b"],
-          );
+  FlutterRustBridgeTaskConstMeta get kConcatenateMethodConcatenateWithConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "concatenate__method__ConcatenateWith",
+        argNames: ["that", "b"],
+      );
 
-  Future<String> concatenateStaticStaticMethodConcatenateWith(
-          {required String a, required String b, dynamic hint}) =>
+  Future<String> concatenateStaticStaticMethodConcatenateWith({required String a, required String b, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_concatenate_static__static_method__ConcatenateWith(
-                port_, _api2wire_String(a), _api2wire_String(b)),
+        callFfi: (port_) => inner.wire_concatenate_static__static_method__ConcatenateWith(
+            port_, _api2wire_String(a), _api2wire_String(b)),
         parseSuccessData: _wire2api_String,
         constMeta: kConcatenateStaticStaticMethodConcatenateWithConstMeta,
         argValues: [a, b],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta
-      get kConcatenateStaticStaticMethodConcatenateWithConstMeta =>
-          const FlutterRustBridgeTaskConstMeta(
-            debugName: "concatenate_static__static_method__ConcatenateWith",
-            argNames: ["a", "b"],
-          );
+  FlutterRustBridgeTaskConstMeta get kConcatenateStaticStaticMethodConcatenateWithConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
+        debugName: "concatenate_static__static_method__ConcatenateWith",
+        argNames: ["a", "b"],
+      );
 
   Stream<Log2> handleSomeStreamSinkMethodConcatenateWith(
-          {required ConcatenateWith that,
-          required int key,
-          required int max,
-          dynamic hint}) =>
+          {required ConcatenateWith that, required int key, required int max, dynamic hint}) =>
       executeStream(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_handle_some_stream_sink__method__ConcatenateWith(
-                port_,
-                _api2wire_box_autoadd_concatenate_with(that),
-                _api2wire_u32(key),
-                _api2wire_u32(max)),
+        callFfi: (port_) => inner.wire_handle_some_stream_sink__method__ConcatenateWith(
+            port_, _api2wire_box_autoadd_concatenate_with(that), _api2wire_u32(key), _api2wire_u32(max)),
         parseSuccessData: _wire2api_log_2,
         constMeta: kHandleSomeStreamSinkMethodConcatenateWithConstMeta,
         argValues: [that, key, max],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta
-      get kHandleSomeStreamSinkMethodConcatenateWithConstMeta =>
-          const FlutterRustBridgeTaskConstMeta(
-            debugName: "handle_some_stream_sink__method__ConcatenateWith",
-            argNames: ["that", "key", "max"],
-          );
+  FlutterRustBridgeTaskConstMeta get kHandleSomeStreamSinkMethodConcatenateWithConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
+        debugName: "handle_some_stream_sink__method__ConcatenateWith",
+        argNames: ["that", "key", "max"],
+      );
 
-  Stream<int> handleSomeStreamSinkAt1MethodConcatenateWith(
-          {required ConcatenateWith that, dynamic hint}) =>
+  Stream<int> handleSomeStreamSinkAt1MethodConcatenateWith({required ConcatenateWith that, dynamic hint}) =>
       executeStream(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_handle_some_stream_sink_at_1__method__ConcatenateWith(
-                port_, _api2wire_box_autoadd_concatenate_with(that)),
+        callFfi: (port_) => inner.wire_handle_some_stream_sink_at_1__method__ConcatenateWith(
+            port_, _api2wire_box_autoadd_concatenate_with(that)),
         parseSuccessData: _wire2api_u32,
         constMeta: kHandleSomeStreamSinkAt1MethodConcatenateWithConstMeta,
         argValues: [that],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta
-      get kHandleSomeStreamSinkAt1MethodConcatenateWithConstMeta =>
-          const FlutterRustBridgeTaskConstMeta(
-            debugName: "handle_some_stream_sink_at_1__method__ConcatenateWith",
-            argNames: ["that"],
-          );
+  FlutterRustBridgeTaskConstMeta get kHandleSomeStreamSinkAt1MethodConcatenateWithConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
+        debugName: "handle_some_stream_sink_at_1__method__ConcatenateWith",
+        argNames: ["that"],
+      );
 
   Stream<Log2> handleSomeStaticStreamSinkStaticMethodConcatenateWith(
           {required int key, required int max, dynamic hint}) =>
       executeStream(FlutterRustBridgeTask(
-        callFfi: (port_) => inner
-            .wire_handle_some_static_stream_sink__static_method__ConcatenateWith(
-                port_, _api2wire_u32(key), _api2wire_u32(max)),
+        callFfi: (port_) => inner.wire_handle_some_static_stream_sink__static_method__ConcatenateWith(
+            port_, _api2wire_u32(key), _api2wire_u32(max)),
         parseSuccessData: _wire2api_log_2,
-        constMeta:
-            kHandleSomeStaticStreamSinkStaticMethodConcatenateWithConstMeta,
+        constMeta: kHandleSomeStaticStreamSinkStaticMethodConcatenateWithConstMeta,
         argValues: [key, max],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta
-      get kHandleSomeStaticStreamSinkStaticMethodConcatenateWithConstMeta =>
-          const FlutterRustBridgeTaskConstMeta(
-            debugName:
-                "handle_some_static_stream_sink__static_method__ConcatenateWith",
-            argNames: ["key", "max"],
-          );
+  FlutterRustBridgeTaskConstMeta get kHandleSomeStaticStreamSinkStaticMethodConcatenateWithConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
+        debugName: "handle_some_static_stream_sink__static_method__ConcatenateWith",
+        argNames: ["key", "max"],
+      );
 
-  Stream<int> handleSomeStaticStreamSinkSingleArgStaticMethodConcatenateWith(
-          {dynamic hint}) =>
+  Stream<int> handleSomeStaticStreamSinkSingleArgStaticMethodConcatenateWith({dynamic hint}) =>
       executeStream(FlutterRustBridgeTask(
-        callFfi: (port_) => inner
-            .wire_handle_some_static_stream_sink_single_arg__static_method__ConcatenateWith(
-                port_),
+        callFfi: (port_) => inner.wire_handle_some_static_stream_sink_single_arg__static_method__ConcatenateWith(port_),
         parseSuccessData: _wire2api_u32,
-        constMeta:
-            kHandleSomeStaticStreamSinkSingleArgStaticMethodConcatenateWithConstMeta,
+        constMeta: kHandleSomeStaticStreamSinkSingleArgStaticMethodConcatenateWithConstMeta,
         argValues: [],
         hint: hint,
       ));
 
-  FlutterRustBridgeTaskConstMeta
-      get kHandleSomeStaticStreamSinkSingleArgStaticMethodConcatenateWithConstMeta =>
-          const FlutterRustBridgeTaskConstMeta(
-            debugName:
-                "handle_some_static_stream_sink_single_arg__static_method__ConcatenateWith",
-            argNames: [],
-          );
+  FlutterRustBridgeTaskConstMeta get kHandleSomeStaticStreamSinkSingleArgStaticMethodConcatenateWithConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
+        debugName: "handle_some_static_stream_sink_single_arg__static_method__ConcatenateWith",
+        argNames: [],
+      );
 
   // Section: api2wire
   ffi.Pointer<wire_uint_8_list> _api2wire_String(String raw) {
@@ -1796,8 +1560,7 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     return ans;
   }
 
-  ffi.Pointer<wire_uint_8_list> _api2wire_ZeroCopyBuffer_Uint8List(
-      Uint8List raw) {
+  ffi.Pointer<wire_uint_8_list> _api2wire_ZeroCopyBuffer_Uint8List(Uint8List raw) {
     return _api2wire_uint_8_list(raw);
   }
 
@@ -1809,15 +1572,13 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     return raw;
   }
 
-  ffi.Pointer<wire_ApplicationEnv> _api2wire_box_application_env(
-      ApplicationEnv raw) {
+  ffi.Pointer<wire_ApplicationEnv> _api2wire_box_application_env(ApplicationEnv raw) {
     final ptr = inner.new_box_application_env_0();
     _api_fill_to_wire_application_env(raw, ptr.ref);
     return ptr;
   }
 
-  ffi.Pointer<wire_ApplicationSettings>
-      _api2wire_box_autoadd_application_settings(ApplicationSettings raw) {
+  ffi.Pointer<wire_ApplicationSettings> _api2wire_box_autoadd_application_settings(ApplicationSettings raw) {
     final ptr = inner.new_box_autoadd_application_settings_0();
     _api_fill_to_wire_application_settings(raw, ptr.ref);
     return ptr;
@@ -1833,22 +1594,19 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     return inner.new_box_autoadd_bool_0(_api2wire_bool(raw));
   }
 
-  ffi.Pointer<wire_ConcatenateWith> _api2wire_box_autoadd_concatenate_with(
-      ConcatenateWith raw) {
+  ffi.Pointer<wire_ConcatenateWith> _api2wire_box_autoadd_concatenate_with(ConcatenateWith raw) {
     final ptr = inner.new_box_autoadd_concatenate_with_0();
     _api_fill_to_wire_concatenate_with(raw, ptr.ref);
     return ptr;
   }
 
-  ffi.Pointer<wire_Customized> _api2wire_box_autoadd_customized(
-      Customized raw) {
+  ffi.Pointer<wire_Customized> _api2wire_box_autoadd_customized(Customized raw) {
     final ptr = inner.new_box_autoadd_customized_0();
     _api_fill_to_wire_customized(raw, ptr.ref);
     return ptr;
   }
 
-  ffi.Pointer<wire_ExoticOptionals> _api2wire_box_autoadd_exotic_optionals(
-      ExoticOptionals raw) {
+  ffi.Pointer<wire_ExoticOptionals> _api2wire_box_autoadd_exotic_optionals(ExoticOptionals raw) {
     final ptr = inner.new_box_autoadd_exotic_optionals_0();
     _api_fill_to_wire_exotic_optionals(raw, ptr.ref);
     return ptr;
@@ -1866,8 +1624,7 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     return inner.new_box_autoadd_i64_0(_api2wire_i64(raw));
   }
 
-  ffi.Pointer<wire_KitchenSink> _api2wire_box_autoadd_kitchen_sink(
-      KitchenSink raw) {
+  ffi.Pointer<wire_KitchenSink> _api2wire_box_autoadd_kitchen_sink(KitchenSink raw) {
     final ptr = inner.new_box_autoadd_kitchen_sink_0();
     _api_fill_to_wire_kitchen_sink(raw, ptr.ref);
     return ptr;
@@ -1891,15 +1648,13 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     return ptr;
   }
 
-  ffi.Pointer<wire_MyTreeNode> _api2wire_box_autoadd_my_tree_node(
-      MyTreeNode raw) {
+  ffi.Pointer<wire_MyTreeNode> _api2wire_box_autoadd_my_tree_node(MyTreeNode raw) {
     final ptr = inner.new_box_autoadd_my_tree_node_0();
     _api_fill_to_wire_my_tree_node(raw, ptr.ref);
     return ptr;
   }
 
-  ffi.Pointer<wire_NewTypeInt> _api2wire_box_autoadd_new_type_int(
-      NewTypeInt raw) {
+  ffi.Pointer<wire_NewTypeInt> _api2wire_box_autoadd_new_type_int(NewTypeInt raw) {
     final ptr = inner.new_box_autoadd_new_type_int_0();
     _api_fill_to_wire_new_type_int(raw, ptr.ref);
     return ptr;
@@ -1945,8 +1700,7 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     return ptr;
   }
 
-  ffi.Pointer<wire_ExoticOptionals> _api2wire_box_exotic_optionals(
-      ExoticOptionals raw) {
+  ffi.Pointer<wire_ExoticOptionals> _api2wire_box_exotic_optionals(ExoticOptionals raw) {
     final ptr = inner.new_box_exotic_optionals_0();
     _api_fill_to_wire_exotic_optionals(raw, ptr.ref);
     return ptr;
@@ -2044,8 +1798,7 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     return ans;
   }
 
-  ffi.Pointer<wire_list_application_env_var> _api2wire_list_application_env_var(
-      List<ApplicationEnvVar> raw) {
+  ffi.Pointer<wire_list_application_env_var> _api2wire_list_application_env_var(List<ApplicationEnvVar> raw) {
     final ans = inner.new_list_application_env_var_0(raw.length);
     for (var i = 0; i < raw.length; ++i) {
       _api_fill_to_wire_application_env_var(raw[i], ans.ref.ptr[i]);
@@ -2053,8 +1806,7 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     return ans;
   }
 
-  ffi.Pointer<wire_list_attribute> _api2wire_list_attribute(
-      List<Attribute> raw) {
+  ffi.Pointer<wire_list_attribute> _api2wire_list_attribute(List<Attribute> raw) {
     final ans = inner.new_list_attribute_0(raw.length);
     for (var i = 0; i < raw.length; ++i) {
       _api_fill_to_wire_attribute(raw[i], ans.ref.ptr[i]);
@@ -2070,8 +1822,7 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     return ans;
   }
 
-  ffi.Pointer<wire_list_my_tree_node> _api2wire_list_my_tree_node(
-      List<MyTreeNode> raw) {
+  ffi.Pointer<wire_list_my_tree_node> _api2wire_list_my_tree_node(List<MyTreeNode> raw) {
     final ans = inner.new_list_my_tree_node_0(raw.length);
     for (var i = 0; i < raw.length; ++i) {
       _api_fill_to_wire_my_tree_node(raw[i], ans.ref.ptr[i]);
@@ -2079,8 +1830,7 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     return ans;
   }
 
-  ffi.Pointer<wire_list_opt_box_autoadd_attribute>
-      _api2wire_list_opt_box_autoadd_attribute(List<Attribute?> raw) {
+  ffi.Pointer<wire_list_opt_box_autoadd_attribute> _api2wire_list_opt_box_autoadd_attribute(List<Attribute?> raw) {
     final ans = inner.new_list_opt_box_autoadd_attribute_0(raw.length);
     for (var i = 0; i < raw.length; ++i) {
       _api_fill_to_wire_opt_box_autoadd_attribute(raw[i], ans.ref.ptr[i]);
@@ -2096,13 +1846,11 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     return raw == null ? ffi.nullptr : _api2wire_String(raw);
   }
 
-  ffi.Pointer<wire_uint_8_list> _api2wire_opt_ZeroCopyBuffer_Uint8List(
-      Uint8List? raw) {
+  ffi.Pointer<wire_uint_8_list> _api2wire_opt_ZeroCopyBuffer_Uint8List(Uint8List? raw) {
     return raw == null ? ffi.nullptr : _api2wire_ZeroCopyBuffer_Uint8List(raw);
   }
 
-  ffi.Pointer<wire_Attribute> _api2wire_opt_box_autoadd_attribute(
-      Attribute? raw) {
+  ffi.Pointer<wire_Attribute> _api2wire_opt_box_autoadd_attribute(Attribute? raw) {
     return raw == null ? ffi.nullptr : _api2wire_box_autoadd_attribute(raw);
   }
 
@@ -2110,11 +1858,8 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     return raw == null ? ffi.nullptr : _api2wire_box_autoadd_bool(raw);
   }
 
-  ffi.Pointer<wire_ExoticOptionals> _api2wire_opt_box_autoadd_exotic_optionals(
-      ExoticOptionals? raw) {
-    return raw == null
-        ? ffi.nullptr
-        : _api2wire_box_autoadd_exotic_optionals(raw);
+  ffi.Pointer<wire_ExoticOptionals> _api2wire_opt_box_autoadd_exotic_optionals(ExoticOptionals? raw) {
+    return raw == null ? ffi.nullptr : _api2wire_box_autoadd_exotic_optionals(raw);
   }
 
   ffi.Pointer<ffi.Double> _api2wire_opt_box_autoadd_f64(double? raw) {
@@ -2129,8 +1874,7 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     return raw == null ? ffi.nullptr : _api2wire_box_autoadd_i64(raw);
   }
 
-  ffi.Pointer<wire_NewTypeInt> _api2wire_opt_box_autoadd_new_type_int(
-      NewTypeInt? raw) {
+  ffi.Pointer<wire_NewTypeInt> _api2wire_opt_box_autoadd_new_type_int(NewTypeInt? raw) {
     return raw == null ? ffi.nullptr : _api2wire_box_autoadd_new_type_int(raw);
   }
 
@@ -2138,8 +1882,7 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     return raw == null ? ffi.nullptr : _api2wire_box_bool(raw);
   }
 
-  ffi.Pointer<wire_ExoticOptionals> _api2wire_opt_box_exotic_optionals(
-      ExoticOptionals? raw) {
+  ffi.Pointer<wire_ExoticOptionals> _api2wire_opt_box_exotic_optionals(ExoticOptionals? raw) {
     return raw == null ? ffi.nullptr : _api2wire_box_exotic_optionals(raw);
   }
 
@@ -2163,13 +1906,11 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     return raw == null ? ffi.nullptr : _api2wire_box_u8(raw);
   }
 
-  ffi.Pointer<wire_float_32_list> _api2wire_opt_float_32_list(
-      Float32List? raw) {
+  ffi.Pointer<wire_float_32_list> _api2wire_opt_float_32_list(Float32List? raw) {
     return raw == null ? ffi.nullptr : _api2wire_float_32_list(raw);
   }
 
-  ffi.Pointer<wire_float_64_list> _api2wire_opt_float_64_list(
-      Float64List? raw) {
+  ffi.Pointer<wire_float_64_list> _api2wire_opt_float_64_list(Float64List? raw) {
     return raw == null ? ffi.nullptr : _api2wire_float_64_list(raw);
   }
 
@@ -2185,16 +1926,12 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     return raw == null ? ffi.nullptr : _api2wire_int_8_list(raw);
   }
 
-  ffi.Pointer<wire_list_attribute> _api2wire_opt_list_attribute(
-      List<Attribute>? raw) {
+  ffi.Pointer<wire_list_attribute> _api2wire_opt_list_attribute(List<Attribute>? raw) {
     return raw == null ? ffi.nullptr : _api2wire_list_attribute(raw);
   }
 
-  ffi.Pointer<wire_list_opt_box_autoadd_attribute>
-      _api2wire_opt_list_opt_box_autoadd_attribute(List<Attribute?>? raw) {
-    return raw == null
-        ? ffi.nullptr
-        : _api2wire_list_opt_box_autoadd_attribute(raw);
+  ffi.Pointer<wire_list_opt_box_autoadd_attribute> _api2wire_opt_list_opt_box_autoadd_attribute(List<Attribute?>? raw) {
+    return raw == null ? ffi.nullptr : _api2wire_list_opt_box_autoadd_attribute(raw);
   }
 
   ffi.Pointer<wire_uint_8_list> _api2wire_opt_uint_8_list(Uint8List? raw) {
@@ -2225,19 +1962,16 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
 
   // Section: api_fill_to_wire
 
-  void _api_fill_to_wire_application_env(
-      ApplicationEnv apiObj, wire_ApplicationEnv wireObj) {
+  void _api_fill_to_wire_application_env(ApplicationEnv apiObj, wire_ApplicationEnv wireObj) {
     wireObj.vars = _api2wire_list_application_env_var(apiObj.vars);
   }
 
-  void _api_fill_to_wire_application_env_var(
-      ApplicationEnvVar apiObj, wire_ApplicationEnvVar wireObj) {
+  void _api_fill_to_wire_application_env_var(ApplicationEnvVar apiObj, wire_ApplicationEnvVar wireObj) {
     wireObj.field0 = _api2wire_String(apiObj.field0);
     wireObj.field1 = _api2wire_bool(apiObj.field1);
   }
 
-  void _api_fill_to_wire_application_settings(
-      ApplicationSettings apiObj, wire_ApplicationSettings wireObj) {
+  void _api_fill_to_wire_application_settings(ApplicationSettings apiObj, wire_ApplicationSettings wireObj) {
     wireObj.name = _api2wire_String(apiObj.name);
     wireObj.version = _api2wire_String(apiObj.version);
     wireObj.mode = _api2wire_application_mode(apiObj.mode);
@@ -2249,19 +1983,16 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     wireObj.value = _api2wire_String(apiObj.value);
   }
 
-  void _api_fill_to_wire_box_application_env(
-      ApplicationEnv apiObj, ffi.Pointer<wire_ApplicationEnv> wireObj) {
+  void _api_fill_to_wire_box_application_env(ApplicationEnv apiObj, ffi.Pointer<wire_ApplicationEnv> wireObj) {
     _api_fill_to_wire_application_env(apiObj, wireObj.ref);
   }
 
   void _api_fill_to_wire_box_autoadd_application_settings(
-      ApplicationSettings apiObj,
-      ffi.Pointer<wire_ApplicationSettings> wireObj) {
+      ApplicationSettings apiObj, ffi.Pointer<wire_ApplicationSettings> wireObj) {
     _api_fill_to_wire_application_settings(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_attribute(
-      Attribute apiObj, ffi.Pointer<wire_Attribute> wireObj) {
+  void _api_fill_to_wire_box_autoadd_attribute(Attribute apiObj, ffi.Pointer<wire_Attribute> wireObj) {
     _api_fill_to_wire_attribute(apiObj, wireObj.ref);
   }
 
@@ -2270,8 +2001,7 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     _api_fill_to_wire_concatenate_with(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_customized(
-      Customized apiObj, ffi.Pointer<wire_Customized> wireObj) {
+  void _api_fill_to_wire_box_autoadd_customized(Customized apiObj, ffi.Pointer<wire_Customized> wireObj) {
     _api_fill_to_wire_customized(apiObj, wireObj.ref);
   }
 
@@ -2280,93 +2010,75 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     _api_fill_to_wire_exotic_optionals(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_kitchen_sink(
-      KitchenSink apiObj, ffi.Pointer<wire_KitchenSink> wireObj) {
+  void _api_fill_to_wire_box_autoadd_kitchen_sink(KitchenSink apiObj, ffi.Pointer<wire_KitchenSink> wireObj) {
     _api_fill_to_wire_kitchen_sink(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_measure(
-      Measure apiObj, ffi.Pointer<wire_Measure> wireObj) {
+  void _api_fill_to_wire_box_autoadd_measure(Measure apiObj, ffi.Pointer<wire_Measure> wireObj) {
     _api_fill_to_wire_measure(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_my_size(
-      MySize apiObj, ffi.Pointer<wire_MySize> wireObj) {
+  void _api_fill_to_wire_box_autoadd_my_size(MySize apiObj, ffi.Pointer<wire_MySize> wireObj) {
     _api_fill_to_wire_my_size(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_my_struct(
-      MyStruct apiObj, ffi.Pointer<wire_MyStruct> wireObj) {
+  void _api_fill_to_wire_box_autoadd_my_struct(MyStruct apiObj, ffi.Pointer<wire_MyStruct> wireObj) {
     _api_fill_to_wire_my_struct(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_my_tree_node(
-      MyTreeNode apiObj, ffi.Pointer<wire_MyTreeNode> wireObj) {
+  void _api_fill_to_wire_box_autoadd_my_tree_node(MyTreeNode apiObj, ffi.Pointer<wire_MyTreeNode> wireObj) {
     _api_fill_to_wire_my_tree_node(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_new_type_int(
-      NewTypeInt apiObj, ffi.Pointer<wire_NewTypeInt> wireObj) {
+  void _api_fill_to_wire_box_autoadd_new_type_int(NewTypeInt apiObj, ffi.Pointer<wire_NewTypeInt> wireObj) {
     _api_fill_to_wire_new_type_int(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_note(
-      Note apiObj, ffi.Pointer<wire_Note> wireObj) {
+  void _api_fill_to_wire_box_autoadd_note(Note apiObj, ffi.Pointer<wire_Note> wireObj) {
     _api_fill_to_wire_note(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_numbers(
-      Numbers apiObj, ffi.Pointer<wire_Numbers> wireObj) {
+  void _api_fill_to_wire_box_autoadd_numbers(Numbers apiObj, ffi.Pointer<wire_Numbers> wireObj) {
     _api_fill_to_wire_numbers(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_sequences(
-      Sequences apiObj, ffi.Pointer<wire_Sequences> wireObj) {
+  void _api_fill_to_wire_box_autoadd_sequences(Sequences apiObj, ffi.Pointer<wire_Sequences> wireObj) {
     _api_fill_to_wire_sequences(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_sum_with(
-      SumWith apiObj, ffi.Pointer<wire_SumWith> wireObj) {
+  void _api_fill_to_wire_box_autoadd_sum_with(SumWith apiObj, ffi.Pointer<wire_SumWith> wireObj) {
     _api_fill_to_wire_sum_with(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_user_id(
-      UserId apiObj, ffi.Pointer<wire_UserId> wireObj) {
+  void _api_fill_to_wire_box_autoadd_user_id(UserId apiObj, ffi.Pointer<wire_UserId> wireObj) {
     _api_fill_to_wire_user_id(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_distance(
-      Distance apiObj, ffi.Pointer<wire_Distance> wireObj) {
+  void _api_fill_to_wire_box_distance(Distance apiObj, ffi.Pointer<wire_Distance> wireObj) {
     _api_fill_to_wire_distance(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_exotic_optionals(
-      ExoticOptionals apiObj, ffi.Pointer<wire_ExoticOptionals> wireObj) {
+  void _api_fill_to_wire_box_exotic_optionals(ExoticOptionals apiObj, ffi.Pointer<wire_ExoticOptionals> wireObj) {
     _api_fill_to_wire_exotic_optionals(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_kitchen_sink(
-      KitchenSink apiObj, ffi.Pointer<wire_KitchenSink> wireObj) {
+  void _api_fill_to_wire_box_kitchen_sink(KitchenSink apiObj, ffi.Pointer<wire_KitchenSink> wireObj) {
     _api_fill_to_wire_kitchen_sink(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_my_size(
-      MySize apiObj, ffi.Pointer<wire_MySize> wireObj) {
+  void _api_fill_to_wire_box_my_size(MySize apiObj, ffi.Pointer<wire_MySize> wireObj) {
     _api_fill_to_wire_my_size(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_speed(
-      Speed apiObj, ffi.Pointer<wire_Speed> wireObj) {
+  void _api_fill_to_wire_box_speed(Speed apiObj, ffi.Pointer<wire_Speed> wireObj) {
     _api_fill_to_wire_speed(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_concatenate_with(
-      ConcatenateWith apiObj, wire_ConcatenateWith wireObj) {
+  void _api_fill_to_wire_concatenate_with(ConcatenateWith apiObj, wire_ConcatenateWith wireObj) {
     wireObj.a = _api2wire_String(apiObj.a);
   }
 
-  void _api_fill_to_wire_customized(
-      Customized apiObj, wire_Customized wireObj) {
+  void _api_fill_to_wire_customized(Customized apiObj, wire_Customized wireObj) {
     wireObj.final_field = _api2wire_String(apiObj.finalField);
     wireObj.non_final_field = _api2wire_opt_String(apiObj.nonFinalField);
   }
@@ -2383,8 +2095,7 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     }
   }
 
-  void _api_fill_to_wire_exotic_optionals(
-      ExoticOptionals apiObj, wire_ExoticOptionals wireObj) {
+  void _api_fill_to_wire_exotic_optionals(ExoticOptionals apiObj, wire_ExoticOptionals wireObj) {
     wireObj.int32 = _api2wire_opt_box_autoadd_i32(apiObj.int32);
     wireObj.int64 = _api2wire_opt_box_autoadd_i64(apiObj.int64);
     wireObj.float64 = _api2wire_opt_box_autoadd_f64(apiObj.float64);
@@ -2397,16 +2108,12 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     wireObj.float32list = _api2wire_opt_float_32_list(apiObj.float32List);
     wireObj.float64list = _api2wire_opt_float_64_list(apiObj.float64List);
     wireObj.attributes = _api2wire_opt_list_attribute(apiObj.attributes);
-    wireObj.attributes_nullable =
-        _api2wire_list_opt_box_autoadd_attribute(apiObj.attributesNullable);
-    wireObj.nullable_attributes =
-        _api2wire_opt_list_opt_box_autoadd_attribute(apiObj.nullableAttributes);
-    wireObj.newtypeint =
-        _api2wire_opt_box_autoadd_new_type_int(apiObj.newtypeint);
+    wireObj.attributes_nullable = _api2wire_list_opt_box_autoadd_attribute(apiObj.attributesNullable);
+    wireObj.nullable_attributes = _api2wire_opt_list_opt_box_autoadd_attribute(apiObj.nullableAttributes);
+    wireObj.newtypeint = _api2wire_opt_box_autoadd_new_type_int(apiObj.newtypeint);
   }
 
-  void _api_fill_to_wire_kitchen_sink(
-      KitchenSink apiObj, wire_KitchenSink wireObj) {
+  void _api_fill_to_wire_kitchen_sink(KitchenSink apiObj, wire_KitchenSink wireObj) {
     if (apiObj is KitchenSink_Empty) {
       wireObj.tag = 0;
       return;
@@ -2421,23 +2128,19 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     if (apiObj is KitchenSink_Nested) {
       wireObj.tag = 2;
       wireObj.kind = inner.inflate_KitchenSink_Nested();
-      wireObj.kind.ref.Nested.ref.field0 =
-          _api2wire_box_kitchen_sink(apiObj.field0);
+      wireObj.kind.ref.Nested.ref.field0 = _api2wire_box_kitchen_sink(apiObj.field0);
       wireObj.kind.ref.Nested.ref.field1 = _api2wire_i32(apiObj.field1);
     }
     if (apiObj is KitchenSink_Optional) {
       wireObj.tag = 3;
       wireObj.kind = inner.inflate_KitchenSink_Optional();
-      wireObj.kind.ref.Optional.ref.field0 =
-          _api2wire_opt_box_autoadd_i32(apiObj.field0);
-      wireObj.kind.ref.Optional.ref.field1 =
-          _api2wire_opt_box_autoadd_i32(apiObj.field1);
+      wireObj.kind.ref.Optional.ref.field0 = _api2wire_opt_box_autoadd_i32(apiObj.field0);
+      wireObj.kind.ref.Optional.ref.field1 = _api2wire_opt_box_autoadd_i32(apiObj.field1);
     }
     if (apiObj is KitchenSink_Buffer) {
       wireObj.tag = 4;
       wireObj.kind = inner.inflate_KitchenSink_Buffer();
-      wireObj.kind.ref.Buffer.ref.field0 =
-          _api2wire_ZeroCopyBuffer_Uint8List(apiObj.field0);
+      wireObj.kind.ref.Buffer.ref.field0 = _api2wire_ZeroCopyBuffer_Uint8List(apiObj.field0);
     }
     if (apiObj is KitchenSink_Enums) {
       wireObj.tag = 5;
@@ -2455,8 +2158,7 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     if (apiObj is Measure_Distance) {
       wireObj.tag = 1;
       wireObj.kind = inner.inflate_Measure_Distance();
-      wireObj.kind.ref.Distance.ref.field0 =
-          _api2wire_box_distance(apiObj.field0);
+      wireObj.kind.ref.Distance.ref.field0 = _api2wire_box_distance(apiObj.field0);
     }
   }
 
@@ -2469,16 +2171,14 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     wireObj.content = _api2wire_bool(apiObj.content);
   }
 
-  void _api_fill_to_wire_my_tree_node(
-      MyTreeNode apiObj, wire_MyTreeNode wireObj) {
+  void _api_fill_to_wire_my_tree_node(MyTreeNode apiObj, wire_MyTreeNode wireObj) {
     wireObj.value_i32 = _api2wire_i32(apiObj.valueI32);
     wireObj.value_vec_u8 = _api2wire_uint_8_list(apiObj.valueVecU8);
     wireObj.value_boolean = _api2wire_bool(apiObj.valueBoolean);
     wireObj.children = _api2wire_list_my_tree_node(apiObj.children);
   }
 
-  void _api_fill_to_wire_new_type_int(
-      NewTypeInt apiObj, wire_NewTypeInt wireObj) {
+  void _api_fill_to_wire_new_type_int(NewTypeInt apiObj, wire_NewTypeInt wireObj) {
     wireObj.field0 = _api2wire_i64(apiObj.field0);
   }
 
@@ -2491,26 +2191,20 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     wireObj.field0 = _api2wire_int_32_list(apiObj.field0);
   }
 
-  void _api_fill_to_wire_opt_box_autoadd_attribute(
-      Attribute? apiObj, ffi.Pointer<wire_Attribute> wireObj) {
-    if (apiObj != null)
-      _api_fill_to_wire_box_autoadd_attribute(apiObj, wireObj);
+  void _api_fill_to_wire_opt_box_autoadd_attribute(Attribute? apiObj, ffi.Pointer<wire_Attribute> wireObj) {
+    if (apiObj != null) _api_fill_to_wire_box_autoadd_attribute(apiObj, wireObj);
   }
 
   void _api_fill_to_wire_opt_box_autoadd_exotic_optionals(
       ExoticOptionals? apiObj, ffi.Pointer<wire_ExoticOptionals> wireObj) {
-    if (apiObj != null)
-      _api_fill_to_wire_box_autoadd_exotic_optionals(apiObj, wireObj);
+    if (apiObj != null) _api_fill_to_wire_box_autoadd_exotic_optionals(apiObj, wireObj);
   }
 
-  void _api_fill_to_wire_opt_box_autoadd_new_type_int(
-      NewTypeInt? apiObj, ffi.Pointer<wire_NewTypeInt> wireObj) {
-    if (apiObj != null)
-      _api_fill_to_wire_box_autoadd_new_type_int(apiObj, wireObj);
+  void _api_fill_to_wire_opt_box_autoadd_new_type_int(NewTypeInt? apiObj, ffi.Pointer<wire_NewTypeInt> wireObj) {
+    if (apiObj != null) _api_fill_to_wire_box_autoadd_new_type_int(apiObj, wireObj);
   }
 
-  void _api_fill_to_wire_opt_box_exotic_optionals(
-      ExoticOptionals? apiObj, ffi.Pointer<wire_ExoticOptionals> wireObj) {
+  void _api_fill_to_wire_opt_box_exotic_optionals(ExoticOptionals? apiObj, ffi.Pointer<wire_ExoticOptionals> wireObj) {
     if (apiObj != null) _api_fill_to_wire_box_exotic_optionals(apiObj, wireObj);
   }
 
@@ -2594,8 +2288,7 @@ Uint8List _wire2api_ZeroCopyBuffer_Uint8List(dynamic raw) {
 
 ApplicationEnv _wire2api_application_env(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 1)
-    throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+  if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
   return ApplicationEnv(
     vars: _wire2api_list_application_env_var(arr[0]),
   );
@@ -2603,8 +2296,7 @@ ApplicationEnv _wire2api_application_env(dynamic raw) {
 
 ApplicationEnvVar _wire2api_application_env_var(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 2)
-    throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+  if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
   return ApplicationEnvVar(
     field0: _wire2api_String(arr[0]),
     field1: _wire2api_bool(arr[1]),
@@ -2635,8 +2327,7 @@ ApplicationMode _wire2api_application_mode(dynamic raw) {
 
 ApplicationSettings _wire2api_application_settings(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 4)
-    throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
+  if (arr.length != 4) throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
   return ApplicationSettings(
     name: _wire2api_String(arr[0]),
     version: _wire2api_String(arr[1]),
@@ -2647,8 +2338,7 @@ ApplicationSettings _wire2api_application_settings(dynamic raw) {
 
 Attribute _wire2api_attribute(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 2)
-    throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+  if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
   return Attribute(
     key: _wire2api_String(arr[0]),
     value: _wire2api_String(arr[1]),
@@ -2707,11 +2397,9 @@ Speed _wire2api_box_speed(dynamic raw) {
   return _wire2api_speed(raw);
 }
 
-ConcatenateWith _wire2api_concatenate_with(
-    FlutterRustBridgeExampleSingleBlockTest bridge, dynamic raw) {
+ConcatenateWith _wire2api_concatenate_with(FlutterRustBridgeExampleSingleBlockTest bridge, dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 1)
-    throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+  if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
   return ConcatenateWith(
     bridge: bridge,
     a: _wire2api_String(arr[0]),
@@ -2733,8 +2421,7 @@ Distance _wire2api_distance(dynamic raw) {
 
 Element _wire2api_element(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 4)
-    throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
+  if (arr.length != 4) throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
   return Element(
     tag: _wire2api_opt_String(arr[0]),
     text: _wire2api_opt_String(arr[1]),
@@ -2745,8 +2432,7 @@ Element _wire2api_element(dynamic raw) {
 
 Event _wire2api_event(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 2)
-    throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+  if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
   return Event(
     address: _wire2api_String(arr[0]),
     payload: _wire2api_String(arr[1]),
@@ -2755,8 +2441,7 @@ Event _wire2api_event(dynamic raw) {
 
 ExoticOptionals _wire2api_exotic_optionals(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 15)
-    throw Exception('unexpected arr length: expect 15 but see ${arr.length}');
+  if (arr.length != 15) throw Exception('unexpected arr length: expect 15 but see ${arr.length}');
   return ExoticOptionals(
     int32: _wire2api_opt_box_autoadd_i32(arr[0]),
     int64: _wire2api_opt_box_autoadd_i64(arr[1]),
@@ -2878,9 +2563,7 @@ List<MyTreeNode> _wire2api_list_my_tree_node(dynamic raw) {
 }
 
 List<Attribute?> _wire2api_list_opt_box_autoadd_attribute(dynamic raw) {
-  return (raw as List<dynamic>)
-      .map(_wire2api_opt_box_autoadd_attribute)
-      .toList();
+  return (raw as List<dynamic>).map(_wire2api_opt_box_autoadd_attribute).toList();
 }
 
 List<Point> _wire2api_list_point(dynamic raw) {
@@ -2889,8 +2572,7 @@ List<Point> _wire2api_list_point(dynamic raw) {
 
 Log _wire2api_log(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 2)
-    throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+  if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
   return Log(
     key: _wire2api_u32(arr[0]),
     value: _wire2api_u32(arr[1]),
@@ -2899,8 +2581,7 @@ Log _wire2api_log(dynamic raw) {
 
 Log2 _wire2api_log_2(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 2)
-    throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+  if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
   return Log2(
     key: _wire2api_u32(arr[0]),
     value: _wire2api_String(arr[1]),
@@ -2924,8 +2605,7 @@ Measure _wire2api_measure(dynamic raw) {
 
 MySize _wire2api_my_size(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 2)
-    throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+  if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
   return MySize(
     width: _wire2api_i32(arr[0]),
     height: _wire2api_i32(arr[1]),
@@ -2934,8 +2614,7 @@ MySize _wire2api_my_size(dynamic raw) {
 
 MyStreamEntry _wire2api_my_stream_entry(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 1)
-    throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+  if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
   return MyStreamEntry(
     hello: _wire2api_String(arr[0]),
   );
@@ -2943,8 +2622,7 @@ MyStreamEntry _wire2api_my_stream_entry(dynamic raw) {
 
 MyTreeNode _wire2api_my_tree_node(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 4)
-    throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
+  if (arr.length != 4) throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
   return MyTreeNode(
     valueI32: _wire2api_i32(arr[0]),
     valueVecU8: _wire2api_uint_8_list(arr[1]),
@@ -2955,8 +2633,7 @@ MyTreeNode _wire2api_my_tree_node(dynamic raw) {
 
 NewSimpleStruct _wire2api_new_simple_struct(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 1)
-    throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+  if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
   return NewSimpleStruct(
     field: _wire2api_i32(arr[0]),
   );
@@ -2964,8 +2641,7 @@ NewSimpleStruct _wire2api_new_simple_struct(dynamic raw) {
 
 NewTypeInt _wire2api_new_type_int(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 1)
-    throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+  if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
   return NewTypeInt(
     field0: _wire2api_i64(arr[0]),
   );
@@ -2973,8 +2649,7 @@ NewTypeInt _wire2api_new_type_int(dynamic raw) {
 
 Numbers _wire2api_numbers(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 1)
-    throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+  if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
   return Numbers(
     field0: _wire2api_int_32_list(arr[0]),
   );
@@ -2982,8 +2657,7 @@ Numbers _wire2api_numbers(dynamic raw) {
 
 OldSimpleStruct _wire2api_old_simple_struct(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 1)
-    throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+  if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
   return OldSimpleStruct(
     field: _wire2api_i32(arr[0]),
   );
@@ -3075,8 +2749,7 @@ Weekdays? _wire2api_opt_weekdays(dynamic raw) {
 
 Point _wire2api_point(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 2)
-    throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+  if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
   return Point(
     x: _wire2api_f32(arr[0]),
     y: _wire2api_f32(arr[1]),
@@ -3085,8 +2758,7 @@ Point _wire2api_point(dynamic raw) {
 
 Sequences _wire2api_sequences(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 1)
-    throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+  if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
   return Sequences(
     field0: _wire2api_int_32_list(arr[0]),
   );
@@ -3105,11 +2777,9 @@ Speed _wire2api_speed(dynamic raw) {
   }
 }
 
-SumWith _wire2api_sum_with(
-    FlutterRustBridgeExampleSingleBlockTest bridge, dynamic raw) {
+SumWith _wire2api_sum_with(FlutterRustBridgeExampleSingleBlockTest bridge, dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 1)
-    throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+  if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
   return SumWith(
     bridge: bridge,
     x: _wire2api_u32(arr[0]),
@@ -3154,8 +2824,7 @@ void _wire2api_unit(dynamic raw) {
 
 UserId _wire2api_user_id(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 1)
-    throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+  if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
   return UserId(
     value: _wire2api_u32(arr[0]),
   );
@@ -3167,8 +2836,7 @@ int _wire2api_usize(dynamic raw) {
 
 VecOfPrimitivePack _wire2api_vec_of_primitive_pack(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 10)
-    throw Exception('unexpected arr length: expect 10 but see ${arr.length}');
+  if (arr.length != 10) throw Exception('unexpected arr length: expect 10 but see ${arr.length}');
   return VecOfPrimitivePack(
     int8List: _wire2api_int_8_list(arr[0]),
     uint8List: _wire2api_uint_8_list(arr[1]),
@@ -3187,11 +2855,9 @@ Weekdays _wire2api_weekdays(dynamic raw) {
   return Weekdays.values[raw];
 }
 
-ZeroCopyVecOfPrimitivePack _wire2api_zero_copy_vec_of_primitive_pack(
-    dynamic raw) {
+ZeroCopyVecOfPrimitivePack _wire2api_zero_copy_vec_of_primitive_pack(dynamic raw) {
   final arr = raw as List<dynamic>;
-  if (arr.length != 10)
-    throw Exception('unexpected arr length: expect 10 but see ${arr.length}');
+  if (arr.length != 10) throw Exception('unexpected arr length: expect 10 but see ${arr.length}');
   return ZeroCopyVecOfPrimitivePack(
     int8List: _wire2api_ZeroCopyBuffer_Int8List(arr[0]),
     uint8List: _wire2api_ZeroCopyBuffer_Uint8List(arr[1]),
@@ -3213,20 +2879,16 @@ ZeroCopyVecOfPrimitivePack _wire2api_zero_copy_vec_of_primitive_pack(
 // Generated by `package:ffigen`.
 
 /// generated by flutter_rust_bridge
-class FlutterRustBridgeExampleSingleBlockTestWire
-    implements FlutterRustBridgeWireBase {
+class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWireBase {
   /// Holds the symbol lookup function.
-  final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
-      _lookup;
+  final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName) _lookup;
 
   /// The symbols are looked up in [dynamicLibrary].
-  FlutterRustBridgeExampleSingleBlockTestWire(ffi.DynamicLibrary dynamicLibrary)
-      : _lookup = dynamicLibrary.lookup;
+  FlutterRustBridgeExampleSingleBlockTestWire(ffi.DynamicLibrary dynamicLibrary) : _lookup = dynamicLibrary.lookup;
 
   /// The symbols are looked up with [lookup].
   FlutterRustBridgeExampleSingleBlockTestWire.fromLookup(
-      ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
-          lookup)
+      ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName) lookup)
       : _lookup = lookup;
 
   void wire_simple_adder(
@@ -3241,12 +2903,9 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_simple_adderPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-              ffi.Int64, ffi.Int32, ffi.Int32)>>('wire_simple_adder');
-  late final _wire_simple_adder =
-      _wire_simple_adderPtr.asFunction<void Function(int, int, int)>();
+  late final _wire_simple_adderPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32, ffi.Int32)>>('wire_simple_adder');
+  late final _wire_simple_adder = _wire_simple_adderPtr.asFunction<void Function(int, int, int)>();
 
   void wire_primitive_types(
     int port_,
@@ -3264,12 +2923,10 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_primitive_typesPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64, ffi.Int32, ffi.Int64, ffi.Double,
-              ffi.Bool)>>('wire_primitive_types');
-  late final _wire_primitive_types = _wire_primitive_typesPtr
-      .asFunction<void Function(int, int, int, double, bool)>();
+  late final _wire_primitive_typesPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32, ffi.Int64, ffi.Double, ffi.Bool)>>(
+          'wire_primitive_types');
+  late final _wire_primitive_types = _wire_primitive_typesPtr.asFunction<void Function(int, int, int, double, bool)>();
 
   void wire_primitive_u32(
     int port_,
@@ -3282,10 +2939,8 @@ class FlutterRustBridgeExampleSingleBlockTestWire
   }
 
   late final _wire_primitive_u32Ptr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Uint32)>>(
-          'wire_primitive_u32');
-  late final _wire_primitive_u32 =
-      _wire_primitive_u32Ptr.asFunction<void Function(int, int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Uint32)>>('wire_primitive_u32');
+  late final _wire_primitive_u32 = _wire_primitive_u32Ptr.asFunction<void Function(int, int)>();
 
   void wire_handle_string(
     int port_,
@@ -3297,12 +2952,10 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_handle_stringPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-              ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>('wire_handle_string');
-  late final _wire_handle_string = _wire_handle_stringPtr
-      .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+  late final _wire_handle_stringPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>('wire_handle_string');
+  late final _wire_handle_string =
+      _wire_handle_stringPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_handle_return_unit(
     int port_,
@@ -3313,10 +2966,8 @@ class FlutterRustBridgeExampleSingleBlockTestWire
   }
 
   late final _wire_handle_return_unitPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
-          'wire_handle_return_unit');
-  late final _wire_handle_return_unit =
-      _wire_handle_return_unitPtr.asFunction<void Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_handle_return_unit');
+  late final _wire_handle_return_unit = _wire_handle_return_unitPtr.asFunction<void Function(int)>();
 
   void wire_handle_vec_u8(
     int port_,
@@ -3328,12 +2979,10 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_handle_vec_u8Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-              ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>('wire_handle_vec_u8');
-  late final _wire_handle_vec_u8 = _wire_handle_vec_u8Ptr
-      .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+  late final _wire_handle_vec_u8Ptr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>('wire_handle_vec_u8');
+  late final _wire_handle_vec_u8 =
+      _wire_handle_vec_u8Ptr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_handle_vec_of_primitive(
     int port_,
@@ -3346,10 +2995,8 @@ class FlutterRustBridgeExampleSingleBlockTestWire
   }
 
   late final _wire_handle_vec_of_primitivePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>(
-          'wire_handle_vec_of_primitive');
-  late final _wire_handle_vec_of_primitive =
-      _wire_handle_vec_of_primitivePtr.asFunction<void Function(int, int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>('wire_handle_vec_of_primitive');
+  late final _wire_handle_vec_of_primitive = _wire_handle_vec_of_primitivePtr.asFunction<void Function(int, int)>();
 
   void wire_handle_zero_copy_vec_of_primitive(
     int port_,
@@ -3362,11 +3009,9 @@ class FlutterRustBridgeExampleSingleBlockTestWire
   }
 
   late final _wire_handle_zero_copy_vec_of_primitivePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>(
-          'wire_handle_zero_copy_vec_of_primitive');
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>('wire_handle_zero_copy_vec_of_primitive');
   late final _wire_handle_zero_copy_vec_of_primitive =
-      _wire_handle_zero_copy_vec_of_primitivePtr
-          .asFunction<void Function(int, int)>();
+      _wire_handle_zero_copy_vec_of_primitivePtr.asFunction<void Function(int, int)>();
 
   void wire_handle_struct(
     int port_,
@@ -3380,12 +3025,11 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_handle_structPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64, ffi.Pointer<wire_MySize>,
-              ffi.Pointer<wire_MySize>)>>('wire_handle_struct');
-  late final _wire_handle_struct = _wire_handle_structPtr.asFunction<
-      void Function(int, ffi.Pointer<wire_MySize>, ffi.Pointer<wire_MySize>)>();
+  late final _wire_handle_structPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_MySize>, ffi.Pointer<wire_MySize>)>>(
+          'wire_handle_struct');
+  late final _wire_handle_struct =
+      _wire_handle_structPtr.asFunction<void Function(int, ffi.Pointer<wire_MySize>, ffi.Pointer<wire_MySize>)>();
 
   void wire_handle_newtype(
     int port_,
@@ -3397,12 +3041,10 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_handle_newtypePtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-              ffi.Int64, ffi.Pointer<wire_NewTypeInt>)>>('wire_handle_newtype');
-  late final _wire_handle_newtype = _wire_handle_newtypePtr
-      .asFunction<void Function(int, ffi.Pointer<wire_NewTypeInt>)>();
+  late final _wire_handle_newtypePtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_NewTypeInt>)>>('wire_handle_newtype');
+  late final _wire_handle_newtype =
+      _wire_handle_newtypePtr.asFunction<void Function(int, ffi.Pointer<wire_NewTypeInt>)>();
 
   void wire_handle_list_of_struct(
     int port_,
@@ -3414,12 +3056,11 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_handle_list_of_structPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64,
-              ffi.Pointer<wire_list_my_size>)>>('wire_handle_list_of_struct');
-  late final _wire_handle_list_of_struct = _wire_handle_list_of_structPtr
-      .asFunction<void Function(int, ffi.Pointer<wire_list_my_size>)>();
+  late final _wire_handle_list_of_structPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_list_my_size>)>>(
+          'wire_handle_list_of_struct');
+  late final _wire_handle_list_of_struct =
+      _wire_handle_list_of_structPtr.asFunction<void Function(int, ffi.Pointer<wire_list_my_size>)>();
 
   void wire_handle_string_list(
     int port_,
@@ -3431,12 +3072,11 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_handle_string_listPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64,
-              ffi.Pointer<wire_StringList>)>>('wire_handle_string_list');
-  late final _wire_handle_string_list = _wire_handle_string_listPtr
-      .asFunction<void Function(int, ffi.Pointer<wire_StringList>)>();
+  late final _wire_handle_string_listPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_StringList>)>>(
+          'wire_handle_string_list');
+  late final _wire_handle_string_list =
+      _wire_handle_string_listPtr.asFunction<void Function(int, ffi.Pointer<wire_StringList>)>();
 
   void wire_handle_complex_struct(
     int port_,
@@ -3448,12 +3088,11 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_handle_complex_structPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64,
-              ffi.Pointer<wire_MyTreeNode>)>>('wire_handle_complex_struct');
-  late final _wire_handle_complex_struct = _wire_handle_complex_structPtr
-      .asFunction<void Function(int, ffi.Pointer<wire_MyTreeNode>)>();
+  late final _wire_handle_complex_structPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_MyTreeNode>)>>(
+          'wire_handle_complex_struct');
+  late final _wire_handle_complex_struct =
+      _wire_handle_complex_structPtr.asFunction<void Function(int, ffi.Pointer<wire_MyTreeNode>)>();
 
   WireSyncReturnStruct wire_handle_sync_return(
     ffi.Pointer<wire_uint_8_list> mode,
@@ -3463,12 +3102,11 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_handle_sync_returnPtr = _lookup<
-      ffi.NativeFunction<
-          WireSyncReturnStruct Function(
-              ffi.Pointer<wire_uint_8_list>)>>('wire_handle_sync_return');
-  late final _wire_handle_sync_return = _wire_handle_sync_returnPtr.asFunction<
-      WireSyncReturnStruct Function(ffi.Pointer<wire_uint_8_list>)>();
+  late final _wire_handle_sync_returnPtr =
+      _lookup<ffi.NativeFunction<WireSyncReturnStruct Function(ffi.Pointer<wire_uint_8_list>)>>(
+          'wire_handle_sync_return');
+  late final _wire_handle_sync_return =
+      _wire_handle_sync_returnPtr.asFunction<WireSyncReturnStruct Function(ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_handle_stream(
     int port_,
@@ -3480,12 +3118,10 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_handle_streamPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-              ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>('wire_handle_stream');
-  late final _wire_handle_stream = _wire_handle_streamPtr
-      .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+  late final _wire_handle_streamPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>('wire_handle_stream');
+  late final _wire_handle_stream =
+      _wire_handle_streamPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_handle_stream_of_struct(
     int port_,
@@ -3496,10 +3132,8 @@ class FlutterRustBridgeExampleSingleBlockTestWire
   }
 
   late final _wire_handle_stream_of_structPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
-          'wire_handle_stream_of_struct');
-  late final _wire_handle_stream_of_struct =
-      _wire_handle_stream_of_structPtr.asFunction<void Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_handle_stream_of_struct');
+  late final _wire_handle_stream_of_struct = _wire_handle_stream_of_structPtr.asFunction<void Function(int)>();
 
   void wire_return_err(
     int port_,
@@ -3509,11 +3143,8 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_return_errPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
-          'wire_return_err');
-  late final _wire_return_err =
-      _wire_return_errPtr.asFunction<void Function(int)>();
+  late final _wire_return_errPtr = _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_return_err');
+  late final _wire_return_err = _wire_return_errPtr.asFunction<void Function(int)>();
 
   void wire_return_panic(
     int port_,
@@ -3523,11 +3154,8 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_return_panicPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
-          'wire_return_panic');
-  late final _wire_return_panic =
-      _wire_return_panicPtr.asFunction<void Function(int)>();
+  late final _wire_return_panicPtr = _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_return_panic');
+  late final _wire_return_panic = _wire_return_panicPtr.asFunction<void Function(int)>();
 
   void wire_handle_optional_return(
     int port_,
@@ -3541,12 +3169,10 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_handle_optional_returnPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64, ffi.Double,
-              ffi.Double)>>('wire_handle_optional_return');
-  late final _wire_handle_optional_return = _wire_handle_optional_returnPtr
-      .asFunction<void Function(int, double, double)>();
+  late final _wire_handle_optional_returnPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Double, ffi.Double)>>('wire_handle_optional_return');
+  late final _wire_handle_optional_return =
+      _wire_handle_optional_returnPtr.asFunction<void Function(int, double, double)>();
 
   void wire_handle_optional_struct(
     int port_,
@@ -3558,12 +3184,11 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_handle_optional_structPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64,
-              ffi.Pointer<wire_uint_8_list>)>>('wire_handle_optional_struct');
-  late final _wire_handle_optional_struct = _wire_handle_optional_structPtr
-      .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+  late final _wire_handle_optional_structPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>(
+          'wire_handle_optional_struct');
+  late final _wire_handle_optional_struct =
+      _wire_handle_optional_structPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_handle_optional_increment(
     int port_,
@@ -3575,13 +3200,11 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_handle_optional_incrementPtr = _lookup<
-          ffi.NativeFunction<
-              ffi.Void Function(ffi.Int64, ffi.Pointer<wire_ExoticOptionals>)>>(
-      'wire_handle_optional_increment');
+  late final _wire_handle_optional_incrementPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_ExoticOptionals>)>>(
+          'wire_handle_optional_increment');
   late final _wire_handle_optional_increment =
-      _wire_handle_optional_incrementPtr
-          .asFunction<void Function(int, ffi.Pointer<wire_ExoticOptionals>)>();
+      _wire_handle_optional_incrementPtr.asFunction<void Function(int, ffi.Pointer<wire_ExoticOptionals>)>();
 
   void wire_handle_increment_boxed_optional(
     int port_,
@@ -3593,13 +3216,11 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_handle_increment_boxed_optionalPtr = _lookup<
-          ffi.NativeFunction<
-              ffi.Void Function(ffi.Int64, ffi.Pointer<ffi.Double>)>>(
-      'wire_handle_increment_boxed_optional');
+  late final _wire_handle_increment_boxed_optionalPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<ffi.Double>)>>(
+          'wire_handle_increment_boxed_optional');
   late final _wire_handle_increment_boxed_optional =
-      _wire_handle_increment_boxed_optionalPtr
-          .asFunction<void Function(int, ffi.Pointer<ffi.Double>)>();
+      _wire_handle_increment_boxed_optionalPtr.asFunction<void Function(int, ffi.Pointer<ffi.Double>)>();
 
   void wire_handle_option_box_arguments(
     int port_,
@@ -3624,28 +3245,19 @@ class FlutterRustBridgeExampleSingleBlockTestWire
   }
 
   late final _wire_handle_option_box_argumentsPtr = _lookup<
-          ffi.NativeFunction<
-              ffi.Void Function(
-                  ffi.Int64,
-                  ffi.Pointer<ffi.Int8>,
-                  ffi.Pointer<ffi.Uint8>,
-                  ffi.Pointer<ffi.Int32>,
-                  ffi.Pointer<ffi.Int64>,
-                  ffi.Pointer<ffi.Double>,
-                  ffi.Pointer<ffi.Bool>,
-                  ffi.Pointer<wire_ExoticOptionals>)>>(
-      'wire_handle_option_box_arguments');
-  late final _wire_handle_option_box_arguments =
-      _wire_handle_option_box_argumentsPtr.asFunction<
-          void Function(
-              int,
+      ffi.NativeFunction<
+          ffi.Void Function(
+              ffi.Int64,
               ffi.Pointer<ffi.Int8>,
               ffi.Pointer<ffi.Uint8>,
               ffi.Pointer<ffi.Int32>,
               ffi.Pointer<ffi.Int64>,
               ffi.Pointer<ffi.Double>,
               ffi.Pointer<ffi.Bool>,
-              ffi.Pointer<wire_ExoticOptionals>)>();
+              ffi.Pointer<wire_ExoticOptionals>)>>('wire_handle_option_box_arguments');
+  late final _wire_handle_option_box_arguments = _wire_handle_option_box_argumentsPtr.asFunction<
+      void Function(int, ffi.Pointer<ffi.Int8>, ffi.Pointer<ffi.Uint8>, ffi.Pointer<ffi.Int32>, ffi.Pointer<ffi.Int64>,
+          ffi.Pointer<ffi.Double>, ffi.Pointer<ffi.Bool>, ffi.Pointer<wire_ExoticOptionals>)>();
 
   void wire_print_note(
     int port_,
@@ -3657,12 +3269,9 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_print_notePtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-              ffi.Int64, ffi.Pointer<wire_Note>)>>('wire_print_note');
-  late final _wire_print_note = _wire_print_notePtr
-      .asFunction<void Function(int, ffi.Pointer<wire_Note>)>();
+  late final _wire_print_notePtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_Note>)>>('wire_print_note');
+  late final _wire_print_note = _wire_print_notePtr.asFunction<void Function(int, ffi.Pointer<wire_Note>)>();
 
   void wire_handle_return_enum(
     int port_,
@@ -3674,12 +3283,11 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_handle_return_enumPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64,
-              ffi.Pointer<wire_uint_8_list>)>>('wire_handle_return_enum');
-  late final _wire_handle_return_enum = _wire_handle_return_enumPtr
-      .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+  late final _wire_handle_return_enumPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>(
+          'wire_handle_return_enum');
+  late final _wire_handle_return_enum =
+      _wire_handle_return_enumPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_handle_enum_parameter(
     int port_,
@@ -3692,10 +3300,8 @@ class FlutterRustBridgeExampleSingleBlockTestWire
   }
 
   late final _wire_handle_enum_parameterPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>(
-          'wire_handle_enum_parameter');
-  late final _wire_handle_enum_parameter =
-      _wire_handle_enum_parameterPtr.asFunction<void Function(int, int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>('wire_handle_enum_parameter');
+  late final _wire_handle_enum_parameter = _wire_handle_enum_parameterPtr.asFunction<void Function(int, int)>();
 
   void wire_handle_customized_struct(
     int port_,
@@ -3707,12 +3313,11 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_handle_customized_structPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64,
-              ffi.Pointer<wire_Customized>)>>('wire_handle_customized_struct');
-  late final _wire_handle_customized_struct = _wire_handle_customized_structPtr
-      .asFunction<void Function(int, ffi.Pointer<wire_Customized>)>();
+  late final _wire_handle_customized_structPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_Customized>)>>(
+          'wire_handle_customized_struct');
+  late final _wire_handle_customized_struct =
+      _wire_handle_customized_structPtr.asFunction<void Function(int, ffi.Pointer<wire_Customized>)>();
 
   void wire_handle_enum_struct(
     int port_,
@@ -3724,12 +3329,11 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_handle_enum_structPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64,
-              ffi.Pointer<wire_KitchenSink>)>>('wire_handle_enum_struct');
-  late final _wire_handle_enum_struct = _wire_handle_enum_structPtr
-      .asFunction<void Function(int, ffi.Pointer<wire_KitchenSink>)>();
+  late final _wire_handle_enum_structPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_KitchenSink>)>>(
+          'wire_handle_enum_struct');
+  late final _wire_handle_enum_struct =
+      _wire_handle_enum_structPtr.asFunction<void Function(int, ffi.Pointer<wire_KitchenSink>)>();
 
   void wire_use_imported_struct(
     int port_,
@@ -3741,12 +3345,10 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_use_imported_structPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64,
-              ffi.Pointer<wire_MyStruct>)>>('wire_use_imported_struct');
-  late final _wire_use_imported_struct = _wire_use_imported_structPtr
-      .asFunction<void Function(int, ffi.Pointer<wire_MyStruct>)>();
+  late final _wire_use_imported_structPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_MyStruct>)>>('wire_use_imported_struct');
+  late final _wire_use_imported_struct =
+      _wire_use_imported_structPtr.asFunction<void Function(int, ffi.Pointer<wire_MyStruct>)>();
 
   void wire_use_imported_enum(
     int port_,
@@ -3759,10 +3361,8 @@ class FlutterRustBridgeExampleSingleBlockTestWire
   }
 
   late final _wire_use_imported_enumPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>(
-          'wire_use_imported_enum');
-  late final _wire_use_imported_enum =
-      _wire_use_imported_enumPtr.asFunction<void Function(int, int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>('wire_use_imported_enum');
+  late final _wire_use_imported_enum = _wire_use_imported_enumPtr.asFunction<void Function(int, int)>();
 
   void wire_get_app_settings(
     int port_,
@@ -3773,10 +3373,8 @@ class FlutterRustBridgeExampleSingleBlockTestWire
   }
 
   late final _wire_get_app_settingsPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
-          'wire_get_app_settings');
-  late final _wire_get_app_settings =
-      _wire_get_app_settingsPtr.asFunction<void Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_get_app_settings');
+  late final _wire_get_app_settings = _wire_get_app_settingsPtr.asFunction<void Function(int)>();
 
   void wire_is_app_embedded(
     int port_,
@@ -3788,12 +3386,11 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_is_app_embeddedPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64,
-              ffi.Pointer<wire_ApplicationSettings>)>>('wire_is_app_embedded');
-  late final _wire_is_app_embedded = _wire_is_app_embeddedPtr
-      .asFunction<void Function(int, ffi.Pointer<wire_ApplicationSettings>)>();
+  late final _wire_is_app_embeddedPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_ApplicationSettings>)>>(
+          'wire_is_app_embedded');
+  late final _wire_is_app_embedded =
+      _wire_is_app_embeddedPtr.asFunction<void Function(int, ffi.Pointer<wire_ApplicationSettings>)>();
 
   void wire_get_message(
     int port_,
@@ -3803,11 +3400,8 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_get_messagePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
-          'wire_get_message');
-  late final _wire_get_message =
-      _wire_get_messagePtr.asFunction<void Function(int)>();
+  late final _wire_get_messagePtr = _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_get_message');
+  late final _wire_get_message = _wire_get_messagePtr.asFunction<void Function(int)>();
 
   void wire_repeat_number(
     int port_,
@@ -3821,12 +3415,9 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_repeat_numberPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-              ffi.Int64, ffi.Int32, uintptr_t)>>('wire_repeat_number');
-  late final _wire_repeat_number =
-      _wire_repeat_numberPtr.asFunction<void Function(int, int, int)>();
+  late final _wire_repeat_numberPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32, uintptr_t)>>('wire_repeat_number');
+  late final _wire_repeat_number = _wire_repeat_numberPtr.asFunction<void Function(int, int, int)>();
 
   void wire_repeat_sequence(
     int port_,
@@ -3840,12 +3431,9 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_repeat_sequencePtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-              ffi.Int64, ffi.Int32, uintptr_t)>>('wire_repeat_sequence');
-  late final _wire_repeat_sequence =
-      _wire_repeat_sequencePtr.asFunction<void Function(int, int, int)>();
+  late final _wire_repeat_sequencePtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32, uintptr_t)>>('wire_repeat_sequence');
+  late final _wire_repeat_sequence = _wire_repeat_sequencePtr.asFunction<void Function(int, int, int)>();
 
   void wire_first_number(
     int port_,
@@ -3857,12 +3445,9 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_first_numberPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-              ffi.Int64, ffi.Pointer<wire_Numbers>)>>('wire_first_number');
-  late final _wire_first_number = _wire_first_numberPtr
-      .asFunction<void Function(int, ffi.Pointer<wire_Numbers>)>();
+  late final _wire_first_numberPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_Numbers>)>>('wire_first_number');
+  late final _wire_first_number = _wire_first_numberPtr.asFunction<void Function(int, ffi.Pointer<wire_Numbers>)>();
 
   void wire_first_sequence(
     int port_,
@@ -3874,12 +3459,10 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_first_sequencePtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-              ffi.Int64, ffi.Pointer<wire_Sequences>)>>('wire_first_sequence');
-  late final _wire_first_sequence = _wire_first_sequencePtr
-      .asFunction<void Function(int, ffi.Pointer<wire_Sequences>)>();
+  late final _wire_first_sequencePtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_Sequences>)>>('wire_first_sequence');
+  late final _wire_first_sequence =
+      _wire_first_sequencePtr.asFunction<void Function(int, ffi.Pointer<wire_Sequences>)>();
 
   void wire_get_array(
     int port_,
@@ -3889,11 +3472,8 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_get_arrayPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
-          'wire_get_array');
-  late final _wire_get_array =
-      _wire_get_arrayPtr.asFunction<void Function(int)>();
+  late final _wire_get_arrayPtr = _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_get_array');
+  late final _wire_get_array = _wire_get_arrayPtr.asFunction<void Function(int)>();
 
   void wire_get_complex_array(
     int port_,
@@ -3904,10 +3484,8 @@ class FlutterRustBridgeExampleSingleBlockTestWire
   }
 
   late final _wire_get_complex_arrayPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
-          'wire_get_complex_array');
-  late final _wire_get_complex_array =
-      _wire_get_complex_arrayPtr.asFunction<void Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_get_complex_array');
+  late final _wire_get_complex_array = _wire_get_complex_arrayPtr.asFunction<void Function(int)>();
 
   void wire_get_usize(
     int port_,
@@ -3920,10 +3498,8 @@ class FlutterRustBridgeExampleSingleBlockTestWire
   }
 
   late final _wire_get_usizePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, uintptr_t)>>(
-          'wire_get_usize');
-  late final _wire_get_usize =
-      _wire_get_usizePtr.asFunction<void Function(int, int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, uintptr_t)>>('wire_get_usize');
+  late final _wire_get_usize = _wire_get_usizePtr.asFunction<void Function(int, int)>();
 
   void wire_next_user_id(
     int port_,
@@ -3935,12 +3511,9 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_next_user_idPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-              ffi.Int64, ffi.Pointer<wire_UserId>)>>('wire_next_user_id');
-  late final _wire_next_user_id = _wire_next_user_idPtr
-      .asFunction<void Function(int, ffi.Pointer<wire_UserId>)>();
+  late final _wire_next_user_idPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_UserId>)>>('wire_next_user_id');
+  late final _wire_next_user_id = _wire_next_user_idPtr.asFunction<void Function(int, ffi.Pointer<wire_UserId>)>();
 
   void wire_register_event_listener(
     int port_,
@@ -3951,10 +3524,8 @@ class FlutterRustBridgeExampleSingleBlockTestWire
   }
 
   late final _wire_register_event_listenerPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
-          'wire_register_event_listener');
-  late final _wire_register_event_listener =
-      _wire_register_event_listenerPtr.asFunction<void Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_register_event_listener');
+  late final _wire_register_event_listener = _wire_register_event_listenerPtr.asFunction<void Function(int)>();
 
   void wire_close_event_listener(
     int port_,
@@ -3965,10 +3536,8 @@ class FlutterRustBridgeExampleSingleBlockTestWire
   }
 
   late final _wire_close_event_listenerPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
-          'wire_close_event_listener');
-  late final _wire_close_event_listener =
-      _wire_close_event_listenerPtr.asFunction<void Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_close_event_listener');
+  late final _wire_close_event_listener = _wire_close_event_listenerPtr.asFunction<void Function(int)>();
 
   void wire_create_event(
     int port_,
@@ -3978,11 +3547,8 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_create_eventPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
-          'wire_create_event');
-  late final _wire_create_event =
-      _wire_create_eventPtr.asFunction<void Function(int)>();
+  late final _wire_create_eventPtr = _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_create_event');
+  late final _wire_create_event = _wire_create_eventPtr.asFunction<void Function(int)>();
 
   void wire_handle_stream_sink_at_1(
     int port_,
@@ -3996,12 +3562,10 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_handle_stream_sink_at_1Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64, ffi.Uint32,
-              ffi.Uint32)>>('wire_handle_stream_sink_at_1');
-  late final _wire_handle_stream_sink_at_1 = _wire_handle_stream_sink_at_1Ptr
-      .asFunction<void Function(int, int, int)>();
+  late final _wire_handle_stream_sink_at_1Ptr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Uint32, ffi.Uint32)>>('wire_handle_stream_sink_at_1');
+  late final _wire_handle_stream_sink_at_1 =
+      _wire_handle_stream_sink_at_1Ptr.asFunction<void Function(int, int, int)>();
 
   void wire_handle_stream_sink_at_2(
     int port_,
@@ -4015,12 +3579,10 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_handle_stream_sink_at_2Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64, ffi.Uint32,
-              ffi.Uint32)>>('wire_handle_stream_sink_at_2');
-  late final _wire_handle_stream_sink_at_2 = _wire_handle_stream_sink_at_2Ptr
-      .asFunction<void Function(int, int, int)>();
+  late final _wire_handle_stream_sink_at_2Ptr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Uint32, ffi.Uint32)>>('wire_handle_stream_sink_at_2');
+  late final _wire_handle_stream_sink_at_2 =
+      _wire_handle_stream_sink_at_2Ptr.asFunction<void Function(int, int, int)>();
 
   void wire_handle_stream_sink_at_3(
     int port_,
@@ -4034,12 +3596,10 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_handle_stream_sink_at_3Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64, ffi.Uint32,
-              ffi.Uint32)>>('wire_handle_stream_sink_at_3');
-  late final _wire_handle_stream_sink_at_3 = _wire_handle_stream_sink_at_3Ptr
-      .asFunction<void Function(int, int, int)>();
+  late final _wire_handle_stream_sink_at_3Ptr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Uint32, ffi.Uint32)>>('wire_handle_stream_sink_at_3');
+  late final _wire_handle_stream_sink_at_3 =
+      _wire_handle_stream_sink_at_3Ptr.asFunction<void Function(int, int, int)>();
 
   void wire_get_sum_struct(
     int port_,
@@ -4049,11 +3609,8 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_get_sum_structPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
-          'wire_get_sum_struct');
-  late final _wire_get_sum_struct =
-      _wire_get_sum_structPtr.asFunction<void Function(int)>();
+  late final _wire_get_sum_structPtr = _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_get_sum_struct');
+  late final _wire_get_sum_struct = _wire_get_sum_structPtr.asFunction<void Function(int)>();
 
   void wire_multiply_by_ten(
     int port_,
@@ -4065,12 +3622,10 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_multiply_by_tenPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-              ffi.Int64, ffi.Pointer<wire_Measure>)>>('wire_multiply_by_ten');
-  late final _wire_multiply_by_ten = _wire_multiply_by_tenPtr
-      .asFunction<void Function(int, ffi.Pointer<wire_Measure>)>();
+  late final _wire_multiply_by_tenPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_Measure>)>>('wire_multiply_by_ten');
+  late final _wire_multiply_by_ten =
+      _wire_multiply_by_tenPtr.asFunction<void Function(int, ffi.Pointer<wire_Measure>)>();
 
   void wire_call_old_module_system(
     int port_,
@@ -4081,10 +3636,8 @@ class FlutterRustBridgeExampleSingleBlockTestWire
   }
 
   late final _wire_call_old_module_systemPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
-          'wire_call_old_module_system');
-  late final _wire_call_old_module_system =
-      _wire_call_old_module_systemPtr.asFunction<void Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_call_old_module_system');
+  late final _wire_call_old_module_system = _wire_call_old_module_systemPtr.asFunction<void Function(int)>();
 
   void wire_call_new_module_system(
     int port_,
@@ -4095,10 +3648,8 @@ class FlutterRustBridgeExampleSingleBlockTestWire
   }
 
   late final _wire_call_new_module_systemPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
-          'wire_call_new_module_system');
-  late final _wire_call_new_module_system =
-      _wire_call_new_module_systemPtr.asFunction<void Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_call_new_module_system');
+  late final _wire_call_new_module_system = _wire_call_new_module_systemPtr.asFunction<void Function(int)>();
 
   void wire_sum__method__SumWith(
     int port_,
@@ -4114,12 +3665,11 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_sum__method__SumWithPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64, ffi.Pointer<wire_SumWith>, ffi.Uint32,
-              ffi.Uint32)>>('wire_sum__method__SumWith');
-  late final _wire_sum__method__SumWith = _wire_sum__method__SumWithPtr
-      .asFunction<void Function(int, ffi.Pointer<wire_SumWith>, int, int)>();
+  late final _wire_sum__method__SumWithPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_SumWith>, ffi.Uint32, ffi.Uint32)>>(
+          'wire_sum__method__SumWith');
+  late final _wire_sum__method__SumWith =
+      _wire_sum__method__SumWithPtr.asFunction<void Function(int, ffi.Pointer<wire_SumWith>, int, int)>();
 
   void wire_new__static_method__ConcatenateWith(
     int port_,
@@ -4131,13 +3681,11 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_new__static_method__ConcatenateWithPtr = _lookup<
-          ffi.NativeFunction<
-              ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>(
-      'wire_new__static_method__ConcatenateWith');
+  late final _wire_new__static_method__ConcatenateWithPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>(
+          'wire_new__static_method__ConcatenateWith');
   late final _wire_new__static_method__ConcatenateWith =
-      _wire_new__static_method__ConcatenateWithPtr
-          .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+      _wire_new__static_method__ConcatenateWithPtr.asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_concatenate__method__ConcatenateWith(
     int port_,
@@ -4152,14 +3700,11 @@ class FlutterRustBridgeExampleSingleBlockTestWire
   }
 
   late final _wire_concatenate__method__ConcatenateWithPtr = _lookup<
-          ffi.NativeFunction<
-              ffi.Void Function(ffi.Int64, ffi.Pointer<wire_ConcatenateWith>,
-                  ffi.Pointer<wire_uint_8_list>)>>(
-      'wire_concatenate__method__ConcatenateWith');
-  late final _wire_concatenate__method__ConcatenateWith =
-      _wire_concatenate__method__ConcatenateWithPtr.asFunction<
-          void Function(int, ffi.Pointer<wire_ConcatenateWith>,
-              ffi.Pointer<wire_uint_8_list>)>();
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Int64, ffi.Pointer<wire_ConcatenateWith>,
+              ffi.Pointer<wire_uint_8_list>)>>('wire_concatenate__method__ConcatenateWith');
+  late final _wire_concatenate__method__ConcatenateWith = _wire_concatenate__method__ConcatenateWithPtr
+      .asFunction<void Function(int, ffi.Pointer<wire_ConcatenateWith>, ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_concatenate_static__static_method__ConcatenateWith(
     int port_,
@@ -4173,16 +3718,13 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_concatenate_static__static_method__ConcatenateWithPtr =
-      _lookup<
-              ffi.NativeFunction<
-                  ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>,
-                      ffi.Pointer<wire_uint_8_list>)>>(
-          'wire_concatenate_static__static_method__ConcatenateWith');
+  late final _wire_concatenate_static__static_method__ConcatenateWithPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>,
+              ffi.Pointer<wire_uint_8_list>)>>('wire_concatenate_static__static_method__ConcatenateWith');
   late final _wire_concatenate_static__static_method__ConcatenateWith =
-      _wire_concatenate_static__static_method__ConcatenateWithPtr.asFunction<
-          void Function(int, ffi.Pointer<wire_uint_8_list>,
-              ffi.Pointer<wire_uint_8_list>)>();
+      _wire_concatenate_static__static_method__ConcatenateWithPtr
+          .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>, ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_handle_some_stream_sink__method__ConcatenateWith(
     int port_,
@@ -4198,18 +3740,12 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _wire_handle_some_stream_sink__method__ConcatenateWithPtr =
-      _lookup<
-              ffi.NativeFunction<
-                  ffi.Void Function(
-                      ffi.Int64,
-                      ffi.Pointer<wire_ConcatenateWith>,
-                      ffi.Uint32,
-                      ffi.Uint32)>>(
-          'wire_handle_some_stream_sink__method__ConcatenateWith');
+  late final _wire_handle_some_stream_sink__method__ConcatenateWithPtr = _lookup<
+          ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_ConcatenateWith>, ffi.Uint32, ffi.Uint32)>>(
+      'wire_handle_some_stream_sink__method__ConcatenateWith');
   late final _wire_handle_some_stream_sink__method__ConcatenateWith =
-      _wire_handle_some_stream_sink__method__ConcatenateWithPtr.asFunction<
-          void Function(int, ffi.Pointer<wire_ConcatenateWith>, int, int)>();
+      _wire_handle_some_stream_sink__method__ConcatenateWithPtr
+          .asFunction<void Function(int, ffi.Pointer<wire_ConcatenateWith>, int, int)>();
 
   void wire_handle_some_stream_sink_at_1__method__ConcatenateWith(
     int port_,
@@ -4222,10 +3758,7 @@ class FlutterRustBridgeExampleSingleBlockTestWire
   }
 
   late final _wire_handle_some_stream_sink_at_1__method__ConcatenateWithPtr =
-      _lookup<
-              ffi.NativeFunction<
-                  ffi.Void Function(
-                      ffi.Int64, ffi.Pointer<wire_ConcatenateWith>)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_ConcatenateWith>)>>(
           'wire_handle_some_stream_sink_at_1__method__ConcatenateWith');
   late final _wire_handle_some_stream_sink_at_1__method__ConcatenateWith =
       _wire_handle_some_stream_sink_at_1__method__ConcatenateWithPtr
@@ -4244,16 +3777,13 @@ class FlutterRustBridgeExampleSingleBlockTestWire
   }
 
   late final _wire_handle_some_static_stream_sink__static_method__ConcatenateWithPtr =
-      _lookup<
-              ffi.NativeFunction<
-                  ffi.Void Function(ffi.Int64, ffi.Uint32, ffi.Uint32)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Uint32, ffi.Uint32)>>(
           'wire_handle_some_static_stream_sink__static_method__ConcatenateWith');
   late final _wire_handle_some_static_stream_sink__static_method__ConcatenateWith =
       _wire_handle_some_static_stream_sink__static_method__ConcatenateWithPtr
           .asFunction<void Function(int, int, int)>();
 
-  void
-      wire_handle_some_static_stream_sink_single_arg__static_method__ConcatenateWith(
+  void wire_handle_some_static_stream_sink_single_arg__static_method__ConcatenateWith(
     int port_,
   ) {
     return _wire_handle_some_static_stream_sink_single_arg__static_method__ConcatenateWith(
@@ -4276,43 +3806,37 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _new_StringList_0Ptr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<wire_StringList> Function(ffi.Int32)>>(
-      'new_StringList_0');
-  late final _new_StringList_0 = _new_StringList_0Ptr
-      .asFunction<ffi.Pointer<wire_StringList> Function(int)>();
+  late final _new_StringList_0Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_StringList> Function(ffi.Int32)>>('new_StringList_0');
+  late final _new_StringList_0 = _new_StringList_0Ptr.asFunction<ffi.Pointer<wire_StringList> Function(int)>();
 
   ffi.Pointer<wire_ApplicationEnv> new_box_application_env_0() {
     return _new_box_application_env_0();
   }
 
   late final _new_box_application_env_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_ApplicationEnv> Function()>>(
-          'new_box_application_env_0');
-  late final _new_box_application_env_0 = _new_box_application_env_0Ptr
-      .asFunction<ffi.Pointer<wire_ApplicationEnv> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_ApplicationEnv> Function()>>('new_box_application_env_0');
+  late final _new_box_application_env_0 =
+      _new_box_application_env_0Ptr.asFunction<ffi.Pointer<wire_ApplicationEnv> Function()>();
 
-  ffi.Pointer<wire_ApplicationSettings>
-      new_box_autoadd_application_settings_0() {
+  ffi.Pointer<wire_ApplicationSettings> new_box_autoadd_application_settings_0() {
     return _new_box_autoadd_application_settings_0();
   }
 
-  late final _new_box_autoadd_application_settings_0Ptr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<wire_ApplicationSettings> Function()>>(
-      'new_box_autoadd_application_settings_0');
+  late final _new_box_autoadd_application_settings_0Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_ApplicationSettings> Function()>>(
+          'new_box_autoadd_application_settings_0');
   late final _new_box_autoadd_application_settings_0 =
-      _new_box_autoadd_application_settings_0Ptr
-          .asFunction<ffi.Pointer<wire_ApplicationSettings> Function()>();
+      _new_box_autoadd_application_settings_0Ptr.asFunction<ffi.Pointer<wire_ApplicationSettings> Function()>();
 
   ffi.Pointer<wire_Attribute> new_box_autoadd_attribute_0() {
     return _new_box_autoadd_attribute_0();
   }
 
   late final _new_box_autoadd_attribute_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Attribute> Function()>>(
-          'new_box_autoadd_attribute_0');
-  late final _new_box_autoadd_attribute_0 = _new_box_autoadd_attribute_0Ptr
-      .asFunction<ffi.Pointer<wire_Attribute> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Attribute> Function()>>('new_box_autoadd_attribute_0');
+  late final _new_box_autoadd_attribute_0 =
+      _new_box_autoadd_attribute_0Ptr.asFunction<ffi.Pointer<wire_Attribute> Function()>();
 
   ffi.Pointer<ffi.Bool> new_box_autoadd_bool_0(
     bool value,
@@ -4323,42 +3847,35 @@ class FlutterRustBridgeExampleSingleBlockTestWire
   }
 
   late final _new_box_autoadd_bool_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Bool> Function(ffi.Bool)>>(
-          'new_box_autoadd_bool_0');
-  late final _new_box_autoadd_bool_0 = _new_box_autoadd_bool_0Ptr
-      .asFunction<ffi.Pointer<ffi.Bool> Function(bool)>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Bool> Function(ffi.Bool)>>('new_box_autoadd_bool_0');
+  late final _new_box_autoadd_bool_0 = _new_box_autoadd_bool_0Ptr.asFunction<ffi.Pointer<ffi.Bool> Function(bool)>();
 
   ffi.Pointer<wire_ConcatenateWith> new_box_autoadd_concatenate_with_0() {
     return _new_box_autoadd_concatenate_with_0();
   }
 
   late final _new_box_autoadd_concatenate_with_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_ConcatenateWith> Function()>>(
-          'new_box_autoadd_concatenate_with_0');
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_ConcatenateWith> Function()>>('new_box_autoadd_concatenate_with_0');
   late final _new_box_autoadd_concatenate_with_0 =
-      _new_box_autoadd_concatenate_with_0Ptr
-          .asFunction<ffi.Pointer<wire_ConcatenateWith> Function()>();
+      _new_box_autoadd_concatenate_with_0Ptr.asFunction<ffi.Pointer<wire_ConcatenateWith> Function()>();
 
   ffi.Pointer<wire_Customized> new_box_autoadd_customized_0() {
     return _new_box_autoadd_customized_0();
   }
 
   late final _new_box_autoadd_customized_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Customized> Function()>>(
-          'new_box_autoadd_customized_0');
-  late final _new_box_autoadd_customized_0 = _new_box_autoadd_customized_0Ptr
-      .asFunction<ffi.Pointer<wire_Customized> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Customized> Function()>>('new_box_autoadd_customized_0');
+  late final _new_box_autoadd_customized_0 =
+      _new_box_autoadd_customized_0Ptr.asFunction<ffi.Pointer<wire_Customized> Function()>();
 
   ffi.Pointer<wire_ExoticOptionals> new_box_autoadd_exotic_optionals_0() {
     return _new_box_autoadd_exotic_optionals_0();
   }
 
   late final _new_box_autoadd_exotic_optionals_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_ExoticOptionals> Function()>>(
-          'new_box_autoadd_exotic_optionals_0');
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_ExoticOptionals> Function()>>('new_box_autoadd_exotic_optionals_0');
   late final _new_box_autoadd_exotic_optionals_0 =
-      _new_box_autoadd_exotic_optionals_0Ptr
-          .asFunction<ffi.Pointer<wire_ExoticOptionals> Function()>();
+      _new_box_autoadd_exotic_optionals_0Ptr.asFunction<ffi.Pointer<wire_ExoticOptionals> Function()>();
 
   ffi.Pointer<ffi.Double> new_box_autoadd_f64_0(
     double value,
@@ -4369,10 +3886,8 @@ class FlutterRustBridgeExampleSingleBlockTestWire
   }
 
   late final _new_box_autoadd_f64_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Double> Function(ffi.Double)>>(
-          'new_box_autoadd_f64_0');
-  late final _new_box_autoadd_f64_0 = _new_box_autoadd_f64_0Ptr
-      .asFunction<ffi.Pointer<ffi.Double> Function(double)>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Double> Function(ffi.Double)>>('new_box_autoadd_f64_0');
+  late final _new_box_autoadd_f64_0 = _new_box_autoadd_f64_0Ptr.asFunction<ffi.Pointer<ffi.Double> Function(double)>();
 
   ffi.Pointer<ffi.Int32> new_box_autoadd_i32_0(
     int value,
@@ -4383,10 +3898,8 @@ class FlutterRustBridgeExampleSingleBlockTestWire
   }
 
   late final _new_box_autoadd_i32_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int32> Function(ffi.Int32)>>(
-          'new_box_autoadd_i32_0');
-  late final _new_box_autoadd_i32_0 = _new_box_autoadd_i32_0Ptr
-      .asFunction<ffi.Pointer<ffi.Int32> Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int32> Function(ffi.Int32)>>('new_box_autoadd_i32_0');
+  late final _new_box_autoadd_i32_0 = _new_box_autoadd_i32_0Ptr.asFunction<ffi.Pointer<ffi.Int32> Function(int)>();
 
   ffi.Pointer<ffi.Int64> new_box_autoadd_i64_0(
     int value,
@@ -4397,123 +3910,106 @@ class FlutterRustBridgeExampleSingleBlockTestWire
   }
 
   late final _new_box_autoadd_i64_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int64> Function(ffi.Int64)>>(
-          'new_box_autoadd_i64_0');
-  late final _new_box_autoadd_i64_0 = _new_box_autoadd_i64_0Ptr
-      .asFunction<ffi.Pointer<ffi.Int64> Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int64> Function(ffi.Int64)>>('new_box_autoadd_i64_0');
+  late final _new_box_autoadd_i64_0 = _new_box_autoadd_i64_0Ptr.asFunction<ffi.Pointer<ffi.Int64> Function(int)>();
 
   ffi.Pointer<wire_KitchenSink> new_box_autoadd_kitchen_sink_0() {
     return _new_box_autoadd_kitchen_sink_0();
   }
 
   late final _new_box_autoadd_kitchen_sink_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_KitchenSink> Function()>>(
-          'new_box_autoadd_kitchen_sink_0');
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_KitchenSink> Function()>>('new_box_autoadd_kitchen_sink_0');
   late final _new_box_autoadd_kitchen_sink_0 =
-      _new_box_autoadd_kitchen_sink_0Ptr
-          .asFunction<ffi.Pointer<wire_KitchenSink> Function()>();
+      _new_box_autoadd_kitchen_sink_0Ptr.asFunction<ffi.Pointer<wire_KitchenSink> Function()>();
 
   ffi.Pointer<wire_Measure> new_box_autoadd_measure_0() {
     return _new_box_autoadd_measure_0();
   }
 
   late final _new_box_autoadd_measure_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Measure> Function()>>(
-          'new_box_autoadd_measure_0');
-  late final _new_box_autoadd_measure_0 = _new_box_autoadd_measure_0Ptr
-      .asFunction<ffi.Pointer<wire_Measure> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Measure> Function()>>('new_box_autoadd_measure_0');
+  late final _new_box_autoadd_measure_0 =
+      _new_box_autoadd_measure_0Ptr.asFunction<ffi.Pointer<wire_Measure> Function()>();
 
   ffi.Pointer<wire_MySize> new_box_autoadd_my_size_0() {
     return _new_box_autoadd_my_size_0();
   }
 
   late final _new_box_autoadd_my_size_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_MySize> Function()>>(
-          'new_box_autoadd_my_size_0');
-  late final _new_box_autoadd_my_size_0 = _new_box_autoadd_my_size_0Ptr
-      .asFunction<ffi.Pointer<wire_MySize> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_MySize> Function()>>('new_box_autoadd_my_size_0');
+  late final _new_box_autoadd_my_size_0 =
+      _new_box_autoadd_my_size_0Ptr.asFunction<ffi.Pointer<wire_MySize> Function()>();
 
   ffi.Pointer<wire_MyStruct> new_box_autoadd_my_struct_0() {
     return _new_box_autoadd_my_struct_0();
   }
 
   late final _new_box_autoadd_my_struct_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_MyStruct> Function()>>(
-          'new_box_autoadd_my_struct_0');
-  late final _new_box_autoadd_my_struct_0 = _new_box_autoadd_my_struct_0Ptr
-      .asFunction<ffi.Pointer<wire_MyStruct> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_MyStruct> Function()>>('new_box_autoadd_my_struct_0');
+  late final _new_box_autoadd_my_struct_0 =
+      _new_box_autoadd_my_struct_0Ptr.asFunction<ffi.Pointer<wire_MyStruct> Function()>();
 
   ffi.Pointer<wire_MyTreeNode> new_box_autoadd_my_tree_node_0() {
     return _new_box_autoadd_my_tree_node_0();
   }
 
   late final _new_box_autoadd_my_tree_node_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_MyTreeNode> Function()>>(
-          'new_box_autoadd_my_tree_node_0');
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_MyTreeNode> Function()>>('new_box_autoadd_my_tree_node_0');
   late final _new_box_autoadd_my_tree_node_0 =
-      _new_box_autoadd_my_tree_node_0Ptr
-          .asFunction<ffi.Pointer<wire_MyTreeNode> Function()>();
+      _new_box_autoadd_my_tree_node_0Ptr.asFunction<ffi.Pointer<wire_MyTreeNode> Function()>();
 
   ffi.Pointer<wire_NewTypeInt> new_box_autoadd_new_type_int_0() {
     return _new_box_autoadd_new_type_int_0();
   }
 
   late final _new_box_autoadd_new_type_int_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_NewTypeInt> Function()>>(
-          'new_box_autoadd_new_type_int_0');
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_NewTypeInt> Function()>>('new_box_autoadd_new_type_int_0');
   late final _new_box_autoadd_new_type_int_0 =
-      _new_box_autoadd_new_type_int_0Ptr
-          .asFunction<ffi.Pointer<wire_NewTypeInt> Function()>();
+      _new_box_autoadd_new_type_int_0Ptr.asFunction<ffi.Pointer<wire_NewTypeInt> Function()>();
 
   ffi.Pointer<wire_Note> new_box_autoadd_note_0() {
     return _new_box_autoadd_note_0();
   }
 
   late final _new_box_autoadd_note_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Note> Function()>>(
-          'new_box_autoadd_note_0');
-  late final _new_box_autoadd_note_0 = _new_box_autoadd_note_0Ptr
-      .asFunction<ffi.Pointer<wire_Note> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Note> Function()>>('new_box_autoadd_note_0');
+  late final _new_box_autoadd_note_0 = _new_box_autoadd_note_0Ptr.asFunction<ffi.Pointer<wire_Note> Function()>();
 
   ffi.Pointer<wire_Numbers> new_box_autoadd_numbers_0() {
     return _new_box_autoadd_numbers_0();
   }
 
   late final _new_box_autoadd_numbers_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Numbers> Function()>>(
-          'new_box_autoadd_numbers_0');
-  late final _new_box_autoadd_numbers_0 = _new_box_autoadd_numbers_0Ptr
-      .asFunction<ffi.Pointer<wire_Numbers> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Numbers> Function()>>('new_box_autoadd_numbers_0');
+  late final _new_box_autoadd_numbers_0 =
+      _new_box_autoadd_numbers_0Ptr.asFunction<ffi.Pointer<wire_Numbers> Function()>();
 
   ffi.Pointer<wire_Sequences> new_box_autoadd_sequences_0() {
     return _new_box_autoadd_sequences_0();
   }
 
   late final _new_box_autoadd_sequences_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Sequences> Function()>>(
-          'new_box_autoadd_sequences_0');
-  late final _new_box_autoadd_sequences_0 = _new_box_autoadd_sequences_0Ptr
-      .asFunction<ffi.Pointer<wire_Sequences> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Sequences> Function()>>('new_box_autoadd_sequences_0');
+  late final _new_box_autoadd_sequences_0 =
+      _new_box_autoadd_sequences_0Ptr.asFunction<ffi.Pointer<wire_Sequences> Function()>();
 
   ffi.Pointer<wire_SumWith> new_box_autoadd_sum_with_0() {
     return _new_box_autoadd_sum_with_0();
   }
 
   late final _new_box_autoadd_sum_with_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_SumWith> Function()>>(
-          'new_box_autoadd_sum_with_0');
-  late final _new_box_autoadd_sum_with_0 = _new_box_autoadd_sum_with_0Ptr
-      .asFunction<ffi.Pointer<wire_SumWith> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_SumWith> Function()>>('new_box_autoadd_sum_with_0');
+  late final _new_box_autoadd_sum_with_0 =
+      _new_box_autoadd_sum_with_0Ptr.asFunction<ffi.Pointer<wire_SumWith> Function()>();
 
   ffi.Pointer<wire_UserId> new_box_autoadd_user_id_0() {
     return _new_box_autoadd_user_id_0();
   }
 
   late final _new_box_autoadd_user_id_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_UserId> Function()>>(
-          'new_box_autoadd_user_id_0');
-  late final _new_box_autoadd_user_id_0 = _new_box_autoadd_user_id_0Ptr
-      .asFunction<ffi.Pointer<wire_UserId> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_UserId> Function()>>('new_box_autoadd_user_id_0');
+  late final _new_box_autoadd_user_id_0 =
+      _new_box_autoadd_user_id_0Ptr.asFunction<ffi.Pointer<wire_UserId> Function()>();
 
   ffi.Pointer<ffi.Bool> new_box_bool_0(
     bool value,
@@ -4524,30 +4020,25 @@ class FlutterRustBridgeExampleSingleBlockTestWire
   }
 
   late final _new_box_bool_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Bool> Function(ffi.Bool)>>(
-          'new_box_bool_0');
-  late final _new_box_bool_0 =
-      _new_box_bool_0Ptr.asFunction<ffi.Pointer<ffi.Bool> Function(bool)>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Bool> Function(ffi.Bool)>>('new_box_bool_0');
+  late final _new_box_bool_0 = _new_box_bool_0Ptr.asFunction<ffi.Pointer<ffi.Bool> Function(bool)>();
 
   ffi.Pointer<wire_Distance> new_box_distance_0() {
     return _new_box_distance_0();
   }
 
   late final _new_box_distance_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Distance> Function()>>(
-          'new_box_distance_0');
-  late final _new_box_distance_0 = _new_box_distance_0Ptr
-      .asFunction<ffi.Pointer<wire_Distance> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Distance> Function()>>('new_box_distance_0');
+  late final _new_box_distance_0 = _new_box_distance_0Ptr.asFunction<ffi.Pointer<wire_Distance> Function()>();
 
   ffi.Pointer<wire_ExoticOptionals> new_box_exotic_optionals_0() {
     return _new_box_exotic_optionals_0();
   }
 
   late final _new_box_exotic_optionals_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_ExoticOptionals> Function()>>(
-          'new_box_exotic_optionals_0');
-  late final _new_box_exotic_optionals_0 = _new_box_exotic_optionals_0Ptr
-      .asFunction<ffi.Pointer<wire_ExoticOptionals> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_ExoticOptionals> Function()>>('new_box_exotic_optionals_0');
+  late final _new_box_exotic_optionals_0 =
+      _new_box_exotic_optionals_0Ptr.asFunction<ffi.Pointer<wire_ExoticOptionals> Function()>();
 
   ffi.Pointer<ffi.Double> new_box_f64_0(
     double value,
@@ -4558,10 +4049,8 @@ class FlutterRustBridgeExampleSingleBlockTestWire
   }
 
   late final _new_box_f64_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Double> Function(ffi.Double)>>(
-          'new_box_f64_0');
-  late final _new_box_f64_0 =
-      _new_box_f64_0Ptr.asFunction<ffi.Pointer<ffi.Double> Function(double)>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Double> Function(ffi.Double)>>('new_box_f64_0');
+  late final _new_box_f64_0 = _new_box_f64_0Ptr.asFunction<ffi.Pointer<ffi.Double> Function(double)>();
 
   ffi.Pointer<ffi.Int32> new_box_i32_0(
     int value,
@@ -4572,10 +4061,8 @@ class FlutterRustBridgeExampleSingleBlockTestWire
   }
 
   late final _new_box_i32_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int32> Function(ffi.Int32)>>(
-          'new_box_i32_0');
-  late final _new_box_i32_0 =
-      _new_box_i32_0Ptr.asFunction<ffi.Pointer<ffi.Int32> Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int32> Function(ffi.Int32)>>('new_box_i32_0');
+  late final _new_box_i32_0 = _new_box_i32_0Ptr.asFunction<ffi.Pointer<ffi.Int32> Function(int)>();
 
   ffi.Pointer<ffi.Int64> new_box_i64_0(
     int value,
@@ -4586,10 +4073,8 @@ class FlutterRustBridgeExampleSingleBlockTestWire
   }
 
   late final _new_box_i64_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int64> Function(ffi.Int64)>>(
-          'new_box_i64_0');
-  late final _new_box_i64_0 =
-      _new_box_i64_0Ptr.asFunction<ffi.Pointer<ffi.Int64> Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int64> Function(ffi.Int64)>>('new_box_i64_0');
+  late final _new_box_i64_0 = _new_box_i64_0Ptr.asFunction<ffi.Pointer<ffi.Int64> Function(int)>();
 
   ffi.Pointer<ffi.Int8> new_box_i8_0(
     int value,
@@ -4599,41 +4084,32 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _new_box_i8_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int8> Function(ffi.Int8)>>(
-          'new_box_i8_0');
-  late final _new_box_i8_0 =
-      _new_box_i8_0Ptr.asFunction<ffi.Pointer<ffi.Int8> Function(int)>();
+  late final _new_box_i8_0Ptr = _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int8> Function(ffi.Int8)>>('new_box_i8_0');
+  late final _new_box_i8_0 = _new_box_i8_0Ptr.asFunction<ffi.Pointer<ffi.Int8> Function(int)>();
 
   ffi.Pointer<wire_KitchenSink> new_box_kitchen_sink_0() {
     return _new_box_kitchen_sink_0();
   }
 
   late final _new_box_kitchen_sink_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_KitchenSink> Function()>>(
-          'new_box_kitchen_sink_0');
-  late final _new_box_kitchen_sink_0 = _new_box_kitchen_sink_0Ptr
-      .asFunction<ffi.Pointer<wire_KitchenSink> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_KitchenSink> Function()>>('new_box_kitchen_sink_0');
+  late final _new_box_kitchen_sink_0 =
+      _new_box_kitchen_sink_0Ptr.asFunction<ffi.Pointer<wire_KitchenSink> Function()>();
 
   ffi.Pointer<wire_MySize> new_box_my_size_0() {
     return _new_box_my_size_0();
   }
 
   late final _new_box_my_size_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_MySize> Function()>>(
-          'new_box_my_size_0');
-  late final _new_box_my_size_0 =
-      _new_box_my_size_0Ptr.asFunction<ffi.Pointer<wire_MySize> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_MySize> Function()>>('new_box_my_size_0');
+  late final _new_box_my_size_0 = _new_box_my_size_0Ptr.asFunction<ffi.Pointer<wire_MySize> Function()>();
 
   ffi.Pointer<wire_Speed> new_box_speed_0() {
     return _new_box_speed_0();
   }
 
-  late final _new_box_speed_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Speed> Function()>>(
-          'new_box_speed_0');
-  late final _new_box_speed_0 =
-      _new_box_speed_0Ptr.asFunction<ffi.Pointer<wire_Speed> Function()>();
+  late final _new_box_speed_0Ptr = _lookup<ffi.NativeFunction<ffi.Pointer<wire_Speed> Function()>>('new_box_speed_0');
+  late final _new_box_speed_0 = _new_box_speed_0Ptr.asFunction<ffi.Pointer<wire_Speed> Function()>();
 
   ffi.Pointer<ffi.Uint8> new_box_u8_0(
     int value,
@@ -4643,11 +4119,8 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _new_box_u8_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Uint8> Function(ffi.Uint8)>>(
-          'new_box_u8_0');
-  late final _new_box_u8_0 =
-      _new_box_u8_0Ptr.asFunction<ffi.Pointer<ffi.Uint8> Function(int)>();
+  late final _new_box_u8_0Ptr = _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Uint8> Function(ffi.Uint8)>>('new_box_u8_0');
+  late final _new_box_u8_0 = _new_box_u8_0Ptr.asFunction<ffi.Pointer<ffi.Uint8> Function(int)>();
 
   ffi.Pointer<ffi.Int32> new_box_weekdays_0(
     int value,
@@ -4658,10 +4131,8 @@ class FlutterRustBridgeExampleSingleBlockTestWire
   }
 
   late final _new_box_weekdays_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int32> Function(ffi.Int32)>>(
-          'new_box_weekdays_0');
-  late final _new_box_weekdays_0 =
-      _new_box_weekdays_0Ptr.asFunction<ffi.Pointer<ffi.Int32> Function(int)>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int32> Function(ffi.Int32)>>('new_box_weekdays_0');
+  late final _new_box_weekdays_0 = _new_box_weekdays_0Ptr.asFunction<ffi.Pointer<ffi.Int32> Function(int)>();
 
   ffi.Pointer<wire_float_32_list> new_float_32_list_0(
     int len,
@@ -4671,12 +4142,9 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _new_float_32_list_0Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<wire_float_32_list> Function(
-              ffi.Int32)>>('new_float_32_list_0');
-  late final _new_float_32_list_0 = _new_float_32_list_0Ptr
-      .asFunction<ffi.Pointer<wire_float_32_list> Function(int)>();
+  late final _new_float_32_list_0Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_float_32_list> Function(ffi.Int32)>>('new_float_32_list_0');
+  late final _new_float_32_list_0 = _new_float_32_list_0Ptr.asFunction<ffi.Pointer<wire_float_32_list> Function(int)>();
 
   ffi.Pointer<wire_float_64_list> new_float_64_list_0(
     int len,
@@ -4686,12 +4154,9 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _new_float_64_list_0Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<wire_float_64_list> Function(
-              ffi.Int32)>>('new_float_64_list_0');
-  late final _new_float_64_list_0 = _new_float_64_list_0Ptr
-      .asFunction<ffi.Pointer<wire_float_64_list> Function(int)>();
+  late final _new_float_64_list_0Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_float_64_list> Function(ffi.Int32)>>('new_float_64_list_0');
+  late final _new_float_64_list_0 = _new_float_64_list_0Ptr.asFunction<ffi.Pointer<wire_float_64_list> Function(int)>();
 
   ffi.Pointer<wire_int_32_list> new_int_32_list_0(
     int len,
@@ -4701,12 +4166,9 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _new_int_32_list_0Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<wire_int_32_list> Function(
-              ffi.Int32)>>('new_int_32_list_0');
-  late final _new_int_32_list_0 = _new_int_32_list_0Ptr
-      .asFunction<ffi.Pointer<wire_int_32_list> Function(int)>();
+  late final _new_int_32_list_0Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_int_32_list> Function(ffi.Int32)>>('new_int_32_list_0');
+  late final _new_int_32_list_0 = _new_int_32_list_0Ptr.asFunction<ffi.Pointer<wire_int_32_list> Function(int)>();
 
   ffi.Pointer<wire_int_64_list> new_int_64_list_0(
     int len,
@@ -4716,12 +4178,9 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _new_int_64_list_0Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<wire_int_64_list> Function(
-              ffi.Int32)>>('new_int_64_list_0');
-  late final _new_int_64_list_0 = _new_int_64_list_0Ptr
-      .asFunction<ffi.Pointer<wire_int_64_list> Function(int)>();
+  late final _new_int_64_list_0Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_int_64_list> Function(ffi.Int32)>>('new_int_64_list_0');
+  late final _new_int_64_list_0 = _new_int_64_list_0Ptr.asFunction<ffi.Pointer<wire_int_64_list> Function(int)>();
 
   ffi.Pointer<wire_int_8_list> new_int_8_list_0(
     int len,
@@ -4731,11 +4190,9 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _new_int_8_list_0Ptr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<wire_int_8_list> Function(ffi.Int32)>>(
-      'new_int_8_list_0');
-  late final _new_int_8_list_0 = _new_int_8_list_0Ptr
-      .asFunction<ffi.Pointer<wire_int_8_list> Function(int)>();
+  late final _new_int_8_list_0Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_int_8_list> Function(ffi.Int32)>>('new_int_8_list_0');
+  late final _new_int_8_list_0 = _new_int_8_list_0Ptr.asFunction<ffi.Pointer<wire_int_8_list> Function(int)>();
 
   ffi.Pointer<wire_list_application_env_var> new_list_application_env_var_0(
     int len,
@@ -4745,13 +4202,11 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _new_list_application_env_var_0Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<wire_list_application_env_var> Function(
-              ffi.Int32)>>('new_list_application_env_var_0');
+  late final _new_list_application_env_var_0Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_list_application_env_var> Function(ffi.Int32)>>(
+          'new_list_application_env_var_0');
   late final _new_list_application_env_var_0 =
-      _new_list_application_env_var_0Ptr.asFunction<
-          ffi.Pointer<wire_list_application_env_var> Function(int)>();
+      _new_list_application_env_var_0Ptr.asFunction<ffi.Pointer<wire_list_application_env_var> Function(int)>();
 
   ffi.Pointer<wire_list_attribute> new_list_attribute_0(
     int len,
@@ -4761,12 +4216,10 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _new_list_attribute_0Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<wire_list_attribute> Function(
-              ffi.Int32)>>('new_list_attribute_0');
-  late final _new_list_attribute_0 = _new_list_attribute_0Ptr
-      .asFunction<ffi.Pointer<wire_list_attribute> Function(int)>();
+  late final _new_list_attribute_0Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_list_attribute> Function(ffi.Int32)>>('new_list_attribute_0');
+  late final _new_list_attribute_0 =
+      _new_list_attribute_0Ptr.asFunction<ffi.Pointer<wire_list_attribute> Function(int)>();
 
   ffi.Pointer<wire_list_my_size> new_list_my_size_0(
     int len,
@@ -4776,12 +4229,9 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _new_list_my_size_0Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<wire_list_my_size> Function(
-              ffi.Int32)>>('new_list_my_size_0');
-  late final _new_list_my_size_0 = _new_list_my_size_0Ptr
-      .asFunction<ffi.Pointer<wire_list_my_size> Function(int)>();
+  late final _new_list_my_size_0Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_list_my_size> Function(ffi.Int32)>>('new_list_my_size_0');
+  late final _new_list_my_size_0 = _new_list_my_size_0Ptr.asFunction<ffi.Pointer<wire_list_my_size> Function(int)>();
 
   ffi.Pointer<wire_list_my_tree_node> new_list_my_tree_node_0(
     int len,
@@ -4791,15 +4241,12 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _new_list_my_tree_node_0Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<wire_list_my_tree_node> Function(
-              ffi.Int32)>>('new_list_my_tree_node_0');
-  late final _new_list_my_tree_node_0 = _new_list_my_tree_node_0Ptr
-      .asFunction<ffi.Pointer<wire_list_my_tree_node> Function(int)>();
+  late final _new_list_my_tree_node_0Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_list_my_tree_node> Function(ffi.Int32)>>('new_list_my_tree_node_0');
+  late final _new_list_my_tree_node_0 =
+      _new_list_my_tree_node_0Ptr.asFunction<ffi.Pointer<wire_list_my_tree_node> Function(int)>();
 
-  ffi.Pointer<wire_list_opt_box_autoadd_attribute>
-      new_list_opt_box_autoadd_attribute_0(
+  ffi.Pointer<wire_list_opt_box_autoadd_attribute> new_list_opt_box_autoadd_attribute_0(
     int len,
   ) {
     return _new_list_opt_box_autoadd_attribute_0(
@@ -4807,13 +4254,11 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _new_list_opt_box_autoadd_attribute_0Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<wire_list_opt_box_autoadd_attribute> Function(
-              ffi.Int32)>>('new_list_opt_box_autoadd_attribute_0');
-  late final _new_list_opt_box_autoadd_attribute_0 =
-      _new_list_opt_box_autoadd_attribute_0Ptr.asFunction<
-          ffi.Pointer<wire_list_opt_box_autoadd_attribute> Function(int)>();
+  late final _new_list_opt_box_autoadd_attribute_0Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_list_opt_box_autoadd_attribute> Function(ffi.Int32)>>(
+          'new_list_opt_box_autoadd_attribute_0');
+  late final _new_list_opt_box_autoadd_attribute_0 = _new_list_opt_box_autoadd_attribute_0Ptr
+      .asFunction<ffi.Pointer<wire_list_opt_box_autoadd_attribute> Function(int)>();
 
   ffi.Pointer<wire_uint_8_list> new_uint_8_list_0(
     int len,
@@ -4823,103 +4268,86 @@ class FlutterRustBridgeExampleSingleBlockTestWire
     );
   }
 
-  late final _new_uint_8_list_0Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<wire_uint_8_list> Function(
-              ffi.Int32)>>('new_uint_8_list_0');
-  late final _new_uint_8_list_0 = _new_uint_8_list_0Ptr
-      .asFunction<ffi.Pointer<wire_uint_8_list> Function(int)>();
+  late final _new_uint_8_list_0Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_uint_8_list> Function(ffi.Int32)>>('new_uint_8_list_0');
+  late final _new_uint_8_list_0 = _new_uint_8_list_0Ptr.asFunction<ffi.Pointer<wire_uint_8_list> Function(int)>();
 
   ffi.Pointer<DistanceKind> inflate_Distance_Map() {
     return _inflate_Distance_Map();
   }
 
   late final _inflate_Distance_MapPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<DistanceKind> Function()>>(
-          'inflate_Distance_Map');
-  late final _inflate_Distance_Map = _inflate_Distance_MapPtr
-      .asFunction<ffi.Pointer<DistanceKind> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<DistanceKind> Function()>>('inflate_Distance_Map');
+  late final _inflate_Distance_Map = _inflate_Distance_MapPtr.asFunction<ffi.Pointer<DistanceKind> Function()>();
 
   ffi.Pointer<KitchenSinkKind> inflate_KitchenSink_Primitives() {
     return _inflate_KitchenSink_Primitives();
   }
 
   late final _inflate_KitchenSink_PrimitivesPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>(
-          'inflate_KitchenSink_Primitives');
+      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>('inflate_KitchenSink_Primitives');
   late final _inflate_KitchenSink_Primitives =
-      _inflate_KitchenSink_PrimitivesPtr
-          .asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
+      _inflate_KitchenSink_PrimitivesPtr.asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
 
   ffi.Pointer<KitchenSinkKind> inflate_KitchenSink_Nested() {
     return _inflate_KitchenSink_Nested();
   }
 
   late final _inflate_KitchenSink_NestedPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>(
-          'inflate_KitchenSink_Nested');
-  late final _inflate_KitchenSink_Nested = _inflate_KitchenSink_NestedPtr
-      .asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>('inflate_KitchenSink_Nested');
+  late final _inflate_KitchenSink_Nested =
+      _inflate_KitchenSink_NestedPtr.asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
 
   ffi.Pointer<KitchenSinkKind> inflate_KitchenSink_Optional() {
     return _inflate_KitchenSink_Optional();
   }
 
   late final _inflate_KitchenSink_OptionalPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>(
-          'inflate_KitchenSink_Optional');
-  late final _inflate_KitchenSink_Optional = _inflate_KitchenSink_OptionalPtr
-      .asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>('inflate_KitchenSink_Optional');
+  late final _inflate_KitchenSink_Optional =
+      _inflate_KitchenSink_OptionalPtr.asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
 
   ffi.Pointer<KitchenSinkKind> inflate_KitchenSink_Buffer() {
     return _inflate_KitchenSink_Buffer();
   }
 
   late final _inflate_KitchenSink_BufferPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>(
-          'inflate_KitchenSink_Buffer');
-  late final _inflate_KitchenSink_Buffer = _inflate_KitchenSink_BufferPtr
-      .asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>('inflate_KitchenSink_Buffer');
+  late final _inflate_KitchenSink_Buffer =
+      _inflate_KitchenSink_BufferPtr.asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
 
   ffi.Pointer<KitchenSinkKind> inflate_KitchenSink_Enums() {
     return _inflate_KitchenSink_Enums();
   }
 
   late final _inflate_KitchenSink_EnumsPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>(
-          'inflate_KitchenSink_Enums');
-  late final _inflate_KitchenSink_Enums = _inflate_KitchenSink_EnumsPtr
-      .asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<KitchenSinkKind> Function()>>('inflate_KitchenSink_Enums');
+  late final _inflate_KitchenSink_Enums =
+      _inflate_KitchenSink_EnumsPtr.asFunction<ffi.Pointer<KitchenSinkKind> Function()>();
 
   ffi.Pointer<MeasureKind> inflate_Measure_Speed() {
     return _inflate_Measure_Speed();
   }
 
   late final _inflate_Measure_SpeedPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<MeasureKind> Function()>>(
-          'inflate_Measure_Speed');
-  late final _inflate_Measure_Speed = _inflate_Measure_SpeedPtr
-      .asFunction<ffi.Pointer<MeasureKind> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<MeasureKind> Function()>>('inflate_Measure_Speed');
+  late final _inflate_Measure_Speed = _inflate_Measure_SpeedPtr.asFunction<ffi.Pointer<MeasureKind> Function()>();
 
   ffi.Pointer<MeasureKind> inflate_Measure_Distance() {
     return _inflate_Measure_Distance();
   }
 
   late final _inflate_Measure_DistancePtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<MeasureKind> Function()>>(
-          'inflate_Measure_Distance');
-  late final _inflate_Measure_Distance = _inflate_Measure_DistancePtr
-      .asFunction<ffi.Pointer<MeasureKind> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<MeasureKind> Function()>>('inflate_Measure_Distance');
+  late final _inflate_Measure_Distance = _inflate_Measure_DistancePtr.asFunction<ffi.Pointer<MeasureKind> Function()>();
 
   ffi.Pointer<SpeedKind> inflate_Speed_GPS() {
     return _inflate_Speed_GPS();
   }
 
   late final _inflate_Speed_GPSPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<SpeedKind> Function()>>(
-          'inflate_Speed_GPS');
-  late final _inflate_Speed_GPS =
-      _inflate_Speed_GPSPtr.asFunction<ffi.Pointer<SpeedKind> Function()>();
+      _lookup<ffi.NativeFunction<ffi.Pointer<SpeedKind> Function()>>('inflate_Speed_GPS');
+  late final _inflate_Speed_GPS = _inflate_Speed_GPSPtr.asFunction<ffi.Pointer<SpeedKind> Function()>();
 
   void free_WireSyncReturnStruct(
     WireSyncReturnStruct val,
@@ -4930,10 +4358,9 @@ class FlutterRustBridgeExampleSingleBlockTestWire
   }
 
   late final _free_WireSyncReturnStructPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(WireSyncReturnStruct)>>(
-          'free_WireSyncReturnStruct');
-  late final _free_WireSyncReturnStruct = _free_WireSyncReturnStructPtr
-      .asFunction<void Function(WireSyncReturnStruct)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(WireSyncReturnStruct)>>('free_WireSyncReturnStruct');
+  late final _free_WireSyncReturnStruct =
+      _free_WireSyncReturnStructPtr.asFunction<void Function(WireSyncReturnStruct)>();
 
   void store_dart_post_cobject(
     DartPostCObjectFnType ptr,
@@ -4944,10 +4371,8 @@ class FlutterRustBridgeExampleSingleBlockTestWire
   }
 
   late final _store_dart_post_cobjectPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(DartPostCObjectFnType)>>(
-          'store_dart_post_cobject');
-  late final _store_dart_post_cobject = _store_dart_post_cobjectPtr
-      .asFunction<void Function(DartPostCObjectFnType)>();
+      _lookup<ffi.NativeFunction<ffi.Void Function(DartPostCObjectFnType)>>('store_dart_post_cobject');
+  late final _store_dart_post_cobject = _store_dart_post_cobjectPtr.asFunction<void Function(DartPostCObjectFnType)>();
 }
 
 class wire_uint_8_list extends ffi.Struct {
@@ -5276,6 +4701,5 @@ class wire_ConcatenateWith extends ffi.Struct {
 }
 
 typedef uintptr_t = ffi.UnsignedLongLong;
-typedef DartPostCObjectFnType = ffi.Pointer<
-    ffi.NativeFunction<ffi.Bool Function(DartPort, ffi.Pointer<ffi.Void>)>>;
+typedef DartPostCObjectFnType = ffi.Pointer<ffi.NativeFunction<ffi.Bool Function(DartPort, ffi.Pointer<ffi.Void>)>>;
 typedef DartPort = ffi.Int64;

--- a/frb_example/pure_dart/dart/lib/bridge_generated.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.dart
@@ -4700,6 +4700,6 @@ class wire_ConcatenateWith extends ffi.Struct {
   external ffi.Pointer<wire_uint_8_list> a;
 }
 
-typedef uintptr_t = ffi.UnsignedLongLong;
+typedef uintptr_t = ffi.UnsignedLong;
 typedef DartPostCObjectFnType = ffi.Pointer<ffi.NativeFunction<ffi.Bool Function(DartPort, ffi.Pointer<ffi.Void>)>>;
 typedef DartPort = ffi.Int64;

--- a/frb_example/pure_dart/dart/lib/bridge_generated.freezed.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.freezed.dart
@@ -40,7 +40,8 @@ mixin _$ApplicationMessage {
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
-    required TResult Function(ApplicationMessage_DisplayMessage value) displayMessage,
+    required TResult Function(ApplicationMessage_DisplayMessage value)
+        displayMessage,
     required TResult Function(ApplicationMessage_RenderPixel value) renderPixel,
     required TResult Function(ApplicationMessage_Exit value) exit,
   }) =>
@@ -64,12 +65,14 @@ mixin _$ApplicationMessage {
 
 /// @nodoc
 abstract class $ApplicationMessageCopyWith<$Res> {
-  factory $ApplicationMessageCopyWith(ApplicationMessage value, $Res Function(ApplicationMessage) then) =
+  factory $ApplicationMessageCopyWith(
+          ApplicationMessage value, $Res Function(ApplicationMessage) then) =
       _$ApplicationMessageCopyWithImpl<$Res>;
 }
 
 /// @nodoc
-class _$ApplicationMessageCopyWithImpl<$Res> implements $ApplicationMessageCopyWith<$Res> {
+class _$ApplicationMessageCopyWithImpl<$Res>
+    implements $ApplicationMessageCopyWith<$Res> {
   _$ApplicationMessageCopyWithImpl(this._value, this._then);
 
   final ApplicationMessage _value;
@@ -80,20 +83,24 @@ class _$ApplicationMessageCopyWithImpl<$Res> implements $ApplicationMessageCopyW
 /// @nodoc
 abstract class _$$ApplicationMessage_DisplayMessageCopyWith<$Res> {
   factory _$$ApplicationMessage_DisplayMessageCopyWith(
-          _$ApplicationMessage_DisplayMessage value, $Res Function(_$ApplicationMessage_DisplayMessage) then) =
+          _$ApplicationMessage_DisplayMessage value,
+          $Res Function(_$ApplicationMessage_DisplayMessage) then) =
       __$$ApplicationMessage_DisplayMessageCopyWithImpl<$Res>;
   $Res call({String field0});
 }
 
 /// @nodoc
-class __$$ApplicationMessage_DisplayMessageCopyWithImpl<$Res> extends _$ApplicationMessageCopyWithImpl<$Res>
+class __$$ApplicationMessage_DisplayMessageCopyWithImpl<$Res>
+    extends _$ApplicationMessageCopyWithImpl<$Res>
     implements _$$ApplicationMessage_DisplayMessageCopyWith<$Res> {
   __$$ApplicationMessage_DisplayMessageCopyWithImpl(
-      _$ApplicationMessage_DisplayMessage _value, $Res Function(_$ApplicationMessage_DisplayMessage) _then)
+      _$ApplicationMessage_DisplayMessage _value,
+      $Res Function(_$ApplicationMessage_DisplayMessage) _then)
       : super(_value, (v) => _then(v as _$ApplicationMessage_DisplayMessage));
 
   @override
-  _$ApplicationMessage_DisplayMessage get _value => super._value as _$ApplicationMessage_DisplayMessage;
+  _$ApplicationMessage_DisplayMessage get _value =>
+      super._value as _$ApplicationMessage_DisplayMessage;
 
   @override
   $Res call({
@@ -110,7 +117,8 @@ class __$$ApplicationMessage_DisplayMessageCopyWithImpl<$Res> extends _$Applicat
 
 /// @nodoc
 
-class _$ApplicationMessage_DisplayMessage implements ApplicationMessage_DisplayMessage {
+class _$ApplicationMessage_DisplayMessage
+    implements ApplicationMessage_DisplayMessage {
   const _$ApplicationMessage_DisplayMessage(this.field0);
 
   @override
@@ -130,12 +138,15 @@ class _$ApplicationMessage_DisplayMessage implements ApplicationMessage_DisplayM
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
 
   @JsonKey(ignore: true)
   @override
-  _$$ApplicationMessage_DisplayMessageCopyWith<_$ApplicationMessage_DisplayMessage> get copyWith =>
-      __$$ApplicationMessage_DisplayMessageCopyWithImpl<_$ApplicationMessage_DisplayMessage>(this, _$identity);
+  _$$ApplicationMessage_DisplayMessageCopyWith<
+          _$ApplicationMessage_DisplayMessage>
+      get copyWith => __$$ApplicationMessage_DisplayMessageCopyWithImpl<
+          _$ApplicationMessage_DisplayMessage>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -174,7 +185,8 @@ class _$ApplicationMessage_DisplayMessage implements ApplicationMessage_DisplayM
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
-    required TResult Function(ApplicationMessage_DisplayMessage value) displayMessage,
+    required TResult Function(ApplicationMessage_DisplayMessage value)
+        displayMessage,
     required TResult Function(ApplicationMessage_RenderPixel value) renderPixel,
     required TResult Function(ApplicationMessage_Exit value) exit,
   }) {
@@ -207,31 +219,37 @@ class _$ApplicationMessage_DisplayMessage implements ApplicationMessage_DisplayM
 }
 
 abstract class ApplicationMessage_DisplayMessage implements ApplicationMessage {
-  const factory ApplicationMessage_DisplayMessage(final String field0) = _$ApplicationMessage_DisplayMessage;
+  const factory ApplicationMessage_DisplayMessage(final String field0) =
+      _$ApplicationMessage_DisplayMessage;
 
   String get field0;
   @JsonKey(ignore: true)
-  _$$ApplicationMessage_DisplayMessageCopyWith<_$ApplicationMessage_DisplayMessage> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$ApplicationMessage_DisplayMessageCopyWith<
+          _$ApplicationMessage_DisplayMessage>
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$ApplicationMessage_RenderPixelCopyWith<$Res> {
   factory _$$ApplicationMessage_RenderPixelCopyWith(
-          _$ApplicationMessage_RenderPixel value, $Res Function(_$ApplicationMessage_RenderPixel) then) =
+          _$ApplicationMessage_RenderPixel value,
+          $Res Function(_$ApplicationMessage_RenderPixel) then) =
       __$$ApplicationMessage_RenderPixelCopyWithImpl<$Res>;
   $Res call({int x, int y});
 }
 
 /// @nodoc
-class __$$ApplicationMessage_RenderPixelCopyWithImpl<$Res> extends _$ApplicationMessageCopyWithImpl<$Res>
+class __$$ApplicationMessage_RenderPixelCopyWithImpl<$Res>
+    extends _$ApplicationMessageCopyWithImpl<$Res>
     implements _$$ApplicationMessage_RenderPixelCopyWith<$Res> {
   __$$ApplicationMessage_RenderPixelCopyWithImpl(
-      _$ApplicationMessage_RenderPixel _value, $Res Function(_$ApplicationMessage_RenderPixel) _then)
+      _$ApplicationMessage_RenderPixel _value,
+      $Res Function(_$ApplicationMessage_RenderPixel) _then)
       : super(_value, (v) => _then(v as _$ApplicationMessage_RenderPixel));
 
   @override
-  _$ApplicationMessage_RenderPixel get _value => super._value as _$ApplicationMessage_RenderPixel;
+  _$ApplicationMessage_RenderPixel get _value =>
+      super._value as _$ApplicationMessage_RenderPixel;
 
   @override
   $Res call({
@@ -253,7 +271,8 @@ class __$$ApplicationMessage_RenderPixelCopyWithImpl<$Res> extends _$Application
 
 /// @nodoc
 
-class _$ApplicationMessage_RenderPixel implements ApplicationMessage_RenderPixel {
+class _$ApplicationMessage_RenderPixel
+    implements ApplicationMessage_RenderPixel {
   const _$ApplicationMessage_RenderPixel({required this.x, required this.y});
 
   @override
@@ -276,13 +295,16 @@ class _$ApplicationMessage_RenderPixel implements ApplicationMessage_RenderPixel
   }
 
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, const DeepCollectionEquality().hash(x), const DeepCollectionEquality().hash(y));
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(x),
+      const DeepCollectionEquality().hash(y));
 
   @JsonKey(ignore: true)
   @override
-  _$$ApplicationMessage_RenderPixelCopyWith<_$ApplicationMessage_RenderPixel> get copyWith =>
-      __$$ApplicationMessage_RenderPixelCopyWithImpl<_$ApplicationMessage_RenderPixel>(this, _$identity);
+  _$$ApplicationMessage_RenderPixelCopyWith<_$ApplicationMessage_RenderPixel>
+      get copyWith => __$$ApplicationMessage_RenderPixelCopyWithImpl<
+          _$ApplicationMessage_RenderPixel>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -321,7 +343,8 @@ class _$ApplicationMessage_RenderPixel implements ApplicationMessage_RenderPixel
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
-    required TResult Function(ApplicationMessage_DisplayMessage value) displayMessage,
+    required TResult Function(ApplicationMessage_DisplayMessage value)
+        displayMessage,
     required TResult Function(ApplicationMessage_RenderPixel value) renderPixel,
     required TResult Function(ApplicationMessage_Exit value) exit,
   }) {
@@ -354,32 +377,35 @@ class _$ApplicationMessage_RenderPixel implements ApplicationMessage_RenderPixel
 }
 
 abstract class ApplicationMessage_RenderPixel implements ApplicationMessage {
-  const factory ApplicationMessage_RenderPixel({required final int x, required final int y}) =
-      _$ApplicationMessage_RenderPixel;
+  const factory ApplicationMessage_RenderPixel(
+      {required final int x,
+      required final int y}) = _$ApplicationMessage_RenderPixel;
 
   int get x;
   int get y;
   @JsonKey(ignore: true)
-  _$$ApplicationMessage_RenderPixelCopyWith<_$ApplicationMessage_RenderPixel> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$ApplicationMessage_RenderPixelCopyWith<_$ApplicationMessage_RenderPixel>
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$ApplicationMessage_ExitCopyWith<$Res> {
-  factory _$$ApplicationMessage_ExitCopyWith(
-          _$ApplicationMessage_Exit value, $Res Function(_$ApplicationMessage_Exit) then) =
+  factory _$$ApplicationMessage_ExitCopyWith(_$ApplicationMessage_Exit value,
+          $Res Function(_$ApplicationMessage_Exit) then) =
       __$$ApplicationMessage_ExitCopyWithImpl<$Res>;
 }
 
 /// @nodoc
-class __$$ApplicationMessage_ExitCopyWithImpl<$Res> extends _$ApplicationMessageCopyWithImpl<$Res>
+class __$$ApplicationMessage_ExitCopyWithImpl<$Res>
+    extends _$ApplicationMessageCopyWithImpl<$Res>
     implements _$$ApplicationMessage_ExitCopyWith<$Res> {
-  __$$ApplicationMessage_ExitCopyWithImpl(
-      _$ApplicationMessage_Exit _value, $Res Function(_$ApplicationMessage_Exit) _then)
+  __$$ApplicationMessage_ExitCopyWithImpl(_$ApplicationMessage_Exit _value,
+      $Res Function(_$ApplicationMessage_Exit) _then)
       : super(_value, (v) => _then(v as _$ApplicationMessage_Exit));
 
   @override
-  _$ApplicationMessage_Exit get _value => super._value as _$ApplicationMessage_Exit;
+  _$ApplicationMessage_Exit get _value =>
+      super._value as _$ApplicationMessage_Exit;
 }
 
 /// @nodoc
@@ -394,7 +420,9 @@ class _$ApplicationMessage_Exit implements ApplicationMessage_Exit {
 
   @override
   bool operator ==(dynamic other) {
-    return identical(this, other) || (other.runtimeType == runtimeType && other is _$ApplicationMessage_Exit);
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ApplicationMessage_Exit);
   }
 
   @override
@@ -437,7 +465,8 @@ class _$ApplicationMessage_Exit implements ApplicationMessage_Exit {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
-    required TResult Function(ApplicationMessage_DisplayMessage value) displayMessage,
+    required TResult Function(ApplicationMessage_DisplayMessage value)
+        displayMessage,
     required TResult Function(ApplicationMessage_RenderPixel value) renderPixel,
     required TResult Function(ApplicationMessage_Exit value) exit,
   }) {
@@ -517,7 +546,8 @@ mixin _$Distance {
 
 /// @nodoc
 abstract class $DistanceCopyWith<$Res> {
-  factory $DistanceCopyWith(Distance value, $Res Function(Distance) then) = _$DistanceCopyWithImpl<$Res>;
+  factory $DistanceCopyWith(Distance value, $Res Function(Distance) then) =
+      _$DistanceCopyWithImpl<$Res>;
 }
 
 /// @nodoc
@@ -531,14 +561,17 @@ class _$DistanceCopyWithImpl<$Res> implements $DistanceCopyWith<$Res> {
 
 /// @nodoc
 abstract class _$$Distance_UnknownCopyWith<$Res> {
-  factory _$$Distance_UnknownCopyWith(_$Distance_Unknown value, $Res Function(_$Distance_Unknown) then) =
+  factory _$$Distance_UnknownCopyWith(
+          _$Distance_Unknown value, $Res Function(_$Distance_Unknown) then) =
       __$$Distance_UnknownCopyWithImpl<$Res>;
 }
 
 /// @nodoc
-class __$$Distance_UnknownCopyWithImpl<$Res> extends _$DistanceCopyWithImpl<$Res>
+class __$$Distance_UnknownCopyWithImpl<$Res>
+    extends _$DistanceCopyWithImpl<$Res>
     implements _$$Distance_UnknownCopyWith<$Res> {
-  __$$Distance_UnknownCopyWithImpl(_$Distance_Unknown _value, $Res Function(_$Distance_Unknown) _then)
+  __$$Distance_UnknownCopyWithImpl(
+      _$Distance_Unknown _value, $Res Function(_$Distance_Unknown) _then)
       : super(_value, (v) => _then(v as _$Distance_Unknown));
 
   @override
@@ -557,7 +590,8 @@ class _$Distance_Unknown implements Distance_Unknown {
 
   @override
   bool operator ==(dynamic other) {
-    return identical(this, other) || (other.runtimeType == runtimeType && other is _$Distance_Unknown);
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$Distance_Unknown);
   }
 
   @override
@@ -632,14 +666,17 @@ abstract class Distance_Unknown implements Distance {
 
 /// @nodoc
 abstract class _$$Distance_MapCopyWith<$Res> {
-  factory _$$Distance_MapCopyWith(_$Distance_Map value, $Res Function(_$Distance_Map) then) =
+  factory _$$Distance_MapCopyWith(
+          _$Distance_Map value, $Res Function(_$Distance_Map) then) =
       __$$Distance_MapCopyWithImpl<$Res>;
   $Res call({double field0});
 }
 
 /// @nodoc
-class __$$Distance_MapCopyWithImpl<$Res> extends _$DistanceCopyWithImpl<$Res> implements _$$Distance_MapCopyWith<$Res> {
-  __$$Distance_MapCopyWithImpl(_$Distance_Map _value, $Res Function(_$Distance_Map) _then)
+class __$$Distance_MapCopyWithImpl<$Res> extends _$DistanceCopyWithImpl<$Res>
+    implements _$$Distance_MapCopyWith<$Res> {
+  __$$Distance_MapCopyWithImpl(
+      _$Distance_Map _value, $Res Function(_$Distance_Map) _then)
       : super(_value, (v) => _then(v as _$Distance_Map));
 
   @override
@@ -680,7 +717,8 @@ class _$Distance_Map implements Distance_Map {
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
 
   @JsonKey(ignore: true)
   @override
@@ -755,7 +793,8 @@ abstract class Distance_Map implements Distance {
 
   double get field0;
   @JsonKey(ignore: true)
-  _$$Distance_MapCopyWith<_$Distance_Map> get copyWith => throw _privateConstructorUsedError;
+  _$$Distance_MapCopyWith<_$Distance_Map> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
@@ -763,7 +802,8 @@ mixin _$KitchenSink {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function() empty,
-    required TResult Function(int int32, double float64, bool boolean) primitives,
+    required TResult Function(int int32, double float64, bool boolean)
+        primitives,
     required TResult Function(KitchenSink field0, int field1) nested,
     required TResult Function(int? field0, int? field1) optional,
     required TResult Function(Uint8List field0) buffer,
@@ -826,7 +866,9 @@ mixin _$KitchenSink {
 
 /// @nodoc
 abstract class $KitchenSinkCopyWith<$Res> {
-  factory $KitchenSinkCopyWith(KitchenSink value, $Res Function(KitchenSink) then) = _$KitchenSinkCopyWithImpl<$Res>;
+  factory $KitchenSinkCopyWith(
+          KitchenSink value, $Res Function(KitchenSink) then) =
+      _$KitchenSinkCopyWithImpl<$Res>;
 }
 
 /// @nodoc
@@ -840,14 +882,17 @@ class _$KitchenSinkCopyWithImpl<$Res> implements $KitchenSinkCopyWith<$Res> {
 
 /// @nodoc
 abstract class _$$KitchenSink_EmptyCopyWith<$Res> {
-  factory _$$KitchenSink_EmptyCopyWith(_$KitchenSink_Empty value, $Res Function(_$KitchenSink_Empty) then) =
+  factory _$$KitchenSink_EmptyCopyWith(
+          _$KitchenSink_Empty value, $Res Function(_$KitchenSink_Empty) then) =
       __$$KitchenSink_EmptyCopyWithImpl<$Res>;
 }
 
 /// @nodoc
-class __$$KitchenSink_EmptyCopyWithImpl<$Res> extends _$KitchenSinkCopyWithImpl<$Res>
+class __$$KitchenSink_EmptyCopyWithImpl<$Res>
+    extends _$KitchenSinkCopyWithImpl<$Res>
     implements _$$KitchenSink_EmptyCopyWith<$Res> {
-  __$$KitchenSink_EmptyCopyWithImpl(_$KitchenSink_Empty _value, $Res Function(_$KitchenSink_Empty) _then)
+  __$$KitchenSink_EmptyCopyWithImpl(
+      _$KitchenSink_Empty _value, $Res Function(_$KitchenSink_Empty) _then)
       : super(_value, (v) => _then(v as _$KitchenSink_Empty));
 
   @override
@@ -866,7 +911,8 @@ class _$KitchenSink_Empty implements KitchenSink_Empty {
 
   @override
   bool operator ==(dynamic other) {
-    return identical(this, other) || (other.runtimeType == runtimeType && other is _$KitchenSink_Empty);
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$KitchenSink_Empty);
   }
 
   @override
@@ -876,7 +922,8 @@ class _$KitchenSink_Empty implements KitchenSink_Empty {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function() empty,
-    required TResult Function(int int32, double float64, bool boolean) primitives,
+    required TResult Function(int int32, double float64, bool boolean)
+        primitives,
     required TResult Function(KitchenSink field0, int field1) nested,
     required TResult Function(int? field0, int? field1) optional,
     required TResult Function(Uint8List field0) buffer,
@@ -965,20 +1012,23 @@ abstract class KitchenSink_Empty implements KitchenSink {
 
 /// @nodoc
 abstract class _$$KitchenSink_PrimitivesCopyWith<$Res> {
-  factory _$$KitchenSink_PrimitivesCopyWith(
-          _$KitchenSink_Primitives value, $Res Function(_$KitchenSink_Primitives) then) =
+  factory _$$KitchenSink_PrimitivesCopyWith(_$KitchenSink_Primitives value,
+          $Res Function(_$KitchenSink_Primitives) then) =
       __$$KitchenSink_PrimitivesCopyWithImpl<$Res>;
   $Res call({int int32, double float64, bool boolean});
 }
 
 /// @nodoc
-class __$$KitchenSink_PrimitivesCopyWithImpl<$Res> extends _$KitchenSinkCopyWithImpl<$Res>
+class __$$KitchenSink_PrimitivesCopyWithImpl<$Res>
+    extends _$KitchenSinkCopyWithImpl<$Res>
     implements _$$KitchenSink_PrimitivesCopyWith<$Res> {
-  __$$KitchenSink_PrimitivesCopyWithImpl(_$KitchenSink_Primitives _value, $Res Function(_$KitchenSink_Primitives) _then)
+  __$$KitchenSink_PrimitivesCopyWithImpl(_$KitchenSink_Primitives _value,
+      $Res Function(_$KitchenSink_Primitives) _then)
       : super(_value, (v) => _then(v as _$KitchenSink_Primitives));
 
   @override
-  _$KitchenSink_Primitives get _value => super._value as _$KitchenSink_Primitives;
+  _$KitchenSink_Primitives get _value =>
+      super._value as _$KitchenSink_Primitives;
 
   @override
   $Res call({
@@ -1006,7 +1056,8 @@ class __$$KitchenSink_PrimitivesCopyWithImpl<$Res> extends _$KitchenSinkCopyWith
 /// @nodoc
 
 class _$KitchenSink_Primitives implements KitchenSink_Primitives {
-  const _$KitchenSink_Primitives({required this.int32, required this.float64, required this.boolean});
+  const _$KitchenSink_Primitives(
+      {required this.int32, required this.float64, required this.boolean});
 
   /// Dart field comment
   @override
@@ -1032,19 +1083,24 @@ class _$KitchenSink_Primitives implements KitchenSink_Primitives {
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, const DeepCollectionEquality().hash(int32),
-      const DeepCollectionEquality().hash(float64), const DeepCollectionEquality().hash(boolean));
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(int32),
+      const DeepCollectionEquality().hash(float64),
+      const DeepCollectionEquality().hash(boolean));
 
   @JsonKey(ignore: true)
   @override
   _$$KitchenSink_PrimitivesCopyWith<_$KitchenSink_Primitives> get copyWith =>
-      __$$KitchenSink_PrimitivesCopyWithImpl<_$KitchenSink_Primitives>(this, _$identity);
+      __$$KitchenSink_PrimitivesCopyWithImpl<_$KitchenSink_Primitives>(
+          this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function() empty,
-    required TResult Function(int int32, double float64, bool boolean) primitives,
+    required TResult Function(int int32, double float64, bool boolean)
+        primitives,
     required TResult Function(KitchenSink field0, int field1) nested,
     required TResult Function(int? field0, int? field1) optional,
     required TResult Function(Uint8List field0) buffer,
@@ -1138,12 +1194,14 @@ abstract class KitchenSink_Primitives implements KitchenSink {
   double get float64;
   bool get boolean;
   @JsonKey(ignore: true)
-  _$$KitchenSink_PrimitivesCopyWith<_$KitchenSink_Primitives> get copyWith => throw _privateConstructorUsedError;
+  _$$KitchenSink_PrimitivesCopyWith<_$KitchenSink_Primitives> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$KitchenSink_NestedCopyWith<$Res> {
-  factory _$$KitchenSink_NestedCopyWith(_$KitchenSink_Nested value, $Res Function(_$KitchenSink_Nested) then) =
+  factory _$$KitchenSink_NestedCopyWith(_$KitchenSink_Nested value,
+          $Res Function(_$KitchenSink_Nested) then) =
       __$$KitchenSink_NestedCopyWithImpl<$Res>;
   $Res call({KitchenSink field0, int field1});
 
@@ -1151,9 +1209,11 @@ abstract class _$$KitchenSink_NestedCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$KitchenSink_NestedCopyWithImpl<$Res> extends _$KitchenSinkCopyWithImpl<$Res>
+class __$$KitchenSink_NestedCopyWithImpl<$Res>
+    extends _$KitchenSinkCopyWithImpl<$Res>
     implements _$$KitchenSink_NestedCopyWith<$Res> {
-  __$$KitchenSink_NestedCopyWithImpl(_$KitchenSink_Nested _value, $Res Function(_$KitchenSink_Nested) _then)
+  __$$KitchenSink_NestedCopyWithImpl(
+      _$KitchenSink_Nested _value, $Res Function(_$KitchenSink_Nested) _then)
       : super(_value, (v) => _then(v as _$KitchenSink_Nested));
 
   @override
@@ -1210,18 +1270,22 @@ class _$KitchenSink_Nested implements KitchenSink_Nested {
 
   @override
   int get hashCode => Object.hash(
-      runtimeType, const DeepCollectionEquality().hash(field0), const DeepCollectionEquality().hash(field1));
+      runtimeType,
+      const DeepCollectionEquality().hash(field0),
+      const DeepCollectionEquality().hash(field1));
 
   @JsonKey(ignore: true)
   @override
   _$$KitchenSink_NestedCopyWith<_$KitchenSink_Nested> get copyWith =>
-      __$$KitchenSink_NestedCopyWithImpl<_$KitchenSink_Nested>(this, _$identity);
+      __$$KitchenSink_NestedCopyWithImpl<_$KitchenSink_Nested>(
+          this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function() empty,
-    required TResult Function(int int32, double float64, bool boolean) primitives,
+    required TResult Function(int int32, double float64, bool boolean)
+        primitives,
     required TResult Function(KitchenSink field0, int field1) nested,
     required TResult Function(int? field0, int? field1) optional,
     required TResult Function(Uint8List field0) buffer,
@@ -1305,25 +1369,30 @@ class _$KitchenSink_Nested implements KitchenSink_Nested {
 }
 
 abstract class KitchenSink_Nested implements KitchenSink {
-  const factory KitchenSink_Nested(final KitchenSink field0, final int field1) = _$KitchenSink_Nested;
+  const factory KitchenSink_Nested(final KitchenSink field0, final int field1) =
+      _$KitchenSink_Nested;
 
   KitchenSink get field0;
   int get field1;
   @JsonKey(ignore: true)
-  _$$KitchenSink_NestedCopyWith<_$KitchenSink_Nested> get copyWith => throw _privateConstructorUsedError;
+  _$$KitchenSink_NestedCopyWith<_$KitchenSink_Nested> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$KitchenSink_OptionalCopyWith<$Res> {
-  factory _$$KitchenSink_OptionalCopyWith(_$KitchenSink_Optional value, $Res Function(_$KitchenSink_Optional) then) =
+  factory _$$KitchenSink_OptionalCopyWith(_$KitchenSink_Optional value,
+          $Res Function(_$KitchenSink_Optional) then) =
       __$$KitchenSink_OptionalCopyWithImpl<$Res>;
   $Res call({int? field0, int? field1});
 }
 
 /// @nodoc
-class __$$KitchenSink_OptionalCopyWithImpl<$Res> extends _$KitchenSinkCopyWithImpl<$Res>
+class __$$KitchenSink_OptionalCopyWithImpl<$Res>
+    extends _$KitchenSinkCopyWithImpl<$Res>
     implements _$$KitchenSink_OptionalCopyWith<$Res> {
-  __$$KitchenSink_OptionalCopyWithImpl(_$KitchenSink_Optional _value, $Res Function(_$KitchenSink_Optional) _then)
+  __$$KitchenSink_OptionalCopyWithImpl(_$KitchenSink_Optional _value,
+      $Res Function(_$KitchenSink_Optional) _then)
       : super(_value, (v) => _then(v as _$KitchenSink_Optional));
 
   @override
@@ -1374,18 +1443,22 @@ class _$KitchenSink_Optional implements KitchenSink_Optional {
 
   @override
   int get hashCode => Object.hash(
-      runtimeType, const DeepCollectionEquality().hash(field0), const DeepCollectionEquality().hash(field1));
+      runtimeType,
+      const DeepCollectionEquality().hash(field0),
+      const DeepCollectionEquality().hash(field1));
 
   @JsonKey(ignore: true)
   @override
   _$$KitchenSink_OptionalCopyWith<_$KitchenSink_Optional> get copyWith =>
-      __$$KitchenSink_OptionalCopyWithImpl<_$KitchenSink_Optional>(this, _$identity);
+      __$$KitchenSink_OptionalCopyWithImpl<_$KitchenSink_Optional>(
+          this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function() empty,
-    required TResult Function(int int32, double float64, bool boolean) primitives,
+    required TResult Function(int int32, double float64, bool boolean)
+        primitives,
     required TResult Function(KitchenSink field0, int field1) nested,
     required TResult Function(int? field0, int? field1) optional,
     required TResult Function(Uint8List field0) buffer,
@@ -1469,26 +1542,31 @@ class _$KitchenSink_Optional implements KitchenSink_Optional {
 }
 
 abstract class KitchenSink_Optional implements KitchenSink {
-  const factory KitchenSink_Optional([final int? field0, final int? field1]) = _$KitchenSink_Optional;
+  const factory KitchenSink_Optional([final int? field0, final int? field1]) =
+      _$KitchenSink_Optional;
 
   /// Comment on anonymous field
   int? get field0;
   int? get field1;
   @JsonKey(ignore: true)
-  _$$KitchenSink_OptionalCopyWith<_$KitchenSink_Optional> get copyWith => throw _privateConstructorUsedError;
+  _$$KitchenSink_OptionalCopyWith<_$KitchenSink_Optional> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$KitchenSink_BufferCopyWith<$Res> {
-  factory _$$KitchenSink_BufferCopyWith(_$KitchenSink_Buffer value, $Res Function(_$KitchenSink_Buffer) then) =
+  factory _$$KitchenSink_BufferCopyWith(_$KitchenSink_Buffer value,
+          $Res Function(_$KitchenSink_Buffer) then) =
       __$$KitchenSink_BufferCopyWithImpl<$Res>;
   $Res call({Uint8List field0});
 }
 
 /// @nodoc
-class __$$KitchenSink_BufferCopyWithImpl<$Res> extends _$KitchenSinkCopyWithImpl<$Res>
+class __$$KitchenSink_BufferCopyWithImpl<$Res>
+    extends _$KitchenSinkCopyWithImpl<$Res>
     implements _$$KitchenSink_BufferCopyWith<$Res> {
-  __$$KitchenSink_BufferCopyWithImpl(_$KitchenSink_Buffer _value, $Res Function(_$KitchenSink_Buffer) _then)
+  __$$KitchenSink_BufferCopyWithImpl(
+      _$KitchenSink_Buffer _value, $Res Function(_$KitchenSink_Buffer) _then)
       : super(_value, (v) => _then(v as _$KitchenSink_Buffer));
 
   @override
@@ -1529,18 +1607,21 @@ class _$KitchenSink_Buffer implements KitchenSink_Buffer {
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
 
   @JsonKey(ignore: true)
   @override
   _$$KitchenSink_BufferCopyWith<_$KitchenSink_Buffer> get copyWith =>
-      __$$KitchenSink_BufferCopyWithImpl<_$KitchenSink_Buffer>(this, _$identity);
+      __$$KitchenSink_BufferCopyWithImpl<_$KitchenSink_Buffer>(
+          this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function() empty,
-    required TResult Function(int int32, double float64, bool boolean) primitives,
+    required TResult Function(int int32, double float64, bool boolean)
+        primitives,
     required TResult Function(KitchenSink field0, int field1) nested,
     required TResult Function(int? field0, int? field1) optional,
     required TResult Function(Uint8List field0) buffer,
@@ -1624,24 +1705,29 @@ class _$KitchenSink_Buffer implements KitchenSink_Buffer {
 }
 
 abstract class KitchenSink_Buffer implements KitchenSink {
-  const factory KitchenSink_Buffer(final Uint8List field0) = _$KitchenSink_Buffer;
+  const factory KitchenSink_Buffer(final Uint8List field0) =
+      _$KitchenSink_Buffer;
 
   Uint8List get field0;
   @JsonKey(ignore: true)
-  _$$KitchenSink_BufferCopyWith<_$KitchenSink_Buffer> get copyWith => throw _privateConstructorUsedError;
+  _$$KitchenSink_BufferCopyWith<_$KitchenSink_Buffer> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$KitchenSink_EnumsCopyWith<$Res> {
-  factory _$$KitchenSink_EnumsCopyWith(_$KitchenSink_Enums value, $Res Function(_$KitchenSink_Enums) then) =
+  factory _$$KitchenSink_EnumsCopyWith(
+          _$KitchenSink_Enums value, $Res Function(_$KitchenSink_Enums) then) =
       __$$KitchenSink_EnumsCopyWithImpl<$Res>;
   $Res call({Weekdays field0});
 }
 
 /// @nodoc
-class __$$KitchenSink_EnumsCopyWithImpl<$Res> extends _$KitchenSinkCopyWithImpl<$Res>
+class __$$KitchenSink_EnumsCopyWithImpl<$Res>
+    extends _$KitchenSinkCopyWithImpl<$Res>
     implements _$$KitchenSink_EnumsCopyWith<$Res> {
-  __$$KitchenSink_EnumsCopyWithImpl(_$KitchenSink_Enums _value, $Res Function(_$KitchenSink_Enums) _then)
+  __$$KitchenSink_EnumsCopyWithImpl(
+      _$KitchenSink_Enums _value, $Res Function(_$KitchenSink_Enums) _then)
       : super(_value, (v) => _then(v as _$KitchenSink_Enums));
 
   @override
@@ -1682,7 +1768,8 @@ class _$KitchenSink_Enums implements KitchenSink_Enums {
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
 
   @JsonKey(ignore: true)
   @override
@@ -1693,7 +1780,8 @@ class _$KitchenSink_Enums implements KitchenSink_Enums {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function() empty,
-    required TResult Function(int int32, double float64, bool boolean) primitives,
+    required TResult Function(int int32, double float64, bool boolean)
+        primitives,
     required TResult Function(KitchenSink field0, int field1) nested,
     required TResult Function(int? field0, int? field1) optional,
     required TResult Function(Uint8List field0) buffer,
@@ -1781,7 +1869,8 @@ abstract class KitchenSink_Enums implements KitchenSink {
 
   Weekdays get field0;
   @JsonKey(ignore: true)
-  _$$KitchenSink_EnumsCopyWith<_$KitchenSink_Enums> get copyWith => throw _privateConstructorUsedError;
+  _$$KitchenSink_EnumsCopyWith<_$KitchenSink_Enums> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
@@ -1828,7 +1917,8 @@ mixin _$Measure {
 
 /// @nodoc
 abstract class $MeasureCopyWith<$Res> {
-  factory $MeasureCopyWith(Measure value, $Res Function(Measure) then) = _$MeasureCopyWithImpl<$Res>;
+  factory $MeasureCopyWith(Measure value, $Res Function(Measure) then) =
+      _$MeasureCopyWithImpl<$Res>;
 }
 
 /// @nodoc
@@ -1842,7 +1932,8 @@ class _$MeasureCopyWithImpl<$Res> implements $MeasureCopyWith<$Res> {
 
 /// @nodoc
 abstract class _$$Measure_SpeedCopyWith<$Res> {
-  factory _$$Measure_SpeedCopyWith(_$Measure_Speed value, $Res Function(_$Measure_Speed) then) =
+  factory _$$Measure_SpeedCopyWith(
+          _$Measure_Speed value, $Res Function(_$Measure_Speed) then) =
       __$$Measure_SpeedCopyWithImpl<$Res>;
   $Res call({Speed field0});
 
@@ -1852,7 +1943,8 @@ abstract class _$$Measure_SpeedCopyWith<$Res> {
 /// @nodoc
 class __$$Measure_SpeedCopyWithImpl<$Res> extends _$MeasureCopyWithImpl<$Res>
     implements _$$Measure_SpeedCopyWith<$Res> {
-  __$$Measure_SpeedCopyWithImpl(_$Measure_Speed _value, $Res Function(_$Measure_Speed) _then)
+  __$$Measure_SpeedCopyWithImpl(
+      _$Measure_Speed _value, $Res Function(_$Measure_Speed) _then)
       : super(_value, (v) => _then(v as _$Measure_Speed));
 
   @override
@@ -1900,7 +1992,8 @@ class _$Measure_Speed implements Measure_Speed {
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
 
   @JsonKey(ignore: true)
   @override
@@ -1975,12 +2068,14 @@ abstract class Measure_Speed implements Measure {
 
   Speed get field0;
   @JsonKey(ignore: true)
-  _$$Measure_SpeedCopyWith<_$Measure_Speed> get copyWith => throw _privateConstructorUsedError;
+  _$$Measure_SpeedCopyWith<_$Measure_Speed> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$Measure_DistanceCopyWith<$Res> {
-  factory _$$Measure_DistanceCopyWith(_$Measure_Distance value, $Res Function(_$Measure_Distance) then) =
+  factory _$$Measure_DistanceCopyWith(
+          _$Measure_Distance value, $Res Function(_$Measure_Distance) then) =
       __$$Measure_DistanceCopyWithImpl<$Res>;
   $Res call({Distance field0});
 
@@ -1990,7 +2085,8 @@ abstract class _$$Measure_DistanceCopyWith<$Res> {
 /// @nodoc
 class __$$Measure_DistanceCopyWithImpl<$Res> extends _$MeasureCopyWithImpl<$Res>
     implements _$$Measure_DistanceCopyWith<$Res> {
-  __$$Measure_DistanceCopyWithImpl(_$Measure_Distance _value, $Res Function(_$Measure_Distance) _then)
+  __$$Measure_DistanceCopyWithImpl(
+      _$Measure_Distance _value, $Res Function(_$Measure_Distance) _then)
       : super(_value, (v) => _then(v as _$Measure_Distance));
 
   @override
@@ -2038,7 +2134,8 @@ class _$Measure_Distance implements Measure_Distance {
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
 
   @JsonKey(ignore: true)
   @override
@@ -2113,7 +2210,8 @@ abstract class Measure_Distance implements Measure {
 
   Distance get field0;
   @JsonKey(ignore: true)
-  _$$Measure_DistanceCopyWith<_$Measure_Distance> get copyWith => throw _privateConstructorUsedError;
+  _$$Measure_DistanceCopyWith<_$Measure_Distance> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
@@ -2160,7 +2258,8 @@ mixin _$Speed {
 
 /// @nodoc
 abstract class $SpeedCopyWith<$Res> {
-  factory $SpeedCopyWith(Speed value, $Res Function(Speed) then) = _$SpeedCopyWithImpl<$Res>;
+  factory $SpeedCopyWith(Speed value, $Res Function(Speed) then) =
+      _$SpeedCopyWithImpl<$Res>;
 }
 
 /// @nodoc
@@ -2174,13 +2273,16 @@ class _$SpeedCopyWithImpl<$Res> implements $SpeedCopyWith<$Res> {
 
 /// @nodoc
 abstract class _$$Speed_UnknownCopyWith<$Res> {
-  factory _$$Speed_UnknownCopyWith(_$Speed_Unknown value, $Res Function(_$Speed_Unknown) then) =
+  factory _$$Speed_UnknownCopyWith(
+          _$Speed_Unknown value, $Res Function(_$Speed_Unknown) then) =
       __$$Speed_UnknownCopyWithImpl<$Res>;
 }
 
 /// @nodoc
-class __$$Speed_UnknownCopyWithImpl<$Res> extends _$SpeedCopyWithImpl<$Res> implements _$$Speed_UnknownCopyWith<$Res> {
-  __$$Speed_UnknownCopyWithImpl(_$Speed_Unknown _value, $Res Function(_$Speed_Unknown) _then)
+class __$$Speed_UnknownCopyWithImpl<$Res> extends _$SpeedCopyWithImpl<$Res>
+    implements _$$Speed_UnknownCopyWith<$Res> {
+  __$$Speed_UnknownCopyWithImpl(
+      _$Speed_Unknown _value, $Res Function(_$Speed_Unknown) _then)
       : super(_value, (v) => _then(v as _$Speed_Unknown));
 
   @override
@@ -2199,7 +2301,8 @@ class _$Speed_Unknown implements Speed_Unknown {
 
   @override
   bool operator ==(dynamic other) {
-    return identical(this, other) || (other.runtimeType == runtimeType && other is _$Speed_Unknown);
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$Speed_Unknown);
   }
 
   @override
@@ -2274,13 +2377,17 @@ abstract class Speed_Unknown implements Speed {
 
 /// @nodoc
 abstract class _$$Speed_GPSCopyWith<$Res> {
-  factory _$$Speed_GPSCopyWith(_$Speed_GPS value, $Res Function(_$Speed_GPS) then) = __$$Speed_GPSCopyWithImpl<$Res>;
+  factory _$$Speed_GPSCopyWith(
+          _$Speed_GPS value, $Res Function(_$Speed_GPS) then) =
+      __$$Speed_GPSCopyWithImpl<$Res>;
   $Res call({double field0});
 }
 
 /// @nodoc
-class __$$Speed_GPSCopyWithImpl<$Res> extends _$SpeedCopyWithImpl<$Res> implements _$$Speed_GPSCopyWith<$Res> {
-  __$$Speed_GPSCopyWithImpl(_$Speed_GPS _value, $Res Function(_$Speed_GPS) _then)
+class __$$Speed_GPSCopyWithImpl<$Res> extends _$SpeedCopyWithImpl<$Res>
+    implements _$$Speed_GPSCopyWith<$Res> {
+  __$$Speed_GPSCopyWithImpl(
+      _$Speed_GPS _value, $Res Function(_$Speed_GPS) _then)
       : super(_value, (v) => _then(v as _$Speed_GPS));
 
   @override
@@ -2321,11 +2428,13 @@ class _$Speed_GPS implements Speed_GPS {
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
 
   @JsonKey(ignore: true)
   @override
-  _$$Speed_GPSCopyWith<_$Speed_GPS> get copyWith => __$$Speed_GPSCopyWithImpl<_$Speed_GPS>(this, _$identity);
+  _$$Speed_GPSCopyWith<_$Speed_GPS> get copyWith =>
+      __$$Speed_GPSCopyWithImpl<_$Speed_GPS>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -2395,7 +2504,8 @@ abstract class Speed_GPS implements Speed {
 
   double get field0;
   @JsonKey(ignore: true)
-  _$$Speed_GPSCopyWith<_$Speed_GPS> get copyWith => throw _privateConstructorUsedError;
+  _$$Speed_GPSCopyWith<_$Speed_GPS> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
@@ -2408,7 +2518,8 @@ mixin _$UserId {
 
 /// @nodoc
 abstract class $UserIdCopyWith<$Res> {
-  factory $UserIdCopyWith(UserId value, $Res Function(UserId) then) = _$UserIdCopyWithImpl<$Res>;
+  factory $UserIdCopyWith(UserId value, $Res Function(UserId) then) =
+      _$UserIdCopyWithImpl<$Res>;
   $Res call({int value});
 }
 
@@ -2435,13 +2546,15 @@ class _$UserIdCopyWithImpl<$Res> implements $UserIdCopyWith<$Res> {
 
 /// @nodoc
 abstract class _$$_UserIdCopyWith<$Res> implements $UserIdCopyWith<$Res> {
-  factory _$$_UserIdCopyWith(_$_UserId value, $Res Function(_$_UserId) then) = __$$_UserIdCopyWithImpl<$Res>;
+  factory _$$_UserIdCopyWith(_$_UserId value, $Res Function(_$_UserId) then) =
+      __$$_UserIdCopyWithImpl<$Res>;
   @override
   $Res call({int value});
 }
 
 /// @nodoc
-class __$$_UserIdCopyWithImpl<$Res> extends _$UserIdCopyWithImpl<$Res> implements _$$_UserIdCopyWith<$Res> {
+class __$$_UserIdCopyWithImpl<$Res> extends _$UserIdCopyWithImpl<$Res>
+    implements _$$_UserIdCopyWith<$Res> {
   __$$_UserIdCopyWithImpl(_$_UserId _value, $Res Function(_$_UserId) _then)
       : super(_value, (v) => _then(v as _$_UserId));
 
@@ -2483,11 +2596,13 @@ class _$_UserId implements _UserId {
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, const DeepCollectionEquality().hash(value));
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(value));
 
   @JsonKey(ignore: true)
   @override
-  _$$_UserIdCopyWith<_$_UserId> get copyWith => __$$_UserIdCopyWithImpl<_$_UserId>(this, _$identity);
+  _$$_UserIdCopyWith<_$_UserId> get copyWith =>
+      __$$_UserIdCopyWithImpl<_$_UserId>(this, _$identity);
 }
 
 abstract class _UserId implements UserId {
@@ -2497,5 +2612,6 @@ abstract class _UserId implements UserId {
   int get value;
   @override
   @JsonKey(ignore: true)
-  _$$_UserIdCopyWith<_$_UserId> get copyWith => throw _privateConstructorUsedError;
+  _$$_UserIdCopyWith<_$_UserId> get copyWith =>
+      throw _privateConstructorUsedError;
 }

--- a/frb_example/pure_dart/dart/lib/bridge_generated.freezed.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.freezed.dart
@@ -40,8 +40,7 @@ mixin _$ApplicationMessage {
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
-    required TResult Function(ApplicationMessage_DisplayMessage value)
-        displayMessage,
+    required TResult Function(ApplicationMessage_DisplayMessage value) displayMessage,
     required TResult Function(ApplicationMessage_RenderPixel value) renderPixel,
     required TResult Function(ApplicationMessage_Exit value) exit,
   }) =>
@@ -65,14 +64,12 @@ mixin _$ApplicationMessage {
 
 /// @nodoc
 abstract class $ApplicationMessageCopyWith<$Res> {
-  factory $ApplicationMessageCopyWith(
-          ApplicationMessage value, $Res Function(ApplicationMessage) then) =
+  factory $ApplicationMessageCopyWith(ApplicationMessage value, $Res Function(ApplicationMessage) then) =
       _$ApplicationMessageCopyWithImpl<$Res>;
 }
 
 /// @nodoc
-class _$ApplicationMessageCopyWithImpl<$Res>
-    implements $ApplicationMessageCopyWith<$Res> {
+class _$ApplicationMessageCopyWithImpl<$Res> implements $ApplicationMessageCopyWith<$Res> {
   _$ApplicationMessageCopyWithImpl(this._value, this._then);
 
   final ApplicationMessage _value;
@@ -83,24 +80,20 @@ class _$ApplicationMessageCopyWithImpl<$Res>
 /// @nodoc
 abstract class _$$ApplicationMessage_DisplayMessageCopyWith<$Res> {
   factory _$$ApplicationMessage_DisplayMessageCopyWith(
-          _$ApplicationMessage_DisplayMessage value,
-          $Res Function(_$ApplicationMessage_DisplayMessage) then) =
+          _$ApplicationMessage_DisplayMessage value, $Res Function(_$ApplicationMessage_DisplayMessage) then) =
       __$$ApplicationMessage_DisplayMessageCopyWithImpl<$Res>;
   $Res call({String field0});
 }
 
 /// @nodoc
-class __$$ApplicationMessage_DisplayMessageCopyWithImpl<$Res>
-    extends _$ApplicationMessageCopyWithImpl<$Res>
+class __$$ApplicationMessage_DisplayMessageCopyWithImpl<$Res> extends _$ApplicationMessageCopyWithImpl<$Res>
     implements _$$ApplicationMessage_DisplayMessageCopyWith<$Res> {
   __$$ApplicationMessage_DisplayMessageCopyWithImpl(
-      _$ApplicationMessage_DisplayMessage _value,
-      $Res Function(_$ApplicationMessage_DisplayMessage) _then)
+      _$ApplicationMessage_DisplayMessage _value, $Res Function(_$ApplicationMessage_DisplayMessage) _then)
       : super(_value, (v) => _then(v as _$ApplicationMessage_DisplayMessage));
 
   @override
-  _$ApplicationMessage_DisplayMessage get _value =>
-      super._value as _$ApplicationMessage_DisplayMessage;
+  _$ApplicationMessage_DisplayMessage get _value => super._value as _$ApplicationMessage_DisplayMessage;
 
   @override
   $Res call({
@@ -117,8 +110,7 @@ class __$$ApplicationMessage_DisplayMessageCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$ApplicationMessage_DisplayMessage
-    implements ApplicationMessage_DisplayMessage {
+class _$ApplicationMessage_DisplayMessage implements ApplicationMessage_DisplayMessage {
   const _$ApplicationMessage_DisplayMessage(this.field0);
 
   @override
@@ -138,15 +130,12 @@ class _$ApplicationMessage_DisplayMessage
   }
 
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
+  int get hashCode => Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
 
   @JsonKey(ignore: true)
   @override
-  _$$ApplicationMessage_DisplayMessageCopyWith<
-          _$ApplicationMessage_DisplayMessage>
-      get copyWith => __$$ApplicationMessage_DisplayMessageCopyWithImpl<
-          _$ApplicationMessage_DisplayMessage>(this, _$identity);
+  _$$ApplicationMessage_DisplayMessageCopyWith<_$ApplicationMessage_DisplayMessage> get copyWith =>
+      __$$ApplicationMessage_DisplayMessageCopyWithImpl<_$ApplicationMessage_DisplayMessage>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -185,8 +174,7 @@ class _$ApplicationMessage_DisplayMessage
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
-    required TResult Function(ApplicationMessage_DisplayMessage value)
-        displayMessage,
+    required TResult Function(ApplicationMessage_DisplayMessage value) displayMessage,
     required TResult Function(ApplicationMessage_RenderPixel value) renderPixel,
     required TResult Function(ApplicationMessage_Exit value) exit,
   }) {
@@ -219,37 +207,31 @@ class _$ApplicationMessage_DisplayMessage
 }
 
 abstract class ApplicationMessage_DisplayMessage implements ApplicationMessage {
-  const factory ApplicationMessage_DisplayMessage(final String field0) =
-      _$ApplicationMessage_DisplayMessage;
+  const factory ApplicationMessage_DisplayMessage(final String field0) = _$ApplicationMessage_DisplayMessage;
 
   String get field0;
   @JsonKey(ignore: true)
-  _$$ApplicationMessage_DisplayMessageCopyWith<
-          _$ApplicationMessage_DisplayMessage>
-      get copyWith => throw _privateConstructorUsedError;
+  _$$ApplicationMessage_DisplayMessageCopyWith<_$ApplicationMessage_DisplayMessage> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$ApplicationMessage_RenderPixelCopyWith<$Res> {
   factory _$$ApplicationMessage_RenderPixelCopyWith(
-          _$ApplicationMessage_RenderPixel value,
-          $Res Function(_$ApplicationMessage_RenderPixel) then) =
+          _$ApplicationMessage_RenderPixel value, $Res Function(_$ApplicationMessage_RenderPixel) then) =
       __$$ApplicationMessage_RenderPixelCopyWithImpl<$Res>;
   $Res call({int x, int y});
 }
 
 /// @nodoc
-class __$$ApplicationMessage_RenderPixelCopyWithImpl<$Res>
-    extends _$ApplicationMessageCopyWithImpl<$Res>
+class __$$ApplicationMessage_RenderPixelCopyWithImpl<$Res> extends _$ApplicationMessageCopyWithImpl<$Res>
     implements _$$ApplicationMessage_RenderPixelCopyWith<$Res> {
   __$$ApplicationMessage_RenderPixelCopyWithImpl(
-      _$ApplicationMessage_RenderPixel _value,
-      $Res Function(_$ApplicationMessage_RenderPixel) _then)
+      _$ApplicationMessage_RenderPixel _value, $Res Function(_$ApplicationMessage_RenderPixel) _then)
       : super(_value, (v) => _then(v as _$ApplicationMessage_RenderPixel));
 
   @override
-  _$ApplicationMessage_RenderPixel get _value =>
-      super._value as _$ApplicationMessage_RenderPixel;
+  _$ApplicationMessage_RenderPixel get _value => super._value as _$ApplicationMessage_RenderPixel;
 
   @override
   $Res call({
@@ -271,8 +253,7 @@ class __$$ApplicationMessage_RenderPixelCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$ApplicationMessage_RenderPixel
-    implements ApplicationMessage_RenderPixel {
+class _$ApplicationMessage_RenderPixel implements ApplicationMessage_RenderPixel {
   const _$ApplicationMessage_RenderPixel({required this.x, required this.y});
 
   @override
@@ -295,16 +276,13 @@ class _$ApplicationMessage_RenderPixel
   }
 
   @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(x),
-      const DeepCollectionEquality().hash(y));
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(x), const DeepCollectionEquality().hash(y));
 
   @JsonKey(ignore: true)
   @override
-  _$$ApplicationMessage_RenderPixelCopyWith<_$ApplicationMessage_RenderPixel>
-      get copyWith => __$$ApplicationMessage_RenderPixelCopyWithImpl<
-          _$ApplicationMessage_RenderPixel>(this, _$identity);
+  _$$ApplicationMessage_RenderPixelCopyWith<_$ApplicationMessage_RenderPixel> get copyWith =>
+      __$$ApplicationMessage_RenderPixelCopyWithImpl<_$ApplicationMessage_RenderPixel>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -343,8 +321,7 @@ class _$ApplicationMessage_RenderPixel
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
-    required TResult Function(ApplicationMessage_DisplayMessage value)
-        displayMessage,
+    required TResult Function(ApplicationMessage_DisplayMessage value) displayMessage,
     required TResult Function(ApplicationMessage_RenderPixel value) renderPixel,
     required TResult Function(ApplicationMessage_Exit value) exit,
   }) {
@@ -377,35 +354,32 @@ class _$ApplicationMessage_RenderPixel
 }
 
 abstract class ApplicationMessage_RenderPixel implements ApplicationMessage {
-  const factory ApplicationMessage_RenderPixel(
-      {required final int x,
-      required final int y}) = _$ApplicationMessage_RenderPixel;
+  const factory ApplicationMessage_RenderPixel({required final int x, required final int y}) =
+      _$ApplicationMessage_RenderPixel;
 
   int get x;
   int get y;
   @JsonKey(ignore: true)
-  _$$ApplicationMessage_RenderPixelCopyWith<_$ApplicationMessage_RenderPixel>
-      get copyWith => throw _privateConstructorUsedError;
+  _$$ApplicationMessage_RenderPixelCopyWith<_$ApplicationMessage_RenderPixel> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$ApplicationMessage_ExitCopyWith<$Res> {
-  factory _$$ApplicationMessage_ExitCopyWith(_$ApplicationMessage_Exit value,
-          $Res Function(_$ApplicationMessage_Exit) then) =
+  factory _$$ApplicationMessage_ExitCopyWith(
+          _$ApplicationMessage_Exit value, $Res Function(_$ApplicationMessage_Exit) then) =
       __$$ApplicationMessage_ExitCopyWithImpl<$Res>;
 }
 
 /// @nodoc
-class __$$ApplicationMessage_ExitCopyWithImpl<$Res>
-    extends _$ApplicationMessageCopyWithImpl<$Res>
+class __$$ApplicationMessage_ExitCopyWithImpl<$Res> extends _$ApplicationMessageCopyWithImpl<$Res>
     implements _$$ApplicationMessage_ExitCopyWith<$Res> {
-  __$$ApplicationMessage_ExitCopyWithImpl(_$ApplicationMessage_Exit _value,
-      $Res Function(_$ApplicationMessage_Exit) _then)
+  __$$ApplicationMessage_ExitCopyWithImpl(
+      _$ApplicationMessage_Exit _value, $Res Function(_$ApplicationMessage_Exit) _then)
       : super(_value, (v) => _then(v as _$ApplicationMessage_Exit));
 
   @override
-  _$ApplicationMessage_Exit get _value =>
-      super._value as _$ApplicationMessage_Exit;
+  _$ApplicationMessage_Exit get _value => super._value as _$ApplicationMessage_Exit;
 }
 
 /// @nodoc
@@ -420,9 +394,7 @@ class _$ApplicationMessage_Exit implements ApplicationMessage_Exit {
 
   @override
   bool operator ==(dynamic other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$ApplicationMessage_Exit);
+    return identical(this, other) || (other.runtimeType == runtimeType && other is _$ApplicationMessage_Exit);
   }
 
   @override
@@ -465,8 +437,7 @@ class _$ApplicationMessage_Exit implements ApplicationMessage_Exit {
   @override
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
-    required TResult Function(ApplicationMessage_DisplayMessage value)
-        displayMessage,
+    required TResult Function(ApplicationMessage_DisplayMessage value) displayMessage,
     required TResult Function(ApplicationMessage_RenderPixel value) renderPixel,
     required TResult Function(ApplicationMessage_Exit value) exit,
   }) {
@@ -546,8 +517,7 @@ mixin _$Distance {
 
 /// @nodoc
 abstract class $DistanceCopyWith<$Res> {
-  factory $DistanceCopyWith(Distance value, $Res Function(Distance) then) =
-      _$DistanceCopyWithImpl<$Res>;
+  factory $DistanceCopyWith(Distance value, $Res Function(Distance) then) = _$DistanceCopyWithImpl<$Res>;
 }
 
 /// @nodoc
@@ -561,17 +531,14 @@ class _$DistanceCopyWithImpl<$Res> implements $DistanceCopyWith<$Res> {
 
 /// @nodoc
 abstract class _$$Distance_UnknownCopyWith<$Res> {
-  factory _$$Distance_UnknownCopyWith(
-          _$Distance_Unknown value, $Res Function(_$Distance_Unknown) then) =
+  factory _$$Distance_UnknownCopyWith(_$Distance_Unknown value, $Res Function(_$Distance_Unknown) then) =
       __$$Distance_UnknownCopyWithImpl<$Res>;
 }
 
 /// @nodoc
-class __$$Distance_UnknownCopyWithImpl<$Res>
-    extends _$DistanceCopyWithImpl<$Res>
+class __$$Distance_UnknownCopyWithImpl<$Res> extends _$DistanceCopyWithImpl<$Res>
     implements _$$Distance_UnknownCopyWith<$Res> {
-  __$$Distance_UnknownCopyWithImpl(
-      _$Distance_Unknown _value, $Res Function(_$Distance_Unknown) _then)
+  __$$Distance_UnknownCopyWithImpl(_$Distance_Unknown _value, $Res Function(_$Distance_Unknown) _then)
       : super(_value, (v) => _then(v as _$Distance_Unknown));
 
   @override
@@ -590,8 +557,7 @@ class _$Distance_Unknown implements Distance_Unknown {
 
   @override
   bool operator ==(dynamic other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType && other is _$Distance_Unknown);
+    return identical(this, other) || (other.runtimeType == runtimeType && other is _$Distance_Unknown);
   }
 
   @override
@@ -666,17 +632,14 @@ abstract class Distance_Unknown implements Distance {
 
 /// @nodoc
 abstract class _$$Distance_MapCopyWith<$Res> {
-  factory _$$Distance_MapCopyWith(
-          _$Distance_Map value, $Res Function(_$Distance_Map) then) =
+  factory _$$Distance_MapCopyWith(_$Distance_Map value, $Res Function(_$Distance_Map) then) =
       __$$Distance_MapCopyWithImpl<$Res>;
   $Res call({double field0});
 }
 
 /// @nodoc
-class __$$Distance_MapCopyWithImpl<$Res> extends _$DistanceCopyWithImpl<$Res>
-    implements _$$Distance_MapCopyWith<$Res> {
-  __$$Distance_MapCopyWithImpl(
-      _$Distance_Map _value, $Res Function(_$Distance_Map) _then)
+class __$$Distance_MapCopyWithImpl<$Res> extends _$DistanceCopyWithImpl<$Res> implements _$$Distance_MapCopyWith<$Res> {
+  __$$Distance_MapCopyWithImpl(_$Distance_Map _value, $Res Function(_$Distance_Map) _then)
       : super(_value, (v) => _then(v as _$Distance_Map));
 
   @override
@@ -717,8 +680,7 @@ class _$Distance_Map implements Distance_Map {
   }
 
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
+  int get hashCode => Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
 
   @JsonKey(ignore: true)
   @override
@@ -793,8 +755,7 @@ abstract class Distance_Map implements Distance {
 
   double get field0;
   @JsonKey(ignore: true)
-  _$$Distance_MapCopyWith<_$Distance_Map> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$Distance_MapCopyWith<_$Distance_Map> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
@@ -802,8 +763,7 @@ mixin _$KitchenSink {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function() empty,
-    required TResult Function(int int32, double float64, bool boolean)
-        primitives,
+    required TResult Function(int int32, double float64, bool boolean) primitives,
     required TResult Function(KitchenSink field0, int field1) nested,
     required TResult Function(int? field0, int? field1) optional,
     required TResult Function(Uint8List field0) buffer,
@@ -866,9 +826,7 @@ mixin _$KitchenSink {
 
 /// @nodoc
 abstract class $KitchenSinkCopyWith<$Res> {
-  factory $KitchenSinkCopyWith(
-          KitchenSink value, $Res Function(KitchenSink) then) =
-      _$KitchenSinkCopyWithImpl<$Res>;
+  factory $KitchenSinkCopyWith(KitchenSink value, $Res Function(KitchenSink) then) = _$KitchenSinkCopyWithImpl<$Res>;
 }
 
 /// @nodoc
@@ -882,17 +840,14 @@ class _$KitchenSinkCopyWithImpl<$Res> implements $KitchenSinkCopyWith<$Res> {
 
 /// @nodoc
 abstract class _$$KitchenSink_EmptyCopyWith<$Res> {
-  factory _$$KitchenSink_EmptyCopyWith(
-          _$KitchenSink_Empty value, $Res Function(_$KitchenSink_Empty) then) =
+  factory _$$KitchenSink_EmptyCopyWith(_$KitchenSink_Empty value, $Res Function(_$KitchenSink_Empty) then) =
       __$$KitchenSink_EmptyCopyWithImpl<$Res>;
 }
 
 /// @nodoc
-class __$$KitchenSink_EmptyCopyWithImpl<$Res>
-    extends _$KitchenSinkCopyWithImpl<$Res>
+class __$$KitchenSink_EmptyCopyWithImpl<$Res> extends _$KitchenSinkCopyWithImpl<$Res>
     implements _$$KitchenSink_EmptyCopyWith<$Res> {
-  __$$KitchenSink_EmptyCopyWithImpl(
-      _$KitchenSink_Empty _value, $Res Function(_$KitchenSink_Empty) _then)
+  __$$KitchenSink_EmptyCopyWithImpl(_$KitchenSink_Empty _value, $Res Function(_$KitchenSink_Empty) _then)
       : super(_value, (v) => _then(v as _$KitchenSink_Empty));
 
   @override
@@ -911,8 +866,7 @@ class _$KitchenSink_Empty implements KitchenSink_Empty {
 
   @override
   bool operator ==(dynamic other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType && other is _$KitchenSink_Empty);
+    return identical(this, other) || (other.runtimeType == runtimeType && other is _$KitchenSink_Empty);
   }
 
   @override
@@ -922,8 +876,7 @@ class _$KitchenSink_Empty implements KitchenSink_Empty {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function() empty,
-    required TResult Function(int int32, double float64, bool boolean)
-        primitives,
+    required TResult Function(int int32, double float64, bool boolean) primitives,
     required TResult Function(KitchenSink field0, int field1) nested,
     required TResult Function(int? field0, int? field1) optional,
     required TResult Function(Uint8List field0) buffer,
@@ -1012,23 +965,20 @@ abstract class KitchenSink_Empty implements KitchenSink {
 
 /// @nodoc
 abstract class _$$KitchenSink_PrimitivesCopyWith<$Res> {
-  factory _$$KitchenSink_PrimitivesCopyWith(_$KitchenSink_Primitives value,
-          $Res Function(_$KitchenSink_Primitives) then) =
+  factory _$$KitchenSink_PrimitivesCopyWith(
+          _$KitchenSink_Primitives value, $Res Function(_$KitchenSink_Primitives) then) =
       __$$KitchenSink_PrimitivesCopyWithImpl<$Res>;
   $Res call({int int32, double float64, bool boolean});
 }
 
 /// @nodoc
-class __$$KitchenSink_PrimitivesCopyWithImpl<$Res>
-    extends _$KitchenSinkCopyWithImpl<$Res>
+class __$$KitchenSink_PrimitivesCopyWithImpl<$Res> extends _$KitchenSinkCopyWithImpl<$Res>
     implements _$$KitchenSink_PrimitivesCopyWith<$Res> {
-  __$$KitchenSink_PrimitivesCopyWithImpl(_$KitchenSink_Primitives _value,
-      $Res Function(_$KitchenSink_Primitives) _then)
+  __$$KitchenSink_PrimitivesCopyWithImpl(_$KitchenSink_Primitives _value, $Res Function(_$KitchenSink_Primitives) _then)
       : super(_value, (v) => _then(v as _$KitchenSink_Primitives));
 
   @override
-  _$KitchenSink_Primitives get _value =>
-      super._value as _$KitchenSink_Primitives;
+  _$KitchenSink_Primitives get _value => super._value as _$KitchenSink_Primitives;
 
   @override
   $Res call({
@@ -1056,8 +1006,7 @@ class __$$KitchenSink_PrimitivesCopyWithImpl<$Res>
 /// @nodoc
 
 class _$KitchenSink_Primitives implements KitchenSink_Primitives {
-  const _$KitchenSink_Primitives(
-      {required this.int32, required this.float64, required this.boolean});
+  const _$KitchenSink_Primitives({required this.int32, required this.float64, required this.boolean});
 
   /// Dart field comment
   @override
@@ -1083,24 +1032,19 @@ class _$KitchenSink_Primitives implements KitchenSink_Primitives {
   }
 
   @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(int32),
-      const DeepCollectionEquality().hash(float64),
-      const DeepCollectionEquality().hash(boolean));
+  int get hashCode => Object.hash(runtimeType, const DeepCollectionEquality().hash(int32),
+      const DeepCollectionEquality().hash(float64), const DeepCollectionEquality().hash(boolean));
 
   @JsonKey(ignore: true)
   @override
   _$$KitchenSink_PrimitivesCopyWith<_$KitchenSink_Primitives> get copyWith =>
-      __$$KitchenSink_PrimitivesCopyWithImpl<_$KitchenSink_Primitives>(
-          this, _$identity);
+      __$$KitchenSink_PrimitivesCopyWithImpl<_$KitchenSink_Primitives>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function() empty,
-    required TResult Function(int int32, double float64, bool boolean)
-        primitives,
+    required TResult Function(int int32, double float64, bool boolean) primitives,
     required TResult Function(KitchenSink field0, int field1) nested,
     required TResult Function(int? field0, int? field1) optional,
     required TResult Function(Uint8List field0) buffer,
@@ -1194,14 +1138,12 @@ abstract class KitchenSink_Primitives implements KitchenSink {
   double get float64;
   bool get boolean;
   @JsonKey(ignore: true)
-  _$$KitchenSink_PrimitivesCopyWith<_$KitchenSink_Primitives> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$KitchenSink_PrimitivesCopyWith<_$KitchenSink_Primitives> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$KitchenSink_NestedCopyWith<$Res> {
-  factory _$$KitchenSink_NestedCopyWith(_$KitchenSink_Nested value,
-          $Res Function(_$KitchenSink_Nested) then) =
+  factory _$$KitchenSink_NestedCopyWith(_$KitchenSink_Nested value, $Res Function(_$KitchenSink_Nested) then) =
       __$$KitchenSink_NestedCopyWithImpl<$Res>;
   $Res call({KitchenSink field0, int field1});
 
@@ -1209,11 +1151,9 @@ abstract class _$$KitchenSink_NestedCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$KitchenSink_NestedCopyWithImpl<$Res>
-    extends _$KitchenSinkCopyWithImpl<$Res>
+class __$$KitchenSink_NestedCopyWithImpl<$Res> extends _$KitchenSinkCopyWithImpl<$Res>
     implements _$$KitchenSink_NestedCopyWith<$Res> {
-  __$$KitchenSink_NestedCopyWithImpl(
-      _$KitchenSink_Nested _value, $Res Function(_$KitchenSink_Nested) _then)
+  __$$KitchenSink_NestedCopyWithImpl(_$KitchenSink_Nested _value, $Res Function(_$KitchenSink_Nested) _then)
       : super(_value, (v) => _then(v as _$KitchenSink_Nested));
 
   @override
@@ -1270,22 +1210,18 @@ class _$KitchenSink_Nested implements KitchenSink_Nested {
 
   @override
   int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(field0),
-      const DeepCollectionEquality().hash(field1));
+      runtimeType, const DeepCollectionEquality().hash(field0), const DeepCollectionEquality().hash(field1));
 
   @JsonKey(ignore: true)
   @override
   _$$KitchenSink_NestedCopyWith<_$KitchenSink_Nested> get copyWith =>
-      __$$KitchenSink_NestedCopyWithImpl<_$KitchenSink_Nested>(
-          this, _$identity);
+      __$$KitchenSink_NestedCopyWithImpl<_$KitchenSink_Nested>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function() empty,
-    required TResult Function(int int32, double float64, bool boolean)
-        primitives,
+    required TResult Function(int int32, double float64, bool boolean) primitives,
     required TResult Function(KitchenSink field0, int field1) nested,
     required TResult Function(int? field0, int? field1) optional,
     required TResult Function(Uint8List field0) buffer,
@@ -1369,30 +1305,25 @@ class _$KitchenSink_Nested implements KitchenSink_Nested {
 }
 
 abstract class KitchenSink_Nested implements KitchenSink {
-  const factory KitchenSink_Nested(final KitchenSink field0, final int field1) =
-      _$KitchenSink_Nested;
+  const factory KitchenSink_Nested(final KitchenSink field0, final int field1) = _$KitchenSink_Nested;
 
   KitchenSink get field0;
   int get field1;
   @JsonKey(ignore: true)
-  _$$KitchenSink_NestedCopyWith<_$KitchenSink_Nested> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$KitchenSink_NestedCopyWith<_$KitchenSink_Nested> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$KitchenSink_OptionalCopyWith<$Res> {
-  factory _$$KitchenSink_OptionalCopyWith(_$KitchenSink_Optional value,
-          $Res Function(_$KitchenSink_Optional) then) =
+  factory _$$KitchenSink_OptionalCopyWith(_$KitchenSink_Optional value, $Res Function(_$KitchenSink_Optional) then) =
       __$$KitchenSink_OptionalCopyWithImpl<$Res>;
   $Res call({int? field0, int? field1});
 }
 
 /// @nodoc
-class __$$KitchenSink_OptionalCopyWithImpl<$Res>
-    extends _$KitchenSinkCopyWithImpl<$Res>
+class __$$KitchenSink_OptionalCopyWithImpl<$Res> extends _$KitchenSinkCopyWithImpl<$Res>
     implements _$$KitchenSink_OptionalCopyWith<$Res> {
-  __$$KitchenSink_OptionalCopyWithImpl(_$KitchenSink_Optional _value,
-      $Res Function(_$KitchenSink_Optional) _then)
+  __$$KitchenSink_OptionalCopyWithImpl(_$KitchenSink_Optional _value, $Res Function(_$KitchenSink_Optional) _then)
       : super(_value, (v) => _then(v as _$KitchenSink_Optional));
 
   @override
@@ -1443,22 +1374,18 @@ class _$KitchenSink_Optional implements KitchenSink_Optional {
 
   @override
   int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(field0),
-      const DeepCollectionEquality().hash(field1));
+      runtimeType, const DeepCollectionEquality().hash(field0), const DeepCollectionEquality().hash(field1));
 
   @JsonKey(ignore: true)
   @override
   _$$KitchenSink_OptionalCopyWith<_$KitchenSink_Optional> get copyWith =>
-      __$$KitchenSink_OptionalCopyWithImpl<_$KitchenSink_Optional>(
-          this, _$identity);
+      __$$KitchenSink_OptionalCopyWithImpl<_$KitchenSink_Optional>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function() empty,
-    required TResult Function(int int32, double float64, bool boolean)
-        primitives,
+    required TResult Function(int int32, double float64, bool boolean) primitives,
     required TResult Function(KitchenSink field0, int field1) nested,
     required TResult Function(int? field0, int? field1) optional,
     required TResult Function(Uint8List field0) buffer,
@@ -1542,31 +1469,26 @@ class _$KitchenSink_Optional implements KitchenSink_Optional {
 }
 
 abstract class KitchenSink_Optional implements KitchenSink {
-  const factory KitchenSink_Optional([final int? field0, final int? field1]) =
-      _$KitchenSink_Optional;
+  const factory KitchenSink_Optional([final int? field0, final int? field1]) = _$KitchenSink_Optional;
 
   /// Comment on anonymous field
   int? get field0;
   int? get field1;
   @JsonKey(ignore: true)
-  _$$KitchenSink_OptionalCopyWith<_$KitchenSink_Optional> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$KitchenSink_OptionalCopyWith<_$KitchenSink_Optional> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$KitchenSink_BufferCopyWith<$Res> {
-  factory _$$KitchenSink_BufferCopyWith(_$KitchenSink_Buffer value,
-          $Res Function(_$KitchenSink_Buffer) then) =
+  factory _$$KitchenSink_BufferCopyWith(_$KitchenSink_Buffer value, $Res Function(_$KitchenSink_Buffer) then) =
       __$$KitchenSink_BufferCopyWithImpl<$Res>;
   $Res call({Uint8List field0});
 }
 
 /// @nodoc
-class __$$KitchenSink_BufferCopyWithImpl<$Res>
-    extends _$KitchenSinkCopyWithImpl<$Res>
+class __$$KitchenSink_BufferCopyWithImpl<$Res> extends _$KitchenSinkCopyWithImpl<$Res>
     implements _$$KitchenSink_BufferCopyWith<$Res> {
-  __$$KitchenSink_BufferCopyWithImpl(
-      _$KitchenSink_Buffer _value, $Res Function(_$KitchenSink_Buffer) _then)
+  __$$KitchenSink_BufferCopyWithImpl(_$KitchenSink_Buffer _value, $Res Function(_$KitchenSink_Buffer) _then)
       : super(_value, (v) => _then(v as _$KitchenSink_Buffer));
 
   @override
@@ -1607,21 +1529,18 @@ class _$KitchenSink_Buffer implements KitchenSink_Buffer {
   }
 
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
+  int get hashCode => Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
 
   @JsonKey(ignore: true)
   @override
   _$$KitchenSink_BufferCopyWith<_$KitchenSink_Buffer> get copyWith =>
-      __$$KitchenSink_BufferCopyWithImpl<_$KitchenSink_Buffer>(
-          this, _$identity);
+      __$$KitchenSink_BufferCopyWithImpl<_$KitchenSink_Buffer>(this, _$identity);
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function() empty,
-    required TResult Function(int int32, double float64, bool boolean)
-        primitives,
+    required TResult Function(int int32, double float64, bool boolean) primitives,
     required TResult Function(KitchenSink field0, int field1) nested,
     required TResult Function(int? field0, int? field1) optional,
     required TResult Function(Uint8List field0) buffer,
@@ -1705,29 +1624,24 @@ class _$KitchenSink_Buffer implements KitchenSink_Buffer {
 }
 
 abstract class KitchenSink_Buffer implements KitchenSink {
-  const factory KitchenSink_Buffer(final Uint8List field0) =
-      _$KitchenSink_Buffer;
+  const factory KitchenSink_Buffer(final Uint8List field0) = _$KitchenSink_Buffer;
 
   Uint8List get field0;
   @JsonKey(ignore: true)
-  _$$KitchenSink_BufferCopyWith<_$KitchenSink_Buffer> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$KitchenSink_BufferCopyWith<_$KitchenSink_Buffer> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$KitchenSink_EnumsCopyWith<$Res> {
-  factory _$$KitchenSink_EnumsCopyWith(
-          _$KitchenSink_Enums value, $Res Function(_$KitchenSink_Enums) then) =
+  factory _$$KitchenSink_EnumsCopyWith(_$KitchenSink_Enums value, $Res Function(_$KitchenSink_Enums) then) =
       __$$KitchenSink_EnumsCopyWithImpl<$Res>;
   $Res call({Weekdays field0});
 }
 
 /// @nodoc
-class __$$KitchenSink_EnumsCopyWithImpl<$Res>
-    extends _$KitchenSinkCopyWithImpl<$Res>
+class __$$KitchenSink_EnumsCopyWithImpl<$Res> extends _$KitchenSinkCopyWithImpl<$Res>
     implements _$$KitchenSink_EnumsCopyWith<$Res> {
-  __$$KitchenSink_EnumsCopyWithImpl(
-      _$KitchenSink_Enums _value, $Res Function(_$KitchenSink_Enums) _then)
+  __$$KitchenSink_EnumsCopyWithImpl(_$KitchenSink_Enums _value, $Res Function(_$KitchenSink_Enums) _then)
       : super(_value, (v) => _then(v as _$KitchenSink_Enums));
 
   @override
@@ -1768,8 +1682,7 @@ class _$KitchenSink_Enums implements KitchenSink_Enums {
   }
 
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
+  int get hashCode => Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
 
   @JsonKey(ignore: true)
   @override
@@ -1780,8 +1693,7 @@ class _$KitchenSink_Enums implements KitchenSink_Enums {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function() empty,
-    required TResult Function(int int32, double float64, bool boolean)
-        primitives,
+    required TResult Function(int int32, double float64, bool boolean) primitives,
     required TResult Function(KitchenSink field0, int field1) nested,
     required TResult Function(int? field0, int? field1) optional,
     required TResult Function(Uint8List field0) buffer,
@@ -1869,8 +1781,7 @@ abstract class KitchenSink_Enums implements KitchenSink {
 
   Weekdays get field0;
   @JsonKey(ignore: true)
-  _$$KitchenSink_EnumsCopyWith<_$KitchenSink_Enums> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$KitchenSink_EnumsCopyWith<_$KitchenSink_Enums> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
@@ -1917,8 +1828,7 @@ mixin _$Measure {
 
 /// @nodoc
 abstract class $MeasureCopyWith<$Res> {
-  factory $MeasureCopyWith(Measure value, $Res Function(Measure) then) =
-      _$MeasureCopyWithImpl<$Res>;
+  factory $MeasureCopyWith(Measure value, $Res Function(Measure) then) = _$MeasureCopyWithImpl<$Res>;
 }
 
 /// @nodoc
@@ -1932,8 +1842,7 @@ class _$MeasureCopyWithImpl<$Res> implements $MeasureCopyWith<$Res> {
 
 /// @nodoc
 abstract class _$$Measure_SpeedCopyWith<$Res> {
-  factory _$$Measure_SpeedCopyWith(
-          _$Measure_Speed value, $Res Function(_$Measure_Speed) then) =
+  factory _$$Measure_SpeedCopyWith(_$Measure_Speed value, $Res Function(_$Measure_Speed) then) =
       __$$Measure_SpeedCopyWithImpl<$Res>;
   $Res call({Speed field0});
 
@@ -1943,8 +1852,7 @@ abstract class _$$Measure_SpeedCopyWith<$Res> {
 /// @nodoc
 class __$$Measure_SpeedCopyWithImpl<$Res> extends _$MeasureCopyWithImpl<$Res>
     implements _$$Measure_SpeedCopyWith<$Res> {
-  __$$Measure_SpeedCopyWithImpl(
-      _$Measure_Speed _value, $Res Function(_$Measure_Speed) _then)
+  __$$Measure_SpeedCopyWithImpl(_$Measure_Speed _value, $Res Function(_$Measure_Speed) _then)
       : super(_value, (v) => _then(v as _$Measure_Speed));
 
   @override
@@ -1992,8 +1900,7 @@ class _$Measure_Speed implements Measure_Speed {
   }
 
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
+  int get hashCode => Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
 
   @JsonKey(ignore: true)
   @override
@@ -2068,14 +1975,12 @@ abstract class Measure_Speed implements Measure {
 
   Speed get field0;
   @JsonKey(ignore: true)
-  _$$Measure_SpeedCopyWith<_$Measure_Speed> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$Measure_SpeedCopyWith<_$Measure_Speed> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$Measure_DistanceCopyWith<$Res> {
-  factory _$$Measure_DistanceCopyWith(
-          _$Measure_Distance value, $Res Function(_$Measure_Distance) then) =
+  factory _$$Measure_DistanceCopyWith(_$Measure_Distance value, $Res Function(_$Measure_Distance) then) =
       __$$Measure_DistanceCopyWithImpl<$Res>;
   $Res call({Distance field0});
 
@@ -2085,8 +1990,7 @@ abstract class _$$Measure_DistanceCopyWith<$Res> {
 /// @nodoc
 class __$$Measure_DistanceCopyWithImpl<$Res> extends _$MeasureCopyWithImpl<$Res>
     implements _$$Measure_DistanceCopyWith<$Res> {
-  __$$Measure_DistanceCopyWithImpl(
-      _$Measure_Distance _value, $Res Function(_$Measure_Distance) _then)
+  __$$Measure_DistanceCopyWithImpl(_$Measure_Distance _value, $Res Function(_$Measure_Distance) _then)
       : super(_value, (v) => _then(v as _$Measure_Distance));
 
   @override
@@ -2134,8 +2038,7 @@ class _$Measure_Distance implements Measure_Distance {
   }
 
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
+  int get hashCode => Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
 
   @JsonKey(ignore: true)
   @override
@@ -2210,8 +2113,7 @@ abstract class Measure_Distance implements Measure {
 
   Distance get field0;
   @JsonKey(ignore: true)
-  _$$Measure_DistanceCopyWith<_$Measure_Distance> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$Measure_DistanceCopyWith<_$Measure_Distance> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
@@ -2258,8 +2160,7 @@ mixin _$Speed {
 
 /// @nodoc
 abstract class $SpeedCopyWith<$Res> {
-  factory $SpeedCopyWith(Speed value, $Res Function(Speed) then) =
-      _$SpeedCopyWithImpl<$Res>;
+  factory $SpeedCopyWith(Speed value, $Res Function(Speed) then) = _$SpeedCopyWithImpl<$Res>;
 }
 
 /// @nodoc
@@ -2273,16 +2174,13 @@ class _$SpeedCopyWithImpl<$Res> implements $SpeedCopyWith<$Res> {
 
 /// @nodoc
 abstract class _$$Speed_UnknownCopyWith<$Res> {
-  factory _$$Speed_UnknownCopyWith(
-          _$Speed_Unknown value, $Res Function(_$Speed_Unknown) then) =
+  factory _$$Speed_UnknownCopyWith(_$Speed_Unknown value, $Res Function(_$Speed_Unknown) then) =
       __$$Speed_UnknownCopyWithImpl<$Res>;
 }
 
 /// @nodoc
-class __$$Speed_UnknownCopyWithImpl<$Res> extends _$SpeedCopyWithImpl<$Res>
-    implements _$$Speed_UnknownCopyWith<$Res> {
-  __$$Speed_UnknownCopyWithImpl(
-      _$Speed_Unknown _value, $Res Function(_$Speed_Unknown) _then)
+class __$$Speed_UnknownCopyWithImpl<$Res> extends _$SpeedCopyWithImpl<$Res> implements _$$Speed_UnknownCopyWith<$Res> {
+  __$$Speed_UnknownCopyWithImpl(_$Speed_Unknown _value, $Res Function(_$Speed_Unknown) _then)
       : super(_value, (v) => _then(v as _$Speed_Unknown));
 
   @override
@@ -2301,8 +2199,7 @@ class _$Speed_Unknown implements Speed_Unknown {
 
   @override
   bool operator ==(dynamic other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType && other is _$Speed_Unknown);
+    return identical(this, other) || (other.runtimeType == runtimeType && other is _$Speed_Unknown);
   }
 
   @override
@@ -2377,17 +2274,13 @@ abstract class Speed_Unknown implements Speed {
 
 /// @nodoc
 abstract class _$$Speed_GPSCopyWith<$Res> {
-  factory _$$Speed_GPSCopyWith(
-          _$Speed_GPS value, $Res Function(_$Speed_GPS) then) =
-      __$$Speed_GPSCopyWithImpl<$Res>;
+  factory _$$Speed_GPSCopyWith(_$Speed_GPS value, $Res Function(_$Speed_GPS) then) = __$$Speed_GPSCopyWithImpl<$Res>;
   $Res call({double field0});
 }
 
 /// @nodoc
-class __$$Speed_GPSCopyWithImpl<$Res> extends _$SpeedCopyWithImpl<$Res>
-    implements _$$Speed_GPSCopyWith<$Res> {
-  __$$Speed_GPSCopyWithImpl(
-      _$Speed_GPS _value, $Res Function(_$Speed_GPS) _then)
+class __$$Speed_GPSCopyWithImpl<$Res> extends _$SpeedCopyWithImpl<$Res> implements _$$Speed_GPSCopyWith<$Res> {
+  __$$Speed_GPSCopyWithImpl(_$Speed_GPS _value, $Res Function(_$Speed_GPS) _then)
       : super(_value, (v) => _then(v as _$Speed_GPS));
 
   @override
@@ -2428,13 +2321,11 @@ class _$Speed_GPS implements Speed_GPS {
   }
 
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
+  int get hashCode => Object.hash(runtimeType, const DeepCollectionEquality().hash(field0));
 
   @JsonKey(ignore: true)
   @override
-  _$$Speed_GPSCopyWith<_$Speed_GPS> get copyWith =>
-      __$$Speed_GPSCopyWithImpl<_$Speed_GPS>(this, _$identity);
+  _$$Speed_GPSCopyWith<_$Speed_GPS> get copyWith => __$$Speed_GPSCopyWithImpl<_$Speed_GPS>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -2504,8 +2395,7 @@ abstract class Speed_GPS implements Speed {
 
   double get field0;
   @JsonKey(ignore: true)
-  _$$Speed_GPSCopyWith<_$Speed_GPS> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$Speed_GPSCopyWith<_$Speed_GPS> get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
@@ -2518,8 +2408,7 @@ mixin _$UserId {
 
 /// @nodoc
 abstract class $UserIdCopyWith<$Res> {
-  factory $UserIdCopyWith(UserId value, $Res Function(UserId) then) =
-      _$UserIdCopyWithImpl<$Res>;
+  factory $UserIdCopyWith(UserId value, $Res Function(UserId) then) = _$UserIdCopyWithImpl<$Res>;
   $Res call({int value});
 }
 
@@ -2546,15 +2435,13 @@ class _$UserIdCopyWithImpl<$Res> implements $UserIdCopyWith<$Res> {
 
 /// @nodoc
 abstract class _$$_UserIdCopyWith<$Res> implements $UserIdCopyWith<$Res> {
-  factory _$$_UserIdCopyWith(_$_UserId value, $Res Function(_$_UserId) then) =
-      __$$_UserIdCopyWithImpl<$Res>;
+  factory _$$_UserIdCopyWith(_$_UserId value, $Res Function(_$_UserId) then) = __$$_UserIdCopyWithImpl<$Res>;
   @override
   $Res call({int value});
 }
 
 /// @nodoc
-class __$$_UserIdCopyWithImpl<$Res> extends _$UserIdCopyWithImpl<$Res>
-    implements _$$_UserIdCopyWith<$Res> {
+class __$$_UserIdCopyWithImpl<$Res> extends _$UserIdCopyWithImpl<$Res> implements _$$_UserIdCopyWith<$Res> {
   __$$_UserIdCopyWithImpl(_$_UserId _value, $Res Function(_$_UserId) _then)
       : super(_value, (v) => _then(v as _$_UserId));
 
@@ -2596,13 +2483,11 @@ class _$_UserId implements _UserId {
   }
 
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, const DeepCollectionEquality().hash(value));
+  int get hashCode => Object.hash(runtimeType, const DeepCollectionEquality().hash(value));
 
   @JsonKey(ignore: true)
   @override
-  _$$_UserIdCopyWith<_$_UserId> get copyWith =>
-      __$$_UserIdCopyWithImpl<_$_UserId>(this, _$identity);
+  _$$_UserIdCopyWith<_$_UserId> get copyWith => __$$_UserIdCopyWithImpl<_$_UserId>(this, _$identity);
 }
 
 abstract class _UserId implements UserId {
@@ -2612,6 +2497,5 @@ abstract class _UserId implements UserId {
   int get value;
   @override
   @JsonKey(ignore: true)
-  _$$_UserIdCopyWith<_$_UserId> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$_UserIdCopyWith<_$_UserId> get copyWith => throw _privateConstructorUsedError;
 }

--- a/frb_example/pure_dart/dart/lib/main.dart
+++ b/frb_example/pure_dart/dart/lib/main.dart
@@ -17,7 +17,8 @@ void main(List<String> args) async {
   });
 
   test('dart call primitiveTypes', () async {
-    expect(await api.primitiveTypes(myI32: 123, myI64: 10000000000000, myF64: 12345678901234567890.123, myBool: true), 42);
+    expect(
+        await api.primitiveTypes(myI32: 123, myI64: 10000000000000, myF64: 12345678901234567890.123, myBool: true), 42);
   });
 
   test('dart call primitiveU32', () async {
@@ -34,7 +35,8 @@ void main(List<String> args) async {
 
   test('dart call handleVecU8', () async {
     final len = 100000;
-    expect(await api.handleVecU8(v: Uint8List.fromList(List.filled(len, 127))), Uint8List.fromList(List.filled(len * 2, 127)));
+    expect(await api.handleVecU8(v: Uint8List.fromList(List.filled(len, 127))),
+        Uint8List.fromList(List.filled(len * 2, 127)));
   });
 
   test('dart call handleVecOfPrimitive', () async {
@@ -68,7 +70,8 @@ void main(List<String> args) async {
   });
 
   test('dart call handleStruct', () async {
-    final structResp = await api.handleStruct(arg: MySize(width: 42, height: 100), boxed: MySize(width: 1000, height: 10000));
+    final structResp =
+        await api.handleStruct(arg: MySize(width: 42, height: 100), boxed: MySize(width: 1000, height: 10000));
     expect(structResp.width, 42 + 1000);
     expect(structResp.height, 100 + 10000);
   });
@@ -79,7 +82,8 @@ void main(List<String> args) async {
   });
 
   test('dart call handleListOfStruct', () async {
-    final listOfStructResp = await api.handleListOfStruct(l: [MySize(width: 42, height: 100), MySize(width: 420, height: 1000)]);
+    final listOfStructResp =
+        await api.handleListOfStruct(l: [MySize(width: 42, height: 100), MySize(width: 420, height: 1000)]);
     expect(listOfStructResp.length, 4);
     expect(listOfStructResp[0].width, 42);
     expect(listOfStructResp[1].width, 420);
@@ -127,7 +131,8 @@ void main(List<String> args) async {
   });
 
   test('dart call handle_stream', () {
-    Future<void> _testHandleStream(Stream<Log> Function({dynamic hint, required int key, required int max}) handleStreamFunction) async {
+    Future<void> _testHandleStream(
+        Stream<Log> Function({dynamic hint, required int key, required int max}) handleStreamFunction) async {
       final max = 5;
       final key = 8;
       final stream = handleStreamFunction(key: key, max: max);

--- a/frb_example/pure_dart/dart/lib/main.dart
+++ b/frb_example/pure_dart/dart/lib/main.dart
@@ -17,8 +17,7 @@ void main(List<String> args) async {
   });
 
   test('dart call primitiveTypes', () async {
-    expect(
-        await api.primitiveTypes(myI32: 123, myI64: 10000000000000, myF64: 12345678901234567890.123, myBool: true), 42);
+    expect(await api.primitiveTypes(myI32: 123, myI64: 10000000000000, myF64: 12345678901234567890.123, myBool: true), 42);
   });
 
   test('dart call primitiveU32', () async {
@@ -35,8 +34,7 @@ void main(List<String> args) async {
 
   test('dart call handleVecU8', () async {
     final len = 100000;
-    expect(await api.handleVecU8(v: Uint8List.fromList(List.filled(len, 127))),
-        Uint8List.fromList(List.filled(len * 2, 127)));
+    expect(await api.handleVecU8(v: Uint8List.fromList(List.filled(len, 127))), Uint8List.fromList(List.filled(len * 2, 127)));
   });
 
   test('dart call handleVecOfPrimitive', () async {
@@ -70,8 +68,7 @@ void main(List<String> args) async {
   });
 
   test('dart call handleStruct', () async {
-    final structResp =
-        await api.handleStruct(arg: MySize(width: 42, height: 100), boxed: MySize(width: 1000, height: 10000));
+    final structResp = await api.handleStruct(arg: MySize(width: 42, height: 100), boxed: MySize(width: 1000, height: 10000));
     expect(structResp.width, 42 + 1000);
     expect(structResp.height, 100 + 10000);
   });
@@ -82,8 +79,7 @@ void main(List<String> args) async {
   });
 
   test('dart call handleListOfStruct', () async {
-    final listOfStructResp =
-        await api.handleListOfStruct(l: [MySize(width: 42, height: 100), MySize(width: 420, height: 1000)]);
+    final listOfStructResp = await api.handleListOfStruct(l: [MySize(width: 42, height: 100), MySize(width: 420, height: 1000)]);
     expect(listOfStructResp.length, 4);
     expect(listOfStructResp[0].width, 42);
     expect(listOfStructResp[1].width, 420);
@@ -131,8 +127,7 @@ void main(List<String> args) async {
   });
 
   test('dart call handle_stream', () {
-    Future<void> _testHandleStream(
-        Stream<Log> Function({dynamic hint, required int key, required int max}) handleStreamFunction) async {
+    Future<void> _testHandleStream(Stream<Log> Function({dynamic hint, required int key, required int max}) handleStreamFunction) async {
       final max = 5;
       final key = 8;
       final stream = handleStreamFunction(key: key, max: max);
@@ -481,6 +476,10 @@ void main(List<String> args) async {
     expect((Speed_GPS).toString(), 'Speed_GPS');
     expect((Distance_Unknown).toString(), 'Distance_Unknown');
     expect((Distance_Map).toString(), 'Distance_Map');
+  });
+
+  test('resolve module for both old and new module system', () async {
+    expect(await api.callBothModuleSystem(), "1/2");
   });
 
   print('flutter_rust_bridge example program end');

--- a/frb_example/pure_dart/dart/lib/main.dart
+++ b/frb_example/pure_dart/dart/lib/main.dart
@@ -478,8 +478,13 @@ void main(List<String> args) async {
     expect((Distance_Map).toString(), 'Distance_Map');
   });
 
-  test('resolve module for both old and new module system', () async {
-    expect(await api.callBothModuleSystem(), "1/2");
+  test('resolve module for old module system', () async {
+    final o = await api.callOldModuleSystem();
+    expect(o.field, 2);
+  });
+  test('resolve module for new module system', () async {
+    final n = await api.callNewModuleSystem();
+    expect(n.field, 1);
   });
 
   print('flutter_rust_bridge example program end');

--- a/frb_example/pure_dart/rust/src/api.rs
+++ b/frb_example/pure_dart/rust/src/api.rs
@@ -10,8 +10,8 @@ use anyhow::{anyhow, Result};
 use flutter_rust_bridge::*;
 
 use crate::data::{MyEnum, MyStruct};
-use crate::new_module_system::use_new_module_system;
-use crate::old_module_system::use_old_module_system;
+use crate::new_module_system::{use_new_module_system, NewSimpleStruct};
+use crate::old_module_system::{use_old_module_system, OldSimpleStruct};
 
 /// Documentation on a simple adder function.
 pub fn simple_adder(a: i32, b: i32) -> i32 {
@@ -782,9 +782,9 @@ pub fn multiply_by_ten(measure: Measure) -> Option<Measure> {
     }
 }
 
-pub fn call_both_module_system() -> String {
-    let n = use_new_module_system(1);
-    let o = use_old_module_system(2);
-
-    format!("{}/{}", n.field, o.field)
+pub fn call_old_module_system() -> OldSimpleStruct {
+    use_old_module_system(2)
+}
+pub fn call_new_module_system() -> NewSimpleStruct {
+    use_new_module_system(1)
 }

--- a/frb_example/pure_dart/rust/src/api.rs
+++ b/frb_example/pure_dart/rust/src/api.rs
@@ -10,6 +10,8 @@ use anyhow::{anyhow, Result};
 use flutter_rust_bridge::*;
 
 use crate::data::{MyEnum, MyStruct};
+use crate::new_module_system::use_new_module_system;
+use crate::old_module_system::use_old_module_system;
 
 /// Documentation on a simple adder function.
 pub fn simple_adder(a: i32, b: i32) -> i32 {
@@ -778,4 +780,11 @@ pub fn multiply_by_ten(measure: Measure) -> Option<Measure> {
             Distance::Unknown => None,
         },
     }
+}
+
+pub fn call_both_module_system() -> String {
+    let n = use_new_module_system(1);
+    let o = use_old_module_system(2);
+
+    format!("{}/{}", n.field, o.field)
 }

--- a/frb_example/pure_dart/rust/src/bridge_generated.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.rs
@@ -17,6 +17,8 @@ use flutter_rust_bridge::*;
 
 use crate::data::MyEnum;
 use crate::data::MyStruct;
+use crate::new_module_system::sub_module::NewSimpleStruct;
+use crate::old_module_system::sub_module::OldSimpleStruct;
 
 // Section: wire functions
 
@@ -777,14 +779,26 @@ pub extern "C" fn wire_multiply_by_ten(port_: i64, measure: *mut wire_Measure) {
 }
 
 #[no_mangle]
-pub extern "C" fn wire_call_both_module_system(port_: i64) {
+pub extern "C" fn wire_call_old_module_system(port_: i64) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {
-            debug_name: "call_both_module_system",
+            debug_name: "call_old_module_system",
             port: Some(port_),
             mode: FfiCallMode::Normal,
         },
-        move || move |task_callback| Ok(call_both_module_system()),
+        move || move |task_callback| Ok(call_old_module_system()),
+    )
+}
+
+#[no_mangle]
+pub extern "C" fn wire_call_new_module_system(port_: i64) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+        WrapInfo {
+            debug_name: "call_new_module_system",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || move |task_callback| Ok(call_new_module_system()),
     )
 }
 
@@ -2808,6 +2822,13 @@ impl support::IntoDart for MyTreeNode {
 }
 impl support::IntoDartExceptPrimitive for MyTreeNode {}
 
+impl support::IntoDart for NewSimpleStruct {
+    fn into_dart(self) -> support::DartCObject {
+        vec![self.field.into_dart()].into_dart()
+    }
+}
+impl support::IntoDartExceptPrimitive for NewSimpleStruct {}
+
 impl support::IntoDart for NewTypeInt {
     fn into_dart(self) -> support::DartCObject {
         vec![self.0.into_dart()].into_dart()
@@ -2821,6 +2842,13 @@ impl support::IntoDart for mirror_Numbers {
     }
 }
 impl support::IntoDartExceptPrimitive for mirror_Numbers {}
+
+impl support::IntoDart for OldSimpleStruct {
+    fn into_dart(self) -> support::DartCObject {
+        vec![self.field.into_dart()].into_dart()
+    }
+}
+impl support::IntoDartExceptPrimitive for OldSimpleStruct {}
 
 impl support::IntoDart for Point {
     fn into_dart(self) -> support::DartCObject {

--- a/frb_example/pure_dart/rust/src/bridge_generated.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.rs
@@ -777,6 +777,18 @@ pub extern "C" fn wire_multiply_by_ten(port_: i64, measure: *mut wire_Measure) {
 }
 
 #[no_mangle]
+pub extern "C" fn wire_call_both_module_system(port_: i64) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+        WrapInfo {
+            debug_name: "call_both_module_system",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || move |task_callback| Ok(call_both_module_system()),
+    )
+}
+
+#[no_mangle]
 pub extern "C" fn wire_sum__method__SumWith(port_: i64, that: *mut wire_SumWith, y: u32, z: u32) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {

--- a/frb_example/pure_dart/rust/src/lib.rs
+++ b/frb_example/pure_dart/rust/src/lib.rs
@@ -1,3 +1,5 @@
 mod api;
 mod bridge_generated;
 mod data;
+mod new_module_system;
+mod old_module_system;

--- a/frb_example/pure_dart/rust/src/new_module_system.rs
+++ b/frb_example/pure_dart/rust/src/new_module_system.rs
@@ -1,0 +1,4 @@
+mod sub_module;
+
+pub use sub_module::use_new_module_system;
+pub use sub_module::NewSimpleStruct;

--- a/frb_example/pure_dart/rust/src/new_module_system.rs
+++ b/frb_example/pure_dart/rust/src/new_module_system.rs
@@ -1,4 +1,4 @@
-mod sub_module;
+pub mod sub_module;
 
 pub use sub_module::use_new_module_system;
 pub use sub_module::NewSimpleStruct;

--- a/frb_example/pure_dart/rust/src/new_module_system/sub_module.rs
+++ b/frb_example/pure_dart/rust/src/new_module_system/sub_module.rs
@@ -1,0 +1,7 @@
+pub struct NewSimpleStruct {
+    pub field: i32,
+}
+
+pub fn use_new_module_system(value: i32) -> NewSimpleStruct {
+    NewSimpleStruct { field: value }
+}

--- a/frb_example/pure_dart/rust/src/old_module_system/mod.rs
+++ b/frb_example/pure_dart/rust/src/old_module_system/mod.rs
@@ -1,4 +1,4 @@
-mod sub_module;
+pub mod sub_module;
 
 pub use sub_module::use_old_module_system;
 pub use sub_module::OldSimpleStruct;

--- a/frb_example/pure_dart/rust/src/old_module_system/mod.rs
+++ b/frb_example/pure_dart/rust/src/old_module_system/mod.rs
@@ -1,0 +1,4 @@
+mod sub_module;
+
+pub use sub_module::use_old_module_system;
+pub use sub_module::OldSimpleStruct;

--- a/frb_example/pure_dart/rust/src/old_module_system/sub_module.rs
+++ b/frb_example/pure_dart/rust/src/old_module_system/sub_module.rs
@@ -1,0 +1,7 @@
+pub struct OldSimpleStruct {
+    pub field: i32,
+}
+
+pub fn use_old_module_system(value: i32) -> OldSimpleStruct {
+    OldSimpleStruct { field: value }
+}


### PR DESCRIPTION
There are warnings "Skipping unresolvable module XXX" when we use the newer rust module system, eg:
```
some_module.rs
some_module/sub_module.rs
```
The cause is that source_graph assume that there must be a `mod.rs` in the module folder, which is not true sometimes.
This PR fix that.
