### PR TITLE
Refactors for `Boxed` and `Option`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,8 +69,8 @@ jobs:
     strategy:
       matrix:
         device:
-          - "iPad (7th generation) Simulator (15.2)"
-          - "iPhone 12 Pro Max Simulator (15.2)"
+          - "iPad (9th generation) Simulator (16.0)"
+          - "iPhone 12 Pro Max Simulator (16.0)"
       fail-fast: false
     uses: ./.github/workflows/flutter_ios_test.yml
     with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
 dependencies = [
  "gimli",
 ]
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
@@ -49,9 +49,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.66"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 dependencies = [
  "backtrace",
 ]
@@ -71,7 +71,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -84,15 +84,15 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
 dependencies = [
  "addr2line",
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide 0.5.4",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
 ]
@@ -123,9 +123,9 @@ checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
 name = "bytemuck"
-version = "1.12.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f5715e491b5a1598fc2bef5a606847b5dc1d48ea625bd3c02c00de8285591da"
+checksum = "aaa3a8d9a1ca92e282c96a32d6511b695d7d994d1d102ba85d279f9b2756947f"
 
 [[package]]
 name = "byteorder"
@@ -185,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.73"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
 
 [[package]]
 name = "cfg-if"
@@ -212,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.22"
+version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "atty",
  "bitflags",
@@ -333,9 +333,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.11"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f916dfc5d356b0ed9dae65f1db9fc9770aa2851d2662b988ccf4fe3516e86348"
+checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
 dependencies = [
  "autocfg",
  "cfg-if",
@@ -346,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd42583b04998a5363558e5f9291ee5a5ff6b49944332103f251e7479a82aa7"
+checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -356,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
  "cfg-if",
 ]
@@ -371,9 +371,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "cxx"
-version = "1.0.83"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf07d07d6531bfcdbe9b8b739b104610c6508dcc4d63b410585faf338241daf"
+checksum = "5add3fc1717409d029b20c5b6903fc0c0b02fa6741d820054f4a2efa5e5816fd"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -383,9 +383,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.83"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2eb5b96ecdc99f72657332953d4d9c50135af1bac34277801cc3937906ebd39"
+checksum = "b4c87959ba14bc6fbc61df77c3fcfe180fc32b93538c4f1031dd802ccb5f2ff0"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -398,15 +398,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.83"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac040a39517fd1674e0f32177648334b0f4074625b5588a64519804ba0553b12"
+checksum = "69a3e162fde4e594ed2b07d0f83c6c67b745e7f28ce58c6df5e6b6bef99dfb59"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.83"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1362b0ddcfc4eb0a1f57b68bd77dd99f0e826958a96abd0ae9bd092e114ffed6"
+checksum = "3e7e2adeb6a0d4a282e581096b06e1791532b7d576dcde5ccd9382acf55db8e6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -432,9 +432,9 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "enum_dispatch"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eb359f1476bf611266ac1f5355bc14aeca37b299d0ebccc038ee7058891c9cb"
+checksum = "1693044dcf452888dd3a6a6a0dab67f0652094e3920dfe029a54d2f37d9b7394"
 dependencies = [
  "once_cell",
  "proc-macro2",
@@ -444,9 +444,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c90bf5f19754d10198ccb95b70664fc925bd1fc090a0fd9a6ebc54acc8cd6272"
+checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
 dependencies = [
  "atty",
  "humantime",
@@ -465,7 +465,7 @@ dependencies = [
  "flume",
  "half",
  "lebe",
- "miniz_oxide 0.6.2",
+ "miniz_oxide",
  "smallvec",
  "threadpool",
 ]
@@ -493,12 +493,12 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.5.4",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -647,15 +647,15 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.26.2"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
+checksum = "dec7af912d60cdbd3677c1af9352ebae6fb8394d165568a2234df0fa00f87793"
 
 [[package]]
 name = "half"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad6a9459c9c30b177b925162351f97e7d967c7ea8bab3b8352805327daf45554"
+checksum = "6c467d36af040b7b2681f5fddd27427f6da8d3d072f575a265e181d2f8e8d157"
 dependencies = [
  "crunchy",
 ]
@@ -677,6 +677,15 @@ name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
@@ -713,9 +722,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.24.4"
+version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd8e4fb07cf672b1642304e731ef8a6a4c7891d67bb4fd4f5ce58cd6ed86803c"
+checksum = "69b7ea949b537b0fd0af141fff8c77690f2ce96f4f41f042ccb6c69c6c965945"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -732,9 +741,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -760,15 +769,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "jpeg-decoder"
-version = "0.2.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9478aa10f73e7528198d75109c8be5cd7d15fb530238040148d5f9a22d4c5b3b"
+checksum = "bc0000e42512c92e31c2252315bda326620a4e034105e900c98ec492fa077b3e"
 dependencies = [
  "rayon",
 ]
@@ -796,15 +805,15 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.135"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "link-cplusplus"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
 dependencies = [
  "cc",
 ]
@@ -842,20 +851,11 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "miniz_oxide"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
-dependencies = [
- "adler",
 ]
 
 [[package]]
@@ -954,34 +954,34 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
 [[package]]
 name = "object"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
+checksum = "239da7f290cfa979f43f85a8efeee9a8a76d0827c356d37f9d3d7254d6b537fb"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.15.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.3.0"
+version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "parking_lot"
@@ -995,9 +995,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
+checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1034,14 +1034,14 @@ dependencies = [
 
 [[package]]
 name = "png"
-version = "0.17.6"
+version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f0e7f4c94ec26ff209cee506314212639d6c91b80afb82984819fafce9df01c"
+checksum = "5d708eaf860a19b19ce538740d2b4bdeeb8337fa53f7738455e706623ad5c638"
 dependencies = [
  "bitflags",
  "crc32fast",
  "flate2",
- "miniz_oxide 0.5.4",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1070,39 +1070,37 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.5.3"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
 dependencies = [
- "autocfg",
- "crossbeam-deque",
  "either",
  "rayon-core",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.9.3"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -1121,9 +1119,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1132,9 +1130,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.27"
+version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "remove_dir_all"
@@ -1153,15 +1151,15 @@ checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "scoped-tls"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scoped_threadpool"
@@ -1177,33 +1175,33 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scratch"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
+checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
 
 [[package]]
 name = "semver"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.146"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6df50b7a60a0ad48e1b42eb38373eac8ff785d619fb14db917b4e63d5439361f"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.146"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a714fd32ba1d66047ce7d53dabd809e9922d538f9047de13cc4cffca47b36205"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1212,9 +1210,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.87"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
+checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
  "itoa",
  "ryu",
@@ -1256,9 +1254,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1290,24 +1288,24 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1325,9 +1323,9 @@ dependencies = [
 
 [[package]]
 name = "tiff"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7259662e32d1e219321eb309d5f9d898b779769d81b76e762c07c8e5d38fcb65"
+checksum = "7449334f9ff2baf290d55d73983a7d6fa15e01198faef72af07e2a8db851e471"
 dependencies = [
  "flate2",
  "jpeg-decoder",
@@ -1336,9 +1334,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
 dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
@@ -1347,9 +1345,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
 dependencies = [
  "serde",
 ]
@@ -1362,9 +1360,9 @@ checksum = "ea68304e134ecd095ac6c3574494fc62b909f416c4fca77e440530221e549d3d"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-width"
@@ -1374,9 +1372,9 @@ checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "uuid"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb41e78f93363bb2df8b0e86a2ca30eed7806ea16ea0c790d757cf93f79be83"
+checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
 
 [[package]]
 name = "version_check"

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     </tr>
     <tr>
       <td align="center"><a href="https://www.floeschner.de/"><img src="https://avatars.githubusercontent.com/u/12967904?v=4?s=100" width="100px;" alt="Fabian Löschner"/><br /><sub><b>Fabian Löschner</b></sub></a><br /><a href="https://github.com/fzyzcjy/flutter_rust_bridge/commits?author=w1th0utnam3" title="Code">💻</a></td>
-      <td align="center"><a href="http://gsconrad.com"><img src="https://avatars.githubusercontent.com/u/15874617?v=4?s=100" width="100px;" alt="Gregory Conrad"/><br /><sub><b>Gregory Conrad</b></sub></a><br /><a href="https://github.com/fzyzcjy/flutter_rust_bridge/commits?author=GregoryConrad" title="Documentation">📖</a> <a href="https://github.com/fzyzcjy/flutter_rust_bridge/commits?author=GregoryConrad" title="Code">💻</a></td>
+      <td align="center"><a href="https://gsconrad.com"><img src="https://avatars.githubusercontent.com/u/15874617?v=4?s=100" width="100px;" alt="Gregory Conrad"/><br /><sub><b>Gregory Conrad</b></sub></a><br /><a href="https://github.com/fzyzcjy/flutter_rust_bridge/commits?author=GregoryConrad" title="Documentation">📖</a> <a href="https://github.com/fzyzcjy/flutter_rust_bridge/commits?author=GregoryConrad" title="Code">💻</a></td>
       <td align="center"><a href="https://www.zaynetro.com/"><img src="https://avatars.githubusercontent.com/u/627197?v=4?s=100" width="100px;" alt="Roman Zaynetdinov"/><br /><sub><b>Roman Zaynetdinov</b></sub></a><br /><a href="https://github.com/fzyzcjy/flutter_rust_bridge/commits?author=zaynetro" title="Documentation">📖</a></td>
     </tr>
   </tbody>

--- a/book/src/contributing/design.md
+++ b/book/src/contributing/design.md
@@ -84,11 +84,11 @@ Does not include delegated types.
 | `String`         | `wire_uint_8_list`       | `wire_uint_8_list`       | `String`          | `String`           | `String`          |
 | `Vec<String>`    | `wire_StringList`        | `wire_StringList`        | `Box<[String]>`   | `List`             | `List<String>`    |
 | `Vec<T>`         | `wire_list_t`            | `wire_list_t`            | `Box<[JsValue]>`  | `List`             | `List<T>`         |
-| `Box<T>`         | `*mut T`                 | `ffi.Pointer<T>`         | `*mut T`          | `int`              | `T`               |
+| `Box<T>`         | `*mut T`                 | `ffi.Pointer<T>`         | `T`               | `T`                | `T`               |
 | `Option<T>`      | `*mut T`                 | `ffi.Pointer<T>`         | `Option<T>`       | `T?`               | `T?`              |
-| `Option<Box<T>>` | `*mut T`                 | `ffi.Pointer<T>`         | `*mut T`          | `T?`               | `T?`              |
+| `Option<Box<T>>` | `*mut T`                 | `ffi.Pointer<T>`         | `Option<T>`       | `T?`               | `T?`              |
 | enum/struct `T`  | `*mut wire_t`            | `ffi.Pointer<T>`         | `Array`           | `List`             | class `T`         |
-| enum `T`[^3]     | `int`                    | `int`[^1]                | `i32`             | `int`              | enum `T`          |
+| enum `T`[^3]     | `i32`[^5]                | `int`[^1]                | `i32`[^5]         | `int`              | enum `T`          |
 
 ## Memory safety
 
@@ -193,6 +193,7 @@ What do you want to know? Feel free to create an issue in GitHub, and I will tel
 
 [^3]: Refers to C-style enums only (no fields).
 [^4]: This is currently implemented as a monotonically-increasing index.
+[^5]: Enums may also specify a `#[repr]`, which is planned to be implemented.
 
 [`bigint`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt
 [`bigint64array`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt64Array

--- a/frb_codegen/src/generator/dart/ty_boxed.rs
+++ b/frb_codegen/src/generator/dart/ty_boxed.rs
@@ -17,13 +17,11 @@ impl TypeDartGeneratorTrait for TypeBoxedGenerator<'_> {
                 self.ir.inner.safe_ident(),
             )
         });
-
         let ident = self.ir.safe_ident();
         let context = self.context.config.block_index;
         let inner = self.ir.inner.safe_ident();
-
         Acc {
-            io: Some(as_primitive.clone().unwrap_or_else(|| {
+            io: Some(as_primitive.unwrap_or_else(|| {
                 if self.ir.inner.is_array() {
                     format!("return api2wire_{inner}(raw);")
                 } else {
@@ -34,9 +32,10 @@ impl TypeDartGeneratorTrait for TypeBoxedGenerator<'_> {
                     )
                 }
             })),
-            wasm: Some(as_primitive.unwrap_or_else(|| {
-                format!("return api2wire_{}(raw);", self.ir.inner.safe_ident())
-            })),
+            wasm: Some(format!(
+                "return api2wire_{}(raw);",
+                self.ir.inner.safe_ident()
+            )),
             ..Default::default()
         }
     }
@@ -63,7 +62,7 @@ impl TypeDartGeneratorTrait for TypeBoxedGenerator<'_> {
             | RustOpaque(_)
             | EnumRef(_)
             | Primitive(IrTypePrimitive::I64 | IrTypePrimitive::U64 | IrTypePrimitive::Usize)
-            | Delegate(IrTypeDelegate::Array(_)) => {
+            | Delegate(IrTypeDelegate::Array(_) | IrTypeDelegate::PrimitiveEnum { .. }) => {
                 format!("return _wire2api_{}(raw);", self.ir.inner.safe_ident())
             }
             _ => gen_wire2api_simple_type_cast(&self.ir.dart_api_type()),

--- a/frb_codegen/src/generator/dart/ty_optional.rs
+++ b/frb_codegen/src/generator/dart/ty_optional.rs
@@ -11,11 +11,7 @@ impl TypeDartGeneratorTrait for TypeOptionalGenerator<'_> {
             Target::Io | Target::Wasm => Some(format!(
                 "return raw == null ? {} : api2wire_{}(raw);",
                 if target.is_wasm() {
-                    if self.ir.is_primitive() || self.ir.is_boxed_primitive() {
-                        "0"
-                    } else {
-                        "null"
-                    }
+                    "null"
                 } else {
                     "ffi.nullptr"
                 },

--- a/frb_codegen/src/generator/rust/ty_optional.rs
+++ b/frb_codegen/src/generator/rust/ty_optional.rs
@@ -21,17 +21,8 @@ impl TypeRustGeneratorTrait for TypeOptionalGenerator<'_> {
     }
 
     fn wire2api_jsvalue(&self) -> Option<std::borrow::Cow<str>> {
-        (!self.ir.inner.is_js_value()).then(|| {
-            if self.ir.is_primitive() {
-                format!(
-                    "(self != 0).then(|| *Wire2Api::<Box<{}>>::wire2api(self))",
-                    self.ir.inner.rust_api_type(),
-                )
-                .into()
-            } else {
-                "(!self.is_undefined() && !self.is_null()).then(|| self.wire2api())".into()
-            }
-        })
+        (!self.ir.inner.is_js_value())
+            .then(|| "(!self.is_undefined() && !self.is_null()).then(|| self.wire2api())".into())
     }
 
     fn convert_to_dart(&self, obj: String) -> String {

--- a/frb_codegen/src/ir/ty.rs
+++ b/frb_codegen/src/ir/ty.rs
@@ -116,8 +116,7 @@ impl IrType {
             | Self::StructRef(_)
             | Self::EnumRef(_)
             | Self::RustOpaque(_)
-            | Self::DartOpaque(_)
-            | Self::Delegate(IrTypeDelegate::PrimitiveEnum { .. }) => true,
+            | Self::DartOpaque(_) => true,
             Self::Boxed(IrTypeBoxed { inner, .. }) => inner.is_js_value(),
             _ => false,
         }

--- a/frb_codegen/src/ir/ty_boxed.rs
+++ b/frb_codegen/src/ir/ty_boxed.rs
@@ -32,7 +32,7 @@ impl IrTypeTrait for IrTypeBoxed {
     fn dart_wire_type(&self, target: Target) -> String {
         match target {
             Target::Wasm => {
-                if self.inner.is_js_value() || self.inner.is_array() {
+                if self.inner.is_js_value() || self.inner.is_array() || self.inner.is_primitive() {
                     self.inner.dart_wire_type(target)
                 } else {
                     format!("int /* *{} */", self.inner.rust_wire_type(target))
@@ -62,10 +62,15 @@ impl IrTypeTrait for IrTypeBoxed {
     }
 
     fn rust_wire_type(&self, target: Target) -> String {
-        self.inner.rust_wire_type(target)
+        if target.is_wasm() && self.inner.is_primitive() {
+            "JsValue".into()
+        } else {
+            self.inner.rust_wire_type(target)
+        }
     }
 
     fn rust_wire_is_pointer(&self, target: Target) -> bool {
-        !target.is_wasm() || (!self.inner.is_js_value() && !self.inner.is_array())
+        !target.is_wasm()
+            || !self.inner.is_js_value() && !self.inner.is_array() && !self.inner.is_primitive()
     }
 }

--- a/frb_example/pure_dart/dart/lib/bridge_generated.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.dart
@@ -639,7 +639,7 @@ class FlutterRustBridgeExampleSingleBlockTestImpl implements FlutterRustBridgeEx
     var arg0 = _platform.api2wire_String(input);
     return _platform.executeNormal(FlutterRustBridgeTask(
       callFfi: (port_) => _platform.inner.wire_handle_return_enum(port_, arg0),
-      parseSuccessData: _wire2api_opt_weekdays,
+      parseSuccessData: _wire2api_opt_box_autoadd_weekdays,
       constMeta: kHandleReturnEnumConstMeta,
       argValues: [input],
       hint: hint,
@@ -1055,7 +1055,7 @@ class FlutterRustBridgeExampleSingleBlockTestImpl implements FlutterRustBridgeEx
     var arg0 = _platform.api2wire_box_autoadd_measure(measure);
     return _platform.executeNormal(FlutterRustBridgeTask(
       callFfi: (port_) => _platform.inner.wire_multiply_by_ten(port_, arg0),
-      parseSuccessData: _wire2api_opt_measure,
+      parseSuccessData: _wire2api_opt_box_autoadd_measure,
       constMeta: kMultiplyByTenConstMeta,
       argValues: [measure],
       hint: hint,
@@ -2561,8 +2561,16 @@ class FlutterRustBridgeExampleSingleBlockTestImpl implements FlutterRustBridgeEx
     return _wire2api_i64(raw);
   }
 
+  Measure _wire2api_box_autoadd_measure(dynamic raw) {
+    return _wire2api_measure(raw);
+  }
+
   NewTypeInt _wire2api_box_autoadd_new_type_int(dynamic raw) {
     return _wire2api_new_type_int(raw);
+  }
+
+  Weekdays _wire2api_box_autoadd_weekdays(dynamic raw) {
+    return _wire2api_weekdays(raw);
   }
 
   Distance _wire2api_box_distance(dynamic raw) {
@@ -3019,8 +3027,16 @@ class FlutterRustBridgeExampleSingleBlockTestImpl implements FlutterRustBridgeEx
     return raw == null ? null : _wire2api_box_autoadd_i64(raw);
   }
 
+  Measure? _wire2api_opt_box_autoadd_measure(dynamic raw) {
+    return raw == null ? null : _wire2api_box_autoadd_measure(raw);
+  }
+
   NewTypeInt? _wire2api_opt_box_autoadd_new_type_int(dynamic raw) {
     return raw == null ? null : _wire2api_box_autoadd_new_type_int(raw);
+  }
+
+  Weekdays? _wire2api_opt_box_autoadd_weekdays(dynamic raw) {
+    return raw == null ? null : _wire2api_box_autoadd_weekdays(raw);
   }
 
   Float32List? _wire2api_opt_float_32_list(dynamic raw) {
@@ -3051,16 +3067,8 @@ class FlutterRustBridgeExampleSingleBlockTestImpl implements FlutterRustBridgeEx
     return raw == null ? null : _wire2api_list_opt_box_autoadd_attribute(raw);
   }
 
-  Measure? _wire2api_opt_measure(dynamic raw) {
-    return raw == null ? null : _wire2api_measure(raw);
-  }
-
   Uint8List? _wire2api_opt_uint_8_list(dynamic raw) {
     return raw == null ? null : _wire2api_uint_8_list(raw);
-  }
-
-  Weekdays? _wire2api_opt_weekdays(dynamic raw) {
-    return raw == null ? null : _wire2api_weekdays(raw);
   }
 
   Point _wire2api_point(dynamic raw) {

--- a/frb_example/pure_dart/dart/lib/bridge_generated.web.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.web.dart
@@ -178,8 +178,8 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
   }
 
   @protected
-  int /* *bool */ api2wire_box_autoadd_bool(bool raw) {
-    return inner.new_box_autoadd_bool_0(api2wire_bool(raw));
+  bool api2wire_box_autoadd_bool(bool raw) {
+    return api2wire_bool(raw);
   }
 
   @protected
@@ -213,8 +213,8 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
   }
 
   @protected
-  int /* *f64 */ api2wire_box_autoadd_f64(double raw) {
-    return inner.new_box_autoadd_f64_0(api2wire_f64(raw));
+  double api2wire_box_autoadd_f64(double raw) {
+    return api2wire_f64(raw);
   }
 
   @protected
@@ -233,13 +233,13 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
   }
 
   @protected
-  int /* *i32 */ api2wire_box_autoadd_i32(int raw) {
-    return inner.new_box_autoadd_i32_0(api2wire_i32(raw));
+  int api2wire_box_autoadd_i32(int raw) {
+    return api2wire_i32(raw);
   }
 
   @protected
-  int /* *i64 */ api2wire_box_autoadd_i64(int raw) {
-    return inner.new_box_autoadd_i64_0(api2wire_i64(raw));
+  Object api2wire_box_autoadd_i64(int raw) {
+    return api2wire_i64(raw);
   }
 
   @protected
@@ -318,8 +318,8 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
   }
 
   @protected
-  int /* *bool */ api2wire_box_bool(bool raw) {
-    return inner.new_box_bool_0(api2wire_bool(raw));
+  bool api2wire_box_bool(bool raw) {
+    return api2wire_bool(raw);
   }
 
   @protected
@@ -333,23 +333,23 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
   }
 
   @protected
-  int /* *f64 */ api2wire_box_f64(double raw) {
-    return inner.new_box_f64_0(api2wire_f64(raw));
+  double api2wire_box_f64(double raw) {
+    return api2wire_f64(raw);
   }
 
   @protected
-  int /* *i32 */ api2wire_box_i32(int raw) {
-    return inner.new_box_i32_0(api2wire_i32(raw));
+  int api2wire_box_i32(int raw) {
+    return api2wire_i32(raw);
   }
 
   @protected
-  int /* *i64 */ api2wire_box_i64(int raw) {
-    return inner.new_box_i64_0(api2wire_i64(raw));
+  Object api2wire_box_i64(int raw) {
+    return api2wire_i64(raw);
   }
 
   @protected
-  int /* *i8 */ api2wire_box_i8(int raw) {
-    return inner.new_box_i8_0(api2wire_i8(raw));
+  int api2wire_box_i8(int raw) {
+    return api2wire_i8(raw);
   }
 
   @protected
@@ -368,8 +368,8 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
   }
 
   @protected
-  int /* *u8 */ api2wire_box_u8(int raw) {
-    return inner.new_box_u8_0(api2wire_u8(raw));
+  int api2wire_box_u8(int raw) {
+    return api2wire_u8(raw);
   }
 
   @protected
@@ -379,7 +379,7 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
 
   @protected
   int api2wire_box_weekdays(Weekdays raw) {
-    return inner.new_box_weekdays_0(api2wire_weekdays(raw));
+    return api2wire_weekdays(raw);
   }
 
   @protected
@@ -669,8 +669,8 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
   }
 
   @protected
-  int /* *bool */ ? api2wire_opt_box_autoadd_bool(bool? raw) {
-    return raw == null ? 0 : api2wire_box_autoadd_bool(raw);
+  bool? api2wire_opt_box_autoadd_bool(bool? raw) {
+    return raw == null ? null : api2wire_box_autoadd_bool(raw);
   }
 
   @protected
@@ -679,18 +679,18 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
   }
 
   @protected
-  int /* *f64 */ ? api2wire_opt_box_autoadd_f64(double? raw) {
-    return raw == null ? 0 : api2wire_box_autoadd_f64(raw);
+  double? api2wire_opt_box_autoadd_f64(double? raw) {
+    return raw == null ? null : api2wire_box_autoadd_f64(raw);
   }
 
   @protected
-  int /* *i32 */ ? api2wire_opt_box_autoadd_i32(int? raw) {
-    return raw == null ? 0 : api2wire_box_autoadd_i32(raw);
+  int? api2wire_opt_box_autoadd_i32(int? raw) {
+    return raw == null ? null : api2wire_box_autoadd_i32(raw);
   }
 
   @protected
-  int /* *i64 */ ? api2wire_opt_box_autoadd_i64(int? raw) {
-    return raw == null ? 0 : api2wire_box_autoadd_i64(raw);
+  Object? api2wire_opt_box_autoadd_i64(int? raw) {
+    return raw == null ? null : api2wire_box_autoadd_i64(raw);
   }
 
   @protected
@@ -699,8 +699,8 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
   }
 
   @protected
-  int /* *bool */ ? api2wire_opt_box_bool(bool? raw) {
-    return raw == null ? 0 : api2wire_box_bool(raw);
+  bool? api2wire_opt_box_bool(bool? raw) {
+    return raw == null ? null : api2wire_box_bool(raw);
   }
 
   @protected
@@ -709,28 +709,28 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
   }
 
   @protected
-  int /* *f64 */ ? api2wire_opt_box_f64(double? raw) {
-    return raw == null ? 0 : api2wire_box_f64(raw);
+  double? api2wire_opt_box_f64(double? raw) {
+    return raw == null ? null : api2wire_box_f64(raw);
   }
 
   @protected
-  int /* *i32 */ ? api2wire_opt_box_i32(int? raw) {
-    return raw == null ? 0 : api2wire_box_i32(raw);
+  int? api2wire_opt_box_i32(int? raw) {
+    return raw == null ? null : api2wire_box_i32(raw);
   }
 
   @protected
-  int /* *i64 */ ? api2wire_opt_box_i64(int? raw) {
-    return raw == null ? 0 : api2wire_box_i64(raw);
+  Object? api2wire_opt_box_i64(int? raw) {
+    return raw == null ? null : api2wire_box_i64(raw);
   }
 
   @protected
-  int /* *i8 */ ? api2wire_opt_box_i8(int? raw) {
-    return raw == null ? 0 : api2wire_box_i8(raw);
+  int? api2wire_opt_box_i8(int? raw) {
+    return raw == null ? null : api2wire_box_i8(raw);
   }
 
   @protected
-  int /* *u8 */ ? api2wire_opt_box_u8(int? raw) {
-    return raw == null ? 0 : api2wire_box_u8(raw);
+  int? api2wire_opt_box_u8(int? raw) {
+    return raw == null ? null : api2wire_box_u8(raw);
   }
 
   @protected
@@ -930,17 +930,10 @@ class FlutterRustBridgeExampleSingleBlockTestWasmModule implements WasmModule {
 
   external dynamic /* void */ wire_handle_optional_increment(NativePortType port_, List<dynamic>? opt);
 
-  external dynamic /* void */ wire_handle_increment_boxed_optional(NativePortType port_, int /* *f64 */ ? opt);
+  external dynamic /* void */ wire_handle_increment_boxed_optional(NativePortType port_, double? opt);
 
-  external dynamic /* void */ wire_handle_option_box_arguments(
-      NativePortType port_,
-      int /* *i8 */ ? i8box,
-      int /* *u8 */ ? u8box,
-      int /* *i32 */ ? i32box,
-      int /* *i64 */ ? i64box,
-      int /* *f64 */ ? f64box,
-      int /* *bool */ ? boolbox,
-      List<dynamic>? structbox);
+  external dynamic /* void */ wire_handle_option_box_arguments(NativePortType port_, int? i8box, int? u8box,
+      int? i32box, Object? i64box, double? f64box, bool? boolbox, List<dynamic>? structbox);
 
   external dynamic /* void */ wire_print_note(NativePortType port_, List<dynamic> note);
 
@@ -1154,28 +1147,6 @@ class FlutterRustBridgeExampleSingleBlockTestWasmModule implements WasmModule {
   external dynamic /* void */ wire_handle_some_static_stream_sink_single_arg__static_method__ConcatenateWith(
       NativePortType port_);
 
-  external int /* *mut bool */ new_box_autoadd_bool_0(bool value);
-
-  external int /* *mut f64 */ new_box_autoadd_f64_0(double value);
-
-  external int /* *mut i32 */ new_box_autoadd_i32_0(int value);
-
-  external int /* *mut i64 */ new_box_autoadd_i64_0(Object value);
-
-  external int /* *mut bool */ new_box_bool_0(bool value);
-
-  external int /* *mut f64 */ new_box_f64_0(double value);
-
-  external int /* *mut i32 */ new_box_i32_0(int value);
-
-  external int /* *mut i64 */ new_box_i64_0(Object value);
-
-  external int /* *mut i8 */ new_box_i8_0(int value);
-
-  external int /* *mut u8 */ new_box_u8_0(int value);
-
-  external int /* *mut i32 */ new_box_weekdays_0(int value);
-
   external dynamic /*  */ drop_opaque_BoxDartDebug(ptr);
 
   external int /* *const c_void */ share_opaque_BoxDartDebug(ptr);
@@ -1300,18 +1271,11 @@ class FlutterRustBridgeExampleSingleBlockTestWire
   void wire_handle_optional_increment(NativePortType port_, List<dynamic>? opt) =>
       wasmModule.wire_handle_optional_increment(port_, opt);
 
-  void wire_handle_increment_boxed_optional(NativePortType port_, int /* *f64 */ ? opt) =>
+  void wire_handle_increment_boxed_optional(NativePortType port_, double? opt) =>
       wasmModule.wire_handle_increment_boxed_optional(port_, opt);
 
-  void wire_handle_option_box_arguments(
-          NativePortType port_,
-          int /* *i8 */ ? i8box,
-          int /* *u8 */ ? u8box,
-          int /* *i32 */ ? i32box,
-          int /* *i64 */ ? i64box,
-          int /* *f64 */ ? f64box,
-          int /* *bool */ ? boolbox,
-          List<dynamic>? structbox) =>
+  void wire_handle_option_box_arguments(NativePortType port_, int? i8box, int? u8box, int? i32box, Object? i64box,
+          double? f64box, bool? boolbox, List<dynamic>? structbox) =>
       wasmModule.wire_handle_option_box_arguments(port_, i8box, u8box, i32box, i64box, f64box, boolbox, structbox);
 
   void wire_print_note(NativePortType port_, List<dynamic> note) => wasmModule.wire_print_note(port_, note);
@@ -1561,28 +1525,6 @@ class FlutterRustBridgeExampleSingleBlockTestWire
 
   void wire_handle_some_static_stream_sink_single_arg__static_method__ConcatenateWith(NativePortType port_) =>
       wasmModule.wire_handle_some_static_stream_sink_single_arg__static_method__ConcatenateWith(port_);
-
-  int /* *mut bool */ new_box_autoadd_bool_0(bool value) => wasmModule.new_box_autoadd_bool_0(value);
-
-  int /* *mut f64 */ new_box_autoadd_f64_0(double value) => wasmModule.new_box_autoadd_f64_0(value);
-
-  int /* *mut i32 */ new_box_autoadd_i32_0(int value) => wasmModule.new_box_autoadd_i32_0(value);
-
-  int /* *mut i64 */ new_box_autoadd_i64_0(Object value) => wasmModule.new_box_autoadd_i64_0(value);
-
-  int /* *mut bool */ new_box_bool_0(bool value) => wasmModule.new_box_bool_0(value);
-
-  int /* *mut f64 */ new_box_f64_0(double value) => wasmModule.new_box_f64_0(value);
-
-  int /* *mut i32 */ new_box_i32_0(int value) => wasmModule.new_box_i32_0(value);
-
-  int /* *mut i64 */ new_box_i64_0(Object value) => wasmModule.new_box_i64_0(value);
-
-  int /* *mut i8 */ new_box_i8_0(int value) => wasmModule.new_box_i8_0(value);
-
-  int /* *mut u8 */ new_box_u8_0(int value) => wasmModule.new_box_u8_0(value);
-
-  int /* *mut i32 */ new_box_weekdays_0(int value) => wasmModule.new_box_weekdays_0(value);
 
   dynamic /*  */ drop_opaque_BoxDartDebug(ptr) => wasmModule.drop_opaque_BoxDartDebug(ptr);
 

--- a/frb_example/pure_dart/rust/src/api.rs
+++ b/frb_example/pure_dart/rust/src/api.rs
@@ -914,7 +914,6 @@ pub fn datetime_local(d: chrono::DateTime<chrono::Local>) -> chrono::DateTime<ch
     assert_eq!(&d.month(), &9);
     assert_eq!(&d.day(), &10);
     if cfg!(target_arch = "wasm32") {
-        assert_eq!(&d.hour(), &19);
         assert_eq!(&d.nanosecond(), &123_000_000);
     } else {
         assert_eq!(&d.hour(), &20);

--- a/frb_example/pure_dart/rust/src/api.rs
+++ b/frb_example/pure_dart/rust/src/api.rs
@@ -913,13 +913,15 @@ pub fn datetime_local(d: chrono::DateTime<chrono::Local>) -> chrono::DateTime<ch
     assert_eq!(&d.year(), &2022);
     assert_eq!(&d.month(), &9);
     assert_eq!(&d.day(), &10);
-    assert_eq!(&d.hour(), &20);
+    if cfg!(target_arch = "wasm32") {
+        assert_eq!(&d.hour(), &19);
+        assert_eq!(&d.nanosecond(), &123_000_000);
+    } else {
+        assert_eq!(&d.hour(), &20);
+        assert_eq!(&d.nanosecond(), &123_456_000);
+    }
     assert_eq!(&d.minute(), &48);
     assert_eq!(&d.second(), &53);
-    #[cfg(target_arch = "wasm32")]
-    assert_eq!(&d.nanosecond(), &123_000_000);
-    #[cfg(not(target_arch = "wasm32"))]
-    assert_eq!(&d.nanosecond(), &123_456_000);
     d
 }
 

--- a/frb_example/pure_dart/rust/src/bridge_generated.io.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.io.rs
@@ -1290,32 +1290,7 @@ impl Wire2Api<chrono::Duration> for i64 {
         chrono::Duration::microseconds(self)
     }
 }
-impl Wire2Api<chrono::DateTime<chrono::Local>> for i64 {
-    fn wire2api(self) -> chrono::DateTime<chrono::Local> {
-        let Timestamp { s, ns } = wire2api_timestamp(self);
-        chrono::DateTime::<chrono::Local>::from(chrono::DateTime::<chrono::Utc>::from_utc(
-            chrono::NaiveDateTime::from_timestamp_opt(s, ns)
-                .expect("invalid or out-of-range datetime"),
-            chrono::Utc,
-        ))
-    }
-}
-impl Wire2Api<chrono::NaiveDateTime> for i64 {
-    fn wire2api(self) -> chrono::NaiveDateTime {
-        let Timestamp { s, ns } = wire2api_timestamp(self);
-        chrono::NaiveDateTime::from_timestamp_opt(s, ns).expect("invalid or out-of-range datetime")
-    }
-}
-impl Wire2Api<chrono::DateTime<chrono::Utc>> for i64 {
-    fn wire2api(self) -> chrono::DateTime<chrono::Utc> {
-        let Timestamp { s, ns } = wire2api_timestamp(self);
-        chrono::DateTime::<chrono::Utc>::from_utc(
-            chrono::NaiveDateTime::from_timestamp_opt(s, ns)
-                .expect("invalid or out-of-range datetime"),
-            chrono::Utc,
-        )
-    }
-}
+
 impl Wire2Api<DartOpaque> for wire_DartOpaque {
     fn wire2api(self) -> DartOpaque {
         unsafe { DartOpaque::new(self.handle as _, self.port) }
@@ -1470,7 +1445,11 @@ impl Wire2Api<Attribute> for *mut wire_Attribute {
         Wire2Api::<Attribute>::wire2api(*wrap).into()
     }
 }
-
+impl Wire2Api<bool> for *mut bool {
+    fn wire2api(self) -> bool {
+        unsafe { *support::box_from_leak_ptr(self) }
+    }
+}
 impl Wire2Api<ConcatenateWith> for *mut wire_ConcatenateWith {
     fn wire2api(self) -> ConcatenateWith {
         let wrap = unsafe { support::box_from_leak_ptr(self) };
@@ -1507,7 +1486,11 @@ impl Wire2Api<ExoticOptionals> for *mut wire_ExoticOptionals {
         Wire2Api::<ExoticOptionals>::wire2api(*wrap).into()
     }
 }
-
+impl Wire2Api<f64> for *mut f64 {
+    fn wire2api(self) -> f64 {
+        unsafe { *support::box_from_leak_ptr(self) }
+    }
+}
 impl Wire2Api<FeatureChrono> for *mut wire_FeatureChrono {
     fn wire2api(self) -> FeatureChrono {
         let wrap = unsafe { support::box_from_leak_ptr(self) };
@@ -1526,7 +1509,16 @@ impl Wire2Api<FeedId> for *mut wire_FeedId {
         Wire2Api::<FeedId>::wire2api(*wrap).into()
     }
 }
-
+impl Wire2Api<i32> for *mut i32 {
+    fn wire2api(self) -> i32 {
+        unsafe { *support::box_from_leak_ptr(self) }
+    }
+}
+impl Wire2Api<i64> for *mut i64 {
+    fn wire2api(self) -> i64 {
+        unsafe { *support::box_from_leak_ptr(self) }
+    }
+}
 impl Wire2Api<KitchenSink> for *mut wire_KitchenSink {
     fn wire2api(self) -> KitchenSink {
         let wrap = unsafe { support::box_from_leak_ptr(self) };
@@ -1617,7 +1609,11 @@ impl Wire2Api<Box<Blob>> for *mut wire_Blob {
         Wire2Api::<Blob>::wire2api(*wrap).into()
     }
 }
-
+impl Wire2Api<Box<bool>> for *mut bool {
+    fn wire2api(self) -> Box<bool> {
+        unsafe { support::box_from_leak_ptr(self) }
+    }
+}
 impl Wire2Api<Box<Distance>> for *mut wire_Distance {
     fn wire2api(self) -> Box<Distance> {
         let wrap = unsafe { support::box_from_leak_ptr(self) };
@@ -1630,7 +1626,26 @@ impl Wire2Api<Box<ExoticOptionals>> for *mut wire_ExoticOptionals {
         Wire2Api::<ExoticOptionals>::wire2api(*wrap).into()
     }
 }
-
+impl Wire2Api<Box<f64>> for *mut f64 {
+    fn wire2api(self) -> Box<f64> {
+        unsafe { support::box_from_leak_ptr(self) }
+    }
+}
+impl Wire2Api<Box<i32>> for *mut i32 {
+    fn wire2api(self) -> Box<i32> {
+        unsafe { support::box_from_leak_ptr(self) }
+    }
+}
+impl Wire2Api<Box<i64>> for *mut i64 {
+    fn wire2api(self) -> Box<i64> {
+        unsafe { support::box_from_leak_ptr(self) }
+    }
+}
+impl Wire2Api<Box<i8>> for *mut i8 {
+    fn wire2api(self) -> Box<i8> {
+        unsafe { support::box_from_leak_ptr(self) }
+    }
+}
 impl Wire2Api<Box<KitchenSink>> for *mut wire_KitchenSink {
     fn wire2api(self) -> Box<KitchenSink> {
         let wrap = unsafe { support::box_from_leak_ptr(self) };
@@ -1649,7 +1664,11 @@ impl Wire2Api<Box<Speed>> for *mut wire_Speed {
         Wire2Api::<Speed>::wire2api(*wrap).into()
     }
 }
-
+impl Wire2Api<Box<u8>> for *mut u8 {
+    fn wire2api(self) -> Box<u8> {
+        unsafe { support::box_from_leak_ptr(self) }
+    }
+}
 impl Wire2Api<Box<[u8; 1600]>> for *mut wire_uint_8_list {
     fn wire2api(self) -> Box<[u8; 1600]> {
         Wire2Api::<[u8; 1600]>::wire2api(self).into()

--- a/frb_example/pure_dart/rust/src/bridge_generated.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.rs
@@ -2137,6 +2137,33 @@ where
     }
 }
 
+impl Wire2Api<chrono::DateTime<chrono::Local>> for i64 {
+    fn wire2api(self) -> chrono::DateTime<chrono::Local> {
+        let Timestamp { s, ns } = wire2api_timestamp(self);
+        chrono::DateTime::<chrono::Local>::from(chrono::DateTime::<chrono::Utc>::from_utc(
+            chrono::NaiveDateTime::from_timestamp_opt(s, ns)
+                .expect("invalid or out-of-range datetime"),
+            chrono::Utc,
+        ))
+    }
+}
+impl Wire2Api<chrono::NaiveDateTime> for i64 {
+    fn wire2api(self) -> chrono::NaiveDateTime {
+        let Timestamp { s, ns } = wire2api_timestamp(self);
+        chrono::NaiveDateTime::from_timestamp_opt(s, ns).expect("invalid or out-of-range datetime")
+    }
+}
+impl Wire2Api<chrono::DateTime<chrono::Utc>> for i64 {
+    fn wire2api(self) -> chrono::DateTime<chrono::Utc> {
+        let Timestamp { s, ns } = wire2api_timestamp(self);
+        chrono::DateTime::<chrono::Utc>::from_utc(
+            chrono::NaiveDateTime::from_timestamp_opt(s, ns)
+                .expect("invalid or out-of-range datetime"),
+            chrono::Utc,
+        )
+    }
+}
+
 impl Wire2Api<ApplicationMode> for i32 {
     fn wire2api(self) -> ApplicationMode {
         match self {
@@ -2150,62 +2177,6 @@ impl Wire2Api<ApplicationMode> for i32 {
 impl Wire2Api<bool> for bool {
     fn wire2api(self) -> bool {
         self
-    }
-}
-
-impl Wire2Api<bool> for *mut bool {
-    fn wire2api(self) -> bool {
-        unsafe { *support::box_from_leak_ptr(self) }
-    }
-}
-
-impl Wire2Api<f64> for *mut f64 {
-    fn wire2api(self) -> f64 {
-        unsafe { *support::box_from_leak_ptr(self) }
-    }
-}
-
-impl Wire2Api<i32> for *mut i32 {
-    fn wire2api(self) -> i32 {
-        unsafe { *support::box_from_leak_ptr(self) }
-    }
-}
-impl Wire2Api<i64> for *mut i64 {
-    fn wire2api(self) -> i64 {
-        unsafe { *support::box_from_leak_ptr(self) }
-    }
-}
-
-impl Wire2Api<Box<bool>> for *mut bool {
-    fn wire2api(self) -> Box<bool> {
-        unsafe { support::box_from_leak_ptr(self) }
-    }
-}
-
-impl Wire2Api<Box<f64>> for *mut f64 {
-    fn wire2api(self) -> Box<f64> {
-        unsafe { support::box_from_leak_ptr(self) }
-    }
-}
-impl Wire2Api<Box<i32>> for *mut i32 {
-    fn wire2api(self) -> Box<i32> {
-        unsafe { support::box_from_leak_ptr(self) }
-    }
-}
-impl Wire2Api<Box<i64>> for *mut i64 {
-    fn wire2api(self) -> Box<i64> {
-        unsafe { support::box_from_leak_ptr(self) }
-    }
-}
-impl Wire2Api<Box<i8>> for *mut i8 {
-    fn wire2api(self) -> Box<i8> {
-        unsafe { support::box_from_leak_ptr(self) }
-    }
-}
-
-impl Wire2Api<Box<u8>> for *mut u8 {
-    fn wire2api(self) -> Box<u8> {
-        unsafe { support::box_from_leak_ptr(self) }
     }
 }
 

--- a/frb_example/pure_dart/rust/src/bridge_generated.web.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.web.rs
@@ -183,19 +183,19 @@ pub fn wire_handle_optional_increment(port_: MessagePort, opt: JsValue) {
 }
 
 #[wasm_bindgen]
-pub fn wire_handle_increment_boxed_optional(port_: MessagePort, opt: *mut f64) {
+pub fn wire_handle_increment_boxed_optional(port_: MessagePort, opt: JsValue) {
     wire_handle_increment_boxed_optional_impl(port_, opt)
 }
 
 #[wasm_bindgen]
 pub fn wire_handle_option_box_arguments(
     port_: MessagePort,
-    i8box: *mut i8,
-    u8box: *mut u8,
-    i32box: *mut i32,
-    i64box: *mut i64,
-    f64box: *mut f64,
-    boolbox: *mut bool,
+    i8box: JsValue,
+    u8box: JsValue,
+    i32box: JsValue,
+    i64box: JsValue,
+    f64box: JsValue,
+    boolbox: JsValue,
     structbox: JsValue,
 ) {
     wire_handle_option_box_arguments_impl(
@@ -738,61 +738,6 @@ pub fn wire_handle_some_static_stream_sink_single_arg__static_method__Concatenat
 
 // Section: allocate functions
 
-#[wasm_bindgen]
-pub fn new_box_autoadd_bool_0(value: bool) -> *mut bool {
-    support::new_leak_box_ptr(value)
-}
-
-#[wasm_bindgen]
-pub fn new_box_autoadd_f64_0(value: f64) -> *mut f64 {
-    support::new_leak_box_ptr(value)
-}
-
-#[wasm_bindgen]
-pub fn new_box_autoadd_i32_0(value: i32) -> *mut i32 {
-    support::new_leak_box_ptr(value)
-}
-
-#[wasm_bindgen]
-pub fn new_box_autoadd_i64_0(value: i64) -> *mut i64 {
-    support::new_leak_box_ptr(value)
-}
-
-#[wasm_bindgen]
-pub fn new_box_bool_0(value: bool) -> *mut bool {
-    support::new_leak_box_ptr(value)
-}
-
-#[wasm_bindgen]
-pub fn new_box_f64_0(value: f64) -> *mut f64 {
-    support::new_leak_box_ptr(value)
-}
-
-#[wasm_bindgen]
-pub fn new_box_i32_0(value: i32) -> *mut i32 {
-    support::new_leak_box_ptr(value)
-}
-
-#[wasm_bindgen]
-pub fn new_box_i64_0(value: i64) -> *mut i64 {
-    support::new_leak_box_ptr(value)
-}
-
-#[wasm_bindgen]
-pub fn new_box_i8_0(value: i8) -> *mut i8 {
-    support::new_leak_box_ptr(value)
-}
-
-#[wasm_bindgen]
-pub fn new_box_u8_0(value: u8) -> *mut u8 {
-    support::new_leak_box_ptr(value)
-}
-
-#[wasm_bindgen]
-pub fn new_box_weekdays_0(value: i32) -> *mut i32 {
-    support::new_leak_box_ptr(value)
-}
-
 // Section: related functions
 
 #[wasm_bindgen]
@@ -922,32 +867,7 @@ impl Wire2Api<chrono::Duration> for i64 {
         chrono::Duration::milliseconds(self)
     }
 }
-impl Wire2Api<chrono::DateTime<chrono::Local>> for i64 {
-    fn wire2api(self) -> chrono::DateTime<chrono::Local> {
-        let Timestamp { s, ns } = wire2api_timestamp(self);
-        chrono::DateTime::<chrono::Local>::from(chrono::DateTime::<chrono::Utc>::from_utc(
-            chrono::NaiveDateTime::from_timestamp_opt(s, ns)
-                .expect("invalid or out-of-range datetime"),
-            chrono::Utc,
-        ))
-    }
-}
-impl Wire2Api<chrono::NaiveDateTime> for i64 {
-    fn wire2api(self) -> chrono::NaiveDateTime {
-        let Timestamp { s, ns } = wire2api_timestamp(self);
-        chrono::NaiveDateTime::from_timestamp_opt(s, ns).expect("invalid or out-of-range datetime")
-    }
-}
-impl Wire2Api<chrono::DateTime<chrono::Utc>> for i64 {
-    fn wire2api(self) -> chrono::DateTime<chrono::Utc> {
-        let Timestamp { s, ns } = wire2api_timestamp(self);
-        chrono::DateTime::<chrono::Utc>::from_utc(
-            chrono::NaiveDateTime::from_timestamp_opt(s, ns)
-                .expect("invalid or out-of-range datetime"),
-            chrono::Utc,
-        )
-    }
-}
+
 impl Wire2Api<DartOpaque> for JsValue {
     fn wire2api(self) -> DartOpaque {
         let arr = self.dyn_into::<JsArray>().unwrap();
@@ -1781,7 +1701,7 @@ impl Wire2Api<Box<Blob>> for JsValue {
 }
 impl Wire2Api<Box<bool>> for JsValue {
     fn wire2api(self) -> Box<bool> {
-        (self.unchecked_into_f64() as usize as *mut bool).wire2api()
+        Box::new(self.wire2api())
     }
 }
 impl Wire2Api<Box<Distance>> for JsValue {
@@ -1796,22 +1716,22 @@ impl Wire2Api<Box<ExoticOptionals>> for JsValue {
 }
 impl Wire2Api<Box<f64>> for JsValue {
     fn wire2api(self) -> Box<f64> {
-        (self.unchecked_into_f64() as usize as *mut f64).wire2api()
+        Box::new(self.wire2api())
     }
 }
 impl Wire2Api<Box<i32>> for JsValue {
     fn wire2api(self) -> Box<i32> {
-        (self.unchecked_into_f64() as usize as *mut i32).wire2api()
+        Box::new(self.wire2api())
     }
 }
 impl Wire2Api<Box<i64>> for JsValue {
     fn wire2api(self) -> Box<i64> {
-        (self.unchecked_into_f64() as usize as *mut i64).wire2api()
+        Box::new(self.wire2api())
     }
 }
 impl Wire2Api<Box<i8>> for JsValue {
     fn wire2api(self) -> Box<i8> {
-        (self.unchecked_into_f64() as usize as *mut i8).wire2api()
+        Box::new(self.wire2api())
     }
 }
 impl Wire2Api<Box<KitchenSink>> for JsValue {
@@ -1831,7 +1751,7 @@ impl Wire2Api<Box<Speed>> for JsValue {
 }
 impl Wire2Api<Box<u8>> for JsValue {
     fn wire2api(self) -> Box<u8> {
-        (self.unchecked_into_f64() as usize as *mut u8).wire2api()
+        Box::new(self.wire2api())
     }
 }
 impl Wire2Api<Box<[u8; 1600]>> for JsValue {
@@ -1842,7 +1762,8 @@ impl Wire2Api<Box<[u8; 1600]>> for JsValue {
 }
 impl Wire2Api<Box<Weekdays>> for JsValue {
     fn wire2api(self) -> Box<Weekdays> {
-        Box::new(self.wire2api())
+        let ptr: Box<i32> = self.wire2api();
+        Box::new(ptr.wire2api())
     }
 }
 impl Wire2Api<f32> for JsValue {
@@ -1923,22 +1844,22 @@ impl Wire2Api<Option<ZeroCopyBuffer<Vec<u8>>>> for JsValue {
 }
 impl Wire2Api<Option<bool>> for JsValue {
     fn wire2api(self) -> Option<bool> {
-        (self != 0).then(|| *Wire2Api::<Box<bool>>::wire2api(self))
+        (!self.is_undefined() && !self.is_null()).then(|| self.wire2api())
     }
 }
 impl Wire2Api<Option<f64>> for JsValue {
     fn wire2api(self) -> Option<f64> {
-        (self != 0).then(|| *Wire2Api::<Box<f64>>::wire2api(self))
+        (!self.is_undefined() && !self.is_null()).then(|| self.wire2api())
     }
 }
 impl Wire2Api<Option<i32>> for JsValue {
     fn wire2api(self) -> Option<i32> {
-        (self != 0).then(|| *Wire2Api::<Box<i32>>::wire2api(self))
+        (!self.is_undefined() && !self.is_null()).then(|| self.wire2api())
     }
 }
 impl Wire2Api<Option<i64>> for JsValue {
     fn wire2api(self) -> Option<i64> {
-        (self != 0).then(|| *Wire2Api::<Box<i64>>::wire2api(self))
+        (!self.is_undefined() && !self.is_null()).then(|| self.wire2api())
     }
 }
 impl Wire2Api<Option<Box<bool>>> for JsValue {

--- a/frb_example/pure_dart_multi/rust/src/lib.rs
+++ b/frb_example/pure_dart_multi/rust/src/lib.rs
@@ -1,4 +1,4 @@
 mod api_1;
 mod api_2;
-mod generated_api_1; /* AUTO INJECTED BY flutter_rust_bridge. This line may not be accurate, and you can change it according to your needs. */
-mod generated_api_2; /* AUTO INJECTED BY flutter_rust_bridge. This line may not be accurate, and you can change it according to your needs. */
+mod generated_api_1;
+mod generated_api_2;

--- a/justfile
+++ b/justfile
@@ -42,10 +42,7 @@ lint *args="":
     dart format --fix -l {{line_length}} {{frb_pure}} {{args}}
     dart format --fix -l {{line_length}} {{frb_pure_multi}} {{args}}
     dart format --fix -l {{line_length}} {{frb_flutter}} {{args}}
-    cd {{frb_pure}}/rust && cargo fmt
-    cd {{frb_pure_multi}}/rust && cargo fmt
-    cd {{frb_flutter}}/rust && cargo fmt
-    cd frb_codegen && cargo fmt
+    cargo fmt
 
 alias t := test
 test: test-support test-pure test-integration


### PR DESCRIPTION
- Refactors `EnumRef` to make `Option<FieldlessEnum>` work
- (Potentially breaking) `Box<primitive>` and `Option<Box<primitive>>` on WASM no longer allocates a Box, but receives a (nullable) value directly from Dart. Makes the implementation cleaner.

Closes #828.

## Checklist

- [x] An issue to be fixed by this PR is listed above.
- [x] New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api.rs` and `dart/lib/main.dart`.
- [x] The code generator is run and the code is formatted (e.g. via `just refresh_all`).
- [x] If this PR adds/changes features, documentations (in the `./book` folder) are updated.
- [x] CI is passing.