### PR TITLE
Fix broken links in book

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -25,8 +25,8 @@ jobs:
         with:
           mdbook-version: 'latest'
       
-      - name: Setup `mdbook-mermaid`
-        run: cargo install mdbook-mermaid
+      - name: Setup mdbook plugins (mermaid, linkcheck)
+        run: cargo install mdbook-linkcheck mdbook-mermaid
 
       - run: mdbook build ./book
 

--- a/book/book.toml
+++ b/book/book.toml
@@ -7,5 +7,7 @@ title = "flutter_rust_bridge"
 
 [preprocessor]
 
+[preprocessor.links]
+
 [preprocessor.mermaid]
 command = "mdbook-mermaid"

--- a/book/book.toml
+++ b/book/book.toml
@@ -11,3 +11,7 @@ title = "flutter_rust_bridge"
 
 [preprocessor.mermaid]
 command = "mdbook-mermaid"
+
+[output.html]
+
+[output.linkcheck]

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -16,6 +16,8 @@
     - [Option](feature/lang_option.md)
     - [Methods](feature/lang_methods.md)
     - [Return types](feature/lang_return_types.md)
+    - [`chrono` types](feature/lang_chrono.md)
+    - [`uuid` type](feature/lang_uuid.md)
   - [Zero copy](feature/zero_copy.md)
   - [Stream / Iterator](feature/stream.md)
   - [Async in Dart](feature/async_dart.md)

--- a/book/src/article/generate_multiple_files.md
+++ b/book/src/article/generate_multiple_files.md
@@ -166,7 +166,7 @@ gen:
 
 Here, with just 1 command, flutter_rust_bridge would smartly check if there are conflicts over all Api over all blocks, be it defined explicitly or implicitly.
 
-That is, for the explicitly defined APIs like `simple_add` and `simple_minus`, if there are duplicated ones, flutter_rust_bridge would throw a panic like "thread 'main' panicked at 'symbol [simple_add] has already been defined'...", and you are responsible to fix it. And for the implicitly defined API like `new_uint_8_list`, since it is essential, flutter_rust_bridge would try to work around it by adding suffix starting from 0, like `new_uint_8_list_0` and `new_uint_8_list_1`.
+That is, for the explicitly defined APIs like `simple_add` and `simple_minus`, if there are duplicated ones, flutter_rust_bridge would throw a panic like "thread 'main' panicked at 'symbol \[simple_add\] has already been defined'...", and you are responsible to fix it. And for the implicitly defined API like `new_uint_8_list`, since it is essential, flutter_rust_bridge would try to work around it by adding suffix starting from 0, like `new_uint_8_list_0` and `new_uint_8_list_1`.
 
 To sum up, **there are 4 compulsory flags when you deal with multiple blocks.** They are `rust-input`, `dart-output`, `class-name` and `rust-output`. Also, the number of fields following each flag should be consistent. You can try to `cargo build` with fewer flags or inconsistent fields to see what kind of panic would be popped up with the [pure_dart_multi](https://github.com/fzyzcjy/flutter_rust_bridge/tree/master/frb_example/pure_dart_multi/rust/build.rs) example when doing generation.
 

--- a/book/src/feature/lang_chrono.md
+++ b/book/src/feature/lang_chrono.md
@@ -1,19 +1,19 @@
 # chrono
 
-Codegen optionally support [chrono crate](https://docs.rs/chrono) with feature `chrono`.
+Codegen optionally support [chrono crate](https://docs.rs/chrono) with default feature `chrono`.
 
-| :crab: Rust       | :dart: Dart                   |
+| 🦀 Rust           | 🎯 Dart                        |
 | -----------       | -----------                   |
 | `DateTime<Utc>`   | `DateTime` *utc*              |
 | `DateTime<Local>` | `DateTime` *local timezone*   |
 | `NaiveDateTime`   | `DateTime` *utc assumed*      |
 | `Duration`        | `Duration`                    |
 
-:warning: Please note that:
+⚠️ Please note that:
 
 - on native platforms, *microseconds* unit is used.
 - on web platform, *milliseconds* unit is used (due to JS limitation with dates).
 
-:bulb: Also a `DateTime<Local>` will always be translated into local time of the device, which might not be what you want if you expect them to be sent *as-is*.
+💡 Also a `DateTime<Local>` will always be translated into local time of the device, which might not be what you want if you expect them to be sent *as-is*.
 
 > In that case, you could implement it in your codebase by sending a `u32` (timezone offset) alongside the `i64` (timestamp) over the wire, or open a issue / PR here to further discuss it. The reason why this choice was originally made is to have all `DateTime<Utc>`, `DateTime<Local>` and `NaiveDateTime` been represented by a single `i64`.

--- a/book/src/feature/lang_simple.md
+++ b/book/src/feature/lang_simple.md
@@ -21,5 +21,5 @@ Here is a brief glance showing what the code generator can generate (non-exhaust
 | `String`                                          | `String`                    |
 | `()`                                              | `void`                      |
 
-Types from `chrono` crate are supported as a feature, see [here](lang_chrono.md).
-Types from `uuid` crate are supported as a feature, see [here](lang_uuid.md).
+- Types from `chrono` crate are supported as a feature, see [here](lang_chrono.md).
+- Types from `uuid` crate are supported as a feature, see [here](lang_uuid.md).

--- a/book/src/feature/lang_uuid.md
+++ b/book/src/feature/lang_uuid.md
@@ -2,10 +2,10 @@
 
 Codegen optionally support [uuid crate](https://docs.rs/uuid) with feature `uuid`.
 
-| :crab: Rust       | :dart: Dart                       |
-| -----------       | -----------                       |
-| `Uuid`            | `UuidValue` see package [uuid](https://pub.dev/packages/uuid)  |
+| 🦀 Rust     | 🎯 Dart                                                         |
+| ----------- | -----------                                                    |
+| `Uuid`      | `UuidValue` see package [uuid](https://pub.dev/packages/uuid)  |
 
-:warning: Please note that you need to add package [uuid](https://pub.dev/packages/uuid/install) to your Dart/Flutter dependencies in `pubspec.yaml` as well.
+⚠️ Please note that you need to add package [uuid](https://pub.dev/packages/uuid/install) to your Dart/Flutter dependencies in `pubspec.yaml` as well.
 
-:bulb: `Vec<Uuid>` implementation detail : all the uuids get concatenated as a single array of bytes for performance optimization.
+💡 `Vec<Uuid>` implementation detail : all the uuids get concatenated as a single array of bytes for performance optimization.

--- a/book/src/integrate/deps.md
+++ b/book/src/integrate/deps.md
@@ -44,7 +44,7 @@ following dependencies are also needed:
 - `freezed` (dev)
 - `freezed_annotation`
 
-Their usage is explained in [Using `build_runner`](../generate/build_runner.md).
+Their usage is explained in [Using `build_runner`](../template/generate_build_runner.md).
 
 ```bash
 flutter pub add flutter_rust_bridge

--- a/book/src/template/generate.md
+++ b/book/src/template/generate.md
@@ -1,5 +1,5 @@
 # Generating code
 
-This section assumes you followed the instructions in [Creating a new project](template.md), and has successfully `flutter run` on your target device.
+This section assumes you followed the instructions in [Creating a new project](setup.md), and has successfully `flutter run` on your target device.
 
 Up until now, all the code necessary for executing the program has been supplied for you, so there was no need to install anything. We will now look at how to create new Rust code, generate the necessary glue code and use them in Dart.


### PR DESCRIPTION
A couple of links are broken in the docs, see #731.
It fixes them and add [mdbook-linkcheck](https://github.com/Michael-F-Bryan/mdbook-linkcheck) to the CI.

## Checklist

- [x] An issue to be fixed by this PR is listed above.
- [ ] New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api.rs` and `dart/lib/main.dart`.
- [x] The code generator is run and the code is formatted (e.g. via `just refresh_all`).
- [ ] If this PR adds/changes features, documentations (in the `./book` folder) are updated.
- [x] CI is passing.
