### PR TITLE
Fix syntax issues warned by lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Want to combine the best between [Flutter](https://flutter.dev/), a cross-platfo
 ## 🚀 Advantages
 
 * **Memory-safe**: Never need to think about malloc/free.
-* **Feature-rich**: `enum`s with values, platform-optimized `Vec`, possibly recursive `struct`, zero-copy big arrays, opaque types on arbitrary structs/classes, `Stream` (iterator) abstraction, error (`Result`) handling, cancellable tasks, concurrency control, and more. See full features [here](https://fzyzcjy.github.io/flutter_rust_bridge/feature.html). 
+* **Feature-rich**: `enum`s with values, platform-optimized `Vec`, possibly recursive `struct`, zero-copy big arrays, opaque types on arbitrary structs/classes, `Stream` (iterator) abstraction, error (`Result`) handling, cancellable tasks, concurrency control, and more. See full features [here](https://fzyzcjy.github.io/flutter_rust_bridge/feature.html).
 * **Async programming**: Rust code will never block the Flutter. Call Rust naturally from Flutter's main isolate (thread); sync mode also equally supported.
 * **Lightweight**: This is not a huge framework that includes everything, so you are free to use your favorite Flutter and Rust libraries. <sub>For example, state-management with Flutter library (e.g. MobX) can be elegant and simple (contrary to implementing in Rust); implementing a photo manipulation algorithm in Rust will be fast and safe (countrary to implementing in Flutter).</sub>
 * **Cross-platform**: Android, iOS, Windows, Linux, MacOS, and Web.
@@ -99,7 +99,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     </tr>
     <tr>
       <td align="center"><a href="https://www.floeschner.de/"><img src="https://avatars.githubusercontent.com/u/12967904?v=4?s=100" width="100px;" alt="Fabian Löschner"/><br /><sub><b>Fabian Löschner</b></sub></a><br /><a href="https://github.com/fzyzcjy/flutter_rust_bridge/commits?author=w1th0utnam3" title="Code">💻</a></td>
-      <td align="center"><a href="http://gsconrad.com"><img src="https://avatars.githubusercontent.com/u/15874617?v=4?s=100" width="100px;" alt="Gregory Conrad"/><br /><sub><b>Gregory Conrad</b></sub></a><br /><a href="https://github.com/fzyzcjy/flutter_rust_bridge/commits?author=GregoryConrad" title="Documentation">📖</a> <a href="https://github.com/fzyzcjy/flutter_rust_bridge/commits?author=GregoryConrad" title="Code">💻</a></td>
+      <td align="center"><a href="https://gsconrad.com"><img src="https://avatars.githubusercontent.com/u/15874617?v=4?s=100" width="100px;" alt="Gregory Conrad"/><br /><sub><b>Gregory Conrad</b></sub></a><br /><a href="https://github.com/fzyzcjy/flutter_rust_bridge/commits?author=GregoryConrad" title="Documentation">📖</a> <a href="https://github.com/fzyzcjy/flutter_rust_bridge/commits?author=GregoryConrad" title="Code">💻</a></td>
     </tr>
   </tbody>
 </table>

--- a/frb_codegen/src/commands.rs
+++ b/frb_codegen/src/commands.rs
@@ -81,7 +81,7 @@ pub(crate) fn call_shell(cmd: &[PathBuf], pwd: Option<&str>) -> Result<Output> {
     let cmd = cmd.iter().map(|section| format!("{:?}", section)).join(" ");
     #[cfg(windows)]
     {
-        return run!("powershell" in pwd, "-noprofile", "-command", format!("& {}", cmd));
+        run!("powershell" in pwd, "-noprofile", "-command", format!("& {}", cmd))
     }
 
     #[cfg(not(windows))]

--- a/frb_dart/pubspec.yaml
+++ b/frb_dart/pubspec.yaml
@@ -38,5 +38,5 @@ ffigen:
     include-directives:
       - '../frb_rust/src/dart_api_dl/include/dart_native_api.h'
   preamble: |
-    // flutter_rust_bridge auto-generated this file with frb_dart 
+    // flutter_rust_bridge auto-generated this file with frb_dart
     // ignore_for_file: camel_case_types, non_constant_identifier_names, avoid_positional_boolean_parameters, annotate_overrides, constant_identifier_names, unused_field, library_private_types_in_public_api

--- a/frb_rust/src/ffi/web.rs
+++ b/frb_rust/src/ffi/web.rs
@@ -391,7 +391,7 @@ pub fn script_path() -> Option<String> {
 #[cfg(feature = "chrono")]
 #[inline]
 pub fn wire2api_timestamp(ts: i64) -> Timestamp {
-    let s = (ts / 1_000) as i64;
+    let s = ts / 1_000;
     let ns = (ts.rem_euclid(1_000) * 1_000_000) as u32;
     Timestamp { s, ns }
 }
@@ -417,11 +417,17 @@ mod tests {
     }
 }
 
+/// # Safety
+///
+/// TODO: need doc
 #[wasm_bindgen]
 pub unsafe fn get_dart_object(ptr: usize) -> JsValue {
     *support::box_from_leak_ptr(ptr as _)
 }
 
+/// # Safety
+///
+/// TODO: need doc
 #[wasm_bindgen]
 pub unsafe fn drop_dart_object(ptr: usize) {
     drop(support::box_from_leak_ptr::<JsValue>(ptr as _));


### PR DESCRIPTION
This pr modified code a little to fix errors posted after running `just precommit` locally and online Github CI test.

By the way, the [lint ](https://rust-lang.github.io/rust-clippy/master/index.html#missing_safety_doc)posted for `get_dart_object` and `drop_dart_object` may need a detailed description, it'd better be written by the one who wrote these methods.