### PR TITLE
Bump Dart SDK to 2.15

### DIFF
--- a/book/src/set_up_from_scratch.md
+++ b/book/src/set_up_from_scratch.md
@@ -10,7 +10,7 @@ However, I can sketch the outline of what to do if you want to set up a new Flut
 
 ## Step 1
 
-Create a new Flutter project (or use an existing one). The Dart SDK should be `>=2.14.0` if you want to use the latest `ffigen` tool.
+Create a new Flutter project (or use an existing one). The Dart SDK should be `>=2.17.0` if you want to use the latest `ffigen` tool.
 
 ## Step 2
 

--- a/book/src/troubleshooting.md
+++ b/book/src/troubleshooting.md
@@ -35,7 +35,7 @@ Related: https://github.com/fzyzcjy/flutter_rust_bridge/issues/330
 
 ## `Can't create typedef from non-function type.`
 
-Ensure min sdk version of Flutter `pubspec.yaml` is at least 2.13.0 to let `ffigen` happy.
+Ensure min sdk version of Flutter `pubspec.yaml` is at least 2.17.0 to let `ffigen` happy.
 
 https://github.com/fzyzcjy/flutter_rust_bridge/issues/334
 
@@ -53,9 +53,9 @@ Select the scheme (eg: `Product > Scheme > native-staticlib`) and go to *Build S
 
 Indeed all generated code are necessary (if you find something that can be simplified, file an issue). Moreover, other code generation tools also generate long code - for example, when using Google protobuf, a very popular serialization library, I see >10k lines of Java code generated for a quite simple source proto file.
 
-## Why need Dart `2.14.0`
+## Why need Dart `2.17.0`
 
-Dart SDK `>=2.14.0` is needed not by this library, but by the latest version of the `ffigen` tool. Therefore, write `sdk: ">=2.14.0 <3.0.0"` in the `environment` section of `pubspec.yaml`. If you do not want that, consider installing a older version of the `ffigen` tool.
+Dart SDK `>=2.15.0` is supported by this library, but by the latest version of the `ffigen` tool requires `>=2.17.0`. Therefore, write `sdk: ">=2.17.0 <3.0.0"` in the `environment` section of `pubspec.yaml`. If you do not want that, consider installing a older version of the `ffigen` tool.
 
 ## Issues on Web?
 

--- a/frb_dart/pubspec.yaml
+++ b/frb_dart/pubspec.yaml
@@ -3,7 +3,7 @@ description: High-level memory-safe binding generator for Flutter/Dart <-> Rust
 version: 1.54.0
 repository: https://github.com/fzyzcjy/flutter_rust_bridge
 environment:
-  sdk: ">=2.14.0 <3.0.0"
+  sdk: ">=2.15.0 <3.0.0"
 dependencies:
   args: ^2.3.1
   build_cli_annotations: ^2.1.0

--- a/frb_example/pure_dart/dart/pubspec.yaml.release
+++ b/frb_example/pure_dart/dart/pubspec.yaml.release
@@ -3,7 +3,7 @@ description: flutter rust bridge example
 version: 1.0.0
 publish_to: none
 environment:
-  sdk: '>=2.14.0 <3.0.0'
+  sdk: '>=2.15.0 <3.0.0'
 dependencies:
   meta: ^1.8.0
   lints: ^2.0.0

--- a/frb_example/pure_dart_multi/dart/pubspec.yaml
+++ b/frb_example/pure_dart_multi/dart/pubspec.yaml
@@ -3,7 +3,7 @@ description: flutter rust bridge example
 version: 1.0.0
 publish_to: none
 environment:
-  sdk: '>=2.14.0 <3.0.0'
+  sdk: '>=2.15.0 <3.0.0'
 dependencies:
   meta: ^1.8.0
   lints: ^2.0.0

--- a/frb_example/pure_dart_multi/dart/pubspec.yaml.release
+++ b/frb_example/pure_dart_multi/dart/pubspec.yaml.release
@@ -3,7 +3,7 @@ description: flutter rust bridge example
 version: 1.0.0
 publish_to: none
 environment:
-  sdk: '>=2.14.0 <3.0.0'
+  sdk: '>=2.15.0 <3.0.0'
 dependencies:
   meta: ^1.8.0
   lints: ^2.0.0

--- a/frb_example/with_flutter/pubspec.yaml
+++ b/frb_example/with_flutter/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.14.0 <3.0.0"
+  sdk: ">=2.15.0 <3.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/frb_example/with_flutter/pubspec.yaml.release
+++ b/frb_example/with_flutter/pubspec.yaml.release
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.14.0 <3.0.0"
+  sdk: ">=2.15.0 <3.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions


### PR DESCRIPTION
Follows up on #882 more precisely [@fzyzcjy's suggestion](https://github.com/fzyzcjy/flutter_rust_bridge/pull/882#issuecomment-1355844249)

This bump is motivated by the use of [constructor tearoffs](https://medium.com/dartlang/dart-2-15-7e7a598e508a#9c16): passing constructor as a regular function.

It shouldn't be a major issue for FRB users considering that ffigen currenttly required sdk is 2.17.