### PR TITLE
Add documentation for Rust versions 1.68 and above with the latest Android NDK

### DIFF
--- a/book/src/tutorial/alternative_ndk.md
+++ b/book/src/tutorial/alternative_ndk.md
@@ -1,7 +1,7 @@
 # Alternative NDK setup
 
-You can alternatively use the latest version of the Android NDK which is greater than 22.
-However, this requires a hack to prevent the [unable to find library -lgcc error].
+This is only needed if you wish to use a version of the Android NDK higher than version 22 with versions of Rust that are lower than version 1.68.
+This guide details how to prevent the [unable to find library -lgcc error].
 
 ## Android NDK
 Install the latest NDK:

--- a/book/src/tutorial/setup_android.md
+++ b/book/src/tutorial/setup_android.md
@@ -5,8 +5,13 @@
 Android Studio depends on the `javax` library being present in the Java runtime, and the only reliable way to ensure this is to install an older version of Java. On Unix-like systems, you can use [asdf](https://asdf-vm.com/) or similar tools to manage your Java versions, and the template defines a known working version of Java in the `.tool-versions` file.
 
 ## Android NDK
+[An issue] regarding building Rust's `core` library against the latest NDK means that when using Rust 1.67 and lower, only NDK versions 22 and older can be used. The issue has been patched in Rust 1.68, which is not yet stable at the time of writing.
 
+Rust < 1.68:
 > Android Studio > SDK Manager > SDK Tools > uncheck Hide Obsolete Packages > NDK (version 22)
+
+Rust >= 1.68:
+> Android Studio > SDK Manager > SDK Tools > NDK (side by side)
 
 The [Android NDK], or Native Development Kit, enables code written in other
 languages to be run on the JVM via the [Java Native Interface], or JNI for short. In this case, we would like to pass the dynamic libraries created by Cargo to be included in the bundle when we run or build the project.
@@ -15,8 +20,6 @@ After following the instructions above, the NDK should be installed in your `$AN
 - on Windows: `%APPDATA%\Local\Android\sdk`
 - on MacOS: `~/Library/Android/sdk`
 - on Linux: set via the environment variable `ANDROID_HOME`, or `~/Android/sdk`
-
-[An issue] regarding building Rust's `core` library against the latest NDK means that as of writing only NDK versions 22 and older can be used.
 
 ## `ANDROID_NDK` Gradle property
 
@@ -33,17 +36,23 @@ ANDROID_NDK=(path to NDK)
 or edit one of the `gradle.properties` that resides within the `android` folder.
 
 ## [cargo-ndk]
+
+[cargo-ndk] is a Cargo plugin for compiling code suitable for plugging into
+the JNI without additional configuration.
+Version 2.7.0 of cargo-ndk introduced changes that broke support for NDK
+version 22, so 2.6.0 must be used if you are on a Rust version below 1.68. If you still want to use cargo-ndk 2.7.0 or above on Rust versions below 1.68 with
+a workaround, see [this article](./alternative_ndk.md).
+
+Rust < 1.68:
 ```shell
 cargo install cargo-ndk --version 2.6.0
 ```
+Rust >= 1.68:
+```shell
+cargo install cargo-ndk
+```
 
-[cargo-ndk] is a Cargo plugin for compiling code suitable for plugging into
-the JNI without additional configuration. Run the above command to install.
-Version 2.7.0 of cargo-ndk introduced changes that broke support for NDK
-version 22 so 2.6.0 must be used for now. If you still want to use 2.7.0 with
-a workaround, see [this article](./alternative_ndk.md)
-
-Then run 
+Then run (all Rust versions)
 ```shell
 cargo ndk -o ../android/app/src/main/jniLibs build`
 ```


### PR DESCRIPTION
## Changes

This PR adds documentation for Rust versions 1.68 and above with the latest Android NDK.
Closes #1069 

## Checklist

- [x] An issue to be fixed by this PR is listed above.
- [x] New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api.rs` and `dart/lib/main.dart`.
- [x] The code generator is run and the code is formatted (via `just precommit`).
- [x] If this PR adds/changes features, documentations (in the `./book` folder) are updated.
- [x] CI is passing.
