### PR TITLE
Specify how to prevent Xcode from stripping symbols in iOS

### DIFF
--- a/book/src/integrate/ios_headers.md
+++ b/book/src/integrate/ios_headers.md
@@ -34,6 +34,15 @@ and in `ios/Runner/AppDelegate.swift`:
 
 It is important that you use the result of `dummy_method_to_enforce_bundling()` (like in the example above), otherwise the symbols might still get stripped.
 
+### Stripping iOS symbols
+
+If you release your app through App Store, the steps above might not be sufficient. In that case you need to modify how Xcode strips the symbols:
+
+1. In Xcode, go to Target Runner > Build Settings > Strip Style.
+2. Change from **All Symbols** to **Non-Global Symbols**.
+
+Ref: https://docs.flutter.dev/development/platform-integration/ios/c-interop#stripping-ios-symbols
+
 
 ## MacOS
 


### PR DESCRIPTION
Everything worked fine with `flutter run` and `flutter run --release`. But when I was distributing my app through TestFlight symbols suddenly disappeared and I was stuck with infamous *"Failed to lookup symbol 'store_dart_post_cobject'"* error.

I had to modify the setting for the app to start working on iOS.

Btw, thank you for this project!
