### PR TITLE
Refactor and enhance `SyncReturn` to support more types

### DIFF
--- a/book/src/feature/sync_dart.md
+++ b/book/src/feature/sync_dart.md
@@ -1,7 +1,7 @@
 # Synchronous in Dart
 
-If you really need to generate synchronous functions in Dart, you can use the `SyncReturn<Vec<u8>>` as the return type.
+If you need to generate synchronous functions in Dart, you can use `SyncReturn<T>` as the return type.
 
 We suggest only do this for very quick Rust functions, or the Dart UI will be blocked.
 
-Currently, due to the lack of need, the only type supported is `Vec<u8>`, and the workaround of using other types is by using a serialization approach such as JSON or Protobuf. Notice that this is *only needed* in *this* very tiny part, and 99% of `flutter_rust_bridge` does not need this bare-matel approach. Moreover, please open an issue if you need other types.
+Currently, `SyncReturn` supports `String`, `Vec<u8>` and primitive types(`bool`, `u8`, `u16`, `u32`, `u64`, `i8`, `i16`, `i32`, `i64`, `f32`, `f64`). Please open an issue if you need other types.

--- a/frb_codegen/src/generator/dart/mod.rs
+++ b/frb_codegen/src/generator/dart/mod.rs
@@ -533,13 +533,14 @@ fn generate_wire2api_func(ty: &IrType, ir_file: &IrFile, dart_api_class_name: &s
     };
     let body = TypeDartGenerator::new(ty.clone(), ir_file, None).wire2api_body();
     format!(
-        "{} _wire2api_{}({}dynamic raw) {{
+        "{} _wire2api_{}({}{} raw) {{
             {}
         }}
         ",
         ty.dart_api_type(),
         ty.safe_ident(),
         extra_argument,
+        ty.dart_param_type(),
         body,
     )
 }

--- a/frb_codegen/src/generator/dart/mod.rs
+++ b/frb_codegen/src/generator/dart/mod.rs
@@ -7,6 +7,7 @@ mod ty_optional;
 mod ty_primitive;
 mod ty_primitive_list;
 mod ty_struct;
+mod ty_sync_return;
 
 use std::collections::HashSet;
 
@@ -19,6 +20,7 @@ pub use ty_optional::*;
 pub use ty_primitive::*;
 pub use ty_primitive_list::*;
 pub use ty_struct::*;
+pub use ty_sync_return::*;
 
 use convert_case::{Case, Casing};
 use log::debug;
@@ -428,12 +430,14 @@ fn generate_api_func(func: &IrFunc, ir_file: &IrFile) -> GeneratedApiFunc {
         IrFuncMode::Sync => format!(
             "{} => {}(FlutterRustBridgeSyncTask(
             callFfi: () => inner.{}({}),
+            parseSuccessData: {},
             {}
         ));",
             partial,
             execute_func_name,
             func.wire_func_name(),
             wire_param_list.join(", "),
+            parse_sucess_data,
             task_common_args,
         ),
         _ => format!(

--- a/frb_codegen/src/generator/dart/ty.rs
+++ b/frb_codegen/src/generator/dart/ty.rs
@@ -46,6 +46,7 @@ pub enum TypeDartGenerator<'a> {
     StructRef(TypeStructRefGenerator<'a>),
     Boxed(TypeBoxedGenerator<'a>),
     EnumRef(TypeEnumRefGenerator<'a>),
+    SyncReturn(TypeSyncReturnGenerator<'a>),
 }
 
 impl<'a> TypeDartGenerator<'a> {
@@ -63,6 +64,7 @@ impl<'a> TypeDartGenerator<'a> {
             StructRef(ir) => TypeStructRefGenerator { ir, context }.into(),
             Boxed(ir) => TypeBoxedGenerator { ir, context }.into(),
             EnumRef(ir) => TypeEnumRefGenerator { ir, context }.into(),
+            SyncReturn(ir) => TypeSyncReturnGenerator { ir, context }.into(),
         }
     }
 }

--- a/frb_codegen/src/generator/dart/ty_delegate.rs
+++ b/frb_codegen/src/generator/dart/ty_delegate.rs
@@ -12,7 +12,6 @@ impl TypeDartGeneratorTrait for TypeDelegateGenerator<'_> {
             IrTypeDelegate::String => {
                 "return _api2wire_uint_8_list(utf8.encoder.convert(raw));".to_string()
             }
-            IrTypeDelegate::SyncReturnVecU8 => "/*unsupported*/".to_string(),
             IrTypeDelegate::ZeroCopyBufferVecPrimitive(_) => {
                 format!(
                     "return _api2wire_{}(raw);",
@@ -35,9 +34,7 @@ impl TypeDartGeneratorTrait for TypeDelegateGenerator<'_> {
 
     fn wire2api_body(&self) -> String {
         match &self.ir {
-            IrTypeDelegate::String
-            | IrTypeDelegate::SyncReturnVecU8
-            | IrTypeDelegate::ZeroCopyBufferVecPrimitive(_) => {
+            IrTypeDelegate::String | IrTypeDelegate::ZeroCopyBufferVecPrimitive(_) => {
                 gen_wire2api_simple_type_cast(&self.ir.dart_api_type())
             }
             IrTypeDelegate::StringList => {

--- a/frb_codegen/src/generator/dart/ty_sync_return.rs
+++ b/frb_codegen/src/generator/dart/ty_sync_return.rs
@@ -7,15 +7,13 @@ type_dart_generator_struct!(TypeSyncReturnGenerator, IrTypeSyncReturn);
 
 impl TypeDartGeneratorTrait for TypeSyncReturnGenerator<'_> {
     fn api2wire_body(&self, _: BlockIndex) -> Option<String> {
-        Some("/*unsupported*/".to_string())
+        unimplemented!("SyncReturn generator for Dart: api2wire_body is not supported")
     }
 
     fn wire2api_body(&self) -> String {
         match self.ir {
             IrTypeSyncReturn::Primitive(ref primitive) => match primitive {
-                IrTypePrimitive::Bool => "final dataView = ByteData.view(raw.buffer);
-                        return dataView.getUint8(0) != 0;"
-                    .into(),
+                IrTypePrimitive::Bool => "return uint8ListToBool(raw as Uint8List);".into(),
                 primitive => {
                     let primitive_name = match primitive {
                         IrTypePrimitive::U8 => "Uint8",
@@ -28,19 +26,22 @@ impl TypeDartGeneratorTrait for TypeSyncReturnGenerator<'_> {
                         IrTypePrimitive::I64 => "Int64",
                         IrTypePrimitive::F32 => "Float32",
                         IrTypePrimitive::F64 => "Float64",
-                        _ => "/*unsupported*/",
+                        _ => panic!(
+                            "SyncReturn generator for Dart: type {} is not supported",
+                            primitive.rust_api_type()
+                        ),
                     };
                     format!(
                         "{}{}{}",
-                        "final dataView = ByteData.view(raw.buffer);
+                        "final dataView = ByteData.view((raw as Uint8List).buffer);
                         return dataView.get",
                         primitive_name,
                         "(0);"
                     )
                 }
             },
-            IrTypeSyncReturn::String => "return utf8.decode(raw);".into(),
-            IrTypeSyncReturn::VecU8 => "return raw;".into(),
+            IrTypeSyncReturn::String => "return utf8.decode(raw as Uint8List);".into(),
+            IrTypeSyncReturn::VecU8 => "return raw as Uint8List;".into(),
         }
     }
 }

--- a/frb_codegen/src/generator/dart/ty_sync_return.rs
+++ b/frb_codegen/src/generator/dart/ty_sync_return.rs
@@ -13,7 +13,7 @@ impl TypeDartGeneratorTrait for TypeSyncReturnGenerator<'_> {
     fn wire2api_body(&self) -> String {
         match self.ir {
             IrTypeSyncReturn::Primitive(ref primitive) => match primitive {
-                IrTypePrimitive::Bool => "return uint8ListToBool(raw as Uint8List);".into(),
+                IrTypePrimitive::Bool => "return uint8ListToBool(raw);".into(),
                 primitive => {
                     let primitive_name = match primitive {
                         IrTypePrimitive::U8 => "Uint8",
@@ -32,16 +32,16 @@ impl TypeDartGeneratorTrait for TypeSyncReturnGenerator<'_> {
                         ),
                     };
                     format!(
-                        "{}{}{}",
-                        "final dataView = ByteData.view((raw as Uint8List).buffer);
-                        return dataView.get",
-                        primitive_name,
-                        "(0);"
+                        r#"
+                        final dataView = ByteData.view(raw.buffer);
+                        return dataView.get{primitive_name}(0);
+                        "#,
+                        primitive_name = primitive_name
                     )
                 }
             },
-            IrTypeSyncReturn::String => "return utf8.decode(raw as Uint8List);".into(),
-            IrTypeSyncReturn::VecU8 => "return raw as Uint8List;".into(),
+            IrTypeSyncReturn::String => "return utf8.decode(raw);".into(),
+            IrTypeSyncReturn::VecU8 => "return raw;".into(),
         }
     }
 }

--- a/frb_codegen/src/generator/dart/ty_sync_return.rs
+++ b/frb_codegen/src/generator/dart/ty_sync_return.rs
@@ -1,0 +1,46 @@
+use crate::generator::dart::ty::*;
+use crate::ir::*;
+use crate::type_dart_generator_struct;
+use crate::utils::BlockIndex;
+
+type_dart_generator_struct!(TypeSyncReturnGenerator, IrTypeSyncReturn);
+
+impl TypeDartGeneratorTrait for TypeSyncReturnGenerator<'_> {
+    fn api2wire_body(&self, _: BlockIndex) -> Option<String> {
+        Some("/*unsupported*/".to_string())
+    }
+
+    fn wire2api_body(&self) -> String {
+        match self.ir {
+            IrTypeSyncReturn::Primitive(ref primitive) => match primitive {
+                IrTypePrimitive::Bool => "final dataView = ByteData.view(raw.buffer);
+                        return dataView.getUint8(0) != 0;"
+                    .into(),
+                primitive => {
+                    let primitive_name = match primitive {
+                        IrTypePrimitive::U8 => "Uint8",
+                        IrTypePrimitive::U16 => "Uint16",
+                        IrTypePrimitive::U32 => "Uint32",
+                        IrTypePrimitive::U64 => "Uint64",
+                        IrTypePrimitive::I8 => "Int8",
+                        IrTypePrimitive::I16 => "Int16",
+                        IrTypePrimitive::I32 => "Int32",
+                        IrTypePrimitive::I64 => "Int64",
+                        IrTypePrimitive::F32 => "Float32",
+                        IrTypePrimitive::F64 => "Float64",
+                        _ => "/*unsupported*/",
+                    };
+                    format!(
+                        "{}{}{}",
+                        "final dataView = ByteData.view(raw.buffer);
+                        return dataView.get",
+                        primitive_name,
+                        "(0);"
+                    )
+                }
+            },
+            IrTypeSyncReturn::String => "return utf8.decode(raw);".into(),
+            IrTypeSyncReturn::VecU8 => "return raw;".into(),
+        }
+    }
+}

--- a/frb_codegen/src/generator/rust/mod.rs
+++ b/frb_codegen/src/generator/rust/mod.rs
@@ -7,6 +7,8 @@ mod ty_optional;
 mod ty_primitive;
 mod ty_primitive_list;
 mod ty_struct;
+mod ty_sync_return;
+
 pub use ty::*;
 pub use ty_boxed::*;
 pub use ty_delegate::*;
@@ -16,6 +18,7 @@ pub use ty_optional::*;
 pub use ty_primitive::*;
 pub use ty_primitive_list::*;
 pub use ty_struct::*;
+pub use ty_sync_return::*;
 
 use std::collections::HashSet;
 

--- a/frb_codegen/src/generator/rust/ty.rs
+++ b/frb_codegen/src/generator/rust/ty.rs
@@ -81,6 +81,7 @@ pub enum TypeRustGenerator<'a> {
     StructRef(TypeStructRefGenerator<'a>),
     Boxed(TypeBoxedGenerator<'a>),
     EnumRef(TypeEnumRefGenerator<'a>),
+    SyncReturn(TypeSyncReturnGenerator<'a>),
 }
 
 impl<'a> TypeRustGenerator<'a> {
@@ -95,6 +96,7 @@ impl<'a> TypeRustGenerator<'a> {
             StructRef(ir) => TypeStructRefGenerator { ir, context }.into(),
             Boxed(ir) => TypeBoxedGenerator { ir, context }.into(),
             EnumRef(ir) => TypeEnumRefGenerator { ir, context }.into(),
+            SyncReturn(ir) => TypeSyncReturnGenerator { ir, context }.into(),
         }
     }
 }

--- a/frb_codegen/src/generator/rust/ty_delegate.rs
+++ b/frb_codegen/src/generator/rust/ty_delegate.rs
@@ -28,7 +28,6 @@ impl TypeRustGeneratorTrait for TypeDelegateGenerator<'_> {
             IrTypeDelegate::String => "let vec: Vec<u8> = self.wire2api();
             String::from_utf8_lossy(&vec).into_owned()"
                 .into(),
-            IrTypeDelegate::SyncReturnVecU8 => "/*unsupported*/".into(),
             IrTypeDelegate::ZeroCopyBufferVecPrimitive(_) => {
                 "ZeroCopyBuffer(self.wire2api())".into()
             }

--- a/frb_codegen/src/generator/rust/ty_sync_return.rs
+++ b/frb_codegen/src/generator/rust/ty_sync_return.rs
@@ -1,0 +1,11 @@
+use crate::generator::rust::ty::*;
+use crate::ir::*;
+use crate::type_rust_generator_struct;
+
+type_rust_generator_struct!(TypeSyncReturnGenerator, IrTypeSyncReturn);
+
+impl TypeRustGeneratorTrait for TypeSyncReturnGenerator<'_> {
+    fn wire2api_body(&self) -> Option<String> {
+        Some("/*unsupported*/".into())
+    }
+}

--- a/frb_codegen/src/generator/rust/ty_sync_return.rs
+++ b/frb_codegen/src/generator/rust/ty_sync_return.rs
@@ -6,6 +6,6 @@ type_rust_generator_struct!(TypeSyncReturnGenerator, IrTypeSyncReturn);
 
 impl TypeRustGeneratorTrait for TypeSyncReturnGenerator<'_> {
     fn wire2api_body(&self) -> Option<String> {
-        Some("/*unsupported*/".into())
+        unimplemented!("SyncReturn generator for Rust: wire2api_body is not supported")
     }
 }

--- a/frb_codegen/src/ir/mod.rs
+++ b/frb_codegen/src/ir/mod.rs
@@ -14,6 +14,7 @@ mod ty_optional;
 mod ty_primitive;
 mod ty_primitive_list;
 mod ty_struct;
+mod ty_sync_return;
 
 pub use annotation::*;
 pub use comment::*;
@@ -31,3 +32,4 @@ pub use ty_optional::*;
 pub use ty_primitive::*;
 pub use ty_primitive_list::*;
 pub use ty_struct::*;
+pub use ty_sync_return::*;

--- a/frb_codegen/src/ir/ty.rs
+++ b/frb_codegen/src/ir/ty.rs
@@ -14,6 +14,7 @@ pub enum IrType {
     StructRef(IrTypeStructRef),
     Boxed(IrTypeBoxed),
     EnumRef(IrTypeEnumRef),
+    SyncReturn(IrTypeSyncReturn),
 }
 
 impl IrType {

--- a/frb_codegen/src/ir/ty.rs
+++ b/frb_codegen/src/ir/ty.rs
@@ -87,6 +87,10 @@ pub trait IrTypeTrait {
     fn rust_wire_is_pointer(&self) -> bool {
         false
     }
+
+    fn dart_param_type(&self) -> &'static str {
+        "dynamic"
+    }
 }
 
 pub fn optional_boundary_index(types: &[&IrType]) -> Option<usize> {

--- a/frb_codegen/src/ir/ty_delegate.rs
+++ b/frb_codegen/src/ir/ty_delegate.rs
@@ -5,7 +5,6 @@ use crate::ir::*;
 pub enum IrTypeDelegate {
     String,
     StringList,
-    SyncReturnVecU8,
     ZeroCopyBufferVecPrimitive(IrTypePrimitive),
     PrimitiveEnum {
         ir: IrTypeEnumRef,
@@ -18,9 +17,6 @@ impl IrTypeDelegate {
     pub fn get_delegate(&self) -> IrType {
         match self {
             IrTypeDelegate::String => IrType::PrimitiveList(IrTypePrimitiveList {
-                primitive: IrTypePrimitive::U8,
-            }),
-            IrTypeDelegate::SyncReturnVecU8 => IrType::PrimitiveList(IrTypePrimitiveList {
                 primitive: IrTypePrimitive::U8,
             }),
             IrTypeDelegate::ZeroCopyBufferVecPrimitive(primitive) => {
@@ -43,7 +39,6 @@ impl IrTypeTrait for IrTypeDelegate {
         match self {
             IrTypeDelegate::String => "String".to_owned(),
             IrTypeDelegate::StringList => "StringList".to_owned(),
-            IrTypeDelegate::SyncReturnVecU8 => "SyncReturnVecU8".to_owned(),
             IrTypeDelegate::ZeroCopyBufferVecPrimitive(_) => {
                 "ZeroCopyBuffer_".to_owned() + &self.get_delegate().dart_api_type()
             }
@@ -55,9 +50,7 @@ impl IrTypeTrait for IrTypeDelegate {
         match self {
             IrTypeDelegate::String => "String".to_string(),
             IrTypeDelegate::StringList => "List<String>".to_owned(),
-            IrTypeDelegate::SyncReturnVecU8 | IrTypeDelegate::ZeroCopyBufferVecPrimitive(_) => {
-                self.get_delegate().dart_api_type()
-            }
+            IrTypeDelegate::ZeroCopyBufferVecPrimitive(_) => self.get_delegate().dart_api_type(),
             IrTypeDelegate::PrimitiveEnum { ir, .. } => ir.dart_api_type(),
         }
     }
@@ -72,7 +65,6 @@ impl IrTypeTrait for IrTypeDelegate {
     fn rust_api_type(&self) -> String {
         match self {
             IrTypeDelegate::String => "String".to_owned(),
-            IrTypeDelegate::SyncReturnVecU8 => "SyncReturn<Vec<u8>>".to_string(),
             IrTypeDelegate::StringList => "Vec<String>".to_owned(),
             IrTypeDelegate::ZeroCopyBufferVecPrimitive(_) => {
                 format!("ZeroCopyBuffer<{}>", self.get_delegate().rust_api_type())

--- a/frb_codegen/src/ir/ty_sync_return.rs
+++ b/frb_codegen/src/ir/ty_sync_return.rs
@@ -1,0 +1,58 @@
+use crate::ir::*;
+
+/// Types that have synchronized return
+/// NOTE for maintainer: Please make sure all the types here
+/// can be parsed by `executeSync` function in basic.dart.
+#[derive(Debug, Clone)]
+pub enum IrTypeSyncReturn {
+    Primitive(IrTypePrimitive),
+    String,
+    VecU8,
+}
+
+impl IrTypeTrait for IrTypeSyncReturn {
+    fn visit_children_types<F: FnMut(&IrType) -> bool>(&self, f: &mut F, ir_file: &IrFile) {
+        self.get_inner().visit_types(f, ir_file)
+    }
+
+    fn safe_ident(&self) -> String {
+        match self {
+            IrTypeSyncReturn::Primitive(_) => {
+                "SyncReturn_".to_owned() + &self.get_inner().rust_api_type()
+            }
+            _ => "SyncReturn_".to_owned() + &self.get_inner().dart_api_type(),
+        }
+    }
+
+    fn dart_api_type(&self) -> String {
+        self.get_inner().dart_api_type()
+    }
+
+    fn dart_wire_type(&self) -> String {
+        self.get_inner().dart_wire_type()
+    }
+
+    fn rust_api_type(&self) -> String {
+        format!("SyncReturn<{}>", self.get_inner().rust_api_type())
+    }
+
+    fn rust_wire_type(&self) -> String {
+        self.get_inner().rust_wire_type()
+    }
+
+    fn rust_wire_is_pointer(&self) -> bool {
+        self.get_inner().rust_wire_is_pointer()
+    }
+}
+
+impl IrTypeSyncReturn {
+    pub fn get_inner(&self) -> IrType {
+        match self {
+            IrTypeSyncReturn::Primitive(primitive) => IrType::Primitive(primitive.clone()),
+            IrTypeSyncReturn::String => IrType::Delegate(IrTypeDelegate::String),
+            IrTypeSyncReturn::VecU8 => IrType::PrimitiveList(IrTypePrimitiveList {
+                primitive: IrTypePrimitive::U8,
+            }),
+        }
+    }
+}

--- a/frb_codegen/src/ir/ty_sync_return.rs
+++ b/frb_codegen/src/ir/ty_sync_return.rs
@@ -44,6 +44,10 @@ impl IrTypeTrait for IrTypeSyncReturn {
     fn rust_wire_is_pointer(&self) -> bool {
         self.get_inner().rust_wire_is_pointer()
     }
+
+    fn dart_param_type(&self) -> &'static str {
+        "dynamic"
+    }
 }
 
 impl IrTypeSyncReturn {

--- a/frb_codegen/src/ir/ty_sync_return.rs
+++ b/frb_codegen/src/ir/ty_sync_return.rs
@@ -18,6 +18,7 @@ impl IrTypeTrait for IrTypeSyncReturn {
     fn safe_ident(&self) -> String {
         match self {
             IrTypeSyncReturn::Primitive(_) => {
+                // We use Rust API type here because some primitive types in Dart share the same API type.
                 "SyncReturn_".to_owned() + &self.get_inner().rust_api_type()
             }
             _ => "SyncReturn_".to_owned() + &self.get_inner().dart_api_type(),
@@ -37,7 +38,7 @@ impl IrTypeTrait for IrTypeSyncReturn {
     }
 
     fn rust_wire_type(&self) -> String {
-        self.get_inner().rust_wire_type()
+        unimplemented!("SyncReturn: rust_wire_type is not supported")
     }
 
     fn rust_wire_is_pointer(&self) -> bool {

--- a/frb_codegen/src/ir/ty_sync_return.rs
+++ b/frb_codegen/src/ir/ty_sync_return.rs
@@ -46,7 +46,7 @@ impl IrTypeTrait for IrTypeSyncReturn {
     }
 
     fn dart_param_type(&self) -> &'static str {
-        "dynamic"
+        "Uint8List"
     }
 }
 

--- a/frb_codegen/src/parser/mod.rs
+++ b/frb_codegen/src/parser/mod.rs
@@ -167,13 +167,11 @@ impl<'a> Parser<'a> {
                     IrType::Primitive(IrTypePrimitive::Unit)
                 }
             });
-            mode = Some(
-                if let Some(IrType::Delegate(IrTypeDelegate::SyncReturnVecU8)) = output {
-                    IrFuncMode::Sync
-                } else {
-                    IrFuncMode::Normal
-                },
-            );
+            mode = Some(if let Some(IrType::SyncReturn(_)) = output {
+                IrFuncMode::Sync
+            } else {
+                IrFuncMode::Normal
+            });
         }
 
         IrFunc {

--- a/frb_dart/lib/src/basic.dart
+++ b/frb_dart/lib/src/basic.dart
@@ -179,3 +179,8 @@ class WireSyncReturnStruct extends ffi.Struct {
   @ffi.Uint8()
   external int success;
 }
+
+bool uint8ListToBool(Uint8List raw) {
+  final dataView = ByteData.view(raw.buffer);
+  return dataView.getUint8(0) != 0;
+}

--- a/frb_dart/lib/src/basic.dart
+++ b/frb_dart/lib/src/basic.dart
@@ -131,7 +131,7 @@ class FlutterRustBridgeSyncTask<S> extends FlutterRustBridgeBaseTask {
   final WireSyncReturnStruct Function() callFfi;
 
   /// Parse the returned data from the underlying function
-  final S Function(dynamic) parseSuccessData;
+  final S Function(Uint8List) parseSuccessData;
 
   const FlutterRustBridgeSyncTask({
     required this.callFfi,
@@ -178,9 +178,4 @@ class WireSyncReturnStruct extends ffi.Struct {
   /// Not to be used by normal users, but has to be public for generated code
   @ffi.Uint8()
   external int success;
-}
-
-bool uint8ListToBool(Uint8List raw) {
-  final dataView = ByteData.view(raw.buffer);
-  return dataView.getUint8(0) != 0;
 }

--- a/frb_dart/lib/src/helpers.dart
+++ b/frb_dart/lib/src/helpers.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:flutter_rust_bridge/src/basic.dart';
 import 'package:flutter_rust_bridge/src/platform_independent.dart';
@@ -88,4 +89,9 @@ mixin FlutterRustBridgeTimeoutMixin<T extends FlutterRustBridgeWireBase>
   /// The time limit for methods using [executeNormal]. Return null means *disable* this functionality.
   @protected
   Duration? get timeLimitForExecuteNormal;
+}
+
+bool uint8ListToBool(Uint8List raw) {
+  final dataView = ByteData.view(raw.buffer);
+  return dataView.getUint8(0) != 0;
 }

--- a/frb_example/pure_dart/dart/lib/bridge_generated.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.dart
@@ -2460,64 +2460,64 @@ List<String> _wire2api_StringList(dynamic raw) {
 }
 
 String _wire2api_SyncReturn_String(dynamic raw) {
-  return utf8.decode(raw as Uint8List);
+  return utf8.decode(raw);
 }
 
 Uint8List _wire2api_SyncReturn_Uint8List(dynamic raw) {
-  return raw as Uint8List;
+  return raw;
 }
 
 bool _wire2api_SyncReturn_bool(dynamic raw) {
-  return uint8ListToBool(raw as Uint8List);
+  return uint8ListToBool(raw);
 }
 
 double _wire2api_SyncReturn_f32(dynamic raw) {
-  final dataView = ByteData.view((raw as Uint8List).buffer);
+  final dataView = ByteData.view(raw.buffer);
   return dataView.getFloat32(0);
 }
 
 double _wire2api_SyncReturn_f64(dynamic raw) {
-  final dataView = ByteData.view((raw as Uint8List).buffer);
+  final dataView = ByteData.view(raw.buffer);
   return dataView.getFloat64(0);
 }
 
 int _wire2api_SyncReturn_i16(dynamic raw) {
-  final dataView = ByteData.view((raw as Uint8List).buffer);
+  final dataView = ByteData.view(raw.buffer);
   return dataView.getInt16(0);
 }
 
 int _wire2api_SyncReturn_i32(dynamic raw) {
-  final dataView = ByteData.view((raw as Uint8List).buffer);
+  final dataView = ByteData.view(raw.buffer);
   return dataView.getInt32(0);
 }
 
 int _wire2api_SyncReturn_i64(dynamic raw) {
-  final dataView = ByteData.view((raw as Uint8List).buffer);
+  final dataView = ByteData.view(raw.buffer);
   return dataView.getInt64(0);
 }
 
 int _wire2api_SyncReturn_i8(dynamic raw) {
-  final dataView = ByteData.view((raw as Uint8List).buffer);
+  final dataView = ByteData.view(raw.buffer);
   return dataView.getInt8(0);
 }
 
 int _wire2api_SyncReturn_u16(dynamic raw) {
-  final dataView = ByteData.view((raw as Uint8List).buffer);
+  final dataView = ByteData.view(raw.buffer);
   return dataView.getUint16(0);
 }
 
 int _wire2api_SyncReturn_u32(dynamic raw) {
-  final dataView = ByteData.view((raw as Uint8List).buffer);
+  final dataView = ByteData.view(raw.buffer);
   return dataView.getUint32(0);
 }
 
 int _wire2api_SyncReturn_u64(dynamic raw) {
-  final dataView = ByteData.view((raw as Uint8List).buffer);
+  final dataView = ByteData.view(raw.buffer);
   return dataView.getUint64(0);
 }
 
 int _wire2api_SyncReturn_u8(dynamic raw) {
-  final dataView = ByteData.view((raw as Uint8List).buffer);
+  final dataView = ByteData.view(raw.buffer);
   return dataView.getUint8(0);
 }
 

--- a/frb_example/pure_dart/dart/lib/bridge_generated.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.dart
@@ -2460,65 +2460,64 @@ List<String> _wire2api_StringList(dynamic raw) {
 }
 
 String _wire2api_SyncReturn_String(dynamic raw) {
-  return utf8.decode(raw);
+  return utf8.decode(raw as Uint8List);
 }
 
 Uint8List _wire2api_SyncReturn_Uint8List(dynamic raw) {
-  return raw;
+  return raw as Uint8List;
 }
 
 bool _wire2api_SyncReturn_bool(dynamic raw) {
-  final dataView = ByteData.view(raw.buffer);
-  return dataView.getUint8(0) != 0;
+  return uint8ListToBool(raw as Uint8List);
 }
 
 double _wire2api_SyncReturn_f32(dynamic raw) {
-  final dataView = ByteData.view(raw.buffer);
+  final dataView = ByteData.view((raw as Uint8List).buffer);
   return dataView.getFloat32(0);
 }
 
 double _wire2api_SyncReturn_f64(dynamic raw) {
-  final dataView = ByteData.view(raw.buffer);
+  final dataView = ByteData.view((raw as Uint8List).buffer);
   return dataView.getFloat64(0);
 }
 
 int _wire2api_SyncReturn_i16(dynamic raw) {
-  final dataView = ByteData.view(raw.buffer);
+  final dataView = ByteData.view((raw as Uint8List).buffer);
   return dataView.getInt16(0);
 }
 
 int _wire2api_SyncReturn_i32(dynamic raw) {
-  final dataView = ByteData.view(raw.buffer);
+  final dataView = ByteData.view((raw as Uint8List).buffer);
   return dataView.getInt32(0);
 }
 
 int _wire2api_SyncReturn_i64(dynamic raw) {
-  final dataView = ByteData.view(raw.buffer);
+  final dataView = ByteData.view((raw as Uint8List).buffer);
   return dataView.getInt64(0);
 }
 
 int _wire2api_SyncReturn_i8(dynamic raw) {
-  final dataView = ByteData.view(raw.buffer);
+  final dataView = ByteData.view((raw as Uint8List).buffer);
   return dataView.getInt8(0);
 }
 
 int _wire2api_SyncReturn_u16(dynamic raw) {
-  final dataView = ByteData.view(raw.buffer);
+  final dataView = ByteData.view((raw as Uint8List).buffer);
   return dataView.getUint16(0);
 }
 
 int _wire2api_SyncReturn_u32(dynamic raw) {
-  final dataView = ByteData.view(raw.buffer);
+  final dataView = ByteData.view((raw as Uint8List).buffer);
   return dataView.getUint32(0);
 }
 
 int _wire2api_SyncReturn_u64(dynamic raw) {
-  final dataView = ByteData.view(raw.buffer);
+  final dataView = ByteData.view((raw as Uint8List).buffer);
   return dataView.getUint64(0);
 }
 
 int _wire2api_SyncReturn_u8(dynamic raw) {
-  final dataView = ByteData.view(raw.buffer);
+  final dataView = ByteData.view((raw as Uint8List).buffer);
   return dataView.getUint8(0);
 }
 

--- a/frb_example/pure_dart/dart/lib/bridge_generated.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.dart
@@ -2459,64 +2459,64 @@ List<String> _wire2api_StringList(dynamic raw) {
   return (raw as List<dynamic>).cast<String>();
 }
 
-String _wire2api_SyncReturn_String(dynamic raw) {
+String _wire2api_SyncReturn_String(Uint8List raw) {
   return utf8.decode(raw);
 }
 
-Uint8List _wire2api_SyncReturn_Uint8List(dynamic raw) {
+Uint8List _wire2api_SyncReturn_Uint8List(Uint8List raw) {
   return raw;
 }
 
-bool _wire2api_SyncReturn_bool(dynamic raw) {
+bool _wire2api_SyncReturn_bool(Uint8List raw) {
   return uint8ListToBool(raw);
 }
 
-double _wire2api_SyncReturn_f32(dynamic raw) {
+double _wire2api_SyncReturn_f32(Uint8List raw) {
   final dataView = ByteData.view(raw.buffer);
   return dataView.getFloat32(0);
 }
 
-double _wire2api_SyncReturn_f64(dynamic raw) {
+double _wire2api_SyncReturn_f64(Uint8List raw) {
   final dataView = ByteData.view(raw.buffer);
   return dataView.getFloat64(0);
 }
 
-int _wire2api_SyncReturn_i16(dynamic raw) {
+int _wire2api_SyncReturn_i16(Uint8List raw) {
   final dataView = ByteData.view(raw.buffer);
   return dataView.getInt16(0);
 }
 
-int _wire2api_SyncReturn_i32(dynamic raw) {
+int _wire2api_SyncReturn_i32(Uint8List raw) {
   final dataView = ByteData.view(raw.buffer);
   return dataView.getInt32(0);
 }
 
-int _wire2api_SyncReturn_i64(dynamic raw) {
+int _wire2api_SyncReturn_i64(Uint8List raw) {
   final dataView = ByteData.view(raw.buffer);
   return dataView.getInt64(0);
 }
 
-int _wire2api_SyncReturn_i8(dynamic raw) {
+int _wire2api_SyncReturn_i8(Uint8List raw) {
   final dataView = ByteData.view(raw.buffer);
   return dataView.getInt8(0);
 }
 
-int _wire2api_SyncReturn_u16(dynamic raw) {
+int _wire2api_SyncReturn_u16(Uint8List raw) {
   final dataView = ByteData.view(raw.buffer);
   return dataView.getUint16(0);
 }
 
-int _wire2api_SyncReturn_u32(dynamic raw) {
+int _wire2api_SyncReturn_u32(Uint8List raw) {
   final dataView = ByteData.view(raw.buffer);
   return dataView.getUint32(0);
 }
 
-int _wire2api_SyncReturn_u64(dynamic raw) {
+int _wire2api_SyncReturn_u64(Uint8List raw) {
   final dataView = ByteData.view(raw.buffer);
   return dataView.getUint64(0);
 }
 
-int _wire2api_SyncReturn_u8(dynamic raw) {
+int _wire2api_SyncReturn_u8(Uint8List raw) {
   final dataView = ByteData.view(raw.buffer);
   return dataView.getUint8(0);
 }

--- a/frb_example/pure_dart/dart/lib/bridge_generated.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.dart
@@ -80,6 +80,54 @@ abstract class FlutterRustBridgeExampleSingleBlockTest {
 
   FlutterRustBridgeTaskConstMeta get kHandleSyncReturnConstMeta;
 
+  bool handleSyncBool({required bool input, dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kHandleSyncBoolConstMeta;
+
+  int handleSyncU8({required int input, dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kHandleSyncU8ConstMeta;
+
+  int handleSyncU16({required int input, dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kHandleSyncU16ConstMeta;
+
+  int handleSyncU32({required int input, dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kHandleSyncU32ConstMeta;
+
+  int handleSyncU64({required int input, dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kHandleSyncU64ConstMeta;
+
+  int handleSyncI8({required int input, dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kHandleSyncI8ConstMeta;
+
+  int handleSyncI16({required int input, dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kHandleSyncI16ConstMeta;
+
+  int handleSyncI32({required int input, dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kHandleSyncI32ConstMeta;
+
+  int handleSyncI64({required int input, dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kHandleSyncI64ConstMeta;
+
+  double handleSyncF32({required double input, dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kHandleSyncF32ConstMeta;
+
+  double handleSyncF64({required double input, dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kHandleSyncF64ConstMeta;
+
+  String handleSyncString({required String input, dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kHandleSyncStringConstMeta;
+
   Stream<String> handleStream({required String arg, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleStreamConstMeta;
@@ -904,6 +952,7 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
 
   Uint8List handleSyncReturn({required String mode, dynamic hint}) => executeSync(FlutterRustBridgeSyncTask(
         callFfi: () => inner.wire_handle_sync_return(_api2wire_String(mode)),
+        parseSuccessData: _wire2api_SyncReturn_Uint8List,
         constMeta: kHandleSyncReturnConstMeta,
         argValues: [mode],
         hint: hint,
@@ -912,6 +961,162 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
   FlutterRustBridgeTaskConstMeta get kHandleSyncReturnConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "handle_sync_return",
         argNames: ["mode"],
+      );
+
+  bool handleSyncBool({required bool input, dynamic hint}) => executeSync(FlutterRustBridgeSyncTask(
+        callFfi: () => inner.wire_handle_sync_bool(input),
+        parseSuccessData: _wire2api_SyncReturn_bool,
+        constMeta: kHandleSyncBoolConstMeta,
+        argValues: [input],
+        hint: hint,
+      ));
+
+  FlutterRustBridgeTaskConstMeta get kHandleSyncBoolConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "handle_sync_bool",
+        argNames: ["input"],
+      );
+
+  int handleSyncU8({required int input, dynamic hint}) => executeSync(FlutterRustBridgeSyncTask(
+        callFfi: () => inner.wire_handle_sync_u8(_api2wire_u8(input)),
+        parseSuccessData: _wire2api_SyncReturn_u8,
+        constMeta: kHandleSyncU8ConstMeta,
+        argValues: [input],
+        hint: hint,
+      ));
+
+  FlutterRustBridgeTaskConstMeta get kHandleSyncU8ConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "handle_sync_u8",
+        argNames: ["input"],
+      );
+
+  int handleSyncU16({required int input, dynamic hint}) => executeSync(FlutterRustBridgeSyncTask(
+        callFfi: () => inner.wire_handle_sync_u16(_api2wire_u16(input)),
+        parseSuccessData: _wire2api_SyncReturn_u16,
+        constMeta: kHandleSyncU16ConstMeta,
+        argValues: [input],
+        hint: hint,
+      ));
+
+  FlutterRustBridgeTaskConstMeta get kHandleSyncU16ConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "handle_sync_u16",
+        argNames: ["input"],
+      );
+
+  int handleSyncU32({required int input, dynamic hint}) => executeSync(FlutterRustBridgeSyncTask(
+        callFfi: () => inner.wire_handle_sync_u32(_api2wire_u32(input)),
+        parseSuccessData: _wire2api_SyncReturn_u32,
+        constMeta: kHandleSyncU32ConstMeta,
+        argValues: [input],
+        hint: hint,
+      ));
+
+  FlutterRustBridgeTaskConstMeta get kHandleSyncU32ConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "handle_sync_u32",
+        argNames: ["input"],
+      );
+
+  int handleSyncU64({required int input, dynamic hint}) => executeSync(FlutterRustBridgeSyncTask(
+        callFfi: () => inner.wire_handle_sync_u64(_api2wire_u64(input)),
+        parseSuccessData: _wire2api_SyncReturn_u64,
+        constMeta: kHandleSyncU64ConstMeta,
+        argValues: [input],
+        hint: hint,
+      ));
+
+  FlutterRustBridgeTaskConstMeta get kHandleSyncU64ConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "handle_sync_u64",
+        argNames: ["input"],
+      );
+
+  int handleSyncI8({required int input, dynamic hint}) => executeSync(FlutterRustBridgeSyncTask(
+        callFfi: () => inner.wire_handle_sync_i8(_api2wire_i8(input)),
+        parseSuccessData: _wire2api_SyncReturn_i8,
+        constMeta: kHandleSyncI8ConstMeta,
+        argValues: [input],
+        hint: hint,
+      ));
+
+  FlutterRustBridgeTaskConstMeta get kHandleSyncI8ConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "handle_sync_i8",
+        argNames: ["input"],
+      );
+
+  int handleSyncI16({required int input, dynamic hint}) => executeSync(FlutterRustBridgeSyncTask(
+        callFfi: () => inner.wire_handle_sync_i16(_api2wire_i16(input)),
+        parseSuccessData: _wire2api_SyncReturn_i16,
+        constMeta: kHandleSyncI16ConstMeta,
+        argValues: [input],
+        hint: hint,
+      ));
+
+  FlutterRustBridgeTaskConstMeta get kHandleSyncI16ConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "handle_sync_i16",
+        argNames: ["input"],
+      );
+
+  int handleSyncI32({required int input, dynamic hint}) => executeSync(FlutterRustBridgeSyncTask(
+        callFfi: () => inner.wire_handle_sync_i32(_api2wire_i32(input)),
+        parseSuccessData: _wire2api_SyncReturn_i32,
+        constMeta: kHandleSyncI32ConstMeta,
+        argValues: [input],
+        hint: hint,
+      ));
+
+  FlutterRustBridgeTaskConstMeta get kHandleSyncI32ConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "handle_sync_i32",
+        argNames: ["input"],
+      );
+
+  int handleSyncI64({required int input, dynamic hint}) => executeSync(FlutterRustBridgeSyncTask(
+        callFfi: () => inner.wire_handle_sync_i64(_api2wire_i64(input)),
+        parseSuccessData: _wire2api_SyncReturn_i64,
+        constMeta: kHandleSyncI64ConstMeta,
+        argValues: [input],
+        hint: hint,
+      ));
+
+  FlutterRustBridgeTaskConstMeta get kHandleSyncI64ConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "handle_sync_i64",
+        argNames: ["input"],
+      );
+
+  double handleSyncF32({required double input, dynamic hint}) => executeSync(FlutterRustBridgeSyncTask(
+        callFfi: () => inner.wire_handle_sync_f32(_api2wire_f32(input)),
+        parseSuccessData: _wire2api_SyncReturn_f32,
+        constMeta: kHandleSyncF32ConstMeta,
+        argValues: [input],
+        hint: hint,
+      ));
+
+  FlutterRustBridgeTaskConstMeta get kHandleSyncF32ConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "handle_sync_f32",
+        argNames: ["input"],
+      );
+
+  double handleSyncF64({required double input, dynamic hint}) => executeSync(FlutterRustBridgeSyncTask(
+        callFfi: () => inner.wire_handle_sync_f64(_api2wire_f64(input)),
+        parseSuccessData: _wire2api_SyncReturn_f64,
+        constMeta: kHandleSyncF64ConstMeta,
+        argValues: [input],
+        hint: hint,
+      ));
+
+  FlutterRustBridgeTaskConstMeta get kHandleSyncF64ConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "handle_sync_f64",
+        argNames: ["input"],
+      );
+
+  String handleSyncString({required String input, dynamic hint}) => executeSync(FlutterRustBridgeSyncTask(
+        callFfi: () => inner.wire_handle_sync_string(_api2wire_String(input)),
+        parseSuccessData: _wire2api_SyncReturn_String,
+        constMeta: kHandleSyncStringConstMeta,
+        argValues: [input],
+        hint: hint,
+      ));
+
+  FlutterRustBridgeTaskConstMeta get kHandleSyncStringConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "handle_sync_string",
+        argNames: ["input"],
       );
 
   Stream<String> handleStream({required String arg, dynamic hint}) => executeStream(FlutterRustBridgeTask(
@@ -1768,6 +1973,10 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     return ans;
   }
 
+  int _api2wire_i16(int raw) {
+    return raw;
+  }
+
   int _api2wire_i32(int raw) {
     return raw;
   }
@@ -1938,7 +2147,15 @@ class FlutterRustBridgeExampleSingleBlockTestImpl
     return raw == null ? ffi.nullptr : _api2wire_uint_8_list(raw);
   }
 
+  int _api2wire_u16(int raw) {
+    return raw;
+  }
+
   int _api2wire_u32(int raw) {
+    return raw;
+  }
+
+  int _api2wire_u64(int raw) {
     return raw;
   }
 
@@ -2242,8 +2459,67 @@ List<String> _wire2api_StringList(dynamic raw) {
   return (raw as List<dynamic>).cast<String>();
 }
 
-Uint8List _wire2api_SyncReturnVecU8(dynamic raw) {
-  return raw as Uint8List;
+String _wire2api_SyncReturn_String(dynamic raw) {
+  return utf8.decode(raw);
+}
+
+Uint8List _wire2api_SyncReturn_Uint8List(dynamic raw) {
+  return raw;
+}
+
+bool _wire2api_SyncReturn_bool(dynamic raw) {
+  final dataView = ByteData.view(raw.buffer);
+  return dataView.getUint8(0) != 0;
+}
+
+double _wire2api_SyncReturn_f32(dynamic raw) {
+  final dataView = ByteData.view(raw.buffer);
+  return dataView.getFloat32(0);
+}
+
+double _wire2api_SyncReturn_f64(dynamic raw) {
+  final dataView = ByteData.view(raw.buffer);
+  return dataView.getFloat64(0);
+}
+
+int _wire2api_SyncReturn_i16(dynamic raw) {
+  final dataView = ByteData.view(raw.buffer);
+  return dataView.getInt16(0);
+}
+
+int _wire2api_SyncReturn_i32(dynamic raw) {
+  final dataView = ByteData.view(raw.buffer);
+  return dataView.getInt32(0);
+}
+
+int _wire2api_SyncReturn_i64(dynamic raw) {
+  final dataView = ByteData.view(raw.buffer);
+  return dataView.getInt64(0);
+}
+
+int _wire2api_SyncReturn_i8(dynamic raw) {
+  final dataView = ByteData.view(raw.buffer);
+  return dataView.getInt8(0);
+}
+
+int _wire2api_SyncReturn_u16(dynamic raw) {
+  final dataView = ByteData.view(raw.buffer);
+  return dataView.getUint16(0);
+}
+
+int _wire2api_SyncReturn_u32(dynamic raw) {
+  final dataView = ByteData.view(raw.buffer);
+  return dataView.getUint32(0);
+}
+
+int _wire2api_SyncReturn_u64(dynamic raw) {
+  final dataView = ByteData.view(raw.buffer);
+  return dataView.getUint64(0);
+}
+
+int _wire2api_SyncReturn_u8(dynamic raw) {
+  final dataView = ByteData.view(raw.buffer);
+  return dataView.getUint8(0);
 }
 
 Float32List _wire2api_ZeroCopyBuffer_Float32List(dynamic raw) {
@@ -3107,6 +3383,152 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
           'wire_handle_sync_return');
   late final _wire_handle_sync_return =
       _wire_handle_sync_returnPtr.asFunction<WireSyncReturnStruct Function(ffi.Pointer<wire_uint_8_list>)>();
+
+  WireSyncReturnStruct wire_handle_sync_bool(
+    bool input,
+  ) {
+    return _wire_handle_sync_bool(
+      input,
+    );
+  }
+
+  late final _wire_handle_sync_boolPtr =
+      _lookup<ffi.NativeFunction<WireSyncReturnStruct Function(ffi.Bool)>>('wire_handle_sync_bool');
+  late final _wire_handle_sync_bool = _wire_handle_sync_boolPtr.asFunction<WireSyncReturnStruct Function(bool)>();
+
+  WireSyncReturnStruct wire_handle_sync_u8(
+    int input,
+  ) {
+    return _wire_handle_sync_u8(
+      input,
+    );
+  }
+
+  late final _wire_handle_sync_u8Ptr =
+      _lookup<ffi.NativeFunction<WireSyncReturnStruct Function(ffi.Uint8)>>('wire_handle_sync_u8');
+  late final _wire_handle_sync_u8 = _wire_handle_sync_u8Ptr.asFunction<WireSyncReturnStruct Function(int)>();
+
+  WireSyncReturnStruct wire_handle_sync_u16(
+    int input,
+  ) {
+    return _wire_handle_sync_u16(
+      input,
+    );
+  }
+
+  late final _wire_handle_sync_u16Ptr =
+      _lookup<ffi.NativeFunction<WireSyncReturnStruct Function(ffi.Uint16)>>('wire_handle_sync_u16');
+  late final _wire_handle_sync_u16 = _wire_handle_sync_u16Ptr.asFunction<WireSyncReturnStruct Function(int)>();
+
+  WireSyncReturnStruct wire_handle_sync_u32(
+    int input,
+  ) {
+    return _wire_handle_sync_u32(
+      input,
+    );
+  }
+
+  late final _wire_handle_sync_u32Ptr =
+      _lookup<ffi.NativeFunction<WireSyncReturnStruct Function(ffi.Uint32)>>('wire_handle_sync_u32');
+  late final _wire_handle_sync_u32 = _wire_handle_sync_u32Ptr.asFunction<WireSyncReturnStruct Function(int)>();
+
+  WireSyncReturnStruct wire_handle_sync_u64(
+    int input,
+  ) {
+    return _wire_handle_sync_u64(
+      input,
+    );
+  }
+
+  late final _wire_handle_sync_u64Ptr =
+      _lookup<ffi.NativeFunction<WireSyncReturnStruct Function(ffi.Uint64)>>('wire_handle_sync_u64');
+  late final _wire_handle_sync_u64 = _wire_handle_sync_u64Ptr.asFunction<WireSyncReturnStruct Function(int)>();
+
+  WireSyncReturnStruct wire_handle_sync_i8(
+    int input,
+  ) {
+    return _wire_handle_sync_i8(
+      input,
+    );
+  }
+
+  late final _wire_handle_sync_i8Ptr =
+      _lookup<ffi.NativeFunction<WireSyncReturnStruct Function(ffi.Int8)>>('wire_handle_sync_i8');
+  late final _wire_handle_sync_i8 = _wire_handle_sync_i8Ptr.asFunction<WireSyncReturnStruct Function(int)>();
+
+  WireSyncReturnStruct wire_handle_sync_i16(
+    int input,
+  ) {
+    return _wire_handle_sync_i16(
+      input,
+    );
+  }
+
+  late final _wire_handle_sync_i16Ptr =
+      _lookup<ffi.NativeFunction<WireSyncReturnStruct Function(ffi.Int16)>>('wire_handle_sync_i16');
+  late final _wire_handle_sync_i16 = _wire_handle_sync_i16Ptr.asFunction<WireSyncReturnStruct Function(int)>();
+
+  WireSyncReturnStruct wire_handle_sync_i32(
+    int input,
+  ) {
+    return _wire_handle_sync_i32(
+      input,
+    );
+  }
+
+  late final _wire_handle_sync_i32Ptr =
+      _lookup<ffi.NativeFunction<WireSyncReturnStruct Function(ffi.Int32)>>('wire_handle_sync_i32');
+  late final _wire_handle_sync_i32 = _wire_handle_sync_i32Ptr.asFunction<WireSyncReturnStruct Function(int)>();
+
+  WireSyncReturnStruct wire_handle_sync_i64(
+    int input,
+  ) {
+    return _wire_handle_sync_i64(
+      input,
+    );
+  }
+
+  late final _wire_handle_sync_i64Ptr =
+      _lookup<ffi.NativeFunction<WireSyncReturnStruct Function(ffi.Int64)>>('wire_handle_sync_i64');
+  late final _wire_handle_sync_i64 = _wire_handle_sync_i64Ptr.asFunction<WireSyncReturnStruct Function(int)>();
+
+  WireSyncReturnStruct wire_handle_sync_f32(
+    double input,
+  ) {
+    return _wire_handle_sync_f32(
+      input,
+    );
+  }
+
+  late final _wire_handle_sync_f32Ptr =
+      _lookup<ffi.NativeFunction<WireSyncReturnStruct Function(ffi.Float)>>('wire_handle_sync_f32');
+  late final _wire_handle_sync_f32 = _wire_handle_sync_f32Ptr.asFunction<WireSyncReturnStruct Function(double)>();
+
+  WireSyncReturnStruct wire_handle_sync_f64(
+    double input,
+  ) {
+    return _wire_handle_sync_f64(
+      input,
+    );
+  }
+
+  late final _wire_handle_sync_f64Ptr =
+      _lookup<ffi.NativeFunction<WireSyncReturnStruct Function(ffi.Double)>>('wire_handle_sync_f64');
+  late final _wire_handle_sync_f64 = _wire_handle_sync_f64Ptr.asFunction<WireSyncReturnStruct Function(double)>();
+
+  WireSyncReturnStruct wire_handle_sync_string(
+    ffi.Pointer<wire_uint_8_list> input,
+  ) {
+    return _wire_handle_sync_string(
+      input,
+    );
+  }
+
+  late final _wire_handle_sync_stringPtr =
+      _lookup<ffi.NativeFunction<WireSyncReturnStruct Function(ffi.Pointer<wire_uint_8_list>)>>(
+          'wire_handle_sync_string');
+  late final _wire_handle_sync_string =
+      _wire_handle_sync_stringPtr.asFunction<WireSyncReturnStruct Function(ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_handle_stream(
     int port_,

--- a/frb_example/pure_dart/dart/lib/main.dart
+++ b/frb_example/pure_dart/dart/lib/main.dart
@@ -106,6 +106,7 @@ void main(List<String> args) async {
     expect(complexStructResp.children[1].valueVecU8, List.filled(arrLen, 120));
   });
 
+  // Test if sync return is working as expected.
   test('dart call handle_sync_return', () async {
     expect(api.handleSyncReturn(mode: 'NORMAL'), List.filled(100, 42));
 
@@ -118,6 +119,37 @@ void main(List<String> args) async {
         expect(e, isA<FfiException>());
       }
     }
+  });
+  // Test other sync return types.
+  test('dart call handle_sync_bool', () async {
+    expect(api.handleSyncBool(input: true), true);
+  });
+  test('dart call handle_sync_u8', () async {
+    expect(api.handleSyncU8(input: 42), 42);
+  });
+  test('dart call handle_sync_u16', () async {
+    expect(api.handleSyncU16(input: 42), 42);
+  });
+  test('dart call handle_sync_u32', () async {
+    expect(api.handleSyncU32(input: 42), 42);
+  });
+  test('dart call handle_sync_u64', () async {
+    expect(api.handleSyncU64(input: 42), 42);
+  });
+  test('dart call handle_sync_i8', () async {
+    expect(api.handleSyncI8(input: 42), 42);
+  });
+  test('dart call handle_sync_i16', () async {
+    expect(api.handleSyncI16(input: 42), 42);
+  });
+  test('dart call handle_sync_i32', () async {
+    expect(api.handleSyncI32(input: 42), 42);
+  });
+  test('dart call handle_sync_i64', () async {
+    expect(api.handleSyncI64(input: 42), 42);
+  });
+  test('dart call handle_sync_string', () async {
+    expect(api.handleSyncString(input: "Hello Rust!"), "Hello Rust!");
   });
 
   test('dart call handle_stream', () async {

--- a/frb_example/pure_dart/rust/src/api.rs
+++ b/frb_example/pure_dart/rust/src/api.rs
@@ -163,6 +163,7 @@ pub fn handle_complex_struct(s: MyTreeNode) -> MyTreeNode {
     s
 }
 
+// Test if sync return is working as expected by using Vec<u8> as return value.
 pub fn handle_sync_return(mode: String) -> Result<SyncReturn<Vec<u8>>> {
     match &mode[..] {
         "NORMAL" => Ok(SyncReturn(vec![42u8; 100])),
@@ -170,6 +171,44 @@ pub fn handle_sync_return(mode: String) -> Result<SyncReturn<Vec<u8>>> {
         "PANIC" => panic!("deliberate panic in handle_sync_return_panic"),
         _ => panic!("unknown mode"),
     }
+}
+
+// Test other sync return types except for Vec<u8> since it's being tested in handle_sync_return.
+pub fn handle_sync_bool(input: bool) -> SyncReturn<bool> {
+    SyncReturn(input)
+}
+pub fn handle_sync_u8(input: u8) -> SyncReturn<u8> {
+    SyncReturn(input)
+}
+pub fn handle_sync_u16(input: u16) -> SyncReturn<u16> {
+    SyncReturn(input)
+}
+pub fn handle_sync_u32(input: u32) -> SyncReturn<u32> {
+    SyncReturn(input)
+}
+pub fn handle_sync_u64(input: u64) -> SyncReturn<u64> {
+    SyncReturn(input)
+}
+pub fn handle_sync_i8(input: i8) -> SyncReturn<i8> {
+    SyncReturn(input)
+}
+pub fn handle_sync_i16(input: i16) -> SyncReturn<i16> {
+    SyncReturn(input)
+}
+pub fn handle_sync_i32(input: i32) -> SyncReturn<i32> {
+    SyncReturn(input)
+}
+pub fn handle_sync_i64(input: i64) -> SyncReturn<i64> {
+    SyncReturn(input)
+}
+pub fn handle_sync_f32(input: f32) -> SyncReturn<f32> {
+    SyncReturn(input)
+}
+pub fn handle_sync_f64(input: f64) -> SyncReturn<f64> {
+    SyncReturn(input)
+}
+pub fn handle_sync_string(input: String) -> SyncReturn<String> {
+    SyncReturn(input)
 }
 
 pub fn handle_stream(sink: StreamSink<String>, arg: String) -> Result<()> {

--- a/frb_example/pure_dart/rust/src/bridge_generated.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.rs
@@ -250,6 +250,188 @@ pub extern "C" fn wire_handle_sync_return(
 }
 
 #[no_mangle]
+pub extern "C" fn wire_handle_sync_bool(input: bool) -> support::WireSyncReturnStruct {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync(
+        WrapInfo {
+            debug_name: "handle_sync_bool",
+            port: None,
+            mode: FfiCallMode::Sync,
+        },
+        move || {
+            let api_input = input.wire2api();
+            Ok(handle_sync_bool(api_input))
+        },
+    )
+}
+
+#[no_mangle]
+pub extern "C" fn wire_handle_sync_u8(input: u8) -> support::WireSyncReturnStruct {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync(
+        WrapInfo {
+            debug_name: "handle_sync_u8",
+            port: None,
+            mode: FfiCallMode::Sync,
+        },
+        move || {
+            let api_input = input.wire2api();
+            Ok(handle_sync_u8(api_input))
+        },
+    )
+}
+
+#[no_mangle]
+pub extern "C" fn wire_handle_sync_u16(input: u16) -> support::WireSyncReturnStruct {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync(
+        WrapInfo {
+            debug_name: "handle_sync_u16",
+            port: None,
+            mode: FfiCallMode::Sync,
+        },
+        move || {
+            let api_input = input.wire2api();
+            Ok(handle_sync_u16(api_input))
+        },
+    )
+}
+
+#[no_mangle]
+pub extern "C" fn wire_handle_sync_u32(input: u32) -> support::WireSyncReturnStruct {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync(
+        WrapInfo {
+            debug_name: "handle_sync_u32",
+            port: None,
+            mode: FfiCallMode::Sync,
+        },
+        move || {
+            let api_input = input.wire2api();
+            Ok(handle_sync_u32(api_input))
+        },
+    )
+}
+
+#[no_mangle]
+pub extern "C" fn wire_handle_sync_u64(input: u64) -> support::WireSyncReturnStruct {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync(
+        WrapInfo {
+            debug_name: "handle_sync_u64",
+            port: None,
+            mode: FfiCallMode::Sync,
+        },
+        move || {
+            let api_input = input.wire2api();
+            Ok(handle_sync_u64(api_input))
+        },
+    )
+}
+
+#[no_mangle]
+pub extern "C" fn wire_handle_sync_i8(input: i8) -> support::WireSyncReturnStruct {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync(
+        WrapInfo {
+            debug_name: "handle_sync_i8",
+            port: None,
+            mode: FfiCallMode::Sync,
+        },
+        move || {
+            let api_input = input.wire2api();
+            Ok(handle_sync_i8(api_input))
+        },
+    )
+}
+
+#[no_mangle]
+pub extern "C" fn wire_handle_sync_i16(input: i16) -> support::WireSyncReturnStruct {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync(
+        WrapInfo {
+            debug_name: "handle_sync_i16",
+            port: None,
+            mode: FfiCallMode::Sync,
+        },
+        move || {
+            let api_input = input.wire2api();
+            Ok(handle_sync_i16(api_input))
+        },
+    )
+}
+
+#[no_mangle]
+pub extern "C" fn wire_handle_sync_i32(input: i32) -> support::WireSyncReturnStruct {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync(
+        WrapInfo {
+            debug_name: "handle_sync_i32",
+            port: None,
+            mode: FfiCallMode::Sync,
+        },
+        move || {
+            let api_input = input.wire2api();
+            Ok(handle_sync_i32(api_input))
+        },
+    )
+}
+
+#[no_mangle]
+pub extern "C" fn wire_handle_sync_i64(input: i64) -> support::WireSyncReturnStruct {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync(
+        WrapInfo {
+            debug_name: "handle_sync_i64",
+            port: None,
+            mode: FfiCallMode::Sync,
+        },
+        move || {
+            let api_input = input.wire2api();
+            Ok(handle_sync_i64(api_input))
+        },
+    )
+}
+
+#[no_mangle]
+pub extern "C" fn wire_handle_sync_f32(input: f32) -> support::WireSyncReturnStruct {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync(
+        WrapInfo {
+            debug_name: "handle_sync_f32",
+            port: None,
+            mode: FfiCallMode::Sync,
+        },
+        move || {
+            let api_input = input.wire2api();
+            Ok(handle_sync_f32(api_input))
+        },
+    )
+}
+
+#[no_mangle]
+pub extern "C" fn wire_handle_sync_f64(input: f64) -> support::WireSyncReturnStruct {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync(
+        WrapInfo {
+            debug_name: "handle_sync_f64",
+            port: None,
+            mode: FfiCallMode::Sync,
+        },
+        move || {
+            let api_input = input.wire2api();
+            Ok(handle_sync_f64(api_input))
+        },
+    )
+}
+
+#[no_mangle]
+pub extern "C" fn wire_handle_sync_string(
+    input: *mut wire_uint_8_list,
+) -> support::WireSyncReturnStruct {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync(
+        WrapInfo {
+            debug_name: "handle_sync_string",
+            port: None,
+            mode: FfiCallMode::Sync,
+        },
+        move || {
+            let api_input = input.wire2api();
+            Ok(handle_sync_string(api_input))
+        },
+    )
+}
+
+#[no_mangle]
 pub extern "C" fn wire_handle_stream(port_: i64, arg: *mut wire_uint_8_list) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {
@@ -2043,6 +2225,12 @@ impl Wire2Api<Vec<f64>> for *mut wire_float_64_list {
     }
 }
 
+impl Wire2Api<i16> for i16 {
+    fn wire2api(self) -> i16 {
+        self
+    }
+}
+
 impl Wire2Api<i32> for i32 {
     fn wire2api(self) -> i32 {
         self
@@ -2281,8 +2469,20 @@ impl Wire2Api<SumWith> for wire_SumWith {
     }
 }
 
+impl Wire2Api<u16> for u16 {
+    fn wire2api(self) -> u16 {
+        self
+    }
+}
+
 impl Wire2Api<u32> for u32 {
     fn wire2api(self) -> u32 {
+        self
+    }
+}
+
+impl Wire2Api<u64> for u64 {
+    fn wire2api(self) -> u64 {
         self
     }
 }

--- a/frb_rust/src/lib.rs
+++ b/frb_rust/src/lib.rs
@@ -3,6 +3,7 @@ pub use allo_isolate::ZeroCopyBuffer;
 pub use flutter_rust_bridge_macros::frb;
 pub use handler::{FfiCallMode, Handler, WrapInfo};
 pub use rust2dart::StreamSink;
+use support::WireSyncReturnStruct;
 
 pub mod handler;
 pub mod rust2dart;
@@ -10,4 +11,6 @@ pub mod support;
 
 /// Use this struct in return type of your function, in order to tell the code generator
 /// the function should return synchronously. Otherwise, it is by default asynchronously.
-pub struct SyncReturn<T>(pub T);
+pub struct SyncReturn<T>(pub T)
+where
+    WireSyncReturnStruct: From<T>;

--- a/frb_rust/src/lib.rs
+++ b/frb_rust/src/lib.rs
@@ -3,7 +3,7 @@ pub use allo_isolate::ZeroCopyBuffer;
 pub use flutter_rust_bridge_macros::frb;
 pub use handler::{FfiCallMode, Handler, WrapInfo};
 pub use rust2dart::StreamSink;
-use support::WireSyncReturnStruct;
+use support::WireSyncReturnData;
 
 pub mod handler;
 pub mod rust2dart;
@@ -13,4 +13,4 @@ pub mod support;
 /// the function should return synchronously. Otherwise, it is by default asynchronously.
 pub struct SyncReturn<T>(pub T)
 where
-    WireSyncReturnStruct: From<T>;
+    WireSyncReturnData: From<T>;

--- a/frb_rust/src/support.rs
+++ b/frb_rust/src/support.rs
@@ -62,7 +62,7 @@ impl From<WireSyncReturnData> for WireSyncReturnStruct {
     }
 }
 
-/// Wrapper struct for [`WireSyncReturnStruct`].
+/// Safe version of [`WireSyncReturnStruct`].
 pub struct WireSyncReturnData(Vec<u8>);
 
 impl From<Vec<u8>> for WireSyncReturnData {
@@ -74,7 +74,7 @@ impl From<Vec<u8>> for WireSyncReturnData {
 /// Bool will be converted to u8 where 0 stands for false and 1 stands for true.
 impl From<bool> for WireSyncReturnData {
     fn from(data: bool) -> Self {
-        if data { 1_u8 } else { 0_u8 }.to_be_bytes().to_vec().into()
+        if data { 1_u8 } else { 0_u8 }.into()
     }
 }
 

--- a/frb_rust/src/support.rs
+++ b/frb_rust/src/support.rs
@@ -50,3 +50,60 @@ pub struct WireSyncReturnStruct {
     pub len: i32,
     pub success: bool,
 }
+
+/// Macro for implementing [`From<Primitive>`] for [`WireSyncReturnStruct`].
+/// This conversion won't fail.
+macro_rules! primitive_to_sync_return {
+    ($($t:ty),+) => {
+        $(impl From<$t> for WireSyncReturnStruct {
+            fn from(data: $t) -> Self {
+                let bytes = data.to_be_bytes().to_vec();
+                let (ptr, len) = into_leak_vec_ptr(bytes);
+                WireSyncReturnStruct {
+                    ptr,
+                    len,
+                    success: true,
+                }
+            }
+        })*
+    }
+}
+
+// For simple types, use macro to implement [`From`] trait.
+primitive_to_sync_return!(u8, i8, u16, i16, u32, i32, u64, i64, f32, f64);
+
+/// Bool will be converted to u8 where 0 stands for false and 1 stands for true.
+impl From<bool> for WireSyncReturnStruct {
+    fn from(data: bool) -> Self {
+        let bytes = if data { 1_u8 } else { 0_u8 }.to_be_bytes().to_vec();
+        let (ptr, len) = into_leak_vec_ptr(bytes);
+        WireSyncReturnStruct {
+            ptr,
+            len,
+            success: true,
+        }
+    }
+}
+
+impl From<String> for WireSyncReturnStruct {
+    fn from(data: String) -> Self {
+        let bytes = data.as_bytes().to_vec();
+        let (ptr, len) = into_leak_vec_ptr(bytes);
+        WireSyncReturnStruct {
+            ptr,
+            len,
+            success: true,
+        }
+    }
+}
+
+impl From<Vec<u8>> for WireSyncReturnStruct {
+    fn from(data: Vec<u8>) -> Self {
+        let (ptr, len) = into_leak_vec_ptr(data);
+        WireSyncReturnStruct {
+            ptr,
+            len,
+            success: true,
+        }
+    }
+}


### PR DESCRIPTION
If there are any problems with my code or design, please let me know😊😊

## Adjustments

* Added a new IR type: IrTypeSyncReturn.
* SyncReturn now supports String, Vec\<u8\> and most of the primitive types(`bool`, `u8`, `u16`, `u32`, `u64`, `i8`, `i16`, `i32`, `i64`, `f32`, `f64`).
* Removed SyncReturnVecU8 from IrTypeDelegate since SyncReturn now has an individual IR.

## Design

* Added `parseSuccessData` for `FlutterRustBridgeSyncTask`, it does the type conversion for Dart.
* Implemented `From` trait for `WireSyncReturnStruct`, it does the type conversion for Rust.
* Added generic type constraint for SyncReturn, now if users are trying to use an unsupported type for SyncReturn, they will immediately get a compiler error.

## Checklist

- [x] New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api.rs` and `dart/lib/main.dart`.
- [x] The code generator is run and the code is formatted (e.g. via `just refresh_all`).
- [x] If this PR adds/changes features, documentations (in the `./book` folder) are updated.
- [x] CI is passing.