### PR TITLE
ci: support concurrency

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
 concurrency:
-  group: ${{ github.head_ref }}
+  group: build-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 jobs:
   # -------------------------- test --------------------------

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,12 +66,21 @@ jobs:
 
 
   # ref https://medium.com/flutter-community/run-flutter-driver-tests-on-github-actions-13c639c7e4ab
-  flutter_ios_test:
-    name: Flutter (iOS) integration test-${{ matrix.device }}
+  flutter_ios_test-iPad7:
+    name: Flutter (iOS) integration test
     strategy:
       matrix:
         device:
           - "iPad (7th generation) Simulator (15.2)"
+      fail-fast: false
+    uses: ./.github/workflows/flutter_ios_test.yml
+    with:
+      device: ${{ matrix.device }}
+  flutter_ios_test-iPhone12:
+    name: Flutter (iOS) integration test
+    strategy:
+      matrix:
+        device:
           - "iPhone 12 Pro Max Simulator (15.2)"
       fail-fast: false
     uses: ./.github/workflows/flutter_ios_test.yml
@@ -79,12 +88,21 @@ jobs:
       device: ${{ matrix.device }}
 
   # ref https://betterprogramming.pub/test-flutter-apps-on-android-with-github-actions-abdba2137b4
-  flutter_android_test:
-    name: Flutter (Android) integration test-${{ matrix.device }}
+  flutter_android_test-pixel:
+    name: Flutter (Android) integration test
     strategy:
       matrix:
         device:
           - "pixel"
+      fail-fast: false
+    uses: ./.github/workflows/flutter_android_test.yml
+    with:
+      device: ${{ matrix.device }}
+  flutter_android_test-Nexus:
+    name: Flutter (Android) integration test
+    strategy:
+      matrix:
+        device:
           - "Nexus 6"
       fail-fast: false
     uses: ./.github/workflows/flutter_android_test.yml
@@ -412,19 +430,39 @@ jobs:
         run: pana --no-warning --line-length 80 --exit-code-threshold 0
 
   # -------------------------- codegen --------------------------
-  codegen:
-    name: Run codegen-${{ matrix.os.image }}-${{ matrix.os.family }}
+  codegen-macos:
+    name: Run codegen
     strategy:
       fail-fast: false
       matrix:
         os:
           - image: macos-11
             family: osx
+
+    uses: ./.github/workflows/code_generator.yml
+    with:
+      image: ${{ matrix.os.image }}
+      family: ${{ matrix.os.family }}
+  codegen-windows:
+    name: Run codegen
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
           - image: windows-2019
             family: windows
+    uses: ./.github/workflows/code_generator.yml
+    with:
+      image: ${{ matrix.os.image }}
+      family: ${{ matrix.os.family }}
+  codegen-ubuntu:
+    name: Run codegen
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
           - image: ubuntu-20.04
             family: linux
-
     uses: ./.github/workflows/code_generator.yml
     with:
       image: ${{ matrix.os.image }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.head_ref }}
   cancel-in-progress: true
 jobs:
   # -------------------------- test --------------------------

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,9 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 jobs:
   # -------------------------- test --------------------------
   valgrind_test:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
 concurrency:
-  group: build-${{ github.event.pull_request.number || github.ref }}
+  group: build-${{ github.event.pull_request.number || github.ref }}-${{ github.job || github.ref}}
   cancel-in-progress: true
 jobs:
   # -------------------------- test --------------------------

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
 concurrency:
-  group: build-${{ github.event.pull_request.number || github.ref }}-${{ github.job || github.ref}}
+  group: build-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}
   cancel-in-progress: true
 jobs:
   # -------------------------- test --------------------------
@@ -67,7 +67,7 @@ jobs:
 
   # ref https://medium.com/flutter-community/run-flutter-driver-tests-on-github-actions-13c639c7e4ab
   flutter_ios_test:
-    name: Flutter (iOS) integration test
+    name: Flutter (iOS) integration test-${{ matrix.device }}
     strategy:
       matrix:
         device:
@@ -80,7 +80,7 @@ jobs:
 
   # ref https://betterprogramming.pub/test-flutter-apps-on-android-with-github-actions-abdba2137b4
   flutter_android_test:
-    name: Flutter (Android) integration test
+    name: Flutter (Android) integration test-${{ matrix.device }}
     strategy:
       matrix:
         device:
@@ -413,7 +413,7 @@ jobs:
 
   # -------------------------- codegen --------------------------
   codegen:
-    name: Run codegen
+    name: Run codegen-${{ matrix.os.image }}-${{ matrix.os.family }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/flutter_android_test.yml
+++ b/.github/workflows/flutter_android_test.yml
@@ -17,7 +17,7 @@ on:
         type: number
         default: 20
 concurrency:
-  group: ${{ github.head_ref }}
+  group: build-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 jobs:
   flutter_android_test:

--- a/.github/workflows/flutter_android_test.yml
+++ b/.github/workflows/flutter_android_test.yml
@@ -17,7 +17,7 @@ on:
         type: number
         default: 20
 concurrency:
-  group: build-${{ github.event.pull_request.number || github.ref }}-${{ github.job}}-${{matrix}}
+  group: build-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}
   cancel-in-progress: true
 jobs:
   flutter_android_test:

--- a/.github/workflows/flutter_android_test.yml
+++ b/.github/workflows/flutter_android_test.yml
@@ -16,7 +16,9 @@ on:
         required: false
         type: number
         default: 20
-
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 jobs:
   flutter_android_test:
     runs-on: macos-latest

--- a/.github/workflows/flutter_android_test.yml
+++ b/.github/workflows/flutter_android_test.yml
@@ -17,7 +17,7 @@ on:
         type: number
         default: 20
 concurrency:
-  group: build-${{ github.event.pull_request.number || github.ref }}
+  group: build-${{ github.event.pull_request.number || github.ref }}-${{ github.job || github.ref}}
   cancel-in-progress: true
 jobs:
   flutter_android_test:

--- a/.github/workflows/flutter_android_test.yml
+++ b/.github/workflows/flutter_android_test.yml
@@ -17,7 +17,7 @@ on:
         type: number
         default: 20
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.head_ref }}
   cancel-in-progress: true
 jobs:
   flutter_android_test:

--- a/.github/workflows/flutter_android_test.yml
+++ b/.github/workflows/flutter_android_test.yml
@@ -17,7 +17,7 @@ on:
         type: number
         default: 20
 concurrency:
-  group: build-${{ github.event.pull_request.number || github.ref }}-${{ github.job || github.ref}}
+  group: build-${{ github.event.pull_request.number || github.ref }}-${{ github.job}}-${{matrix}}
   cancel-in-progress: true
 jobs:
   flutter_android_test:

--- a/.github/workflows/flutter_ios_test.yml
+++ b/.github/workflows/flutter_ios_test.yml
@@ -13,7 +13,7 @@ on:
         required: true
         type: string
 concurrency:
-  group: ${{ github.head_ref }}
+  group: build-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 jobs:
   flutter_ios_test:

--- a/.github/workflows/flutter_ios_test.yml
+++ b/.github/workflows/flutter_ios_test.yml
@@ -13,7 +13,7 @@ on:
         required: true
         type: string
 concurrency:
-  group: build-${{ github.event.pull_request.number || github.ref }}-${{ github.job || github.ref}}
+  group: build-${{ github.event.pull_request.number || github.ref }}-${{ github.job}}-${{matrix}}
   cancel-in-progress: true
 jobs:
   flutter_ios_test:

--- a/.github/workflows/flutter_ios_test.yml
+++ b/.github/workflows/flutter_ios_test.yml
@@ -12,7 +12,9 @@ on:
       device:
         required: true
         type: string
-
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 jobs:
   flutter_ios_test:
     runs-on: macos-latest

--- a/.github/workflows/flutter_ios_test.yml
+++ b/.github/workflows/flutter_ios_test.yml
@@ -13,7 +13,7 @@ on:
         required: true
         type: string
 concurrency:
-  group: build-${{ github.event.pull_request.number || github.ref }}
+  group: build-${{ github.event.pull_request.number || github.ref }}-${{ github.job || github.ref}}
   cancel-in-progress: true
 jobs:
   flutter_ios_test:

--- a/.github/workflows/flutter_ios_test.yml
+++ b/.github/workflows/flutter_ios_test.yml
@@ -13,7 +13,7 @@ on:
         required: true
         type: string
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.head_ref }}
   cancel-in-progress: true
 jobs:
   flutter_ios_test:

--- a/.github/workflows/flutter_ios_test.yml
+++ b/.github/workflows/flutter_ios_test.yml
@@ -13,7 +13,7 @@ on:
         required: true
         type: string
 concurrency:
-  group: build-${{ github.event.pull_request.number || github.ref }}-${{ github.job}}-${{matrix}}
+  group: build-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}
   cancel-in-progress: true
 jobs:
   flutter_ios_test:

--- a/.github/workflows/flutter_linux_test.yml
+++ b/.github/workflows/flutter_linux_test.yml
@@ -10,7 +10,7 @@ on:
         type: string
         default: '1.64.0'
 concurrency:
-  group: build-${{ github.event.pull_request.number || github.ref }}-${{ github.job}}-${{matrix}}
+  group: build-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}
   cancel-in-progress: true
 jobs:
   flutter_linux_test:

--- a/.github/workflows/flutter_linux_test.yml
+++ b/.github/workflows/flutter_linux_test.yml
@@ -10,7 +10,7 @@ on:
         type: string
         default: '1.64.0'
 concurrency:
-  group: build-${{ github.event.pull_request.number || github.ref }}
+  group: build-${{ github.event.pull_request.number || github.ref }}-${{ github.job || github.ref}}
   cancel-in-progress: true
 jobs:
   flutter_linux_test:

--- a/.github/workflows/flutter_linux_test.yml
+++ b/.github/workflows/flutter_linux_test.yml
@@ -9,7 +9,9 @@ on:
         required: false
         type: string
         default: '1.64.0'
-
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 jobs:
   flutter_linux_test:
     runs-on: ubuntu-latest

--- a/.github/workflows/flutter_linux_test.yml
+++ b/.github/workflows/flutter_linux_test.yml
@@ -10,7 +10,7 @@ on:
         type: string
         default: '1.64.0'
 concurrency:
-  group: build-${{ github.event.pull_request.number || github.ref }}-${{ github.job || github.ref}}
+  group: build-${{ github.event.pull_request.number || github.ref }}-${{ github.job}}-${{matrix}}
   cancel-in-progress: true
 jobs:
   flutter_linux_test:

--- a/.github/workflows/flutter_linux_test.yml
+++ b/.github/workflows/flutter_linux_test.yml
@@ -10,7 +10,7 @@ on:
         type: string
         default: '1.64.0'
 concurrency:
-  group: ${{ github.head_ref }}
+  group: build-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 jobs:
   flutter_linux_test:

--- a/.github/workflows/flutter_linux_test.yml
+++ b/.github/workflows/flutter_linux_test.yml
@@ -10,7 +10,7 @@ on:
         type: string
         default: '1.64.0'
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.head_ref }}
   cancel-in-progress: true
 jobs:
   flutter_linux_test:

--- a/.github/workflows/flutter_macos_test.yml
+++ b/.github/workflows/flutter_macos_test.yml
@@ -10,7 +10,7 @@ on:
         type: string
         default: '1.64.0'
 concurrency:
-  group: build-${{ github.event.pull_request.number || github.ref }}
+  group: build-${{ github.event.pull_request.number || github.ref }}-${{ github.job || github.ref}}
   cancel-in-progress: true
 jobs:
   flutter_macos_test:

--- a/.github/workflows/flutter_macos_test.yml
+++ b/.github/workflows/flutter_macos_test.yml
@@ -10,7 +10,7 @@ on:
         type: string
         default: '1.64.0'
 concurrency:
-  group: build-${{ github.event.pull_request.number || github.ref }}-${{ github.job || github.ref}}
+  group: build-${{ github.event.pull_request.number || github.ref }}-${{ github.job}}-${{matrix}}
   cancel-in-progress: true
 jobs:
   flutter_macos_test:

--- a/.github/workflows/flutter_macos_test.yml
+++ b/.github/workflows/flutter_macos_test.yml
@@ -10,7 +10,7 @@ on:
         type: string
         default: '1.64.0'
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.head_ref }}
   cancel-in-progress: true
 jobs:
   flutter_macos_test:

--- a/.github/workflows/flutter_macos_test.yml
+++ b/.github/workflows/flutter_macos_test.yml
@@ -10,7 +10,7 @@ on:
         type: string
         default: '1.64.0'
 concurrency:
-  group: ${{ github.head_ref }}
+  group: build-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 jobs:
   flutter_macos_test:

--- a/.github/workflows/flutter_macos_test.yml
+++ b/.github/workflows/flutter_macos_test.yml
@@ -10,7 +10,7 @@ on:
         type: string
         default: '1.64.0'
 concurrency:
-  group: build-${{ github.event.pull_request.number || github.ref }}-${{ github.job}}-${{matrix}}
+  group: build-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}
   cancel-in-progress: true
 jobs:
   flutter_macos_test:

--- a/.github/workflows/flutter_macos_test.yml
+++ b/.github/workflows/flutter_macos_test.yml
@@ -9,7 +9,9 @@ on:
         required: false
         type: string
         default: '1.64.0'
-
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 jobs:
   flutter_macos_test:
     runs-on: macos-11

--- a/.github/workflows/flutter_windows_test.yml
+++ b/.github/workflows/flutter_windows_test.yml
@@ -10,7 +10,7 @@ on:
         type: string
         default: '1.64.0'
 concurrency:
-  group: ${{ github.head_ref }}
+  group: build-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 jobs:
   flutter_windows_test:

--- a/.github/workflows/flutter_windows_test.yml
+++ b/.github/workflows/flutter_windows_test.yml
@@ -9,7 +9,9 @@ on:
         required: false
         type: string
         default: '1.64.0'
-
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 jobs:
   flutter_windows_test:
     runs-on: windows-2019

--- a/.github/workflows/flutter_windows_test.yml
+++ b/.github/workflows/flutter_windows_test.yml
@@ -10,7 +10,7 @@ on:
         type: string
         default: '1.64.0'
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.head_ref }}
   cancel-in-progress: true
 jobs:
   flutter_windows_test:

--- a/.github/workflows/flutter_windows_test.yml
+++ b/.github/workflows/flutter_windows_test.yml
@@ -10,7 +10,7 @@ on:
         type: string
         default: '1.64.0'
 concurrency:
-  group: build-${{ github.event.pull_request.number || github.ref }}-${{ github.job || github.ref}}
+  group: build-${{ github.event.pull_request.number || github.ref }}-${{ github.job}}-${{matrix}}
   cancel-in-progress: true
 jobs:
   flutter_windows_test:

--- a/.github/workflows/flutter_windows_test.yml
+++ b/.github/workflows/flutter_windows_test.yml
@@ -10,7 +10,7 @@ on:
         type: string
         default: '1.64.0'
 concurrency:
-  group: build-${{ github.event.pull_request.number || github.ref }}
+  group: build-${{ github.event.pull_request.number || github.ref }}-${{ github.job || github.ref}}
   cancel-in-progress: true
 jobs:
   flutter_windows_test:

--- a/.github/workflows/flutter_windows_test.yml
+++ b/.github/workflows/flutter_windows_test.yml
@@ -10,7 +10,7 @@ on:
         type: string
         default: '1.64.0'
 concurrency:
-  group: build-${{ github.event.pull_request.number || github.ref }}-${{ github.job}}-${{matrix}}
+  group: build-${{ github.event.pull_request.number || github.ref }}-${{ github.job }}
   cancel-in-progress: true
 jobs:
   flutter_windows_test:


### PR DESCRIPTION
inspire from https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency:~:text=%E4%B8%BA%E8%BF%90%E8%A1%8C%E5%AE%9A%E4%B9%89%E3%80%82-,concurrency%3A%0A%20%20group%3A%20%24%7B%7B%20github.head_ref%20%7C%7C%20github.run_id%20%7D%7D%0A%20%20cancel%2Din%2Dprogress%3A%20true,-%E7%A4%BA%E4%BE%8B%EF%BC%9A%E4%BB%85%E5%8F%96%E6%B6%88

and 
https://stackoverflow.com/questions/66335225/how-to-cancel-previous-runs-in-the-pr-when-you-push-new-commitsupdate-the-curre

