### PR TITLE
Return error when rust input file cannot be read

### DIFF
--- a/frb_codegen/src/lib.rs
+++ b/frb_codegen/src/lib.rs
@@ -51,7 +51,7 @@ pub fn frb_codegen(config: &config::Opts, all_symbols: &[String]) -> anyhow::Res
     let dart_output_dir = Path::new(&config.dart_output_path).parent().unwrap();
 
     info!("Phase: Parse source code to AST, then to IR");
-    let raw_ir_file = config.get_ir_file();
+    let raw_ir_file = config.get_ir_file()?;
 
     info!("Phase: Transform IR");
     let ir_file = transformer::transform(raw_ir_file);

--- a/frb_codegen/src/utils.rs
+++ b/frb_codegen/src/utils.rs
@@ -48,7 +48,7 @@ pub fn get_symbols_if_no_duplicates(configs: &[crate::Opts]) -> Result<Vec<Strin
     let mut explicit_raw_symbols = Vec::new();
     let mut all_symbols = Vec::new();
     for config in configs {
-        let raw_ir_file = config.get_ir_file();
+        let raw_ir_file = config.get_ir_file()?;
 
         // for checking explicit api duplication
         explicit_raw_symbols.extend(raw_ir_file.funcs.iter().map(|f| f.name.clone()));


### PR DESCRIPTION
Fixes #911.

New output when rust input file does not exist:
```
Error: Failed to read rust input file "[...]/flutter_rust_bridge/frb_example/with_flutter/rust/api.rs"

Caused by:
    No such file or directory (os error 2)
```

Feel free to suggest a different way of reporting the error.

## Checklist

- [X] An issue to be fixed by this PR is listed above.
- [ ] New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api.rs` and `dart/lib/main.dart`.
- [ ] The code generator is run and the code is formatted (e.g. via `just refresh_all`).
- [ ] If this PR adds/changes features, documentations (in the `./book` folder) are updated.
- [ ] CI is passing.

