### PR TITLE
Clarify NDK setup for Android

### DIFF
--- a/book/src/template/setup_android.md
+++ b/book/src/template/setup_android.md
@@ -21,7 +21,7 @@ Android Studio depends on the `javax` library being present in the Java runtime,
 
 ## Android NDK
 
-> Android Studio > SDK Manager > SDK Tools > uncheck Hide Obsolete Packages > NDK (version 22)
+> Android Studio > SDK Manager > SDK Tools > Show Package Details > NDK (Side by side) > check the latest 22.x.x
 
 The [Android NDK], or Native Development Kit, enables code written in other
 languages to be run on the JVM via the [Java Native Interface], or JNI for short. In this case, we would like to pass the dynamic libraries created by Cargo to be included in the bundle when we run or build the project.


### PR DESCRIPTION
At least for me, using `NDK (Obsolete)` gave me the error
```
error occurred: Failed to find tool. Is `/home/voklen/programs/Android/Sdk/ndk/25.2.9519653/toolchains/llvm/prebuilt/linux-x86_64/bin/arm-linux-androideabi-ar` installed?
```
But after instead using `NDK (Side by side)` version `22.1.7171670` now works and runs on my device

OS: Arch Linux
Android device: Fairphone 4 running LineageOS

## Changes

Changed NDK install instructions

## Checklist

- [ ] An issue to be fixed by this PR is listed above.
- [X] If this PR adds/changes features, documentations (in the `./book` folder) are updated.
- [X] CI is passing.

### N/A
- [ ] New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api.rs` and `dart/lib/main.dart`.
- [ ] The code generator is run and the code is formatted (via `just precommit`).
