### PR TITLE
fix: force library bundling for iOS and macOS in release mode

### DIFF
--- a/book/src/library/platform_setup/ios_and_macos.md
+++ b/book/src/library/platform_setup/ios_and_macos.md
@@ -19,9 +19,10 @@ We will need to create several files for both iOS and macOS to:
 
 ### `ios/Classes/EnforceBundling.swift` and `macos/Classes/EnforceBundling.swift`
 ```swift
-public func dummyMethodToEnforceBundling() {
-    dummy_method_to_enforce_bundling()
+public func dummyMethodToEnforceBundling() -> Int64 {
+  return dummy_method_to_enforce_bundling()
 }
+let dummyVar = dummyMethodToEnforceBundling();
 ```
 
 ### `ios/Frameworks/.gitkeep` and `macos/Frameworks/.gitkeep`


### PR DESCRIPTION
Hi, I just noticed that in release mode the static library was getting stripped for iOS and macOS.

I can't quite explain why, but this exact change with separating a method from a variable seems to do the trick. Note: setting the variable directly to the result of `dummy_...` does *not* work.