### PR TITLE
Add a guide about threads in `sync_dart.md` docs

### DIFF
--- a/book/src/feature/sync_dart.md
+++ b/book/src/feature/sync_dart.md
@@ -2,4 +2,6 @@
 
 If you need to generate synchronous functions in Dart, you can use `SyncReturn<T>` as the return type. It supports whatever types that we have described in other places, i.e. whatever types that async mode supports.
 
-We suggest only do this for very quick Rust functions, or the Dart UI will be blocked. This behavior is completely different from normal Rust functions. Normal function calls are executed in the [worker pool](worker_pool.md). However, Rust functions with return type of `SyncReturn<T>` are executed on the _main_ thread. This means that if a `SyncReturn<T>` function takes time, Dart UI will not be able to respond.
+We suggest only do this for very quick Rust functions, or the Dart UI will be blocked.
+
+If you are using the default handler, the behavior about threading is different from normal Rust functions. Normal function calls are executed in the [worker pool](worker_pool.md). However, Rust functions with return type of `SyncReturn<T>` are executed on the _main_ thread. This means that if a `SyncReturn<T>` function takes time, Dart UI will not be able to respond.

--- a/book/src/feature/sync_dart.md
+++ b/book/src/feature/sync_dart.md
@@ -2,4 +2,4 @@
 
 If you need to generate synchronous functions in Dart, you can use `SyncReturn<T>` as the return type. It supports whatever types that we have described in other places, i.e. whatever types that async mode supports.
 
-We suggest only do this for very quick Rust functions, or the Dart UI will be blocked.
+We suggest only do this for very quick Rust functions, or the Dart UI will be blocked. This behavior is completely different from normal Rust functions. Normal function calls are executed in the [worker pool](worker_pool.md). However, Rust functions with return type of `SyncReturn<T>` are executed on the _main_ thread. This means that if a `SyncReturn<T>` function takes time, Dart UI will not be able to respond.


### PR DESCRIPTION
## Changes

Add a guide about threads in `sync_dart.md` docs. This behavior was inspected in https://github.com/fzyzcjy/flutter_rust_bridge/discussions/1028.

## Checklist

- [x] An issue to be fixed by this PR is listed above.
- [x] New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api.rs` and `dart/lib/main.dart`.
- [x] The code generator is run and the code is formatted (via `just precommit`).
- [x] If this PR adds/changes features, documentations (in the `./book` folder) are updated.
- [x] CI is passing.

## Remark for PR creator

- Justfile is a task runner for the command line interface that allows you to run shell commands from a file named `justfile` in your project directory. You can use Justfile after [installing it](https://github.com/casey/just). Note that commands written in `justfile` of this repository are expected to be run in `bash`, not `cmd` or `powershell`. Running `just ...` commands in `cmd` or `powershell` will produce errors as the syntax is not compatible. On Windows, you can use `git bash` if you have Git installed.
- If fzyzcjy does not reply for a few days, maybe he just did not see it, so please ping him.
