### PR TITLE
Reorder Android setup docs

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -6,6 +6,8 @@
 
 - [🧭 Quickstart](quickstart.md)
 - [📚 Tutorial: A Flutter+Rust app](tutorial_with_flutter.md)
+	- [Android setup](tutorial/setup_android.md)
+		- [Alternative NDK setup](tutorial/alternative_ndk.md)
 - [🎼 Features](feature.md)
   - [Language translations](feature/lang.md)
     - [Simple correspondence](feature/lang_simple.md)

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -6,8 +6,8 @@
 
 - [🧭 Quickstart](quickstart.md)
 - [📚 Tutorial: A Flutter+Rust app](tutorial_with_flutter.md)
-	- [Android setup](tutorial/setup_android.md)
-		- [Alternative NDK setup](tutorial/alternative_ndk.md)
+  - [Android setup](tutorial/setup_android.md)
+    - [Alternative NDK setup](tutorial/alternative_ndk.md)
 - [🎼 Features](feature.md)
   - [Language translations](feature/lang.md)
     - [Simple correspondence](feature/lang_simple.md)

--- a/book/src/template/setup_android.md
+++ b/book/src/template/setup_android.md
@@ -1,6 +1,6 @@
 # Android setup
 
-For Android, a few components are required to get started:
+Before trying this, ensure you can [run the example project](../tutorial/setup_android.md)
 
 ## Rust targets
 
@@ -14,96 +14,3 @@ rustup target add \
     x86_64-linux-android \
     i686-linux-android
 ```
-
-## JDK 8
-
-Android Studio depends on the `javax` library being present in the Java runtime, and the only reliable way to ensure this is to install an older version of Java. On Unix-like systems, you can use [asdf](https://asdf-vm.com/) or similar tools to manage your Java versions, and the template defines a known working version of Java in the `.tool-versions` file.
-
-## Android NDK
-
-> Android Studio > SDK Manager > SDK Tools > Show Package Details > NDK (Side by side) > check the latest 22.x.x
-
-The [Android NDK], or Native Development Kit, enables code written in other
-languages to be run on the JVM via the [Java Native Interface], or JNI for short. In this case, we would like to pass the dynamic libraries created by Cargo to be included in the bundle when we run or build the project.
-
-After following the instructions above, the NDK should be installed in your `$ANDROID_HOME/ndk` folder, where `ANDROID_HOME` usually is:
-- on Windows: `%APPDATA%\Local\Android\sdk`
-- on MacOS: `~/Library/Android/sdk`
-- on Linux: set via the environment variable `ANDROID_HOME`, or `~/Android/sdk`
-
-[An issue] regarding building Rust's `core` library against the latest NDK means that as of writing only NDK versions 22 and older can be used.
-
-## `ANDROID_NDK` Gradle property
-
-```shell
-echo "ANDROID_NDK=(path to NDK)" >> ~/.gradle/gradle.properties
-```
-
-Next, you need to make this NDK visible to Gradle. The way to do this depends on your current system and is unlikely to be portable, but generally you can add a `gradle.properties` in your `~/.gradle` folder like this:
-
-```
-ANDROID_NDK=(path to NDK)
-```
-
-or edit one of the `gradle.properties` that resides within the `android` folder.
-
-## [cargo-ndk]
-```shell
-cargo install cargo-ndk --version 2.6.0
-```
-
-[cargo-ndk] is a Cargo plugin for compiling code suitable for plugging into
-the JNI without additional configuration. Run the above command to install.
-Version 2.7.0 of cargo-ndk introduced changes that breaked support for NDK
-version 22 so 2.6.0 must be used for now.
-
-## Alternative NDK setup
-
-You can alternatively use the latest version of the Android NDK which is greater than 22.
-However, this requires a hack to prevent the [unable to find library -lgcc error].
-
-### Android NDK
-Install the latest NDK:
-
-> Android Studio > SDK Manager > SDK Tools > NDK (Side by side)
-
-Click on OK at the bottom right corner to start the installation.
-
-### [cargo-ndk]
-You should install `cargo-ndk` version 2.7.0 or above which works for
-Android NDK versions greater than 22.
-
-```
-cargo install cargo-ndk --version ^2.7.0
-```
-
-A workaround may be under development in the cargo-ndk project. Until it is finished,
-you need to manually create four text files to redirect calls from libgcc to libunwind ([reference]):
-
-1. Find out all the 4 folders containing file `libunwind.a`.
-   * On Windows, it is similar to:
-      ```
-      C:\Users\Administrator\AppData\Local\Android\Sdk\ndk\24.0.8215888\toolchains\llvm\prebuilt\windows-x86_64\lib64\clang\14.0.1\lib\linux\x86_64\
-      ```
-
-   * On macOS Monterey, it is similar to:
-      ```
-      ~/Library/Android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/darwin-x86_64/lib64/clang/14.0.1/lib/linux/x86_64/
-      ```
-   The three other folders end with `aarch64`, `arm`,    `i386` instead of `x86_64`.
-
-2. Create 4 text files named `libgcc.a` in the four folders mentioned above with these contents
-
-   ```
-   INPUT(-lunwind)
-   ```
-
-## More details on NDK with flutter_rust_bridge
-For more details on how NDK works with `flutter_rust_bridge`, have a look at this [article](../integrate/android_tasks.md) please.
-
-[Android NDK]: https://developer.android.com/ndk
-[Java Native Interface]: https://docs.oracle.com/javase/7/docs/technotes/guides/jni/spec/jniTOC.html
-[An issue]: https://github.com/rust-lang/rust/pull/85806
-[cargo-ndk]: https://github.com/bbqsrc/cargo-ndk
-[unable to find library -lgcc error]:https://github.com/bbqsrc/cargo-ndk/issues/22
-[reference]: https://github.com/rust-lang/rust/pull/85806#issuecomment-1096266946

--- a/book/src/tutorial/alternative_ndk.md
+++ b/book/src/tutorial/alternative_ndk.md
@@ -1,0 +1,50 @@
+# Alternative NDK setup
+
+You can alternatively use the latest version of the Android NDK which is greater than 22.
+However, this requires a hack to prevent the [unable to find library -lgcc error].
+
+### Android NDK
+Install the latest NDK:
+
+> Android Studio > SDK Manager > SDK Tools > NDK (Side by side)
+
+Click on OK at the bottom right corner to start the installation.
+
+### [cargo-ndk]
+You should install `cargo-ndk` version 2.7.0 or above which works for
+Android NDK versions greater than 22.
+
+```
+cargo install cargo-ndk --version ^2.7.0
+```
+
+A workaround may be under development in the cargo-ndk project. Until it is finished,
+you need to manually create four text files to redirect calls from libgcc to libunwind ([reference]):
+
+1. Find out all the 4 folders containing file `libunwind.a`.
+   * On Windows, it is similar to:
+      ```
+      C:\Users\Administrator\AppData\Local\Android\Sdk\ndk\24.0.8215888\toolchains\llvm\prebuilt\windows-x86_64\lib64\clang\14.0.1\lib\linux\x86_64\
+      ```
+
+   * On macOS Monterey, it is similar to:
+      ```
+      ~/Library/Android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/darwin-x86_64/lib64/clang/14.0.1/lib/linux/x86_64/
+      ```
+   The three other folders end with `aarch64`, `arm`,    `i386` instead of `x86_64`.
+
+2. Create 4 text files named `libgcc.a` in the four folders mentioned above with these contents
+
+   ```
+   INPUT(-lunwind)
+   ```
+
+## More details on NDK with flutter_rust_bridge
+For more details on how NDK works with `flutter_rust_bridge`, have a look at this [article](../integrate/android_tasks.md) please.
+
+[Android NDK]: https://developer.android.com/ndk
+[Java Native Interface]: https://docs.oracle.com/javase/7/docs/technotes/guides/jni/spec/jniTOC.html
+[An issue]: https://github.com/rust-lang/rust/pull/85806
+[cargo-ndk]: https://github.com/bbqsrc/cargo-ndk
+[unable to find library -lgcc error]:https://github.com/bbqsrc/cargo-ndk/issues/22
+[reference]: https://github.com/rust-lang/rust/pull/85806#issuecomment-1096266946

--- a/book/src/tutorial/alternative_ndk.md
+++ b/book/src/tutorial/alternative_ndk.md
@@ -3,14 +3,14 @@
 You can alternatively use the latest version of the Android NDK which is greater than 22.
 However, this requires a hack to prevent the [unable to find library -lgcc error].
 
-### Android NDK
+## Android NDK
 Install the latest NDK:
 
 > Android Studio > SDK Manager > SDK Tools > NDK (Side by side)
 
 Click on OK at the bottom right corner to start the installation.
 
-### [cargo-ndk]
+## [cargo-ndk]
 You should install `cargo-ndk` version 2.7.0 or above which works for
 Android NDK versions greater than 22.
 
@@ -42,9 +42,6 @@ you need to manually create four text files to redirect calls from libgcc to lib
 ## More details on NDK with flutter_rust_bridge
 For more details on how NDK works with `flutter_rust_bridge`, have a look at this [article](../integrate/android_tasks.md) please.
 
-[Android NDK]: https://developer.android.com/ndk
-[Java Native Interface]: https://docs.oracle.com/javase/7/docs/technotes/guides/jni/spec/jniTOC.html
-[An issue]: https://github.com/rust-lang/rust/pull/85806
 [cargo-ndk]: https://github.com/bbqsrc/cargo-ndk
 [unable to find library -lgcc error]:https://github.com/bbqsrc/cargo-ndk/issues/22
 [reference]: https://github.com/rust-lang/rust/pull/85806#issuecomment-1096266946

--- a/book/src/tutorial/setup_android.md
+++ b/book/src/tutorial/setup_android.md
@@ -40,7 +40,8 @@ cargo install cargo-ndk --version 2.6.0
 [cargo-ndk] is a Cargo plugin for compiling code suitable for plugging into
 the JNI without additional configuration. Run the above command to install.
 Version 2.7.0 of cargo-ndk introduced changes that broke support for NDK
-version 22 so 2.6.0 must be used for now.
+version 22 so 2.6.0 must be used for now. If you still want to use 2.7.0 with
+a workaround, see [this article](./alternative_ndk.md)
 
 Then run 
 ```shell

--- a/book/src/tutorial/setup_android.md
+++ b/book/src/tutorial/setup_android.md
@@ -51,3 +51,7 @@ Then run the Flutter app normally with `flutter run`.
 
 **Remark**: [This tutorial](https://stackoverflow.com/q/69515032/4619958) will help you automatically execute `cargo` builds when building Flutter app.
 
+[Android NDK]: https://developer.android.com/ndk
+[Java Native Interface]: https://docs.oracle.com/javase/7/docs/technotes/guides/jni/spec/jniTOC.html
+[An issue]: https://github.com/rust-lang/rust/pull/85806
+[cargo-ndk]: https://github.com/bbqsrc/cargo-ndk

--- a/book/src/tutorial/setup_android.md
+++ b/book/src/tutorial/setup_android.md
@@ -1,0 +1,52 @@
+# Android setup
+
+## JDK 8
+
+Android Studio depends on the `javax` library being present in the Java runtime, and the only reliable way to ensure this is to install an older version of Java. On Unix-like systems, you can use [asdf](https://asdf-vm.com/) or similar tools to manage your Java versions, and the template defines a known working version of Java in the `.tool-versions` file.
+
+## Android NDK
+
+> Android Studio > SDK Manager > SDK Tools > uncheck Hide Obsolete Packages > NDK (version 22)
+
+The [Android NDK], or Native Development Kit, enables code written in other
+languages to be run on the JVM via the [Java Native Interface], or JNI for short. In this case, we would like to pass the dynamic libraries created by Cargo to be included in the bundle when we run or build the project.
+
+After following the instructions above, the NDK should be installed in your `$ANDROID_HOME/ndk` folder, where `ANDROID_HOME` usually is:
+- on Windows: `%APPDATA%\Local\Android\sdk`
+- on MacOS: `~/Library/Android/sdk`
+- on Linux: set via the environment variable `ANDROID_HOME`, or `~/Android/sdk`
+
+[An issue] regarding building Rust's `core` library against the latest NDK means that as of writing only NDK versions 22 and older can be used.
+
+## `ANDROID_NDK` Gradle property
+
+```shell
+echo "ANDROID_NDK=(path to NDK)" >> ~/.gradle/gradle.properties
+```
+
+Next, you need to make this NDK visible to Gradle. The way to do this depends on your current system and is unlikely to be portable, but generally you can add a `gradle.properties` in your `~/.gradle` folder like this:
+
+```
+ANDROID_NDK=(path to NDK)
+```
+
+or edit one of the `gradle.properties` that resides within the `android` folder.
+
+## [cargo-ndk]
+```shell
+cargo install cargo-ndk --version 2.6.0
+```
+
+[cargo-ndk] is a Cargo plugin for compiling code suitable for plugging into
+the JNI without additional configuration. Run the above command to install.
+Version 2.7.0 of cargo-ndk introduced changes that broke support for NDK
+version 22 so 2.6.0 must be used for now.
+
+Then run 
+```shell
+cargo ndk -o ../android/app/src/main/jniLibs build`
+```
+Then run the Flutter app normally with `flutter run`.
+
+**Remark**: [This tutorial](https://stackoverflow.com/q/69515032/4619958) will help you automatically execute `cargo` builds when building Flutter app.
+

--- a/book/src/tutorial_with_flutter.md
+++ b/book/src/tutorial_with_flutter.md
@@ -39,10 +39,7 @@ At this step you may need to [setup dependencies](./integrate/deps.md).
 The [CI workflow](https://github.com/fzyzcjy/flutter_rust_bridge/blob/master/.github/workflows/ci.yaml) is useful if you want details of each command. The `flutter_android_test`, `flutter_ios_test`, `flutter_windows_test`, `flutter_macos_test` and `flutter_linux_test` demonstrates the exact commands needed to run this tutorial codebase from a brand new machine.
 
 ### Android app
-
-Append line `ANDROID_NDK=(path to NDK)` to `android/gradle.properties` and run `cargo ndk -o ../android/app/src/main/jniLibs build`. Then run the Flutter app normally such as `flutter run`.
-
-**Remark**: [This tutorial](https://stackoverflow.com/q/69515032/4619958) will help you automatically execute `cargo` builds when building Flutter app.
+See [Android setup](tutorial/setup_android.md)
 
 ### iOS app
 


### PR DESCRIPTION
## Changes

When I was trying to run the example project it worked perfectly on Linux but for Android I had to first setup the NDK. I've therefore put that bit in the initial tutorial for running for Android and then linked to it from the template Android setup. I've also move the `Alternative NDK setup` into a separate file to make the main one more focused.

## Checklist

- [X] If this PR adds/changes features, documentations (in the `./book` folder) are updated.
- [X] CI is passing.

 ### Not applicable
 
- [ ] An issue to be fixed by this PR is listed above.
- [ ] New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api.rs` and `dart/lib/main.dart`.
- [ ] The code generator is run and the code is formatted (via `just precommit`).
