### PR TITLE
add setup steps in tutorial

### DIFF
--- a/book/src/integrate/deps.md
+++ b/book/src/integrate/deps.md
@@ -65,3 +65,20 @@ Add these lines to `Cargo.toml`:
 +flutter_rust_bridge = "1"
 ```
 
+## System dependencies
+
+For non-debian based Linux distributions, there are a few prerequisites:
+Ensure that packages are up to date (or install by demand).
+
+- clang
+- llvm-libs
+- glibc
+
+> restart may be required
+
+Set environment variable in your shell profile (`.bashrc`, `.zshrc`, etc).
+
+```bash
+export CPATH="$(clang -v 2>&1 | grep "Selected GCC installation" | rev | cut -d' ' -f1 | rev)/include"
+```
+

--- a/book/src/tutorial_with_flutter.md
+++ b/book/src/tutorial_with_flutter.md
@@ -24,21 +24,6 @@ Please [install Flutter](https://flutter.dev/docs/get-started/install) (optional
 git clone https://github.com/fzyzcjy/flutter_rust_bridge && cd flutter_rust_bridge/frb_example/with_flutter
 ```
 
-## Setup dependencies
-
-For non-debian based distributions a few tricks required.
-Ensure that packages are up to date (or install by demand).
-
-- clang
-- llvm-libs
-- glibc
-
-Set environment variable in your shell profile (`.bashrc`, `.zshrc`, etc).
-
-```bash
-export CPATH="$(clang -v 2>&1 | grep "Selected GCC installation" | rev | cut -d' ' -f1 | rev)/include"
-```
-
 ## Optional: Run generator
 
 This step is optional, since I have generated the source code already (in quickstart). Even if you do it, you should not see anything changed.

--- a/book/src/tutorial_with_flutter.md
+++ b/book/src/tutorial_with_flutter.md
@@ -30,6 +30,8 @@ This step is optional, since I have generated the source code already (in quicks
 
 As soon as you make any modification to `api.rs`, you need to run codegen again. More information about requirements for code generation can be seen in the [Installing dependencies](integrate/deps.md) section.
 
+At this step you may need to [setup dependencies](./integrate/deps.md).
+
 ## Run app
 
 ### Prelogue: Command details

--- a/book/src/tutorial_with_flutter.md
+++ b/book/src/tutorial_with_flutter.md
@@ -24,6 +24,21 @@ Please [install Flutter](https://flutter.dev/docs/get-started/install) (optional
 git clone https://github.com/fzyzcjy/flutter_rust_bridge && cd flutter_rust_bridge/frb_example/with_flutter
 ```
 
+## Setup dependencies
+
+For non-debian based distributions a few tricks required.
+Ensure that packages are up to date (or install by demand).
+
+- clang
+- llvm-libs
+- glibc
+
+Set environment variable in your shell profile (`.bashrc`, `.zshrc`, etc).
+
+```bash
+export CPATH="$(clang -v 2>&1 | grep "Selected GCC installation" | rev | cut -d' ' -f1 | rev)/include"
+```
+
 ## Optional: Run generator
 
 This step is optional, since I have generated the source code already (in quickstart). Even if you do it, you should not see anything changed.


### PR DESCRIPTION
Fixes  source of #1011 and similar https://github.com/fzyzcjy/flutter_rust_bridge/issues?q=%27stdbool.h%27+file+not+found

Have **not** changed source code, only add info in docs. So, skip code test part 

## Checklist

- [x] An issue to be fixed by this PR is listed above.
- [ ] New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api.rs` and `dart/lib/main.dart`.
- [x] The code generator is run and the code is formatted (e.g. via `just refresh_all`).
- [x] If this PR adds/changes features, documentations (in the `./book` folder) are updated.
- [ ] CI is passing.

