### PR TITLE
Fix workflows

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,5 +12,5 @@ _Please list issues fixed by this PR here, using format "Fixes #the-issue-number
 
 ## Remark for PR creator
 
-- Justfile is a task runner for the command line interface that allows you to run shell commands from a file named `justfile` in your project directory, You can use Justfile after [installing it](https://github.com/casey/just). Note that commands written in `justfile` of this repository are expected to be run in `bash`, not `cmd` or `powershell`. Running `just ...` commands in `cmd` or `powershell` will produce erorrs as the syntax is not compatible. On Windows, you can use `git bash` if you have Git installed.
+- Justfile is a task runner for the command line interface that allows you to run shell commands from a file named `justfile` in your project directory. You can use Justfile after [installing it](https://github.com/casey/just). Note that commands written in `justfile` of this repository are expected to be run in `bash`, not `cmd` or `powershell`. Running `just ...` commands in `cmd` or `powershell` will produce erorrs as the syntax is not compatible. On Windows, you can use `git bash` if you have Git installed.
 - If fzyzcjy does not reply for a few days, maybe he just did not see it, so please ping him.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,5 +12,5 @@ _Please list issues fixed by this PR here, using format "Fixes #the-issue-number
 
 ## Remark for PR creator
 
-- Justfile is a task runner for the command line interface that allows you to run shell commands from a file named `justfile` in your project directory. You can use Justfile after [installing it](https://github.com/casey/just). Note that commands written in `justfile` of this repository are expected to be run in `bash`, not `cmd` or `powershell`. Running `just ...` commands in `cmd` or `powershell` will produce erorrs as the syntax is not compatible. On Windows, you can use `git bash` if you have Git installed.
+- Justfile is a task runner for the command line interface that allows you to run shell commands from a file named `justfile` in your project directory. You can use Justfile after [installing it](https://github.com/casey/just). Note that commands written in `justfile` of this repository are expected to be run in `bash`, not `cmd` or `powershell`. Running `just ...` commands in `cmd` or `powershell` will produce errors as the syntax is not compatible. On Windows, you can use `git bash` if you have Git installed.
 - If fzyzcjy does not reply for a few days, maybe he just did not see it, so please ping him.

--- a/.github/workflows/post_release.yaml
+++ b/.github/workflows/post_release.yaml
@@ -219,5 +219,5 @@ jobs:
         env:
           RUST_LOG: debug
 
-      - name: "Check no code change (If fail: Please ensure you have run codegen on examples and commit those changes!)"
+      - name: "Check no code change (Use `just precommit` if error occured)"
         run: git diff --exit-code

--- a/.github/workflows/post_release.yaml
+++ b/.github/workflows/post_release.yaml
@@ -42,7 +42,9 @@ jobs:
 
       - uses: dart-lang/setup-dart@v1
         with:
-          sdk: "2.19.2"
+          # TODO should be 2.19.2 but has a weird bug currently
+          # https://github.com/fzyzcjy/flutter_rust_bridge/pull/1039#issuecomment-1424292105
+          sdk: "2.17.6"
 
       - name: Install dart dependencies (single block)
         working-directory: ./frb_example/pure_dart/dart

--- a/justfile
+++ b/justfile
@@ -18,10 +18,10 @@ frb_tools := justfile_directory() / "tools"
 default: gen-bridge
 
 precommit:
-    gen-bridge
-    check
-    lint
-    gen-help
+    just gen-bridge
+    just check
+    just lint
+    just gen-help
     # sed -i "" -e 's/pub.flutter-io.cn/pub.dartlang.org/g' frb_example/pure_dart/dart/pubspec.lock
     # sed -i "" -e 's/pub.flutter-io.cn/pub.dartlang.org/g' frb_example/pure_dart_multi/dart/pubspec.lock
     # sed -i "" -e 's/pub.flutter-io.cn/pub.dartlang.org/g' frb_example/with_flutter/pubspec.lock


### PR DESCRIPTION
## Changes

This PR fixes side-effects caused by https://github.com/fzyzcjy/flutter_rust_bridge/pull/1039. Specifically, Post-Release Valgrind test is throwing errors and some justfile commands are broken.

## Checklist

- [x] An issue to be fixed by this PR is listed above.
- [x] New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api.rs` and `dart/lib/main.dart`.
- [x] The code generator is run and the code is formatted (via `just precommit`).
- [x] If this PR adds/changes features, documentations (in the `./book` folder) are updated.
- [x] CI is passing.

## Remark for PR creator

- Justfile is a task runner for the command line interface that allows you to run shell commands from a file named `justfile` in your project directory, You can use Justfile after [installing it](https://github.com/casey/just). Note that commands written in `justfile` of this repository are expected to be run in `bash`, not `cmd` or `powershell`. Running `just ...` commands in `cmd` or `powershell` will produce erorrs as the syntax is not compatible. On Windows, you can use `git bash` if you have Git installed.
- If fzyzcjy does not reply for a few days, maybe he just did not see it, so please ping him.
