### PR TITLE
Fixed generating Dart structs with freezed + methods

### DIFF
--- a/frb_codegen/src/generator/dart/ty_struct.rs
+++ b/frb_codegen/src/generator/dart/ty_struct.rs
@@ -138,11 +138,6 @@ impl TypeDartGeneratorTrait for TypeStructRefGenerator<'_> {
             })
             .collect::<Vec<_>>()
             .concat();
-        let extra_argument = "required this.bridge,".to_string();
-        let field_bridge = format!(
-            "final {} bridge;",
-            self.context.config.dart_api_class_name(),
-        );
         if src.using_freezed() {
             let mut constructor_params = src
                 .fields
@@ -158,7 +153,13 @@ impl TypeDartGeneratorTrait for TypeStructRefGenerator<'_> {
                 })
                 .collect::<Vec<_>>();
             if has_methods {
-                constructor_params.insert(0, extra_argument);
+                constructor_params.insert(
+                    0,
+                    format!(
+                        "required {} bridge,",
+                        self.context.config.dart_api_class_name()
+                    ),
+                );
             }
             let constructor_params = constructor_params.join("");
 
@@ -195,7 +196,13 @@ impl TypeDartGeneratorTrait for TypeStructRefGenerator<'_> {
                 })
                 .collect::<Vec<_>>();
             if has_methods {
-                field_declarations.insert(0, field_bridge);
+                field_declarations.insert(
+                    0,
+                    format!(
+                        "final {} bridge;",
+                        self.context.config.dart_api_class_name(),
+                    ),
+                );
             }
             let field_declarations = field_declarations.join("\n");
 
@@ -212,7 +219,7 @@ impl TypeDartGeneratorTrait for TypeStructRefGenerator<'_> {
                 })
                 .collect::<Vec<_>>();
             if has_methods {
-                constructor_params.insert(0, extra_argument);
+                constructor_params.insert(0, "required this.bridge,".to_string());
             }
 
             let (left, right) = if constructor_params.is_empty() {

--- a/frb_codegen/src/generator/dart/ty_struct.rs
+++ b/frb_codegen/src/generator/dart/ty_struct.rs
@@ -164,11 +164,17 @@ impl TypeDartGeneratorTrait for TypeStructRefGenerator<'_> {
 
             format!(
                 "{comments}{meta}class {Name} with _${Name} {{
+                    {private_constructor}
                     const factory {Name}({{{}}}) = _{Name};
                     {}
                 }}",
                 constructor_params,
                 methods_string,
+                private_constructor = if has_methods {
+                    format!("const {}._();", self.ir.name)
+                } else {
+                    "".to_owned()
+                },
                 comments = comments,
                 meta = metadata,
                 Name = self.ir.name

--- a/frb_example/pure_dart/dart/lib/bridge_definitions.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_definitions.dart
@@ -640,6 +640,10 @@ abstract class FlutterRustBridgeExampleSingleBlockTest {
 
   FlutterRustBridgeTaskConstMeta get kTestContainsMirroredSubStructConstMeta;
 
+  Future<String> asStringMethodEvent({required Event that, dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kAsStringMethodEventConstMeta;
+
   Future<int> sumMethodSumWith({required SumWith that, required int y, required int z, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kSumMethodSumWithConstMeta;
@@ -1140,10 +1144,15 @@ class EnumOpaque with _$EnumOpaque {
 
 @freezed
 class Event with _$Event {
+  const Event._();
   const factory Event({
+    required FlutterRustBridgeExampleSingleBlockTest bridge,
     required String address,
     required String payload,
   }) = _Event;
+  Future<String> asString({dynamic hint}) => bridge.asStringMethodEvent(
+        that: this,
+      );
 }
 
 class ExoticOptionals {

--- a/frb_example/pure_dart/dart/lib/bridge_definitions.freezed.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_definitions.freezed.dart
@@ -2519,6 +2519,7 @@ abstract class EnumOpaque_RwLock implements EnumOpaque {
 
 /// @nodoc
 mixin _$Event {
+  FlutterRustBridgeExampleSingleBlockTest get bridge => throw _privateConstructorUsedError;
   String get address => throw _privateConstructorUsedError;
   String get payload => throw _privateConstructorUsedError;
 
@@ -2530,7 +2531,7 @@ mixin _$Event {
 abstract class $EventCopyWith<$Res> {
   factory $EventCopyWith(Event value, $Res Function(Event) then) = _$EventCopyWithImpl<$Res, Event>;
   @useResult
-  $Res call({String address, String payload});
+  $Res call({FlutterRustBridgeExampleSingleBlockTest bridge, String address, String payload});
 }
 
 /// @nodoc
@@ -2545,10 +2546,15 @@ class _$EventCopyWithImpl<$Res, $Val extends Event> implements $EventCopyWith<$R
   @pragma('vm:prefer-inline')
   @override
   $Res call({
+    Object? bridge = null,
     Object? address = null,
     Object? payload = null,
   }) {
     return _then(_value.copyWith(
+      bridge: null == bridge
+          ? _value.bridge
+          : bridge // ignore: cast_nullable_to_non_nullable
+              as FlutterRustBridgeExampleSingleBlockTest,
       address: null == address
           ? _value.address
           : address // ignore: cast_nullable_to_non_nullable
@@ -2566,7 +2572,7 @@ abstract class _$$_EventCopyWith<$Res> implements $EventCopyWith<$Res> {
   factory _$$_EventCopyWith(_$_Event value, $Res Function(_$_Event) then) = __$$_EventCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({String address, String payload});
+  $Res call({FlutterRustBridgeExampleSingleBlockTest bridge, String address, String payload});
 }
 
 /// @nodoc
@@ -2576,10 +2582,15 @@ class __$$_EventCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res, _$_Event> i
   @pragma('vm:prefer-inline')
   @override
   $Res call({
+    Object? bridge = null,
     Object? address = null,
     Object? payload = null,
   }) {
     return _then(_$_Event(
+      bridge: null == bridge
+          ? _value.bridge
+          : bridge // ignore: cast_nullable_to_non_nullable
+              as FlutterRustBridgeExampleSingleBlockTest,
       address: null == address
           ? _value.address
           : address // ignore: cast_nullable_to_non_nullable
@@ -2595,8 +2606,10 @@ class __$$_EventCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res, _$_Event> i
 /// @nodoc
 
 class _$_Event implements _Event {
-  const _$_Event({required this.address, required this.payload});
+  const _$_Event({required this.bridge, required this.address, required this.payload});
 
+  @override
+  final FlutterRustBridgeExampleSingleBlockTest bridge;
   @override
   final String address;
   @override
@@ -2604,7 +2617,7 @@ class _$_Event implements _Event {
 
   @override
   String toString() {
-    return 'Event(address: $address, payload: $payload)';
+    return 'Event(bridge: $bridge, address: $address, payload: $payload)';
   }
 
   @override
@@ -2612,12 +2625,13 @@ class _$_Event implements _Event {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_Event &&
+            (identical(other.bridge, bridge) || other.bridge == bridge) &&
             (identical(other.address, address) || other.address == address) &&
             (identical(other.payload, payload) || other.payload == payload));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, address, payload);
+  int get hashCode => Object.hash(runtimeType, bridge, address, payload);
 
   @JsonKey(ignore: true)
   @override
@@ -2626,8 +2640,13 @@ class _$_Event implements _Event {
 }
 
 abstract class _Event implements Event {
-  const factory _Event({required final String address, required final String payload}) = _$_Event;
+  const factory _Event(
+      {required final FlutterRustBridgeExampleSingleBlockTest bridge,
+      required final String address,
+      required final String payload}) = _$_Event;
 
+  @override
+  FlutterRustBridgeExampleSingleBlockTest get bridge;
   @override
   String get address;
   @override

--- a/frb_example/pure_dart/dart/lib/bridge_definitions.freezed.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_definitions.freezed.dart
@@ -2605,8 +2605,8 @@ class __$$_EventCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res, _$_Event> i
 
 /// @nodoc
 
-class _$_Event implements _Event {
-  const _$_Event({required this.bridge, required this.address, required this.payload});
+class _$_Event extends _Event {
+  const _$_Event({required this.bridge, required this.address, required this.payload}) : super._();
 
   @override
   final FlutterRustBridgeExampleSingleBlockTest bridge;
@@ -2639,11 +2639,12 @@ class _$_Event implements _Event {
   _$$_EventCopyWith<_$_Event> get copyWith => __$$_EventCopyWithImpl<_$_Event>(this, _$identity);
 }
 
-abstract class _Event implements Event {
+abstract class _Event extends Event {
   const factory _Event(
       {required final FlutterRustBridgeExampleSingleBlockTest bridge,
       required final String address,
       required final String payload}) = _$_Event;
+  const _Event._() : super._();
 
   @override
   FlutterRustBridgeExampleSingleBlockTest get bridge;

--- a/frb_example/pure_dart/dart/lib/bridge_generated.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.dart
@@ -957,7 +957,7 @@ class FlutterRustBridgeExampleSingleBlockTestImpl implements FlutterRustBridgeEx
   Stream<Event> registerEventListener({dynamic hint}) {
     return _platform.executeStream(FlutterRustBridgeTask(
       callFfi: (port_) => _platform.inner.wire_register_event_listener(port_),
-      parseSuccessData: _wire2api_event,
+      parseSuccessData: (d) => _wire2api_event(d),
       constMeta: kRegisterEventListenerConstMeta,
       argValues: [],
       hint: hint,
@@ -2422,6 +2422,22 @@ class FlutterRustBridgeExampleSingleBlockTestImpl implements FlutterRustBridgeEx
         argNames: [],
       );
 
+  Future<String> asStringMethodEvent({required Event that, dynamic hint}) {
+    var arg0 = _platform.api2wire_box_autoadd_event(that);
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_as_string__method__Event(port_, arg0),
+      parseSuccessData: _wire2api_String,
+      constMeta: kAsStringMethodEventConstMeta,
+      argValues: [that],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kAsStringMethodEventConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "as_string__method__Event",
+        argNames: ["that"],
+      );
+
   Future<int> sumMethodSumWith({required SumWith that, required int y, required int z, dynamic hint}) {
     var arg0 = _platform.api2wire_box_autoadd_sum_with(that);
     var arg1 = api2wire_u32(y);
@@ -3091,6 +3107,7 @@ class FlutterRustBridgeExampleSingleBlockTestImpl implements FlutterRustBridgeEx
     final arr = raw as List<dynamic>;
     if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return Event(
+      bridge: this,
       address: _wire2api_String(arr[0]),
       payload: _wire2api_String(arr[1]),
     );

--- a/frb_example/pure_dart/dart/lib/bridge_generated.io.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.io.dart
@@ -269,6 +269,13 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
   }
 
   @protected
+  ffi.Pointer<wire_Event> api2wire_box_autoadd_event(Event raw) {
+    final ptr = inner.new_box_autoadd_event_0();
+    _api_fill_to_wire_event(raw, ptr.ref);
+    return ptr;
+  }
+
+  @protected
   ffi.Pointer<wire_ExoticOptionals> api2wire_box_autoadd_exotic_optionals(ExoticOptionals raw) {
     final ptr = inner.new_box_autoadd_exotic_optionals_0();
     _api_fill_to_wire_exotic_optionals(raw, ptr.ref);
@@ -979,6 +986,10 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
     _api_fill_to_wire_enum_opaque(apiObj, wireObj.ref);
   }
 
+  void _api_fill_to_wire_box_autoadd_event(Event apiObj, ffi.Pointer<wire_Event> wireObj) {
+    _api_fill_to_wire_event(apiObj, wireObj.ref);
+  }
+
   void _api_fill_to_wire_box_autoadd_exotic_optionals(
       ExoticOptionals apiObj, ffi.Pointer<wire_ExoticOptionals> wireObj) {
     _api_fill_to_wire_exotic_optionals(apiObj, wireObj.ref);
@@ -1171,6 +1182,11 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
       wireObj.kind.ref.RwLock.ref.field0 = pre_field0;
       return;
     }
+  }
+
+  void _api_fill_to_wire_event(Event apiObj, wire_Event wireObj) {
+    wireObj.address = api2wire_String(apiObj.address);
+    wireObj.payload = api2wire_String(apiObj.payload);
   }
 
   void _api_fill_to_wire_exotic_optionals(ExoticOptionals apiObj, wire_ExoticOptionals wireObj) {
@@ -3578,6 +3594,22 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   late final _wire_test_contains_mirrored_sub_struct =
       _wire_test_contains_mirrored_sub_structPtr.asFunction<void Function(int)>();
 
+  void wire_as_string__method__Event(
+    int port_,
+    ffi.Pointer<wire_Event> that,
+  ) {
+    return _wire_as_string__method__Event(
+      port_,
+      that,
+    );
+  }
+
+  late final _wire_as_string__method__EventPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_Event>)>>(
+          'wire_as_string__method__Event');
+  late final _wire_as_string__method__Event =
+      _wire_as_string__method__EventPtr.asFunction<void Function(int, ffi.Pointer<wire_Event>)>();
+
   void wire_sum__method__SumWith(
     int port_,
     ffi.Pointer<wire_SumWith> that,
@@ -3952,6 +3984,14 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
       _lookup<ffi.NativeFunction<ffi.Pointer<wire_EnumOpaque> Function()>>('new_box_autoadd_enum_opaque_0');
   late final _new_box_autoadd_enum_opaque_0 =
       _new_box_autoadd_enum_opaque_0Ptr.asFunction<ffi.Pointer<wire_EnumOpaque> Function()>();
+
+  ffi.Pointer<wire_Event> new_box_autoadd_event_0() {
+    return _new_box_autoadd_event_0();
+  }
+
+  late final _new_box_autoadd_event_0Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Event> Function()>>('new_box_autoadd_event_0');
+  late final _new_box_autoadd_event_0 = _new_box_autoadd_event_0Ptr.asFunction<ffi.Pointer<wire_Event> Function()>();
 
   ffi.Pointer<wire_ExoticOptionals> new_box_autoadd_exotic_optionals_0() {
     return _new_box_autoadd_exotic_optionals_0();
@@ -5409,6 +5449,12 @@ class wire_Abc extends ffi.Struct {
   external int tag;
 
   external ffi.Pointer<AbcKind> kind;
+}
+
+class wire_Event extends ffi.Struct {
+  external ffi.Pointer<wire_uint_8_list> address;
+
+  external ffi.Pointer<wire_uint_8_list> payload;
 }
 
 class wire_SumWith extends ffi.Struct {

--- a/frb_example/pure_dart/dart/lib/bridge_generated.web.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.web.dart
@@ -280,6 +280,11 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
   }
 
   @protected
+  List<dynamic> api2wire_box_autoadd_event(Event raw) {
+    return api2wire_event(raw);
+  }
+
+  @protected
   List<dynamic> api2wire_box_autoadd_exotic_optionals(ExoticOptionals raw) {
     return api2wire_exotic_optionals(raw);
   }
@@ -527,6 +532,11 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
     }
 
     throw Exception('unreachable');
+  }
+
+  @protected
+  List<dynamic> api2wire_event(Event raw) {
+    return [api2wire_String(raw.address), api2wire_String(raw.payload)];
   }
 
   @protected
@@ -1273,6 +1283,8 @@ class FlutterRustBridgeExampleSingleBlockTestWasmModule implements WasmModule {
 
   external dynamic /* void */ wire_test_contains_mirrored_sub_struct(NativePortType port_);
 
+  external dynamic /* void */ wire_as_string__method__Event(NativePortType port_, List<dynamic> that);
+
   external dynamic /* void */ wire_sum__method__SumWith(NativePortType port_, List<dynamic> that, int y, int z);
 
   external dynamic /* void */ wire_new__static_method__ConcatenateWith(NativePortType port_, String a);
@@ -1699,6 +1711,9 @@ class FlutterRustBridgeExampleSingleBlockTestWire
 
   void wire_test_contains_mirrored_sub_struct(NativePortType port_) =>
       wasmModule.wire_test_contains_mirrored_sub_struct(port_);
+
+  void wire_as_string__method__Event(NativePortType port_, List<dynamic> that) =>
+      wasmModule.wire_as_string__method__Event(port_, that);
 
   void wire_sum__method__SumWith(NativePortType port_, List<dynamic> that, int y, int z) =>
       wasmModule.wire_sum__method__SumWith(port_, that, y, z);

--- a/frb_example/pure_dart/dart/lib/main.dart
+++ b/frb_example/pure_dart/dart/lib/main.dart
@@ -516,8 +516,7 @@ void main(List<String> args) async {
   });
 
   test('dart register event listener & create event with delay', () async {
-    expectLater(api.registerEventListener(),
-        emits(Event(bridge: api, address: 'foo', payload: 'bar')));
+    expectLater(api.registerEventListener(), emits(Event(bridge: api, address: 'foo', payload: 'bar')));
     await Future.delayed(const Duration(milliseconds: 20));
     await api.createEvent(address: 'foo', payload: 'bar');
     await api.closeEventListener();

--- a/frb_example/pure_dart/dart/lib/main.dart
+++ b/frb_example/pure_dart/dart/lib/main.dart
@@ -516,7 +516,8 @@ void main(List<String> args) async {
   });
 
   test('dart register event listener & create event with delay', () async {
-    expectLater(api.registerEventListener(), emits(Event(address: 'foo', payload: 'bar')));
+    expectLater(api.registerEventListener(),
+        emits(Event(bridge: api, address: 'foo', payload: 'bar')));
     await Future.delayed(const Duration(milliseconds: 20));
     await api.createEvent(address: 'foo', payload: 'bar');
     await api.closeEventListener();

--- a/frb_example/pure_dart/rust/c_output_path/c_output.h
+++ b/frb_example/pure_dart/rust/c_output_path/c_output.h
@@ -435,6 +435,11 @@ typedef struct wire_Abc {
   union AbcKind *kind;
 } wire_Abc;
 
+typedef struct wire_Event {
+  struct wire_uint_8_list *address;
+  struct wire_uint_8_list *payload;
+} wire_Event;
+
 typedef struct wire_SumWith {
   uint32_t x;
 } wire_SumWith;
@@ -775,6 +780,8 @@ void wire_test_abc_enum(int64_t port_, struct wire_Abc *abc);
 
 void wire_test_contains_mirrored_sub_struct(int64_t port_);
 
+void wire_as_string__method__Event(int64_t port_, struct wire_Event *that);
+
 void wire_sum__method__SumWith(int64_t port_, struct wire_SumWith *that, uint32_t y, uint32_t z);
 
 void wire_new__static_method__ConcatenateWith(int64_t port_, struct wire_uint_8_list *a);
@@ -852,6 +859,8 @@ struct wire_Empty *new_box_autoadd_empty_0(void);
 struct wire_EnumDartOpaque *new_box_autoadd_enum_dart_opaque_0(void);
 
 struct wire_EnumOpaque *new_box_autoadd_enum_opaque_0(void);
+
+struct wire_Event *new_box_autoadd_event_0(void);
 
 struct wire_ExoticOptionals *new_box_autoadd_exotic_optionals_0(void);
 
@@ -1179,6 +1188,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_list_of_primitive_enums);
     dummy_var ^= ((int64_t) (void*) wire_test_abc_enum);
     dummy_var ^= ((int64_t) (void*) wire_test_contains_mirrored_sub_struct);
+    dummy_var ^= ((int64_t) (void*) wire_as_string__method__Event);
     dummy_var ^= ((int64_t) (void*) wire_sum__method__SumWith);
     dummy_var ^= ((int64_t) (void*) wire_new__static_method__ConcatenateWith);
     dummy_var ^= ((int64_t) (void*) wire_concatenate__method__ConcatenateWith);
@@ -1213,6 +1223,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_empty_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_enum_dart_opaque_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_enum_opaque_0);
+    dummy_var ^= ((int64_t) (void*) new_box_autoadd_event_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_exotic_optionals_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_f64_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_feature_chrono_0);

--- a/frb_example/pure_dart/rust/c_output_path_extra/c_output.h
+++ b/frb_example/pure_dart/rust/c_output_path_extra/c_output.h
@@ -435,6 +435,11 @@ typedef struct wire_Abc {
   union AbcKind *kind;
 } wire_Abc;
 
+typedef struct wire_Event {
+  struct wire_uint_8_list *address;
+  struct wire_uint_8_list *payload;
+} wire_Event;
+
 typedef struct wire_SumWith {
   uint32_t x;
 } wire_SumWith;
@@ -775,6 +780,8 @@ void wire_test_abc_enum(int64_t port_, struct wire_Abc *abc);
 
 void wire_test_contains_mirrored_sub_struct(int64_t port_);
 
+void wire_as_string__method__Event(int64_t port_, struct wire_Event *that);
+
 void wire_sum__method__SumWith(int64_t port_, struct wire_SumWith *that, uint32_t y, uint32_t z);
 
 void wire_new__static_method__ConcatenateWith(int64_t port_, struct wire_uint_8_list *a);
@@ -852,6 +859,8 @@ struct wire_Empty *new_box_autoadd_empty_0(void);
 struct wire_EnumDartOpaque *new_box_autoadd_enum_dart_opaque_0(void);
 
 struct wire_EnumOpaque *new_box_autoadd_enum_opaque_0(void);
+
+struct wire_Event *new_box_autoadd_event_0(void);
 
 struct wire_ExoticOptionals *new_box_autoadd_exotic_optionals_0(void);
 
@@ -1179,6 +1188,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_list_of_primitive_enums);
     dummy_var ^= ((int64_t) (void*) wire_test_abc_enum);
     dummy_var ^= ((int64_t) (void*) wire_test_contains_mirrored_sub_struct);
+    dummy_var ^= ((int64_t) (void*) wire_as_string__method__Event);
     dummy_var ^= ((int64_t) (void*) wire_sum__method__SumWith);
     dummy_var ^= ((int64_t) (void*) wire_new__static_method__ConcatenateWith);
     dummy_var ^= ((int64_t) (void*) wire_concatenate__method__ConcatenateWith);
@@ -1213,6 +1223,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_empty_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_enum_dart_opaque_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_enum_opaque_0);
+    dummy_var ^= ((int64_t) (void*) new_box_autoadd_event_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_exotic_optionals_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_f64_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_feature_chrono_0);

--- a/frb_example/pure_dart/rust/src/api.rs
+++ b/frb_example/pure_dart/rust/src/api.rs
@@ -762,6 +762,12 @@ pub struct Event {
     pub payload: String,
 }
 
+impl Event {
+    pub fn as_string(&self) -> String {
+        format!("{}: {}", self.address, self.payload)
+    }
+}
+
 pub fn register_event_listener(listener: StreamSink<Event>) -> Result<()> {
     match EVENTS.lock() {
         Ok(mut guard) => {

--- a/frb_example/pure_dart/rust/src/bridge_generated.io.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.io.rs
@@ -805,6 +805,11 @@ pub extern "C" fn wire_test_contains_mirrored_sub_struct(port_: i64) {
 }
 
 #[no_mangle]
+pub extern "C" fn wire_as_string__method__Event(port_: i64, that: *mut wire_Event) {
+    wire_as_string__method__Event_impl(port_, that)
+}
+
+#[no_mangle]
 pub extern "C" fn wire_sum__method__SumWith(port_: i64, that: *mut wire_SumWith, y: u32, z: u32) {
     wire_sum__method__SumWith_impl(port_, that, y, z)
 }
@@ -1000,6 +1005,11 @@ pub extern "C" fn new_box_autoadd_enum_dart_opaque_0() -> *mut wire_EnumDartOpaq
 #[no_mangle]
 pub extern "C" fn new_box_autoadd_enum_opaque_0() -> *mut wire_EnumOpaque {
     support::new_leak_box_ptr(wire_EnumOpaque::new_with_null_ptr())
+}
+
+#[no_mangle]
+pub extern "C" fn new_box_autoadd_event_0() -> *mut wire_Event {
+    support::new_leak_box_ptr(wire_Event::new_with_null_ptr())
 }
 
 #[no_mangle]
@@ -1728,6 +1738,12 @@ impl Wire2Api<EnumOpaque> for *mut wire_EnumOpaque {
         Wire2Api::<EnumOpaque>::wire2api(*wrap).into()
     }
 }
+impl Wire2Api<Event> for *mut wire_Event {
+    fn wire2api(self) -> Event {
+        let wrap = unsafe { support::box_from_leak_ptr(self) };
+        Wire2Api::<Event>::wire2api(*wrap).into()
+    }
+}
 impl Wire2Api<ExoticOptionals> for *mut wire_ExoticOptionals {
     fn wire2api(self) -> ExoticOptionals {
         let wrap = unsafe { support::box_from_leak_ptr(self) };
@@ -2028,6 +2044,14 @@ impl Wire2Api<EnumOpaque> for wire_EnumOpaque {
                 EnumOpaque::RwLock(ans.field0.wire2api())
             },
             _ => unreachable!(),
+        }
+    }
+}
+impl Wire2Api<Event> for wire_Event {
+    fn wire2api(self) -> Event {
+        Event {
+            address: self.address.wire2api(),
+            payload: self.payload.wire2api(),
         }
     }
 }
@@ -2524,6 +2548,13 @@ pub struct wire_DartOpaqueNested {
 #[repr(C)]
 #[derive(Clone)]
 pub struct wire_Empty {}
+
+#[repr(C)]
+#[derive(Clone)]
+pub struct wire_Event {
+    address: *mut wire_uint_8_list,
+    payload: *mut wire_uint_8_list,
+}
 
 #[repr(C)]
 #[derive(Clone)]
@@ -3370,6 +3401,21 @@ pub extern "C" fn inflate_EnumOpaque_RwLock() -> *mut EnumOpaqueKind {
             field0: wire_RwLockHideData::new_with_null_ptr(),
         }),
     })
+}
+
+impl NewWithNullPtr for wire_Event {
+    fn new_with_null_ptr() -> Self {
+        Self {
+            address: core::ptr::null_mut(),
+            payload: core::ptr::null_mut(),
+        }
+    }
+}
+
+impl Default for wire_Event {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
 }
 
 impl NewWithNullPtr for wire_ExoticOptionals {

--- a/frb_example/pure_dart/rust/src/bridge_generated.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.rs
@@ -2169,6 +2169,19 @@ fn wire_test_contains_mirrored_sub_struct_impl(port_: MessagePort) {
         move || move |task_callback| Ok(test_contains_mirrored_sub_struct()),
     )
 }
+fn wire_as_string__method__Event_impl(port_: MessagePort, that: impl Wire2Api<Event> + UnwindSafe) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+        WrapInfo {
+            debug_name: "as_string__method__Event",
+            port: Some(port_),
+            mode: FfiCallMode::Normal,
+        },
+        move || {
+            let api_that = that.wire2api();
+            move |task_callback| Ok(Event::as_string(&api_that))
+        },
+    )
+}
 fn wire_sum__method__SumWith_impl(
     port_: MessagePort,
     that: impl Wire2Api<SumWith> + UnwindSafe,

--- a/frb_example/pure_dart/rust/src/bridge_generated.web.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.web.rs
@@ -780,6 +780,11 @@ pub fn wire_test_contains_mirrored_sub_struct(port_: MessagePort) {
 }
 
 #[wasm_bindgen]
+pub fn wire_as_string__method__Event(port_: MessagePort, that: JsValue) {
+    wire_as_string__method__Event_impl(port_, that)
+}
+
+#[wasm_bindgen]
 pub fn wire_sum__method__SumWith(port_: MessagePort, that: JsValue, y: u32, z: u32) {
     wire_sum__method__SumWith_impl(port_, that, y, z)
 }
@@ -1240,6 +1245,21 @@ impl Wire2Api<EnumOpaque> for JsValue {
             3 => EnumOpaque::Mutex(self_.get(1).wire2api()),
             4 => EnumOpaque::RwLock(self_.get(1).wire2api()),
             _ => unreachable!(),
+        }
+    }
+}
+impl Wire2Api<Event> for JsValue {
+    fn wire2api(self) -> Event {
+        let self_ = self.dyn_into::<JsArray>().unwrap();
+        assert_eq!(
+            self_.length(),
+            2,
+            "Expected 2 elements, got {}",
+            self_.length()
+        );
+        Event {
+            address: self_.get(0).wire2api(),
+            payload: self_.get(1).wire2api(),
         }
     }
 }


### PR DESCRIPTION
#969

## Checklist

- [X] An issue to be fixed by this PR is listed above.
- [X] New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api.rs` and `dart/lib/main.dart`.
- [X] The code generator is run and the code is formatted (e.g. via `just refresh_all`).
- [X] If this PR adds/changes features, documentations (in the `./book` folder) are updated.
- [x] CI is passing.
