### PR TITLE
Remove reference to `usePubspecOverrides`

### DIFF
--- a/book/src/library/melos.md
+++ b/book/src/library/melos.md
@@ -20,10 +20,6 @@ name: library_name
 
 repository: https://github.com/YourGitHubAccount/library_name
 
-command:
-  bootstrap:
-    usePubspecOverrides: true
-
 packages:
   - packages/**
 


### PR DESCRIPTION
This is the only supported behaviour now - see https://github.com/invertase/melos/pull/430 .