### PR TITLE
Fix mirroring to support `Result` return type and `Option<T>` field

### DIFF
--- a/frb_codegen/src/generator/rust/mod.rs
+++ b/frb_codegen/src/generator/rust/mod.rs
@@ -332,18 +332,20 @@ impl<'a> Generator<'a> {
             } else {
                 panic!("{} is not a method, nor a static method.", func.name)
             };
-            TypeRustGenerator::new(func.output.clone(), ir_file, self.config).wrap_obj(format!(
-                r"{}::{}({})",
-                struct_name.unwrap(),
-                method_name,
-                inner_func_params.join(", ")
-            ))
+            TypeRustGenerator::new(func.output.clone(), ir_file, self.config).wrap_obj(
+                format!(
+                    r"{}::{}({})",
+                    struct_name.unwrap(),
+                    method_name,
+                    inner_func_params.join(", ")
+                ),
+                func.fallible,
+            )
         } else {
-            TypeRustGenerator::new(func.output.clone(), ir_file, self.config).wrap_obj(format!(
-                "{}({})",
-                func.name,
-                inner_func_params.join(", ")
-            ))
+            TypeRustGenerator::new(func.output.clone(), ir_file, self.config).wrap_obj(
+                format!("{}({})", func.name, inner_func_params.join(", ")),
+                func.fallible,
+            )
         };
         let code_call_inner_func_result = if func.fallible {
             code_call_inner_func

--- a/frb_codegen/src/generator/rust/ty.rs
+++ b/frb_codegen/src/generator/rust/ty.rs
@@ -29,7 +29,7 @@ pub trait TypeRustGeneratorTrait {
         obj
     }
 
-    fn wrap_obj(&self, obj: String) -> String {
+    fn wrap_obj(&self, obj: String, _wired_fallible_func: bool) -> String {
         obj
     }
 

--- a/frb_codegen/src/generator/rust/ty_boxed.rs
+++ b/frb_codegen/src/generator/rust/ty_boxed.rs
@@ -66,13 +66,13 @@ impl TypeRustGeneratorTrait for TypeBoxedGenerator<'_> {
         format!("(*{})", obj)
     }
 
-    fn wrap_obj(&self, obj: String) -> String {
+    fn wrap_obj(&self, obj: String, wired_fallible_func: bool) -> String {
         let src = TypeRustGenerator::new(
             *self.ir.inner.clone(),
             self.context.ir_file,
             self.context.config,
         );
-        src.wrap_obj(self.self_access(obj))
+        src.wrap_obj(self.self_access(obj), wired_fallible_func)
     }
 
     fn allocate_funcs(

--- a/frb_codegen/src/generator/rust/ty_dart_opaque.rs
+++ b/frb_codegen/src/generator/rust/ty_dart_opaque.rs
@@ -63,7 +63,7 @@ impl TypeRustGeneratorTrait for TypeDartOpaqueGenerator<'_> {
         "".to_owned()
     }
 
-    fn wrap_obj(&self, obj: String) -> String {
+    fn wrap_obj(&self, obj: String, _wired_fallible_func: bool) -> String {
         obj
     }
 

--- a/frb_codegen/src/generator/rust/ty_delegate.rs
+++ b/frb_codegen/src/generator/rust/ty_delegate.rs
@@ -207,8 +207,8 @@ impl TypeRustGeneratorTrait for TypeDelegateGenerator<'_> {
         delegate_enum!(self, wrapper_struct(), None)
     }
 
-    fn wrap_obj(&self, obj: String) -> String {
-        delegate_enum!(self, wrap_obj(obj), obj)
+    fn wrap_obj(&self, obj: String, wired_fallible_func: bool) -> String {
+        delegate_enum!(self, wrap_obj(obj, wired_fallible_func), obj)
     }
 
     fn self_access(&self, obj: String) -> String {

--- a/frb_codegen/src/generator/rust/ty_enum.rs
+++ b/frb_codegen/src/generator/rust/ty_enum.rs
@@ -198,7 +198,7 @@ impl TypeRustGeneratorTrait for TypeEnumRefGenerator<'_> {
         }
     }
 
-    fn wrap_obj(&self, obj: String) -> String {
+    fn wrap_obj(&self, obj: String, _wired_fallible_func: bool) -> String {
         match self.wrapper_struct() {
             Some(wrapper) => format!("{}({})", wrapper, obj),
             None => obj,

--- a/frb_codegen/src/generator/rust/ty_general_list.rs
+++ b/frb_codegen/src/generator/rust/ty_general_list.rs
@@ -38,7 +38,7 @@ impl TypeRustGeneratorTrait for TypeGeneralListGenerator<'_> {
         ])
     }
 
-    fn wrap_obj(&self, obj: String) -> String {
+    fn wrap_obj(&self, obj: String, _wired_fallible_func: bool) -> String {
         let inner = TypeRustGenerator::new(
             *self.ir.inner.clone(),
             self.context.ir_file,

--- a/frb_codegen/src/generator/rust/ty_optional.rs
+++ b/frb_codegen/src/generator/rust/ty_optional.rs
@@ -41,12 +41,14 @@ impl TypeRustGeneratorTrait for TypeOptionalGenerator<'_> {
             self.context.config,
         );
         let obj = match inner.wrapper_struct() {
-            Some(wrapper) => format!(
-                "{}.map(|v| {}({}))",
-                obj,
-                wrapper,
-                inner.self_access("v".to_owned())
-            ),
+            // An architecture has been created so that the inner type of optional field is always IrTypeBoxed.
+            // Here, too, if we use inner.self_access("v".to_owned()), since it will go to self_access in TypeBoxedGenerator,
+            // the dereferenced value *v was returned from there, which gave the error that the external struct could not be dereferenced.
+            //
+            // For now, removed the parameter inner.self_access("v".to_owned())
+            // and then added a bit of a hacky method here (not used self_access function),
+            // as it only covers mirrored optional fields.
+            Some(wrapper) => format!("{}.map(|v| {}(v))", obj, wrapper,),
             None => obj,
         };
         format!("{}.into_dart()", obj)

--- a/frb_codegen/src/generator/rust/ty_rust_opaque.rs
+++ b/frb_codegen/src/generator/rust/ty_rust_opaque.rs
@@ -55,7 +55,7 @@ impl TypeRustGeneratorTrait for TypeRustOpaqueGenerator<'_> {
         obj
     }
 
-    fn wrap_obj(&self, obj: String) -> String {
+    fn wrap_obj(&self, obj: String, _wired_fallible_func: bool) -> String {
         obj
     }
 

--- a/frb_codegen/src/generator/rust/ty_struct.rs
+++ b/frb_codegen/src/generator/rust/ty_struct.rs
@@ -108,9 +108,16 @@ impl TypeRustGeneratorTrait for TypeStructRefGenerator<'_> {
         src.wrapper_name.as_ref().cloned()
     }
 
-    fn wrap_obj(&self, obj: String) -> String {
+    fn wrap_obj(&self, obj: String, wired_fallible_func: bool) -> String {
         match self.wrapper_struct() {
-            Some(wrapper) => format!("{}({})", wrapper, obj),
+            Some(wrapper) => {
+                if wired_fallible_func {
+                    format!("Ok({}({}?))", wrapper, obj)
+                } else {
+                    format!("{}({})", wrapper, obj)
+                }
+            }
+
             None => obj,
         }
     }
@@ -137,7 +144,8 @@ impl TypeRustGeneratorTrait for TypeStructRefGenerator<'_> {
                     self.context.ir_file,
                     self.context.config,
                 );
-                gen.convert_to_dart(gen.wrap_obj(format!("self{}.{}", unwrap, field_ref)))
+                // wired_fallible is always false here, this parameter is only used for generate_wire_func
+                gen.convert_to_dart(gen.wrap_obj(format!("self{}.{}", unwrap, field_ref), false))
             })
             .collect::<Vec<_>>()
             .join(",\n");

--- a/frb_example/pure_dart/dart/lib/bridge_definitions.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_definitions.dart
@@ -811,12 +811,14 @@ class ApplicationSettings {
   final String version;
   final ApplicationMode mode;
   final ApplicationEnv env;
+  final ApplicationEnv? envOptional;
 
   ApplicationSettings({
     required this.name,
     required this.version,
     required this.mode,
     required this.env,
+    this.envOptional,
   });
 }
 

--- a/frb_example/pure_dart/dart/lib/bridge_definitions.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_definitions.dart
@@ -201,6 +201,10 @@ abstract class FlutterRustBridgeExampleSingleBlockTest {
 
   FlutterRustBridgeTaskConstMeta get kGetAppSettingsConstMeta;
 
+  Future<ApplicationSettings> getFallibleAppSettings({dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kGetFallibleAppSettingsConstMeta;
+
   Future<bool> isAppEmbedded({required ApplicationSettings appSettings, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kIsAppEmbeddedConstMeta;

--- a/frb_example/pure_dart/dart/lib/bridge_generated.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.dart
@@ -2519,12 +2519,13 @@ class FlutterRustBridgeExampleSingleBlockTestImpl implements FlutterRustBridgeEx
 
   ApplicationSettings _wire2api_application_settings(dynamic raw) {
     final arr = raw as List<dynamic>;
-    if (arr.length != 4) throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
+    if (arr.length != 5) throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
     return ApplicationSettings(
       name: _wire2api_String(arr[0]),
       version: _wire2api_String(arr[1]),
       mode: _wire2api_application_mode(arr[2]),
       env: _wire2api_box_application_env(arr[3]),
+      envOptional: _wire2api_opt_box_autoadd_application_env(arr[4]),
     );
   }
 
@@ -2568,6 +2569,10 @@ class FlutterRustBridgeExampleSingleBlockTestImpl implements FlutterRustBridgeEx
 
   HideData _wire2api_box_autoadd_HideData(dynamic raw) {
     return raw as HideData;
+  }
+
+  ApplicationEnv _wire2api_box_autoadd_application_env(dynamic raw) {
+    return _wire2api_application_env(raw);
   }
 
   Attribute _wire2api_box_autoadd_attribute(dynamic raw) {
@@ -3030,6 +3035,10 @@ class FlutterRustBridgeExampleSingleBlockTestImpl implements FlutterRustBridgeEx
 
   HideData? _wire2api_opt_box_autoadd_HideData(dynamic raw) {
     return raw == null ? null : _wire2api_box_autoadd_HideData(raw);
+  }
+
+  ApplicationEnv? _wire2api_opt_box_autoadd_application_env(dynamic raw) {
+    return raw == null ? null : _wire2api_box_autoadd_application_env(raw);
   }
 
   Attribute? _wire2api_opt_box_autoadd_attribute(dynamic raw) {

--- a/frb_example/pure_dart/dart/lib/bridge_generated.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.dart
@@ -725,6 +725,21 @@ class FlutterRustBridgeExampleSingleBlockTestImpl implements FlutterRustBridgeEx
         argNames: [],
       );
 
+  Future<ApplicationSettings> getFallibleAppSettings({dynamic hint}) {
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_get_fallible_app_settings(port_),
+      parseSuccessData: _wire2api_application_settings,
+      constMeta: kGetFallibleAppSettingsConstMeta,
+      argValues: [],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kGetFallibleAppSettingsConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "get_fallible_app_settings",
+        argNames: [],
+      );
+
   Future<bool> isAppEmbedded({required ApplicationSettings appSettings, dynamic hint}) {
     var arg0 = _platform.api2wire_box_autoadd_application_settings(appSettings);
     return _platform.executeNormal(FlutterRustBridgeTask(

--- a/frb_example/pure_dart/dart/lib/bridge_generated.io.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.io.dart
@@ -155,6 +155,13 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
   }
 
   @protected
+  ffi.Pointer<wire_ApplicationEnv> api2wire_box_autoadd_application_env(ApplicationEnv raw) {
+    final ptr = inner.new_box_autoadd_application_env_0();
+    _api_fill_to_wire_application_env(raw, ptr.ref);
+    return ptr;
+  }
+
+  @protected
   ffi.Pointer<wire_ApplicationSettings> api2wire_box_autoadd_application_settings(ApplicationSettings raw) {
     final ptr = inner.new_box_autoadd_application_settings_0();
     _api_fill_to_wire_application_settings(raw, ptr.ref);
@@ -571,6 +578,11 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
   }
 
   @protected
+  ffi.Pointer<wire_ApplicationEnv> api2wire_opt_box_autoadd_application_env(ApplicationEnv? raw) {
+    return raw == null ? ffi.nullptr : api2wire_box_autoadd_application_env(raw);
+  }
+
+  @protected
   ffi.Pointer<wire_Attribute> api2wire_opt_box_autoadd_attribute(Attribute? raw) {
     return raw == null ? ffi.nullptr : api2wire_box_autoadd_attribute(raw);
   }
@@ -769,6 +781,7 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
     wireObj.version = api2wire_String(apiObj.version);
     wireObj.mode = api2wire_application_mode(apiObj.mode);
     wireObj.env = api2wire_box_application_env(apiObj.env);
+    wireObj.env_optional = api2wire_opt_box_autoadd_application_env(apiObj.envOptional);
   }
 
   void _api_fill_to_wire_attribute(Attribute apiObj, wire_Attribute wireObj) {
@@ -790,6 +803,10 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
 
   void _api_fill_to_wire_box_autoadd_HideData(HideData apiObj, ffi.Pointer<wire_HideData> wireObj) {
     _api_fill_to_wire_HideData(apiObj, wireObj.ref);
+  }
+
+  void _api_fill_to_wire_box_autoadd_application_env(ApplicationEnv apiObj, ffi.Pointer<wire_ApplicationEnv> wireObj) {
+    _api_fill_to_wire_application_env(apiObj, wireObj.ref);
   }
 
   void _api_fill_to_wire_box_autoadd_application_settings(
@@ -1151,6 +1168,11 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
 
   void _api_fill_to_wire_opt_box_autoadd_HideData(HideData? apiObj, ffi.Pointer<wire_HideData> wireObj) {
     if (apiObj != null) _api_fill_to_wire_box_autoadd_HideData(apiObj, wireObj);
+  }
+
+  void _api_fill_to_wire_opt_box_autoadd_application_env(
+      ApplicationEnv? apiObj, ffi.Pointer<wire_ApplicationEnv> wireObj) {
+    if (apiObj != null) _api_fill_to_wire_box_autoadd_application_env(apiObj, wireObj);
   }
 
   void _api_fill_to_wire_opt_box_autoadd_attribute(Attribute? apiObj, ffi.Pointer<wire_Attribute> wireObj) {
@@ -3314,6 +3336,15 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   late final _new_box_autoadd_HideData_0 =
       _new_box_autoadd_HideData_0Ptr.asFunction<ffi.Pointer<wire_HideData> Function()>();
 
+  ffi.Pointer<wire_ApplicationEnv> new_box_autoadd_application_env_0() {
+    return _new_box_autoadd_application_env_0();
+  }
+
+  late final _new_box_autoadd_application_env_0Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_ApplicationEnv> Function()>>('new_box_autoadd_application_env_0');
+  late final _new_box_autoadd_application_env_0 =
+      _new_box_autoadd_application_env_0Ptr.asFunction<ffi.Pointer<wire_ApplicationEnv> Function()>();
+
   ffi.Pointer<wire_ApplicationSettings> new_box_autoadd_application_settings_0() {
     return _new_box_autoadd_application_settings_0();
   }
@@ -4450,6 +4481,8 @@ class wire_ApplicationSettings extends ffi.Struct {
   external int mode;
 
   external ffi.Pointer<wire_ApplicationEnv> env;
+
+  external ffi.Pointer<wire_ApplicationEnv> env_optional;
 }
 
 class wire_Numbers extends ffi.Struct {

--- a/frb_example/pure_dart/dart/lib/bridge_generated.io.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.io.dart
@@ -1911,6 +1911,18 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_get_app_settings');
   late final _wire_get_app_settings = _wire_get_app_settingsPtr.asFunction<void Function(int)>();
 
+  void wire_get_fallible_app_settings(
+    int port_,
+  ) {
+    return _wire_get_fallible_app_settings(
+      port_,
+    );
+  }
+
+  late final _wire_get_fallible_app_settingsPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_get_fallible_app_settings');
+  late final _wire_get_fallible_app_settings = _wire_get_fallible_app_settingsPtr.asFunction<void Function(int)>();
+
   void wire_is_app_embedded(
     int port_,
     ffi.Pointer<wire_ApplicationSettings> app_settings,

--- a/frb_example/pure_dart/dart/lib/bridge_generated.web.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.web.dart
@@ -132,7 +132,8 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
       api2wire_String(raw.name),
       api2wire_String(raw.version),
       api2wire_application_mode(raw.mode),
-      api2wire_box_application_env(raw.env)
+      api2wire_box_application_env(raw.env),
+      api2wire_opt_box_autoadd_application_env(raw.envOptional)
     ];
   }
 
@@ -159,6 +160,11 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
   @protected
   Object api2wire_box_autoadd_HideData(HideData raw) {
     return api2wire_HideData(raw);
+  }
+
+  @protected
+  List<dynamic> api2wire_box_autoadd_application_env(ApplicationEnv raw) {
+    return api2wire_application_env(raw);
   }
 
   @protected
@@ -650,6 +656,11 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
   @protected
   Object? api2wire_opt_box_autoadd_HideData(HideData? raw) {
     return raw == null ? null : api2wire_box_autoadd_HideData(raw);
+  }
+
+  @protected
+  List<dynamic>? api2wire_opt_box_autoadd_application_env(ApplicationEnv? raw) {
+    return raw == null ? null : api2wire_box_autoadd_application_env(raw);
   }
 
   @protected

--- a/frb_example/pure_dart/dart/lib/bridge_generated.web.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.web.dart
@@ -941,6 +941,8 @@ class FlutterRustBridgeExampleSingleBlockTestWasmModule implements WasmModule {
 
   external void wire_get_app_settings(NativePortType port_);
 
+  external void wire_get_fallible_app_settings(NativePortType port_);
+
   external void wire_is_app_embedded(NativePortType port_, List<dynamic> app_settings);
 
   external void wire_get_message(NativePortType port_);
@@ -1293,6 +1295,8 @@ class FlutterRustBridgeExampleSingleBlockTestWire
   void wire_use_imported_enum(NativePortType port_, int my_enum) => wasmModule.wire_use_imported_enum(port_, my_enum);
 
   void wire_get_app_settings(NativePortType port_) => wasmModule.wire_get_app_settings(port_);
+
+  void wire_get_fallible_app_settings(NativePortType port_) => wasmModule.wire_get_fallible_app_settings(port_);
 
   void wire_is_app_embedded(NativePortType port_, List<dynamic> app_settings) =>
       wasmModule.wire_is_app_embedded(port_, app_settings);

--- a/frb_example/pure_dart/rust/external/src/lib.rs
+++ b/frb_example/pure_dart/rust/external/src/lib.rs
@@ -6,6 +6,7 @@ pub struct ApplicationSettings {
     pub version: String,
     pub mode: ApplicationMode,
     pub env: Box<ApplicationEnv>,
+    pub env_optional: Option<ApplicationEnv>,
 }
 
 #[derive(Debug, Clone)]
@@ -52,6 +53,7 @@ impl ApplicationSettings {
                     .map(|(k, v)| ApplicationEnvVar(k.into(), v))
                     .collect(),
             }),
+            env_optional: None,
         }
     }
 }

--- a/frb_example/pure_dart/rust/src/api.rs
+++ b/frb_example/pure_dart/rust/src/api.rs
@@ -535,6 +535,7 @@ pub struct _ApplicationSettings {
     pub version: String,
     pub mode: ApplicationMode,
     pub env: Box<ApplicationEnv>,
+    pub env_optional: Option<ApplicationEnv>,
 }
 
 #[frb(mirror(ApplicationMode))]

--- a/frb_example/pure_dart/rust/src/api.rs
+++ b/frb_example/pure_dart/rust/src/api.rs
@@ -556,6 +556,11 @@ pub fn get_app_settings() -> ApplicationSettings {
     external_lib::get_app_settings()
 }
 
+// This function can return a Result, that includes an object of the external type ApplicationSettings because it has a mirror
+pub fn get_fallible_app_settings() -> anyhow::Result<ApplicationSettings> {
+    Ok(external_lib::get_app_settings())
+}
+
 // Similarly, receiving an object from Dart works. Please note that the mirror definition must match entirely and the original struct must have all its fields public.
 pub fn is_app_embedded(app_settings: ApplicationSettings) -> bool {
     // println!("env: {:?}", app_settings.env.vars);

--- a/frb_example/pure_dart/rust/src/bridge_generated.io.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.io.rs
@@ -238,6 +238,11 @@ pub extern "C" fn wire_get_app_settings(port_: i64) {
 }
 
 #[no_mangle]
+pub extern "C" fn wire_get_fallible_app_settings(port_: i64) {
+    wire_get_fallible_app_settings_impl(port_)
+}
+
+#[no_mangle]
 pub extern "C" fn wire_is_app_embedded(port_: i64, app_settings: *mut wire_ApplicationSettings) {
     wire_is_app_embedded_impl(port_, app_settings)
 }

--- a/frb_example/pure_dart/rust/src/bridge_generated.io.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.io.rs
@@ -806,6 +806,11 @@ pub extern "C" fn new_box_autoadd_HideData_0() -> *mut wire_HideData {
 }
 
 #[no_mangle]
+pub extern "C" fn new_box_autoadd_application_env_0() -> *mut wire_ApplicationEnv {
+    support::new_leak_box_ptr(wire_ApplicationEnv::new_with_null_ptr())
+}
+
+#[no_mangle]
 pub extern "C" fn new_box_autoadd_application_settings_0() -> *mut wire_ApplicationSettings {
     support::new_leak_box_ptr(wire_ApplicationSettings::new_with_null_ptr())
 }
@@ -1379,6 +1384,7 @@ impl Wire2Api<ApplicationSettings> for wire_ApplicationSettings {
             version: self.version.wire2api(),
             mode: self.mode.wire2api(),
             env: self.env.wire2api(),
+            env_optional: self.env_optional.wire2api(),
         }
     }
 }
@@ -1412,6 +1418,12 @@ impl Wire2Api<RustOpaque<HideData>> for *mut wire_HideData {
     fn wire2api(self) -> RustOpaque<HideData> {
         let wrap = unsafe { support::box_from_leak_ptr(self) };
         Wire2Api::<RustOpaque<HideData>>::wire2api(*wrap).into()
+    }
+}
+impl Wire2Api<ApplicationEnv> for *mut wire_ApplicationEnv {
+    fn wire2api(self) -> ApplicationEnv {
+        let wrap = unsafe { support::box_from_leak_ptr(self) };
+        Wire2Api::<ApplicationEnv>::wire2api(*wrap).into()
     }
 }
 impl Wire2Api<ApplicationSettings> for *mut wire_ApplicationSettings {
@@ -2113,6 +2125,7 @@ pub struct wire_ApplicationSettings {
     version: *mut wire_uint_8_list,
     mode: i32,
     env: *mut wire_ApplicationEnv,
+    env_optional: *mut wire_ApplicationEnv,
 }
 
 #[repr(C)]
@@ -2640,6 +2653,7 @@ impl NewWithNullPtr for wire_ApplicationSettings {
             version: core::ptr::null_mut(),
             mode: Default::default(),
             env: core::ptr::null_mut(),
+            env_optional: core::ptr::null_mut(),
         }
     }
 }

--- a/frb_example/pure_dart/rust/src/bridge_generated.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.rs
@@ -676,6 +676,16 @@ fn wire_get_app_settings_impl(port_: MessagePort) {
         move || move |task_callback| Ok(mirror_ApplicationSettings(get_app_settings())),
     )
 }
+fn wire_get_fallible_app_settings_impl(port_: MessagePort) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+        WrapInfo {
+            debug_name: "get_fallible_app_settings",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || move |task_callback| Ok(mirror_ApplicationSettings(get_fallible_app_settings()?)),
+    )
+}
 fn wire_is_app_embedded_impl(
     port_: MessagePort,
     app_settings: impl Wire2Api<ApplicationSettings> + UnwindSafe,

--- a/frb_example/pure_dart/rust/src/bridge_generated.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.rs
@@ -2063,6 +2063,7 @@ const _: fn() = || {
         let _: String = ApplicationSettings.version;
         let _: ApplicationMode = ApplicationSettings.mode;
         let _: Box<ApplicationEnv> = ApplicationSettings.env;
+        let _: Option<ApplicationEnv> = ApplicationSettings.env_optional;
     }
     {
         let Numbers_ = None::<Numbers>.unwrap();
@@ -2299,6 +2300,10 @@ impl support::IntoDart for mirror_ApplicationSettings {
             self.0.version.into_dart(),
             mirror_ApplicationMode(self.0.mode).into_dart(),
             mirror_ApplicationEnv((*self.0.env)).into_dart(),
+            self.0
+                .env_optional
+                .map(|v| mirror_ApplicationEnv(v))
+                .into_dart(),
         ]
         .into_dart()
     }

--- a/frb_example/pure_dart/rust/src/bridge_generated.web.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.web.rs
@@ -984,8 +984,8 @@ impl Wire2Api<ApplicationSettings> for JsValue {
         let self_ = self.dyn_into::<JsArray>().unwrap();
         assert_eq!(
             self_.length(),
-            4,
-            "Expected 4 elements, got {}",
+            5,
+            "Expected 5 elements, got {}",
             self_.length()
         );
         ApplicationSettings {
@@ -993,6 +993,7 @@ impl Wire2Api<ApplicationSettings> for JsValue {
             version: self_.get(1).wire2api(),
             mode: self_.get(2).wire2api(),
             env: self_.get(3).wire2api(),
+            env_optional: self_.get(4).wire2api(),
         }
     }
 }
@@ -1443,6 +1444,11 @@ impl Wire2Api<Option<DartOpaque>> for JsValue {
 }
 impl Wire2Api<Option<RustOpaque<HideData>>> for JsValue {
     fn wire2api(self) -> Option<RustOpaque<HideData>> {
+        (!self.is_undefined() && !self.is_null()).then(|| self.wire2api())
+    }
+}
+impl Wire2Api<Option<ApplicationEnv>> for JsValue {
+    fn wire2api(self) -> Option<ApplicationEnv> {
         (!self.is_undefined() && !self.is_null()).then(|| self.wire2api())
     }
 }

--- a/frb_example/pure_dart/rust/src/bridge_generated.web.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.web.rs
@@ -234,6 +234,11 @@ pub fn wire_get_app_settings(port_: MessagePort) {
 }
 
 #[wasm_bindgen]
+pub fn wire_get_fallible_app_settings(port_: MessagePort) {
+    wire_get_fallible_app_settings_impl(port_)
+}
+
+#[wasm_bindgen]
 pub fn wire_is_app_embedded(port_: MessagePort, app_settings: JsValue) {
     wire_is_app_embedded_impl(port_, app_settings)
 }


### PR DESCRIPTION
Fixes #895
Fixes #897 

## Checklist

- [x] An issue to be fixed by this PR is listed above.
- [x] New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api.rs` and `dart/lib/main.dart`.
- [x] The code generator is run and the code is formatted (e.g. via `just refresh_all`).
- [ ] If this PR adds/changes features, documentations (in the `./book` folder) are updated.
- [x] CI is passing.

## Remark for PR creator

* New contributors will be blocked by GitHub from running CI, but you can use [a trick](https://github.com/fzyzcjy/flutter_rust_bridge/pull/663#discussion_r962150638) to workaround this, and verify your code using CI by yourself.
* If fzyzcjy does not reply for a few days, maybe he just did not see it, so please ping him.
