### PR TITLE
Add tests to gen, build, run pure_dart(_multi)

### DIFF
--- a/book/src/feature/build_rs.md
+++ b/book/src/feature/build_rs.md
@@ -4,3 +4,4 @@ There are basically two approaches to execute the code generator. The first and 
 
 The second approach is to integrate it into `build.rs` of your project. With this approach, the code generator is automatically triggered whenever you build your Rust project. For example configuration, have a look at this [build.rs](https://github.com/fzyzcjy/flutter_rust_bridge/blob/master/frb_example/pure_dart/rust/build.rs) file.
 
+If the `build.rs` in the example projects is making it difficult to modify and test flutter_rust_bridge_codegen, you can rename it to disable it, and instead use the pure_dart and pure_dart_multi tests to debug any issues.

--- a/book/src/feature/build_rs.md
+++ b/book/src/feature/build_rs.md
@@ -4,4 +4,4 @@ There are basically two approaches to execute the code generator. The first and 
 
 The second approach is to integrate it into `build.rs` of your project. With this approach, the code generator is automatically triggered whenever you build your Rust project. For example configuration, have a look at this [build.rs](https://github.com/fzyzcjy/flutter_rust_bridge/blob/master/frb_example/pure_dart/rust/build.rs) file.
 
-If the `build.rs` in the example projects is making it difficult to modify and test flutter_rust_bridge_codegen, you can rename it to disable it, and instead use the pure_dart and pure_dart_multi tests to debug any issues.
+If the `build.rs` in the example projects is making it difficult to modify and test flutter_rust_bridge_codegen, you can rename it to disable it, and instead use the pure_dart and pure_dart_multi tests to debug any issues. Please refer to `frb_codege/src/main.rs`'s tests for more details.

--- a/frb_codegen/src/main.rs
+++ b/frb_codegen/src/main.rs
@@ -40,13 +40,10 @@ mod tests {
     // VS Code runs in frb_codegen with "Run test" and flutter_rust_bridge with "Debug test" >_>
     #[allow(dead_code)]
     fn set_dir() {
-        match fs::metadata("frb_codegen") {
-            Ok(metadata) => {
-                if metadata.is_dir() {
-                    std::env::set_current_dir("frb_codegen").unwrap();
-                }
-            },
-            _ => {}
+        if let Ok(metadata) = fs::metadata("frb_codegen") {
+            if metadata.is_dir() {
+                std::env::set_current_dir("frb_codegen").unwrap();
+            }
         }
     }
 

--- a/frb_codegen/src/main.rs
+++ b/frb_codegen/src/main.rs
@@ -28,11 +28,26 @@ fn main() -> anyhow::Result<()> {
 }
 
 mod tests {
+    use std::fs;
+
     use lazy_static::lazy_static;
     use lib_flutter_rust_bridge_codegen::init_logger;
 
     lazy_static! {
         static ref LOGGER: () = init_logger(".", true).unwrap();
+    }
+
+    // VS Code runs in frb_codegen with "Run test" and flutter_rust_bridge with "Debug test" >_>
+    #[allow(dead_code)]
+    fn set_dir() {
+        match fs::metadata("frb_codegen") {
+            Ok(metadata) => {
+                if metadata.is_dir() {
+                    std::env::set_current_dir("frb_codegen").unwrap();
+                }
+            },
+            _ => {}
+        }
     }
 
     #[test]
@@ -49,6 +64,8 @@ mod tests {
             config_parse, frb_codegen, get_symbols_if_no_duplicates, RawOpts,
         };
         use std::process::Command;
+
+        set_dir();
 
         /// Path of input Rust code
         const RUST_INPUT: &str = "../frb_example/pure_dart/rust/src/api.rs";
@@ -121,6 +138,8 @@ mod tests {
             config_parse, frb_codegen_multi, get_symbols_if_no_duplicates, RawOpts,
         };
         use std::process::Command;
+
+        set_dir();
 
         /// Path of input Rust code
         const RUST_INPUT_1: &str = "../frb_example/pure_dart_multi/rust/src/api_1.rs";

--- a/frb_codegen/src/main.rs
+++ b/frb_codegen/src/main.rs
@@ -26,3 +26,179 @@ fn main() -> anyhow::Result<()> {
     info!("Now go and use it :)");
     Ok(())
 }
+
+mod tests {
+    use lazy_static::lazy_static;
+    use lib_flutter_rust_bridge_codegen::init_logger;
+
+    lazy_static! {
+        static ref LOGGER: () = init_logger(".", true).unwrap();
+    }
+
+    #[test]
+    fn pure_dart() {
+        // `cargo build` can fail because frb_example/pure_dart makes testing a build step! *gasp*
+        // If you want to get `cargo build` working again and investigate why pure_dart fails:
+        // 1. mv ../frb_example/pure_dart/rust/build.rs ../rb_example/pure_dart/rust/_build.rs
+        // 2. Run this test in the debugger - which is a copy of build.rs (but more complete)
+
+        assert!(cfg!(feature = "chrono"));
+        assert!(cfg!(feature = "uuid"));
+
+        use lib_flutter_rust_bridge_codegen::{
+            config_parse, frb_codegen, get_symbols_if_no_duplicates, RawOpts,
+        };
+        use std::process::Command;
+
+        /// Path of input Rust code
+        const RUST_INPUT: &str = "../frb_example/pure_dart/rust/src/api.rs";
+        /// Path of output generated Dart code
+        const DART_OUTPUT: &str = "../frb_example/pure_dart//dart/lib/bridge_generated.dart";
+
+        let _ = *LOGGER;
+
+        // Tell Cargo that if the input Rust code changes, to rerun this build script.
+        println!("cargo:rerun-if-changed={RUST_INPUT}");
+        // Options for frb_codegen
+        let raw_opts = RawOpts {
+            // Path of input Rust code
+            rust_input: vec![RUST_INPUT.to_string()],
+            // Path of output generated Dart code
+            dart_output: vec![DART_OUTPUT.to_string()],
+            wasm: true,
+            dart_decl_output: Some(
+                "../frb_example/pure_dart/dart/lib/bridge_definitions.dart".into(),
+            ),
+            dart_format_line_length: 120,
+            // (extra) c output path
+            c_output: Some(vec![
+                // each field should contain head file name
+                "../frb_example/pure_dart/rust/c_output_path/c_output.h".into(),
+            ]),
+            extra_c_output_path: Some(vec![
+                "../frb_example/pure_dart/rust/c_output_path_extra/".into()
+            ]),
+
+            // for other options use defaults
+            ..Default::default()
+        };
+
+        // get opts from raw opts
+        let all_configs = config_parse(raw_opts);
+
+        // generation of rust api for ffi (single block)
+        let all_symbols = get_symbols_if_no_duplicates(&all_configs).unwrap();
+        assert_eq!(all_configs.len(), 1);
+        frb_codegen(&all_configs[0], &all_symbols).unwrap();
+
+        let status = Command::new("cargo")
+            .current_dir("../frb_example/pure_dart/rust")
+            .arg("build")
+            .spawn()
+            .expect("failed to execute cargo")
+            .wait()
+            .expect("failed to wait for cargo to finish");
+        assert!(status.success(), "cargo build failed");
+
+        let status = Command::new("dart")
+            .arg("../frb_example/pure_dart/dart/lib/main.dart")
+            .arg("../target/debug/libflutter_rust_bridge_example.so")
+            .spawn()
+            .expect("failed to execute pure_dart")
+            .wait()
+            .expect("failed to wait for pure_dart");
+        assert!(status.success(), "pure_dart failed");
+    }
+
+    #[test]
+    fn pure_dart_multi() {
+        // `cargo build` can fail because frb_example/pure_dart makes testing a build step! *gasp*
+        // If you want to get `cargo build` working again and investigate why pure_dart fails:
+        // 1. mv ../frb_example/pure_dart_multi/rust/build.rs ../rb_example/pure_dart_multi/rust/_build.rs
+        // 2. Run this test in the debugger - which is a copy of build.rs (but more complete)
+
+        use lib_flutter_rust_bridge_codegen::{
+            config_parse, frb_codegen_multi, get_symbols_if_no_duplicates, RawOpts,
+        };
+        use std::process::Command;
+
+        /// Path of input Rust code
+        const RUST_INPUT_1: &str = "../frb_example/pure_dart_multi/rust/src/api_1.rs";
+        const RUST_INPUT_2: &str = "../frb_example/pure_dart_multi/rust/src/api_2.rs";
+        /// Path of output generated Dart code
+        const DART_OUTPUT_1: &str =
+            "../frb_example/pure_dart_multi/dart/lib/bridge_generated_api_1.dart";
+        const DART_OUTPUT_2: &str =
+            "../frb_example/pure_dart_multi/dart/lib/bridge_generated_api_2.dart";
+        /// Path of output Rust code
+        const RUST_OUTPUT_1: &str = "../frb_example/pure_dart_multi/rust/src/generated_api_1.rs";
+        const RUST_OUTPUT_2: &str = "../frb_example/pure_dart_multi/rust/src/generated_api_2.rs";
+        /// Class name to use in dart, corresponding to each Rust block
+        const CLASS_NAME_1: &str = "ApiClass1";
+        const CLASS_NAME_2: &str = "ApiClass2";
+
+        let _ = *LOGGER;
+
+        // Tell Cargo that if the input Rust code changes, to rerun this build script.
+        println!("cargo:rerun-if-changed={RUST_INPUT_1}");
+        println!("cargo:rerun-if-changed={RUST_INPUT_2}");
+        // Options for frb_codegen
+        let mut raw_opts = RawOpts {
+            // Path of input Rust code
+            rust_input: vec![RUST_INPUT_1.to_string(), RUST_INPUT_2.to_string()],
+            // Path of output generated Dart code
+            dart_output: vec![DART_OUTPUT_1.to_string(), DART_OUTPUT_2.to_string()],
+            // Path of output Rust code
+            rust_output: Some(vec![RUST_OUTPUT_1.to_string(), RUST_OUTPUT_2.to_string()]),
+            wasm: true,
+            // Class name of each Rust block of api
+            class_name: Some(vec![CLASS_NAME_1.to_string(), CLASS_NAME_2.to_string()]),
+            dart_format_line_length: 120,
+            // for other options use defaults
+            ..Default::default()
+        };
+
+        if cfg!(feature = "c-output") {
+            raw_opts.c_output = Some(vec![
+                // each field should contain head file name
+                "../frb_example/pure_dart_multi/rust/c_output_path/c_output_1.h".into(),
+                "../frb_example/pure_dart_multi/rust/c_output_path/c_output_2.h".into(),
+            ]);
+        }
+
+        if cfg!(feature = "extra-c-output-path") {
+            raw_opts.extra_c_output_path = Some(vec![
+                // For test, the below 2 paths format are made a little different
+                "../frb_example/pure_dart_multi/rust/./extra_c_output_path_1/".into(),
+                "../frb_example/pure_dart_multi/rust/extra_c_output_path_2".into(),
+            ]);
+        }
+
+        // get opts from raw opts
+        let configs = config_parse(raw_opts);
+
+        // generation of rust api for ffi (multi-blocks)
+        let all_symbols = get_symbols_if_no_duplicates(&configs).unwrap();
+        for config_index in 0..configs.len() {
+            frb_codegen_multi(&configs, config_index, &all_symbols).unwrap()
+        }
+
+        let status = Command::new("cargo")
+            .current_dir("../frb_example/pure_dart_multi/rust")
+            .arg("build")
+            .spawn()
+            .expect("failed to execute cargo")
+            .wait()
+            .expect("failed to wait for cargo to finish");
+        assert!(status.success(), "cargo build failed");
+
+        let status = Command::new("dart")
+            .arg("../frb_example/pure_dart_multi/dart/lib/main.dart")
+            .arg("../target/debug/libflutter_rust_bridge_example_multi.so")
+            .spawn()
+            .expect("failed to execute pure_dart")
+            .wait()
+            .expect("failed to wait for pure_dart");
+        assert!(status.success(), "pure_dart failed");
+    }
+}

--- a/frb_codegen/src/main.rs
+++ b/frb_codegen/src/main.rs
@@ -47,10 +47,17 @@ mod tests {
         }
     }
 
-    /// `cargo build` can fail because frb_example/pure_dart makes testing a build step! *gasp*
-    /// If you want to get `cargo build` working again and investigate why pure_dart fails:
-    /// 1. mv ../frb_example/pure_dart/rust/build.rs ../frb_example/pure_dart/rust/_build.rs
-    /// 2. Run this test in the debugger - which is a copy of build.rs (but more complete)
+    /// When the `frb_example/pure_dart` fails to build, i.e. the `cargo build` there fails,
+    /// i.e. the frb_codegen fails to generate code in that repo, you may want to use this
+    /// test to examine the problems, because this one is a copy of `build.rs` in that
+    /// `frb_example/pure_dart`. For example, you may run this `fn pure_dart()` unit
+    /// test in the debugger.
+    /// 
+    /// In some scenarios, such as when using VSCode to execute this test, the `cargo build`
+    /// will be run before this `fn pure_dart()` test gets executed (see #1106 for details).
+    /// Therefore, you may even fail to execute *this* function. In that case, you may run: 
+    /// `mv ../frb_example/pure_dart/rust/build.rs ../frb_example/pure_dart/rust/_build.rs`
+    /// Then that `build.rs` is temporarily disabled and cargo build can run.
     #[test]
     fn pure_dart() {
         assert!(cfg!(feature = "chrono"));

--- a/frb_codegen/src/main.rs
+++ b/frb_codegen/src/main.rs
@@ -28,8 +28,6 @@ fn main() -> anyhow::Result<()> {
 }
 
 mod tests {
-    use std::fs;
-
     use lazy_static::lazy_static;
     use lib_flutter_rust_bridge_codegen::init_logger;
 
@@ -38,8 +36,10 @@ mod tests {
     }
 
     // VS Code runs in frb_codegen with "Run test" and flutter_rust_bridge with "Debug test" >_>
-    #[allow(dead_code)]
+    #[cfg(test)]
     fn set_dir() {
+        use std::fs;
+
         if let Ok(metadata) = fs::metadata("frb_codegen") {
             if metadata.is_dir() {
                 std::env::set_current_dir("frb_codegen").unwrap();
@@ -47,13 +47,12 @@ mod tests {
         }
     }
 
+    /// `cargo build` can fail because frb_example/pure_dart makes testing a build step! *gasp*
+    /// If you want to get `cargo build` working again and investigate why pure_dart fails:
+    /// 1. mv ../frb_example/pure_dart/rust/build.rs ../frb_example/pure_dart/rust/_build.rs
+    /// 2. Run this test in the debugger - which is a copy of build.rs (but more complete)
     #[test]
     fn pure_dart() {
-        // `cargo build` can fail because frb_example/pure_dart makes testing a build step! *gasp*
-        // If you want to get `cargo build` working again and investigate why pure_dart fails:
-        // 1. mv ../frb_example/pure_dart/rust/build.rs ../rb_example/pure_dart/rust/_build.rs
-        // 2. Run this test in the debugger - which is a copy of build.rs (but more complete)
-
         assert!(cfg!(feature = "chrono"));
         assert!(cfg!(feature = "uuid"));
 
@@ -71,8 +70,6 @@ mod tests {
 
         let _ = *LOGGER;
 
-        // Tell Cargo that if the input Rust code changes, to rerun this build script.
-        println!("cargo:rerun-if-changed={RUST_INPUT}");
         // Options for frb_codegen
         let raw_opts = RawOpts {
             // Path of input Rust code
@@ -124,13 +121,9 @@ mod tests {
         assert!(status.success(), "pure_dart failed");
     }
 
+    /// See the documentation for the `pure_dart` test
     #[test]
     fn pure_dart_multi() {
-        // `cargo build` can fail because frb_example/pure_dart makes testing a build step! *gasp*
-        // If you want to get `cargo build` working again and investigate why pure_dart fails:
-        // 1. mv ../frb_example/pure_dart_multi/rust/build.rs ../rb_example/pure_dart_multi/rust/_build.rs
-        // 2. Run this test in the debugger - which is a copy of build.rs (but more complete)
-
         use lib_flutter_rust_bridge_codegen::{
             config_parse, frb_codegen_multi, get_symbols_if_no_duplicates, RawOpts,
         };
@@ -155,9 +148,6 @@ mod tests {
 
         let _ = *LOGGER;
 
-        // Tell Cargo that if the input Rust code changes, to rerun this build script.
-        println!("cargo:rerun-if-changed={RUST_INPUT_1}");
-        println!("cargo:rerun-if-changed={RUST_INPUT_2}");
         // Options for frb_codegen
         let mut raw_opts = RawOpts {
             // Path of input Rust code

--- a/justfile
+++ b/justfile
@@ -44,7 +44,7 @@ dart_pub_get mode="default":
 # ============================ build & test ============================
 
 rust_build_and_test:
-    just _rust_build_and_test_single frb_codegen
+    just _rust_build_and_test_single frb_codegen --features uuid --features chrono
     just _rust_build_and_test_single frb_rust
     just _rust_build_and_test_single frb_macros
     just _rust_build_and_test_single {{dir_example_pure_dart}}/rust


### PR DESCRIPTION
## Changes

For #1105, this PR adds `#[test]`s to `frb_codegen/main.rs` to generate, build, and run pure_dart and pure_dart_multi.

It may be desirable to remove `frb_example/pure_dart/rust/build.rs` and `frb_example/pure_dart_multi/rust/build.rs` entirely, to prevent divergence, leverage Rust's test capabilities, and to avoid confusion caused by #1105 in the first place, but I have left them there to keep changes to a minimum.

I also experimented with making `pure_dart` and `pure_dart_multi` independent, not part of the workspace, but I ran into problems with Rust failing to resolve `IntoDart` implementations for Vecs of `chrono` types.

## Checklist

- [x] An issue to be fixed by this PR is listed above.
- [x] New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api.rs` and `dart/lib/main.dart`.
- [x] The code generator is run and the code is formatted (via `just precommit`).
- [x] If this PR adds/changes features, documentations (in the `./book` folder) are updated.
- [ ] CI is passing.

## Remark for PR creator

- Justfile is a task runner for the command line interface that allows you to run shell commands from a file named `justfile` in your project directory. You can use Justfile after [installing it](https://github.com/casey/just). Note that commands written in `justfile` of this repository are expected to be run in `bash`, not `cmd` or `powershell`. Running `just ...` commands in `cmd` or `powershell` will produce errors as the syntax is not compatible. On Windows, you can use `git bash` if you have Git installed.
- If fzyzcjy does not reply for a few days, maybe he just did not see it, so please ping him.
