### PR TITLE
:bug: fix minor issue when running just command

### DIFF
--- a/justfile
+++ b/justfile
@@ -13,7 +13,7 @@ dylib := if os() == "windows" {
     "libflutter_rust_bridge_example.so"
 }
 frb_linux_so := "target/x86_64-unknown-linux-gnu/debug/libflutter_rust_bridge_example.so"
-frb_tools := justfile_directory() / "tools"
+frb_tools := "{{justfile_directory()}}/tools"
 
 default: gen-bridge
 precommit: gen-bridge check lint gen-help


### PR DESCRIPTION
A trivial issue encountered while running `just g` after latest update with `just` `1.1.2`.
This issue indeed does not happen with latest version of `just` `1.4.0`.
There's no opened issue related.

issue:

```sh
$ just g
error: Unknown start of token:
   |
16 | frb_tools := justfile_directory() / "tools"
```

This PR can be dismissed by otherwise mentioning it in the docs, whichever you think is best.

## Checklist

- [ ] An issue to be fixed by this PR is listed above.
- [ ] New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api.rs` and `dart/lib/main.dart`.
- [ ] The code generator is run and the code is formatted (e.g. via `just refresh_all`).
- [ ] If this PR adds/changes features, documentations (in the `./book` folder) are updated.
- [ ] CI is passing.

