### PR TITLE
nested `struct`s and `enum`s in `struct`s without `Box`

### DIFF
--- a/frb_codegen/src/generator/dart/ty_struct.rs
+++ b/frb_codegen/src/generator/dart/ty_struct.rs
@@ -39,12 +39,21 @@ impl TypeDartGeneratorTrait for TypeStructRefGenerator<'_> {
             s.fields
                 .iter()
                 .map(|field| {
-                    format!(
-                        "wireObj.{} = api2wire_{}(apiObj.{});",
-                        field.name.rust_style(),
-                        field.ty.safe_ident(),
-                        field.name.dart_style()
-                    )
+                    if field.ty.is_struct() {
+                        format!(
+                            "_api_fill_to_wire_{}(apiObj.{}, wireObj.{});",
+                            field.ty.safe_ident(),
+                            field.name.dart_style(),
+                            field.name.rust_style(),
+                        )
+                    } else {
+                        format!(
+                            "wireObj.{} = api2wire_{}(apiObj.{});",
+                            field.name.rust_style(),
+                            field.ty.safe_ident(),
+                            field.name.dart_style()
+                        )
+                    }
                 })
                 .collect::<Vec<_>>()
                 .join("\n"),

--- a/frb_codegen/src/generator/rust/ty_struct.rs
+++ b/frb_codegen/src/generator/rust/ty_struct.rs
@@ -207,9 +207,16 @@ impl TypeRustGeneratorTrait for TypeStructRefGenerator<'_> {
                         Self {{ {} }}
                     }}
                 }}
+
+                impl Default for {} {{
+                    fn default() -> Self {{
+                        Self::new_with_null_ptr()
+                    }}
+                }}
             "#,
             self.ir.rust_wire_type(Target::Io),
             body,
+            self.ir.rust_wire_type(Target::Io),
         )
     }
 

--- a/frb_example/pure_dart/dart/lib/bridge_definitions.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_definitions.dart
@@ -131,6 +131,10 @@ abstract class FlutterRustBridgeExampleSingleBlockTest {
 
   FlutterRustBridgeTaskConstMeta get kHandleComplexStructSyncConstMeta;
 
+  Future<MyNestedStruct> handleNestedStruct({required MyNestedStruct s, dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kHandleNestedStructConstMeta;
+
   Uint8List handleSyncReturn({required String mode, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleSyncReturnConstMeta;
@@ -1171,6 +1175,15 @@ class MessageId {
 enum MyEnum {
   False,
   True,
+}
+
+class MyNestedStruct {
+  final MyTreeNode treeNode;
+  final Weekdays weekday;
+  MyNestedStruct({
+    required this.treeNode,
+    required this.weekday,
+  });
 }
 
 class MySize {

--- a/frb_example/pure_dart/dart/lib/bridge_generated.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.dart
@@ -464,6 +464,22 @@ class FlutterRustBridgeExampleSingleBlockTestImpl implements FlutterRustBridgeEx
         argNames: ["s"],
       );
 
+  Future<MyNestedStruct> handleNestedStruct({required MyNestedStruct s, dynamic hint}) {
+    var arg0 = _platform.api2wire_box_autoadd_my_nested_struct(s);
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_handle_nested_struct(port_, arg0),
+      parseSuccessData: _wire2api_my_nested_struct,
+      constMeta: kHandleNestedStructConstMeta,
+      argValues: [s],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kHandleNestedStructConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "handle_nested_struct",
+        argNames: ["s"],
+      );
+
   Uint8List handleSyncReturn({required String mode, dynamic hint}) {
     var arg0 = _platform.api2wire_String(mode);
     return _platform.executeSync(FlutterRustBridgeSyncTask(
@@ -2998,6 +3014,15 @@ class FlutterRustBridgeExampleSingleBlockTestImpl implements FlutterRustBridgeEx
 
   MyEnum _wire2api_my_enum(dynamic raw) {
     return MyEnum.values[raw];
+  }
+
+  MyNestedStruct _wire2api_my_nested_struct(dynamic raw) {
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return MyNestedStruct(
+      treeNode: _wire2api_my_tree_node(arr[0]),
+      weekday: _wire2api_weekdays(arr[1]),
+    );
   }
 
   MySize _wire2api_my_size(dynamic raw) {

--- a/frb_example/pure_dart/dart/lib/bridge_generated.io.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.io.dart
@@ -291,6 +291,13 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
   }
 
   @protected
+  ffi.Pointer<wire_MyNestedStruct> api2wire_box_autoadd_my_nested_struct(MyNestedStruct raw) {
+    final ptr = inner.new_box_autoadd_my_nested_struct_0();
+    _api_fill_to_wire_my_nested_struct(raw, ptr.ref);
+    return ptr;
+  }
+
+  @protected
   ffi.Pointer<wire_MySize> api2wire_box_autoadd_my_size(MySize raw) {
     final ptr = inner.new_box_autoadd_my_size_0();
     _api_fill_to_wire_my_size(raw, ptr.ref);
@@ -888,6 +895,10 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
     _api_fill_to_wire_message_id(apiObj, wireObj.ref);
   }
 
+  void _api_fill_to_wire_box_autoadd_my_nested_struct(MyNestedStruct apiObj, ffi.Pointer<wire_MyNestedStruct> wireObj) {
+    _api_fill_to_wire_my_nested_struct(apiObj, wireObj.ref);
+  }
+
   void _api_fill_to_wire_box_autoadd_my_size(MySize apiObj, ffi.Pointer<wire_MySize> wireObj) {
     _api_fill_to_wire_my_size(apiObj, wireObj.ref);
   }
@@ -1147,6 +1158,11 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
 
   void _api_fill_to_wire_message_id(MessageId apiObj, wire_MessageId wireObj) {
     wireObj.field0 = api2wire_u8_array_32(apiObj.field0);
+  }
+
+  void _api_fill_to_wire_my_nested_struct(MyNestedStruct apiObj, wire_MyNestedStruct wireObj) {
+    _api_fill_to_wire_my_tree_node(apiObj.treeNode, wireObj.tree_node);
+    wireObj.weekday = api2wire_weekdays(apiObj.weekday);
   }
 
   void _api_fill_to_wire_my_size(MySize apiObj, wire_MySize wireObj) {
@@ -1726,6 +1742,22 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
           'wire_handle_complex_struct_sync');
   late final _wire_handle_complex_struct_sync =
       _wire_handle_complex_struct_syncPtr.asFunction<WireSyncReturn Function(ffi.Pointer<wire_MyTreeNode>)>();
+
+  void wire_handle_nested_struct(
+    int port_,
+    ffi.Pointer<wire_MyNestedStruct> s,
+  ) {
+    return _wire_handle_nested_struct(
+      port_,
+      s,
+    );
+  }
+
+  late final _wire_handle_nested_structPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_MyNestedStruct>)>>(
+          'wire_handle_nested_struct');
+  late final _wire_handle_nested_struct =
+      _wire_handle_nested_structPtr.asFunction<void Function(int, ffi.Pointer<wire_MyNestedStruct>)>();
 
   WireSyncReturn wire_handle_sync_return(
     ffi.Pointer<wire_uint_8_list> mode,
@@ -3688,6 +3720,15 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   late final _new_box_autoadd_message_id_0 =
       _new_box_autoadd_message_id_0Ptr.asFunction<ffi.Pointer<wire_MessageId> Function()>();
 
+  ffi.Pointer<wire_MyNestedStruct> new_box_autoadd_my_nested_struct_0() {
+    return _new_box_autoadd_my_nested_struct_0();
+  }
+
+  late final _new_box_autoadd_my_nested_struct_0Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_MyNestedStruct> Function()>>('new_box_autoadd_my_nested_struct_0');
+  late final _new_box_autoadd_my_nested_struct_0 =
+      _new_box_autoadd_my_nested_struct_0Ptr.asFunction<ffi.Pointer<wire_MyNestedStruct> Function()>();
+
   ffi.Pointer<wire_MySize> new_box_autoadd_my_size_0() {
     return _new_box_autoadd_my_size_0();
   }
@@ -4494,6 +4535,13 @@ class wire_MyTreeNode extends ffi.Struct {
   external bool value_boolean;
 
   external ffi.Pointer<wire_list_my_tree_node> children;
+}
+
+class wire_MyNestedStruct extends ffi.Struct {
+  external wire_MyTreeNode tree_node;
+
+  @ffi.Int32()
+  external int weekday;
 }
 
 class wire_int_8_list extends ffi.Struct {

--- a/frb_example/pure_dart/dart/lib/bridge_generated.web.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.web.dart
@@ -268,6 +268,11 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
   }
 
   @protected
+  List<dynamic> api2wire_box_autoadd_my_nested_struct(MyNestedStruct raw) {
+    return api2wire_my_nested_struct(raw);
+  }
+
+  @protected
   List<dynamic> api2wire_box_autoadd_my_size(MySize raw) {
     return api2wire_my_size(raw);
   }
@@ -614,6 +619,11 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
   }
 
   @protected
+  List<dynamic> api2wire_my_nested_struct(MyNestedStruct raw) {
+    return [api2wire_my_tree_node(raw.treeNode), api2wire_weekdays(raw.weekday)];
+  }
+
+  @protected
   List<dynamic> api2wire_my_size(MySize raw) {
     return [api2wire_i32(raw.width), api2wire_i32(raw.height)];
   }
@@ -936,6 +946,8 @@ class FlutterRustBridgeExampleSingleBlockTestWasmModule implements WasmModule {
   external dynamic /* void */ wire_handle_complex_struct(NativePortType port_, List<dynamic> s);
 
   external dynamic /* List<dynamic> */ wire_handle_complex_struct_sync(List<dynamic> s);
+
+  external dynamic /* void */ wire_handle_nested_struct(NativePortType port_, List<dynamic> s);
 
   external dynamic /* Uint8List */ wire_handle_sync_return(String mode);
 
@@ -1286,6 +1298,9 @@ class FlutterRustBridgeExampleSingleBlockTestWire
 
   dynamic /* List<dynamic> */ wire_handle_complex_struct_sync(List<dynamic> s) =>
       wasmModule.wire_handle_complex_struct_sync(s);
+
+  void wire_handle_nested_struct(NativePortType port_, List<dynamic> s) =>
+      wasmModule.wire_handle_nested_struct(port_, s);
 
   dynamic /* Uint8List */ wire_handle_sync_return(String mode) => wasmModule.wire_handle_sync_return(mode);
 

--- a/frb_example/pure_dart/dart/lib/main.dart
+++ b/frb_example/pure_dart/dart/lib/main.dart
@@ -193,15 +193,26 @@ void main(List<String> args) async {
     expect(names, ['Steve', 'Bob', 'Alex']);
   });
 
-  test('dart call handleComplexStruct', () async {
-    final arrLen = 5;
-    final complexStructResp = await api.handleComplexStruct(s: _createMyTreeNode(arrLen: arrLen));
+  testComplexStruct(MyTreeNode complexStructResp, {required int arrLen}) {
     expect(complexStructResp.valueI32, 100);
     expect(complexStructResp.valueVecU8, List.filled(arrLen, 100));
     expect(complexStructResp.children[0].valueVecU8, List.filled(arrLen, 110));
     expect(complexStructResp.children[0].children[0].valueVecU8, List.filled(arrLen, 111));
     expect(complexStructResp.children[1].valueVecU8, List.filled(arrLen, 120));
+  }
+
+  test('dart call handleComplexStruct', () async {
+    final arrLen = 5;
+    final complexStructResp = await api.handleComplexStruct(s: _createMyTreeNode(arrLen: arrLen));
+    testComplexStruct(complexStructResp, arrLen: arrLen);
   });
+
+  test('dart call handleNestedStruct', () async {
+    final r = await api.handleNestedStruct(s: _createMyNestedStruct());
+    testComplexStruct(r.treeNode, arrLen: 5);
+    expect(r.weekday, Weekdays.Friday);
+  });
+
   test('dart call handleComplexStructSync', () {
     final arrLen = 5;
     final complexStructResp = api.handleComplexStructSync(s: _createMyTreeNode(arrLen: arrLen));
@@ -1198,6 +1209,10 @@ MyTreeNode _createMyTreeNode({required int arrLen}) {
       ),
     ],
   );
+}
+
+MyNestedStruct _createMyNestedStruct() {
+  return MyNestedStruct(treeNode: _createMyTreeNode(arrLen: 5), weekday: Weekdays.Friday);
 }
 
 class MatchBigInt extends CustomMatcher {

--- a/frb_example/pure_dart/dart/pubspec.lock
+++ b/frb_example/pure_dart/dart/pubspec.lock
@@ -221,10 +221,10 @@ packages:
     dependency: transitive
     description:
       name: fixnum
-      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
+      sha256: "04be3e934c52e082558cc9ee21f42f5c1cd7a1262f4c63cd0357c08d5bba81ec"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.0.1"
   flutter_rust_bridge:
     dependency: "direct main"
     description:
@@ -308,10 +308,10 @@ packages:
     dependency: "direct main"
     description:
       name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.7"
+    version: "0.6.5"
   json_annotation:
     dependency: transitive
     description:
@@ -388,10 +388,10 @@ packages:
     dependency: transitive
     description:
       name: petitparser
-      sha256: "32e46db8021f6d027d9221b937653f5c8aa043e0dc093998e18331912f22936b"
+      sha256: "49392a45ced973e8d94a85fdb21293fbb40ba805fc49f2965101ae748a3683b4"
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.0"
+    version: "5.1.0"
   pointycastle:
     dependency: transitive
     description:
@@ -649,4 +649,4 @@ packages:
     source: hosted
     version: "2.0.3"
 sdks:
-  dart: ">=2.19.0 <3.0.0"
+  dart: ">=2.18.0 <3.0.0"

--- a/frb_example/pure_dart/rust/src/api.rs
+++ b/frb_example/pure_dart/rust/src/api.rs
@@ -305,6 +305,18 @@ pub fn handle_complex_struct_sync(s: MyTreeNode) -> SyncReturn<MyTreeNode> {
     SyncReturn(s)
 }
 
+#[derive(Debug, Clone)]
+pub struct MyNestedStruct {
+    pub tree_node: MyTreeNode,
+    pub weekday: Weekdays,
+}
+
+pub fn handle_nested_struct(s: MyNestedStruct) -> MyNestedStruct {
+    println!("handle_nested_struct({s:?})");
+    let s_cloned = s.clone();
+    s
+}
+
 // Test if sync return is working as expected by using Vec<u8> as return value.
 pub fn handle_sync_return(mode: String) -> Result<SyncReturn<Vec<u8>>> {
     match &mode[..] {
@@ -494,7 +506,7 @@ pub fn handle_option_box_arguments(
 }
 
 /// Simple enums.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum Weekdays {
     Monday,
     Tuesday,

--- a/frb_example/pure_dart/rust/src/bridge_generated.io.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.io.rs
@@ -163,6 +163,11 @@ pub extern "C" fn wire_handle_complex_struct_sync(
 }
 
 #[no_mangle]
+pub extern "C" fn wire_handle_nested_struct(port_: i64, s: *mut wire_MyNestedStruct) {
+    wire_handle_nested_struct_impl(port_, s)
+}
+
+#[no_mangle]
 pub extern "C" fn wire_handle_sync_return(mode: *mut wire_uint_8_list) -> support::WireSyncReturn {
     wire_handle_sync_return_impl(mode)
 }
@@ -959,6 +964,11 @@ pub extern "C" fn new_box_autoadd_message_id_0() -> *mut wire_MessageId {
 }
 
 #[no_mangle]
+pub extern "C" fn new_box_autoadd_my_nested_struct_0() -> *mut wire_MyNestedStruct {
+    support::new_leak_box_ptr(wire_MyNestedStruct::new_with_null_ptr())
+}
+
+#[no_mangle]
 pub extern "C" fn new_box_autoadd_my_size_0() -> *mut wire_MySize {
     support::new_leak_box_ptr(wire_MySize::new_with_null_ptr())
 }
@@ -1590,6 +1600,12 @@ impl Wire2Api<MessageId> for *mut wire_MessageId {
         Wire2Api::<MessageId>::wire2api(*wrap).into()
     }
 }
+impl Wire2Api<MyNestedStruct> for *mut wire_MyNestedStruct {
+    fn wire2api(self) -> MyNestedStruct {
+        let wrap = unsafe { support::box_from_leak_ptr(self) };
+        Wire2Api::<MyNestedStruct>::wire2api(*wrap).into()
+    }
+}
 impl Wire2Api<MySize> for *mut wire_MySize {
     fn wire2api(self) -> MySize {
         let wrap = unsafe { support::box_from_leak_ptr(self) };
@@ -2045,6 +2061,14 @@ impl Wire2Api<MessageId> for wire_MessageId {
     }
 }
 
+impl Wire2Api<MyNestedStruct> for wire_MyNestedStruct {
+    fn wire2api(self) -> MyNestedStruct {
+        MyNestedStruct {
+            tree_node: self.tree_node.wire2api(),
+            weekday: self.weekday.wire2api(),
+        }
+    }
+}
 impl Wire2Api<MySize> for wire_MySize {
     fn wire2api(self) -> MySize {
         MySize {
@@ -2407,6 +2431,13 @@ pub struct wire_MessageId {
 
 #[repr(C)]
 #[derive(Clone)]
+pub struct wire_MyNestedStruct {
+    tree_node: wire_MyTreeNode,
+    weekday: i32,
+}
+
+#[repr(C)]
+#[derive(Clone)]
 pub struct wire_MySize {
     width: i32,
     height: i32,
@@ -2751,12 +2782,24 @@ impl NewWithNullPtr for wire_ApplicationEnv {
     }
 }
 
+impl Default for wire_ApplicationEnv {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
+
 impl NewWithNullPtr for wire_ApplicationEnvVar {
     fn new_with_null_ptr() -> Self {
         Self {
             field0: core::ptr::null_mut(),
             field1: Default::default(),
         }
+    }
+}
+
+impl Default for wire_ApplicationEnvVar {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
     }
 }
 
@@ -2772,12 +2815,24 @@ impl NewWithNullPtr for wire_ApplicationSettings {
     }
 }
 
+impl Default for wire_ApplicationSettings {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
+
 impl NewWithNullPtr for wire_Attribute {
     fn new_with_null_ptr() -> Self {
         Self {
             key: core::ptr::null_mut(),
             value: core::ptr::null_mut(),
         }
+    }
+}
+
+impl Default for wire_Attribute {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
     }
 }
 
@@ -2789,11 +2844,23 @@ impl NewWithNullPtr for wire_Blob {
     }
 }
 
+impl Default for wire_Blob {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
+
 impl NewWithNullPtr for wire_ConcatenateWith {
     fn new_with_null_ptr() -> Self {
         Self {
             a: core::ptr::null_mut(),
         }
+    }
+}
+
+impl Default for wire_ConcatenateWith {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
     }
 }
 
@@ -2806,12 +2873,24 @@ impl NewWithNullPtr for wire_Customized {
     }
 }
 
+impl Default for wire_Customized {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
+
 impl NewWithNullPtr for wire_DartOpaqueNested {
     fn new_with_null_ptr() -> Self {
         Self {
             first: wire_DartOpaque::new_with_null_ptr(),
             second: wire_DartOpaque::new_with_null_ptr(),
         }
+    }
+}
+
+impl Default for wire_DartOpaqueNested {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
     }
 }
 
@@ -2836,6 +2915,12 @@ pub extern "C" fn inflate_Distance_Map() -> *mut DistanceKind {
 impl NewWithNullPtr for wire_Empty {
     fn new_with_null_ptr() -> Self {
         Self {}
+    }
+}
+
+impl Default for wire_Empty {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
     }
 }
 
@@ -2941,6 +3026,12 @@ impl NewWithNullPtr for wire_ExoticOptionals {
     }
 }
 
+impl Default for wire_ExoticOptionals {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
+
 impl NewWithNullPtr for wire_FeatureChrono {
     fn new_with_null_ptr() -> Self {
         Self {
@@ -2949,6 +3040,12 @@ impl NewWithNullPtr for wire_FeatureChrono {
             duration: Default::default(),
             naive: Default::default(),
         }
+    }
+}
+
+impl Default for wire_FeatureChrono {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
     }
 }
 
@@ -2961,11 +3058,23 @@ impl NewWithNullPtr for wire_FeatureUuid {
     }
 }
 
+impl Default for wire_FeatureUuid {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
+
 impl NewWithNullPtr for wire_FeedId {
     fn new_with_null_ptr() -> Self {
         Self {
             field0: core::ptr::null_mut(),
         }
+    }
+}
+
+impl Default for wire_FeedId {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
     }
 }
 
@@ -3062,6 +3171,27 @@ impl NewWithNullPtr for wire_MessageId {
     }
 }
 
+impl Default for wire_MessageId {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
+
+impl NewWithNullPtr for wire_MyNestedStruct {
+    fn new_with_null_ptr() -> Self {
+        Self {
+            tree_node: Default::default(),
+            weekday: Default::default(),
+        }
+    }
+}
+
+impl Default for wire_MyNestedStruct {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
+
 impl NewWithNullPtr for wire_MySize {
     fn new_with_null_ptr() -> Self {
         Self {
@@ -3071,11 +3201,23 @@ impl NewWithNullPtr for wire_MySize {
     }
 }
 
+impl Default for wire_MySize {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
+
 impl NewWithNullPtr for wire_MyStruct {
     fn new_with_null_ptr() -> Self {
         Self {
             content: Default::default(),
         }
+    }
+}
+
+impl Default for wire_MyStruct {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
     }
 }
 
@@ -3090,11 +3232,23 @@ impl NewWithNullPtr for wire_MyTreeNode {
     }
 }
 
+impl Default for wire_MyTreeNode {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
+
 impl NewWithNullPtr for wire_NewTypeInt {
     fn new_with_null_ptr() -> Self {
         Self {
             field0: Default::default(),
         }
+    }
+}
+
+impl Default for wire_NewTypeInt {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
     }
 }
 
@@ -3107,11 +3261,23 @@ impl NewWithNullPtr for wire_Note {
     }
 }
 
+impl Default for wire_Note {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
+
 impl NewWithNullPtr for wire_Numbers {
     fn new_with_null_ptr() -> Self {
         Self {
             field0: core::ptr::null_mut(),
         }
+    }
+}
+
+impl Default for wire_Numbers {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
     }
 }
 
@@ -3124,11 +3290,23 @@ impl NewWithNullPtr for wire_OpaqueNested {
     }
 }
 
+impl Default for wire_OpaqueNested {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
+
 impl NewWithNullPtr for wire_Sequences {
     fn new_with_null_ptr() -> Self {
         Self {
             field0: core::ptr::null_mut(),
         }
+    }
+}
+
+impl Default for wire_Sequences {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
     }
 }
 
@@ -3158,6 +3336,12 @@ impl NewWithNullPtr for wire_SumWith {
     }
 }
 
+impl Default for wire_SumWith {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
+
 impl NewWithNullPtr for wire_TestId {
     fn new_with_null_ptr() -> Self {
         Self {
@@ -3166,11 +3350,23 @@ impl NewWithNullPtr for wire_TestId {
     }
 }
 
+impl Default for wire_TestId {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
+
 impl NewWithNullPtr for wire_UserId {
     fn new_with_null_ptr() -> Self {
         Self {
             value: Default::default(),
         }
+    }
+}
+
+impl Default for wire_UserId {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
     }
 }
 

--- a/frb_example/pure_dart/rust/src/bridge_generated.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.rs
@@ -454,6 +454,22 @@ fn wire_handle_complex_struct_sync_impl(
         },
     )
 }
+fn wire_handle_nested_struct_impl(
+    port_: MessagePort,
+    s: impl Wire2Api<MyNestedStruct> + UnwindSafe,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+        WrapInfo {
+            debug_name: "handle_nested_struct",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || {
+            let api_s = s.wire2api();
+            move |task_callback| Ok(handle_nested_struct(api_s))
+        },
+    )
+}
 fn wire_handle_sync_return_impl(
     mode: impl Wire2Api<String> + UnwindSafe,
 ) -> support::WireSyncReturn {
@@ -2593,6 +2609,13 @@ impl support::IntoDart for MyEnum {
         .into_dart()
     }
 }
+impl support::IntoDart for MyNestedStruct {
+    fn into_dart(self) -> support::DartAbi {
+        vec![self.tree_node.into_dart(), self.weekday.into_dart()].into_dart()
+    }
+}
+impl support::IntoDartExceptPrimitive for MyNestedStruct {}
+
 impl support::IntoDart for MySize {
     fn into_dart(self) -> support::DartAbi {
         vec![self.width.into_dart(), self.height.into_dart()].into_dart()

--- a/frb_example/pure_dart/rust/src/bridge_generated.web.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.web.rs
@@ -154,6 +154,11 @@ pub fn wire_handle_complex_struct_sync(s: JsValue) -> support::WireSyncReturn {
 }
 
 #[wasm_bindgen]
+pub fn wire_handle_nested_struct(port_: MessagePort, s: JsValue) {
+    wire_handle_nested_struct_impl(port_, s)
+}
+
+#[wasm_bindgen]
 pub fn wire_handle_sync_return(mode: String) -> support::WireSyncReturn {
     wire_handle_sync_return_impl(mode)
 }
@@ -1325,6 +1330,21 @@ impl Wire2Api<MessageId> for JsValue {
     }
 }
 
+impl Wire2Api<MyNestedStruct> for JsValue {
+    fn wire2api(self) -> MyNestedStruct {
+        let self_ = self.dyn_into::<JsArray>().unwrap();
+        assert_eq!(
+            self_.length(),
+            2,
+            "Expected 2 elements, got {}",
+            self_.length()
+        );
+        MyNestedStruct {
+            tree_node: self_.get(0).wire2api(),
+            weekday: self_.get(1).wire2api(),
+        }
+    }
+}
 impl Wire2Api<MySize> for JsValue {
     fn wire2api(self) -> MySize {
         let self_ = self.dyn_into::<JsArray>().unwrap();

--- a/frb_example/pure_dart_multi/dart/pubspec.lock
+++ b/frb_example/pure_dart_multi/dart/pubspec.lock
@@ -221,10 +221,10 @@ packages:
     dependency: transitive
     description:
       name: fixnum
-      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
+      sha256: "04be3e934c52e082558cc9ee21f42f5c1cd7a1262f4c63cd0357c08d5bba81ec"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.0.1"
   flutter_rust_bridge:
     dependency: "direct main"
     description:
@@ -308,10 +308,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.7"
+    version: "0.6.5"
   json_annotation:
     dependency: transitive
     description:
@@ -388,10 +388,10 @@ packages:
     dependency: transitive
     description:
       name: petitparser
-      sha256: "32e46db8021f6d027d9221b937653f5c8aa043e0dc093998e18331912f22936b"
+      sha256: "49392a45ced973e8d94a85fdb21293fbb40ba805fc49f2965101ae748a3683b4"
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.0"
+    version: "5.1.0"
   pointycastle:
     dependency: transitive
     description:
@@ -649,4 +649,4 @@ packages:
     source: hosted
     version: "2.0.3"
 sdks:
-  dart: ">=2.19.0 <3.0.0"
+  dart: ">=2.18.0 <3.0.0"

--- a/frb_example/with_flutter/pubspec.lock
+++ b/frb_example/with_flutter/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: e440ac42679dfc04bbbefb58ed225c994bc7e07fccc8a68ec7d3631a127e5da9
+      sha256: "3444216bfd127af50bbe4862d8843ed44db946dd933554f0d7285e89f10e28ac"
       url: "https://pub.dev"
     source: hosted
-    version: "54.0.0"
+    version: "50.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "2c2e3721ee9fb36de92faa060f3480c81b23e904352b087e5c64224b1a044427"
+      sha256: "68796c31f510c8455a06fed75fc97d8e5ad04d324a830322ab3efc9feb6201c1"
       url: "https://pub.dev"
     source: hosted
-    version: "5.6.0"
+    version: "5.2.0"
   archive:
     dependency: transitive
     description:
@@ -85,10 +85,10 @@ packages:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: db49b8609ef8c81cca2b310618c3017c00f03a92af44c04d310b907b2d692d95
+      sha256: "7c35a3a7868626257d8aee47b51c26b9dba11eaddf3431117ed2744951416aab"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.1.0"
   build_runner:
     dependency: "direct dev"
     description:
@@ -245,10 +245,10 @@ packages:
     dependency: transitive
     description:
       name: fixnum
-      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
+      sha256: "04be3e934c52e082558cc9ee21f42f5c1cd7a1262f4c63cd0357c08d5bba81ec"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.0.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -312,10 +312,10 @@ packages:
     dependency: transitive
     description:
       name: glob
-      sha256: "4515b5b6ddb505ebdd242a5f2cc5d22d3d6a80013789debfbda7777f47ea308c"
+      sha256: c51b4fdfee4d281f49b8c957f1add91b815473597f76bcf07377987f66a55729
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.0"
   graphs:
     dependency: transitive
     description:
@@ -695,4 +695,4 @@ packages:
     source: hosted
     version: "2.0.3"
 sdks:
-  dart: ">=2.19.0 <3.0.0"
+  dart: ">=2.18.0 <3.0.0"

--- a/frb_example/with_flutter/rust/src/bridge_generated.io.rs
+++ b/frb_example/with_flutter/rust/src/bridge_generated.io.rs
@@ -262,6 +262,12 @@ impl NewWithNullPtr for wire_Point {
     }
 }
 
+impl Default for wire_Point {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
+
 impl NewWithNullPtr for wire_Size {
     fn new_with_null_ptr() -> Self {
         Self {
@@ -271,12 +277,24 @@ impl NewWithNullPtr for wire_Size {
     }
 }
 
+impl Default for wire_Size {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
+
 impl NewWithNullPtr for wire_TreeNode {
     fn new_with_null_ptr() -> Self {
         Self {
             name: core::ptr::null_mut(),
             children: core::ptr::null_mut(),
         }
+    }
+}
+
+impl Default for wire_TreeNode {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
     }
 }
 


### PR DESCRIPTION
Allows the use of nested `struct`s or `enum`s in `struct`s without wrapping the inner struct with `Box`.
E. g. `struct A { b: B }` now also works in addition to `struct A { b: Box<B> }` (which had to be used before).

This is related to some of the problems encountered in #525, #548, though there might be [more related issues](https://github.com/fzyzcjy/flutter_rust_bridge/issues/525#issuecomment-1223580725).

So far this seems to be working with nested `struct`s and simple `enum`s (without associated data) in `struct`s,
though I haven't really looked into `enum`s with associated data (e. g. `enum B { A, B { s: String, i: i64 }, C(C) }`), yet.

TODO: update [docs](https://cjycode.com/flutter_rust_bridge/feature/lang_struct.html)

## Checklist

- [ ] An issue to be fixed by this PR is listed above.
- [ ] New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api.rs` and `dart/lib/main.dart`.
- [ ] The code generator is run and the code is formatted (e.g. via `just refresh_all`).
- [ ] If this PR adds/changes features, documentations (in the `./book` folder) are updated.
- [ ] CI is passing.

## Remark for PR creator

* New contributors will be blocked by GitHub from running CI, but you can use [a trick](https://github.com/fzyzcjy/flutter_rust_bridge/pull/663#discussion_r962150638) to workaround this, and verify your code using CI by yourself.
* If fzyzcjy does not reply for a few days, maybe he just did not see it, so please ping him.
