### PR TITLE
Fix post-release

### DIFF
--- a/.github/workflows/post_release.yaml
+++ b/.github/workflows/post_release.yaml
@@ -181,7 +181,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install released version of codegen
-        run: cargo install flutter_rust_bridge_codegen
+        run: cargo install flutter_rust_bridge_codegen --features="chrono,uuid"
 
       # needed by `ffigen`, see https://github.com/dart-lang/ffigen#installing-llvm
       - name: Install llvm dependency (Linux)


### PR DESCRIPTION
Feature flags are missing in CI when running `frb_codegen` in `post-release` CI workflow.

## Checklist

- [ ] An issue to be fixed by this PR is listed above. (I haven't opened any issue so far)
- [ ] ~New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api.rs` and `dart/lib/main.dart`.~
- [x] The code generator is run and the code is formatted (e.g. via `just refresh_all`).
- [ ] ~If this PR adds/changes features, documentations (in the `./book` folder) are updated.~
- [x] CI is passing.

### Remark

I haven't checked yet if there are other places where it's missing.
