### PR TITLE
bump constraint on ffigen

### DIFF
--- a/frb_codegen/src/tools.rs
+++ b/frb_codegen/src/tools.rs
@@ -17,7 +17,7 @@ lazy_static! {
     pub(crate) static ref FFI_REQUIREMENT: VersionReq =
         VersionReq::parse(">= 2.0.1, < 3.0.0").unwrap();
     pub(crate) static ref FFIGEN_REQUIREMENT: VersionReq =
-        VersionReq::parse(">= 6.0.1, < 7.0.0").unwrap();
+        VersionReq::parse(">= 6.0.1, < 8.0.0").unwrap();
 }
 
 /// represents dart or flutter toolchain

--- a/frb_example/pure_dart/dart/pubspec.lock
+++ b/frb_example/pure_dart/dart/pubspec.lock
@@ -182,7 +182,7 @@ packages:
       name: ffigen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.2"
+    version: "7.2.0"
   file:
     dependency: transitive
     description:
@@ -547,5 +547,12 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.1"
+  yaml_edit:
+    dependency: transitive
+    description:
+      name: yaml_edit
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.3"
 sdks:
   dart: ">=2.18.0 <3.0.0"

--- a/frb_example/pure_dart/dart/pubspec.yaml
+++ b/frb_example/pure_dart/dart/pubspec.yaml
@@ -20,4 +20,4 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.2.0
   freezed: ^2.1.0+1
-  ffigen: ^6.0.1
+  ffigen: ^7.0.0

--- a/frb_example/pure_dart/dart/pubspec.yaml.release
+++ b/frb_example/pure_dart/dart/pubspec.yaml.release
@@ -18,4 +18,4 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.2.0
   freezed: ^2.1.0+1
-  ffigen: ^6.0.1
+  ffigen: ^7.0.0

--- a/frb_example/pure_dart_multi/dart/pubspec.lock
+++ b/frb_example/pure_dart_multi/dart/pubspec.lock
@@ -182,7 +182,7 @@ packages:
       name: ffigen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.2"
+    version: "7.2.0"
   file:
     dependency: transitive
     description:
@@ -547,5 +547,12 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.1"
+  yaml_edit:
+    dependency: transitive
+    description:
+      name: yaml_edit
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.3"
 sdks:
   dart: ">=2.18.0 <3.0.0"

--- a/frb_example/pure_dart_multi/dart/pubspec.yaml
+++ b/frb_example/pure_dart_multi/dart/pubspec.yaml
@@ -16,4 +16,4 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.1.11
   freezed: ^2.0.2
-  ffigen: ^6.0.1
+  ffigen: ^7.0.0

--- a/frb_example/pure_dart_multi/dart/pubspec.yaml.release
+++ b/frb_example/pure_dart_multi/dart/pubspec.yaml.release
@@ -15,4 +15,4 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.1.11
   freezed: ^2.0.2
-  ffigen: ^6.0.1
+  ffigen: ^7.0.0

--- a/frb_example/with_flutter/pubspec.lock
+++ b/frb_example/with_flutter/pubspec.lock
@@ -203,7 +203,7 @@ packages:
       name: ffigen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.2"
+    version: "7.2.0"
   file:
     dependency: transitive
     description:
@@ -598,5 +598,12 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.1"
+  yaml_edit:
+    dependency: transitive
+    description:
+      name: yaml_edit
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.3"
 sdks:
   dart: ">=2.18.0 <3.0.0"

--- a/frb_example/with_flutter/pubspec.yaml
+++ b/frb_example/with_flutter/pubspec.yaml
@@ -53,7 +53,7 @@ dev_dependencies:
   flutter_lints: ^1.0.0
   freezed: ^2.2.0
   build_runner: ^2.2.0
-  ffigen: ^6.0.1
+  ffigen: ^7.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/frb_example/with_flutter/pubspec.yaml.release
+++ b/frb_example/with_flutter/pubspec.yaml.release
@@ -52,7 +52,7 @@ dev_dependencies:
   flutter_lints: ^1.0.0
   freezed: ^2.1.0+1
   build_runner: ^2.2.0
-  ffigen: ^6.0.1
+  ffigen: ^7.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
Fixes #822

## Checklist

- [x] An issue to be fixed by this PR is listed above.
- [ ] New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api.rs` and `dart/lib/main.dart`.
- [ ] The code generator is run and the code is formatted (e.g. via `just refresh_all`).
- [ ] If this PR adds/changes features, documentations (in the `./book` folder) are updated.
- [ ] CI is passing.

## Remark for PR creator

* New contributors will be blocked by GitHub from running CI, but you can use [a trick](https://github.com/fzyzcjy/flutter_rust_bridge/pull/663#discussion_r962150638) to workaround this, and verify your code using CI by yourself.
* If fzyzcjy does not reply for a few days, maybe he just did not see it, so please ping him.
