### PR TITLE
Do not compare `runtimeType` string reprs in test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -361,8 +361,8 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: "stable"
-          flutter-version: '3.3.1'
-          architecture: x64
+          # flutter-version: '3.3.1'
+          # architecture: x64
 
       - name: Install dependencies for with_flutter example
         working-directory: ./frb_example/with_flutter

--- a/frb_dart/bin/serve.dart
+++ b/frb_dart/bin/serve.dart
@@ -272,7 +272,7 @@ Future<void> build(
   } else {
     await system(
       'flutter',
-      ['build', 'web', if (!config.release) '--release'] + Opts.rest(args),
+      ['build', 'web', if (!config.release) '--profile'] + Opts.rest(args),
     );
   }
 }

--- a/frb_example/pure_dart/dart/lib/main.dart
+++ b/frb_example/pure_dart/dart/lib/main.dart
@@ -12,6 +12,11 @@ String? skipWeb([String reason = 'unspecified']) => isWeb ? 'Skipped on web (rea
 
 void main(List<String> args) async {
   String dylibPath = args[0];
+  var releaseMode = true;
+  assert(() {
+    releaseMode = false;
+    return true;
+  }());
   print('flutter_rust_bridge example program start (dylibPath=$dylibPath)');
   print('construct api');
   final api = initializeExternalLibrary(dylibPath);
@@ -505,6 +510,11 @@ void main(List<String> args) async {
       await api.multiplyByTen(measure: Measure.speed(Speed_Unknown())),
       null,
     );
+    final skipMinified = releaseMode ? skipWeb('Minified names cannot be compared.') : null;
+    expect((Speed_Unknown).toString(), 'Speed_Unknown', skip: skipMinified);
+    expect((Speed_GPS).toString(), 'Speed_GPS', skip: skipMinified);
+    expect((Distance_Unknown).toString(), 'Distance_Unknown', skip: skipMinified);
+    expect((Distance_Map).toString(), 'Distance_Map', skip: skipMinified);
   });
 
   test('resolve module for old module system', () async {

--- a/frb_example/pure_dart/dart/lib/main.dart
+++ b/frb_example/pure_dart/dart/lib/main.dart
@@ -505,10 +505,6 @@ void main(List<String> args) async {
       await api.multiplyByTen(measure: Measure.speed(Speed_Unknown())),
       null,
     );
-    expect((Speed_Unknown).toString(), 'Speed_Unknown');
-    expect((Speed_GPS).toString(), 'Speed_GPS');
-    expect((Distance_Unknown).toString(), 'Distance_Unknown');
-    expect((Distance_Map).toString(), 'Distance_Map');
   });
 
   test('resolve module for old module system', () async {


### PR DESCRIPTION
Prevents unit tests failing in release mode. Fixes #752

## Checklist

- [x] An issue to be fixed by this PR is listed above.
- [ ] New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api.rs` and `dart/lib/main.dart`.
- [ ] The code generator is run and the code is formatted (e.g. via `just refresh_all`).
- [ ] If this PR adds/changes features, documentations (in the `./book` folder) are updated.
- [x] CI is passing.

## Remark for PR creator

* New contributors will be blocked by GitHub from running CI, but you can use [a trick](https://github.com/fzyzcjy/flutter_rust_bridge/pull/663#discussion_r962150638) to workaround this, and verify your code using CI by yourself.
* If fzyzcjy does not reply for a few days, maybe he just did not see it, so please ping him.
