### PR TITLE
fix: default on freezed structs not applied

### DIFF
--- a/book/src/feature/lang_default.md
+++ b/book/src/feature/lang_default.md
@@ -6,6 +6,8 @@ Dart allows default values for function and constructor parameters, and you can 
 - If the parameter is a class or an enum, `#[frb(default = "..")]` annotates the *Dart code* to initialize the parameter.
   Note that this is run in the *constant context*, so classes can only be constructed if they are preceded with `const`.
 
+This will be translated to either a default value annotation, or Freezed's `@Default` in the case of enum constructor parameters.
+
 ```rust,noplayground
 pub enum Answer { Yes, No }
 pub struct Point(pub f64, pub f64);

--- a/frb_codegen/src/generator/dart/ty_struct.rs
+++ b/frb_codegen/src/generator/dart/ty_struct.rs
@@ -139,12 +139,13 @@ impl TypeDartGeneratorTrait for TypeStructRefGenerator<'_> {
             let mut constructor_params = src
                 .fields
                 .iter()
-                .map(|f| {
+                .map(|field| {
+                    let r#default = field.field_default(true);
                     format!(
-                        "{} {} {},",
-                        f.ty.dart_required_modifier(),
-                        f.ty.dart_api_type(),
-                        f.name.dart_style()
+                        "{default} {} {} {},",
+                        field.required_modifier(),
+                        field.ty.dart_api_type(),
+                        field.name.dart_style()
                     )
                 })
                 .collect::<Vec<_>>();

--- a/frb_example/pure_dart/dart/lib/bridge_definitions.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_definitions.dart
@@ -1426,7 +1426,7 @@ class U8Array8 extends NonGrowableListView<int> {
 @meta.immutable
 class UserId with _$UserId {
   const factory UserId({
-    required int value,
+    @Default(0) int value,
   }) = _UserId;
 }
 

--- a/frb_example/pure_dart/dart/lib/bridge_definitions.freezed.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_definitions.freezed.dart
@@ -3722,9 +3722,10 @@ class __$$_UserIdCopyWithImpl<$Res> extends _$UserIdCopyWithImpl<$Res, _$_UserId
 /// @nodoc
 
 class _$_UserId implements _UserId {
-  const _$_UserId({required this.value});
+  const _$_UserId({this.value = 0});
 
   @override
+  @JsonKey()
   final int value;
 
   @override
@@ -3750,7 +3751,7 @@ class _$_UserId implements _UserId {
 }
 
 abstract class _UserId implements UserId {
-  const factory _UserId({required final int value}) = _$_UserId;
+  const factory _UserId({final int value}) = _$_UserId;
 
   @override
   int get value;

--- a/frb_example/pure_dart/rust/src/api.rs
+++ b/frb_example/pure_dart/rust/src/api.rs
@@ -577,7 +577,7 @@ pub enum KitchenSink {
     },
     Nested(
         i32,
-        #[frb(default = "const KitchenSink.empty()")] Box<KitchenSink>,
+        #[frb(default = "KitchenSink.empty()")] Box<KitchenSink>,
     ),
     Optional(
         /// Comment on anonymous field
@@ -738,6 +738,7 @@ pub fn get_usize(u: usize) -> usize {
 /// Example for @freezed and @meta.immutable
 #[frb(dart_metadata=("freezed", "immutable" import "package:meta/meta.dart" as meta))]
 pub struct UserId {
+    #[frb(default = 0)]
     pub value: u32,
 }
 

--- a/justfile
+++ b/justfile
@@ -212,7 +212,7 @@ serve *args:
 
 # ============================ precommit ============================
 
-precommit: dart_pub_get generate_all rust_linter (dart_linter "fix")
+precommit: dart_pub_get generate_all rust_linter dart_linter
 
 # ============================ releasing new versions ============================
 


### PR DESCRIPTION
## Changes

Continued from #1095.
Also fixes CI failing from incorrect assumption regarding lints.

## Checklist

- [x] An issue to be fixed by this PR is listed above.
- [ ] New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api.rs` and `dart/lib/main.dart`.
- [x] The code generator is run and the code is formatted (via `just precommit`).
- [x] If this PR adds/changes features, documentations (in the `./book` folder) are updated.
- [ ] CI is passing.

## Remark for PR creator

- Justfile is a task runner for the command line interface that allows you to run shell commands from a file named `justfile` in your project directory. You can use Justfile after [installing it](https://github.com/casey/just). Note that commands written in `justfile` of this repository are expected to be run in `bash`, not `cmd` or `powershell`. Running `just ...` commands in `cmd` or `powershell` will produce errors as the syntax is not compatible. On Windows, you can use `git bash` if you have Git installed.
- If fzyzcjy does not reply for a few days, maybe he just did not see it, so please ping him.
