### PR TITLE
Fix store dart post cobject (latest Silicon)

### DIFF
--- a/book/src/set_up_from_scratch.md
+++ b/book/src/set_up_from_scratch.md
@@ -10,7 +10,7 @@ However, I can sketch the outline of what to do if you want to set up a new Flut
 
 ## Step 1
 
-Create a new Flutter project (or use an existing one). The Dart SDK should be `>=2.14.0` if you want to use the latest `ffigen` tool.
+Create a new Flutter project (or use an existing one). The Dart SDK should be `>=2.17.0` if you want to use the latest `ffigen` tool.
 
 ## Step 2
 

--- a/book/src/troubleshooting.md
+++ b/book/src/troubleshooting.md
@@ -47,9 +47,9 @@ If you use a Rust type with `Kind` in it's name it may conflict with some genera
 
 Indeed all generated code are necessary (if you find something that can be simplified, file an issue). Moreover, other code generation tools also generate long code - for example, when using Google protobuf, a very popular serialization library, I see >10k lines of Java code generated for a quite simple source proto file.
 
-## Why need Dart `2.14.0`
+## Why need Dart `2.17.0`
 
-Dart SDK `>=2.14.0` is needed not by this library, but by the latest version of the `ffigen` tool. Therefore, write `sdk: ">=2.14.0 <3.0.0"` in the `environment` section of `pubspec.yaml`. If you do not want that, consider installing a older version of the `ffigen` tool.
+Dart SDK `>=2.17.0` is needed by the latest version of the `ffigen` tool, and for some cool Dart features also used in this library (e.g. enhanced enums). Therefore, write `sdk: ">=2.17.0 <3.0.0"` in the `environment` section of `pubspec.yaml`. If you do not want that, consider installing a older version of the `ffigen` tool, but this is not recommended.
 
 ## Issues on Web?
 

--- a/book/src/troubleshooting.md
+++ b/book/src/troubleshooting.md
@@ -15,6 +15,28 @@ If calling rust function gives the error below, please consider running **cargo 
 [ERROR:flutter/lib/ui/ui_dart_state.cc(209)] Unhandled Exception: Invalid argument(s): Failed to lookup symbol 'store_dart_post_cobject': target/debug/libadder.so: undefined symbol: store_dart_post_cobject
 ```
 
+### :warning: on latest Apple Silicon
+Users also sometimes face it because of how Rust dynamic library is opened.
+
+At the moment it's not clear yet how to differentiate MacOS lineage in Dart, so in the meantime here's a workaround:
+
+Instead of e.g.:
+
+```sh
+just test-pure
+```
+
+Just run:
+```sh
+just define="DYNAMIC_LIBRARY_SOURCE=open" test-pure
+# must precede the command
+```
+
+Also please note that:
+- :dart: **Dart** uses `define` like `define="DYNAMIC_LIBRARY_SOURCE"=...`.
+- :bird: **Flutter** use `dart-define` like `dart-define="DYNAMIC_LIBRARY_SOURCE"=...`.
+- `DYNAMIC_LIBRARY_SOURCE` possible values: `open`, `process` or `executable` (as per Dart [DynamicLibrary](https://api.dart.dev/stable/2.18.2/dart-ffi/DynamicLibrary-class.html#constructors)).
+
 ## Error running `cargo ndk`: `ld: error: unable to find library -lgcc`
 
 Downgrade Android NDK to version 22. This is an [ongoing issue](https://github.com/bbqsrc/cargo-ndk/issues/22) with `cargo-ndk`, a library unrelated to flutter_rust_bridge but solely used to build the examples, when using Android NDK version 23. (See [#149](https://github.com/fzyzcjy/flutter_rust_bridge/issues/149))

--- a/frb_dart/lib/flutter_rust_bridge.dart
+++ b/frb_dart/lib/flutter_rust_bridge.dart
@@ -2,3 +2,4 @@ export 'src/basic.dart';
 export 'src/helpers.dart';
 export 'src/platform_independent.dart';
 export 'src/typed_data.dart';
+export 'src/utils.dart';

--- a/frb_dart/lib/src/utils.dart
+++ b/frb_dart/lib/src/utils.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'isolate.dart';
-export '' if (dart.library.io) 'utils.io.dart';
 
 // NOTE XXX copy from: https://github.com/dart-archive/isolate/blob/master/lib/ports.dart
 // Because [package:isolate] is not maintained anymore, so the code is copied and maintained by ourselves.

--- a/frb_dart/lib/src/utils.dart
+++ b/frb_dart/lib/src/utils.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
+
 import 'isolate.dart';
+export '' if (dart.library.io) 'utils.io.dart';
 
 // NOTE XXX copy from: https://github.com/dart-archive/isolate/blob/master/lib/ports.dart
 // Because [package:isolate] is not maintained anymore, so the code is copied and maintained by ourselves.

--- a/frb_dart/lib/src/utils.io.dart
+++ b/frb_dart/lib/src/utils.io.dart
@@ -9,26 +9,24 @@ enum DylibSourceKind {
   open;
 
   static DylibSourceKind? fromEnvironment(String value) {
-    const String source = String.fromEnvironment(dylibSource);
-    if (source.isNotEmpty) {
-      if (!['executable', 'process', 'open'].contains(source.trim())) {
-        print(
-            "warning: invalid $dylibSource '$source' ignored (expected 'executable', 'process' or 'open')");
-      } else {
-        print('info: use $dylibSource=$source to open dynamic library');
-      }
-      switch (source) {
-        case 'executable':
-          return DylibSourceKind.executable;
-        case 'process':
-          return DylibSourceKind.process;
-        case 'open':
-          return DylibSourceKind.open;
-        default:
-          break;
-      }
+    String source = String.fromEnvironment(dylibSource).trim();
+    if (source.isEmpty) return null;
+    if (!['executable', 'process', 'open'].contains(source)) {
+      print(
+          "warning: invalid $dylibSource '$source' ignored (expected 'executable', 'process' or 'open')");
+    } else {
+      print('info: use $dylibSource=$source to open dynamic library');
     }
-    return null;
+    switch (source) {
+      case 'executable':
+        return DylibSourceKind.executable;
+      case 'process':
+        return DylibSourceKind.process;
+      case 'open':
+        return DylibSourceKind.open;
+      default:
+        return null;
+    }
   }
 }
 

--- a/frb_dart/lib/src/utils.io.dart
+++ b/frb_dart/lib/src/utils.io.dart
@@ -1,0 +1,65 @@
+import 'dart:ffi';
+import 'dart:io';
+
+const dylibSource = 'DYNAMIC_LIBRARY_SOURCE';
+
+enum DylibSourceKind {
+  executable,
+  process,
+  open;
+
+  static DylibSourceKind? fromEnvironment(String value) {
+    const String source = String.fromEnvironment(dylibSource);
+    if (source.isNotEmpty) {
+      if (!['executable', 'process', 'open'].contains(source.trim())) {
+        print(
+            "warning: invalid $dylibSource '$source' ignored (expected 'executable', 'process' or 'open')");
+      } else {
+        print('info: use $dylibSource=$source to open dynamic library');
+      }
+      switch (source) {
+        case 'executable':
+          return DylibSourceKind.executable;
+        case 'process':
+          return DylibSourceKind.process;
+        case 'open':
+          return DylibSourceKind.open;
+        default:
+          break;
+      }
+    }
+    return null;
+  }
+}
+
+enum LanguageExecutionContext {
+  dart,
+  flutter;
+}
+
+/// open dynamic library
+/// if user defines a `DYNAMIC_LIBRARY_SOURCE` for Dart in CLI it takes precedence,
+/// otherwise fallback to default dynamic library opening mode
+DynamicLibrary open(
+    {DylibSourceKind? maybeUserDefinedKind,
+    required String path,
+    required LanguageExecutionContext ctx}) {
+  switch (maybeUserDefinedKind) {
+    case DylibSourceKind.executable:
+      return DynamicLibrary.executable();
+    case DylibSourceKind.process:
+      return DynamicLibrary.process();
+    case DylibSourceKind.open:
+      return DynamicLibrary.open(path);
+    default:
+      return ctx == LanguageExecutionContext.dart
+          ? (Platform.isMacOS || Platform.isIOS)
+              ? DynamicLibrary.executable()
+              : DynamicLibrary.open(path)
+          : Platform.isIOS
+              ? DynamicLibrary.process()
+              : Platform.isMacOS
+                  ? DynamicLibrary.executable()
+                  : DynamicLibrary.open(path);
+  }
+}

--- a/frb_dart/pubspec.yaml
+++ b/frb_dart/pubspec.yaml
@@ -3,7 +3,7 @@ description: High-level memory-safe binding generator for Flutter/Dart <-> Rust
 version: 1.48.1
 repository: https://github.com/fzyzcjy/flutter_rust_bridge
 environment:
-  sdk: ">=2.14.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
 dependencies:
   args: ^2.3.1
   build_cli_annotations: ^2.1.0

--- a/frb_dart/pubspec.yaml
+++ b/frb_dart/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   uuid: ^3.0.6
   web_socket_channel: ^2.2.0
   yaml: ^3.1.1
+  ffi: ^2.0.1
 dev_dependencies:
   build_cli: ^2.2.0
   build_runner: ^2.2.0

--- a/frb_example/pure_dart/dart/lib/ffi.io.dart
+++ b/frb_example/pure_dart/dart/lib/ffi.io.dart
@@ -1,4 +1,5 @@
-import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
+// ignore: implementation_imports
+import 'package:flutter_rust_bridge/src/utils.io.dart';
 
 import 'bridge_generated.io.dart';
 export 'bridge_generated.io.dart';

--- a/frb_example/pure_dart/dart/lib/ffi.io.dart
+++ b/frb_example/pure_dart/dart/lib/ffi.io.dart
@@ -1,11 +1,11 @@
-import 'dart:ffi';
-import 'dart:io';
+import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
 
 import 'bridge_generated.io.dart';
 export 'bridge_generated.io.dart';
 
 FlutterRustBridgeExampleSingleBlockTestImpl initializeExternalLibrary(String path) {
-  return FlutterRustBridgeExampleSingleBlockTestImpl(
-    Platform.isMacOS || Platform.isIOS ? DynamicLibrary.executable() : DynamicLibrary.open(path),
-  );
+  return FlutterRustBridgeExampleSingleBlockTestImpl(open(
+      maybeUserDefinedKind: DylibSourceKind.fromEnvironment(dylibSource),
+      path: path,
+      ctx: LanguageExecutionContext.dart));
 }

--- a/frb_example/pure_dart/dart/pubspec.yaml
+++ b/frb_example/pure_dart/dart/pubspec.yaml
@@ -3,7 +3,7 @@ description: flutter rust bridge example
 version: 1.0.0
 publish_to: none
 environment:
-  sdk: '>=2.14.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 dependencies:
   meta: ^1.8.0
   lints: ^2.0.0

--- a/frb_example/pure_dart/dart/pubspec.yaml.release
+++ b/frb_example/pure_dart/dart/pubspec.yaml.release
@@ -3,7 +3,7 @@ description: flutter rust bridge example
 version: 1.0.0
 publish_to: none
 environment:
-  sdk: '>=2.14.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 dependencies:
   meta: ^1.8.0
   lints: ^2.0.0

--- a/frb_example/pure_dart_multi/dart/lib/main.dart
+++ b/frb_example/pure_dart_multi/dart/lib/main.dart
@@ -1,4 +1,4 @@
-import 'dart:ffi';
+import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
 
 import 'bridge_generated_api_1.dart';
 import 'bridge_generated_api_2.dart';
@@ -10,7 +10,10 @@ void main(List<String> args) {
   String dylibPath = args[0];
   print('flutter_rust_bridge example program start (dylibPath=$dylibPath)');
   print('construct api');
-  final dylib = DynamicLibrary.open(dylibPath);
+  final dylib = open(
+      maybeUserDefinedKind: DylibSourceKind.fromEnvironment(dylibSource),
+      path: dylibPath,
+      ctx: LanguageExecutionContext.dart);
   final api1 = ApiClass1Impl(dylib);
   test('dart call simpleAdder', () async {
     expect(await api1.simpleAdder1(a: 42, b: 100), 142);

--- a/frb_example/pure_dart_multi/dart/lib/main.dart
+++ b/frb_example/pure_dart_multi/dart/lib/main.dart
@@ -1,7 +1,7 @@
-import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
-
 import 'bridge_generated_api_1.dart';
 import 'bridge_generated_api_2.dart';
+// ignore: implementation_imports
+import 'package:flutter_rust_bridge/src/utils.io.dart';
 import 'package:test/test.dart';
 
 void main(List<String> args) {

--- a/frb_example/pure_dart_multi/dart/pubspec.yaml
+++ b/frb_example/pure_dart_multi/dart/pubspec.yaml
@@ -3,7 +3,7 @@ description: flutter rust bridge example
 version: 1.0.0
 publish_to: none
 environment:
-  sdk: '>=2.14.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 dependencies:
   meta: ^1.8.0
   lints: ^2.0.0

--- a/frb_example/pure_dart_multi/dart/pubspec.yaml.release
+++ b/frb_example/pure_dart_multi/dart/pubspec.yaml.release
@@ -3,7 +3,7 @@ description: flutter rust bridge example
 version: 1.0.0
 publish_to: none
 environment:
-  sdk: '>=2.14.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 dependencies:
   meta: ^1.8.0
   lints: ^2.0.0

--- a/frb_example/with_flutter/lib/ffi.io.dart
+++ b/frb_example/with_flutter/lib/ffi.io.dart
@@ -1,13 +1,13 @@
-import 'dart:ffi';
 import 'dart:io';
+
+import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
 
 import 'bridge_generated.io.dart';
 
 const base = 'flutter_rust_bridge_example';
 final path = Platform.isWindows ? '$base.dll' : 'lib$base.so';
-late final dylib = Platform.isIOS
-    ? DynamicLibrary.process()
-    : Platform.isMacOS
-        ? DynamicLibrary.executable()
-        : DynamicLibrary.open(path);
+late final dylib = open(
+    maybeUserDefinedKind: DylibSourceKind.fromEnvironment(dylibSource),
+    path: path,
+    ctx: LanguageExecutionContext.flutter);
 late final api = FlutterRustBridgeExampleImpl(dylib);

--- a/frb_example/with_flutter/lib/ffi.io.dart
+++ b/frb_example/with_flutter/lib/ffi.io.dart
@@ -1,7 +1,7 @@
 import 'dart:io';
 
-import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
-
+// ignore: implementation_imports
+import 'package:flutter_rust_bridge/src/utils.io.dart';
 import 'bridge_generated.io.dart';
 
 const base = 'flutter_rust_bridge_example';

--- a/frb_example/with_flutter/pubspec.yaml
+++ b/frb_example/with_flutter/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.14.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/frb_example/with_flutter/pubspec.yaml.release
+++ b/frb_example/with_flutter/pubspec.yaml.release
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.14.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/justfile
+++ b/justfile
@@ -51,7 +51,7 @@ test-pure *args="":
     cd {{frb_pure}}/rust && cargo b
     cd {{frb_pure}}/dart && \
         dart pub get && \
-        dart {{args}} lib/main.dart ../../../rust/target/debug/{{dylib}}
+        dart {{args}} lib/main.dart ../../../target/debug/{{dylib}}
 # TODO: Make ASan tests work for other platforms
 test-pure-asan $RUSTFLAGS="-Zsanitizer=address":
     ./tools/dartsdk/fetch.sh

--- a/justfile
+++ b/justfile
@@ -47,11 +47,11 @@ lint *args="":
 
 alias t := test
 test: test-support test-pure test-integration
-test-pure:
+test-pure *args="":
     cd {{frb_pure}}/rust && cargo b
     cd {{frb_pure}}/dart && \
         dart pub get && \
-        dart lib/main.dart ../rust/target/debug/{{dylib}}
+        dart {{args}} lib/main.dart ../../../rust/target/debug/{{dylib}}
 # TODO: Make ASan tests work for other platforms
 test-pure-asan $RUSTFLAGS="-Zsanitizer=address":
     ./tools/dartsdk/fetch.sh

--- a/justfile
+++ b/justfile
@@ -61,7 +61,7 @@ test-pure-asan $RUSTFLAGS="-Zsanitizer=address":
     cd {{frb_pure}}/rust && cargo +nightly b --target x86_64-unknown-linux-gnu
     cd {{frb_pure}}/dart --define={{define}} && \
         {{frb_tools}}/dartsdk/x64/dart pub get && \
-        {{frb_tools}}/dartsdk/x64/dart lib/main.dart  ../rust/{{frb_linux_so}}
+        {{frb_tools}}/dartsdk/x64/dart lib/main.dart  {{justfile_directory()}}/{{frb_linux_so}}
 
 test-pure-web *args="":
     cd {{frb_pure}}/dart && just serve --dart-input lib/main.web.dart --root web/ -c ../rust --port 8081 {{args}}

--- a/justfile
+++ b/justfile
@@ -5,6 +5,9 @@ frb_pure := "frb_example/pure_dart"
 frb_pure_multi := "frb_example/pure_dart_multi"
 frb_flutter := "frb_example/with_flutter"
 line_length := "120"
+dylib_src := "DYNAMIC_LIBRARY_SOURCE"
+define := ""
+dart-define := ""
 dylib := if os() == "windows" {
     "flutter_rust_bridge_example.dll"
 } else if os() == "macos" {
@@ -47,16 +50,16 @@ lint *args="":
 
 alias t := test
 test: test-support test-pure test-integration
-test-pure *args="":
+test-pure:
     cd {{frb_pure}}/rust && cargo b
     cd {{frb_pure}}/dart && \
         dart pub get && \
-        dart {{args}} lib/main.dart ../../../target/debug/{{dylib}}
+        dart --define={{define}} lib/main.dart {{justfile_directory()}}/target/debug/{{dylib}}
 # TODO: Make ASan tests work for other platforms
 test-pure-asan $RUSTFLAGS="-Zsanitizer=address":
     ./tools/dartsdk/fetch.sh
     cd {{frb_pure}}/rust && cargo +nightly b --target x86_64-unknown-linux-gnu
-    cd {{frb_pure}}/dart && \
+    cd {{frb_pure}}/dart --define={{define}} && \
         {{frb_tools}}/dartsdk/x64/dart pub get && \
         {{frb_tools}}/dartsdk/x64/dart lib/main.dart  ../rust/{{frb_linux_so}}
 


### PR DESCRIPTION
Fix #754 temporarily until Dart provides a way to differentiate MacOS lineage.

## Checklist

- [x] An issue to be fixed by this PR is listed above.
- [ ] New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api.rs` and `dart/lib/main.dart`.
- [x] The code generator is run and the code is formatted (e.g. via `just refresh_all`).
- [ ] If this PR adds/changes features, documentations (in the `./book` folder) are updated.
- [ ] CI is passing.
