### PR TITLE
Update documents for Android Settings

### DIFF
--- a/book/src/integrate/android_tasks.md
+++ b/book/src/integrate/android_tasks.md
@@ -52,6 +52,8 @@ and fill it with this:
 ANDROID_NDK=(path to NDK)
 ```
 
+Note the ABIs `x86_64` and `x86` in `ndk_command` are usually used for Android simulators. Feel free to remove them as needed.
+
 [^1]:
     This excerpt might be outdated, please check out
-    the source file at the template repository.
+    the [source file](https://github.com/Desdaemon/flutter_rust_bridge_template/blob/main/android/app/build.gradle) at the [template repository](https://github.com/Desdaemon/flutter_rust_bridge_template).

--- a/book/src/template/setup_android.md
+++ b/book/src/template/setup_android.md
@@ -85,18 +85,21 @@ you need to manually create four text files to redirect calls from libgcc to lib
       ```
       C:\Users\Administrator\AppData\Local\Android\Sdk\ndk\24.0.8215888\toolchains\llvm\prebuilt\windows-x86_64\lib64\clang\14.0.1\lib\linux\x86_64\
       ```
-   
+
    * On macOS Monterey, it is similar to:
       ```
       ~/Library/Android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/darwin-x86_64/lib64/clang/14.0.1/lib/linux/x86_64/
       ```
    The three other folders end with `aarch64`, `arm`,    `i386` instead of `x86_64`.
 
-2. Create 4 text files named `libgcc.a` in the four folders mentioned above with this contents
-   
+2. Create 4 text files named `libgcc.a` in the four folders mentioned above with these contents
+
    ```
    INPUT(-lunwind)
    ```
+
+## More details on NDK with flutter_rust_bridge
+For more details on how NDK works with `flutter_rust_bridge`, have a look at this [article](../integrate/android_tasks.md) please.
 
 [Android NDK]: https://developer.android.com/ndk
 [Java Native Interface]: https://docs.oracle.com/javase/7/docs/technotes/guides/jni/spec/jniTOC.html


### PR DESCRIPTION
## what's new
Some details are added for using Android with frb.
Some syntax is fixed for the corresponding articles.

## related issue
https://github.com/fzyzcjy/flutter_rust_bridge/issues/788

## Others
When testing with the latest Android NDK((Side by side) 25.1.8937393), there is no need to do any workaround as stated in the article [Android setup](https://cjycode.com/flutter_rust_bridge/template/setup_android.html#android-setup) for NDK lower than v22.