### PR TITLE
fix `SyncReturn` restrictions and update CI

### DIFF
--- a/.github/workflows/code_generator.yml
+++ b/.github/workflows/code_generator.yml
@@ -147,15 +147,6 @@ jobs:
         env:
           RUST_LOG: debug
 
-      # #467
-      - name: "Modify cross-platform code (windows) (single block)"
-        if: ${{ inputs.family == 'windows' }}
-        run: |
-          sed -i -e 's/^typedef uintptr_t =.*$/typedef uintptr_t = ffi.UnsignedLong;/g' frb_example/pure_dart/dart/lib/bridge_generated.io.dart
-          sed -i -e 's/^typedef uintptr_t =.*$/typedef uintptr_t = ffi.UnsignedLong;/g' frb_example/pure_dart_multi/dart/lib/bridge_generated_api_1.io.dart
-          sed -i -e 's/^typedef uintptr_t =.*$/typedef uintptr_t = ffi.UnsignedLong;/g' frb_example/pure_dart_multi/dart/lib/bridge_generated_api_2.io.dart
-          sed -i -e 's/^typedef uintptr_t =.*$/typedef uintptr_t = ffi.UnsignedLong;/g' frb_example/with_flutter/lib/bridge_generated.io.dart
-
       - name: Generate codegen help
         working-directory: ./frb_codegen
         # The file extension is different on Windows.

--- a/.github/workflows/post_release.yaml
+++ b/.github/workflows/post_release.yaml
@@ -219,14 +219,5 @@ jobs:
         env:
           RUST_LOG: debug
 
-      # #467
-      - name: "Modify cross-platform code (osx)"
-        if: ${{ matrix.os.family == 'osx' }}
-        # note the "-i '' -e" is a bug of sed specific to MacOS https://stackoverflow.com/questions/19456518
-        run: sed -i '' -e 's/^typedef uintptr_t =.*$/typedef uintptr_t = ffi.UnsignedLong;/g' frb_example/pure_dart/dart/lib/bridge_generated.dart
-      - name: "Modify cross-platform code (non-osx)"
-        if: ${{ matrix.os.family != 'osx' }}
-        run: sed -i -e 's/^typedef uintptr_t =.*$/typedef uintptr_t = ffi.UnsignedLong;/g' frb_example/pure_dart/dart/lib/bridge_generated.dart
-
       - name: 'Check no code change (If fail: Please ensure you have run codegen on examples and commit those changes!)'
         run: git diff --exit-code

--- a/frb_rust/src/lib.rs
+++ b/frb_rust/src/lib.rs
@@ -20,7 +20,7 @@ mod wasm_bindgen_src;
 
 /// Use this struct in return type of your function, in order to tell the code generator
 /// the function should return synchronously. Otherwise, it is by default asynchronously.
-pub struct SyncReturn<T: IntoDart>(pub T);
+pub struct SyncReturn<T>(pub T);
 
 /// Marker trait for types that are safe to share with Dart and can be dropped
 /// safely in case of a panic.


### PR DESCRIPTION
This PR fixes #935 the limitation of SyncReturn IntoDart as this limitation duplicates the limitation in the generated code and may cause errors on first generation.

additionally `ffigen 7.2.4` now generates `UIntPtr` instead of `UnsignedLongLong` (ci fix)

## Checklist

- [x] An issue to be fixed by this PR is listed above.
- [x] New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api.rs` and `dart/lib/main.dart`.
- [x] The code generator is run and the code is formatted (e.g. via `just refresh_all`).
- [x] If this PR adds/changes features, documentations (in the `./book` folder) are updated.
- [x] CI is passing.
