### PR TITLE
Fixes for `serde-yml`

### DIFF
--- a/book/src/command_line.md
+++ b/book/src/command_line.md
@@ -16,11 +16,31 @@ $ dart run flutter_rust_bridge_serve --help
 
 ## Configuration files
 
-You can also run `flutter_rust_bridge_codegen` with no arguments, provided one of these files exist (in order of priority):
+You can run `flutter_rust_bridge_codegen` with no arguments, provided any of these files exists in the working directory (in order of priority):
 
 - `.flutter_rust_bridge.yml`
 - `.flutter_rust_bridge.yaml`
 - `.flutter_rust_bridge.json`
 
-The codegen will try to read a configuration from any of these files. The same arguments from the CLI are accepted, but
-they will be in snake_case.
+The codegen will try to read a configuration from these files. Otherwise, you can pass to the CLI any YAML file that contains the config.
+The same arguments from the CLI are accepted, but they will be in snake_case.
+
+```yaml
+# in .flutter_rust_bridge.yml
+rust_input:
+  - path/to/api.rs
+dart_output:
+  - path/to/bridge_generated.dart
+```
+
+Similarly, if you're calling `flutter_rust_bridge_codegen` from the root of your Dart project, you can also fill in your config
+under the `flutter_rust_bridge` entry in `pubspec.yaml`:
+
+```yaml
+# put this somewhere in your pubspec.yaml
+flutter_rust_bridge:
+  rust_input:
+    - path/to/api.rs
+  dart_output:
+    - lib/src/bridge_generated.dart
+```

--- a/book/src/feature/build_rs.md
+++ b/book/src/feature/build_rs.md
@@ -4,4 +4,4 @@ There are basically two approaches to execute the code generator. The first and 
 
 The second approach is to integrate it into `build.rs` of your project. With this approach, the code generator is automatically triggered whenever you build your Rust project. For example configuration, have a look at this [build.rs](https://github.com/fzyzcjy/flutter_rust_bridge/blob/master/frb_example/pure_dart/rust/build.rs) file.
 
-If the `build.rs` in the example projects is making it difficult to modify and test flutter_rust_bridge_codegen, you can rename it to disable it, and instead use the pure_dart and pure_dart_multi tests to debug any issues. Please refer to `frb_codege/src/main.rs`'s tests for more details.
+If the `build.rs` in the example projects is making it difficult to modify and test flutter_rust_bridge_codegen, you can rename it to disable it, and instead use the pure_dart and pure_dart_multi tests to debug any issues. Please refer to `frb_codegen/src/main.rs`'s tests for more details.

--- a/book/src/troubleshooting.md
+++ b/book/src/troubleshooting.md
@@ -57,6 +57,11 @@ Indeed all generated code are necessary (if you find something that can be simpl
 
 Dart SDK `>=2.15.0` is supported by this library, but by the latest version of the `ffigen` tool requires `>=2.17.0`. Therefore, write `sdk: ">=2.17.0 <3.0.0"` in the `environment` section of `pubspec.yaml`. If you do not want that, consider installing a older version of the `ffigen` tool.
 
+## Why doesn't `flutter_rust_bridge_serve` work on Firefox?
+
+This is a known issue stemming from Firefox's stricter rules regarding cross-origin requests. Use Chromium for testing, and check out
+[this guide on enabling `crossOriginIsolated`](https://web.dev/cross-origin-isolation-guide/) for your production servers.
+
 ## Issues on Web?
 
 Check out [Limitations on WASM](./wasm_limitations.md) for some common problems and solutions

--- a/frb_codegen/src/config.rs
+++ b/frb_codegen/src/config.rs
@@ -194,11 +194,13 @@ impl RawOpts {
                         }
                         match serde_yaml::from_reader(pubspec) {
                             Ok(Needle { data: Some(data) }) => return Ok(data),
-                            Ok(_) => {
+                            Ok(Needle { data: None }) => {
                                 hint = format!("create an entry called 'flutter_rust_bridge' in {location} with your config.");
                             }
                             Err(err) => {
-                                eprintln!("The 'flutter_rust_bridge' entry in {location} could not be parsed:\n  {err}");
+                                return Err(anyhow::Error::new(err).context(format!(
+                                    "Could not parse the 'flutter_rust_bridge' entry in {location}"
+                                )));
                             }
                         }
                     }

--- a/frb_codegen/src/config.rs
+++ b/frb_codegen/src/config.rs
@@ -161,30 +161,54 @@ fn bail(err: clap::error::ErrorKind, message: Cow<str>) -> ! {
 impl RawOpts {
     /// Parses options from arguments, or from a config file if no arguments are given.
     /// Terminates the program if argument validation fails.
+    #[cfg(feature = "serde")]
     pub fn try_parse_args_or_yaml() -> anyhow::Result<Self> {
         const CONFIG_LOCATIONS: [&str; 3] = [
             ".flutter_rust_bridge.yml",
             ".flutter_rust_bridge.yaml",
             ".flutter_rust_bridge.json",
         ];
+        const PUBSPEC_LOCATIONS: [&str; 2] = ["pubspec.yaml", "pubspec.yml"];
+
         let has_args = std::env::args_os().len() > 1;
-        Ok(match Self::try_parse() {
-            Ok(opts) => opts,
+        match Self::try_parse() {
+            Ok(opts) => Ok(opts),
             Err(err) if has_args => err.exit(),
             // Try to parse a command file, if exists
-            Err(err) => 'from_file: {
+            Err(err) => {
                 for location in CONFIG_LOCATIONS {
-                    let Ok(file) = fs::File::open(location) else {continue};
-                    log::info!("Found config file {location}");
-                    break 'from_file serde_yaml::from_reader(file)
-                        .map_err(|err| anyhow::anyhow!("Could not parse {location}: {err}"))?;
+                    if let Ok(file) = fs::File::open(location) {
+                        eprintln!("Found config file {location}");
+                        return serde_yaml::from_reader(file)
+                            .with_context(|| format!("Could not parse {location}"));
+                    }
                 }
-                _ = err.print();
 
-                eprintln!("Hint: To call flutter_rust_bridge_codegen with no arguments, fill in .flutter_rust_bridge.yml with your config.");
+                let mut hint = "fill in .flutter_rust_bridge.yml with your config.".to_owned();
+                for location in PUBSPEC_LOCATIONS {
+                    if let Ok(pubspec) = fs::File::open(location) {
+                        #[derive(serde::Deserialize)]
+                        struct Needle {
+                            #[serde(rename = "flutter_rust_bridge")]
+                            data: Option<RawOpts>,
+                        }
+                        match serde_yaml::from_reader(pubspec) {
+                            Ok(Needle { data: Some(data) }) => return Ok(data),
+                            Ok(_) => {
+                                hint = format!("create an entry called 'flutter_rust_bridge' in {location} with your config.");
+                            }
+                            Err(err) => {
+                                eprintln!("The 'flutter_rust_bridge' entry in {location} could not be parsed:\n  {err}");
+                            }
+                        }
+                    }
+                }
+
+                _ = err.print();
+                eprintln!("Hint: To call flutter_rust_bridge_codegen with no arguments, {hint}");
                 std::process::exit(1)
             }
-        })
+        }
     }
 }
 

--- a/frb_example/with_flutter/README.md
+++ b/frb_example/with_flutter/README.md
@@ -6,3 +6,8 @@ For a pure-Dart example without UI, please see the `pure_dart` example which is 
 
 For full documentation, please see README.md of the main repository.
 
+### Running in Flutter Web
+
+```shell
+flutter pub run flutter_rust_bridge:serve --crate rust
+```


### PR DESCRIPTION
## Changes

- Closes #1121
- Closes #1120
- feat: look in `pubspec.yaml` for a flutter_rust_bridge config
- docs: general improvements

## Checklist

- [x] An issue to be fixed by this PR is listed above.
- [ ] New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api.rs` and `dart/lib/main.dart`.
- [ ] The code generator is run and the code is formatted (via `just precommit`).
- [x] If this PR adds/changes features, documentations (in the `./book` folder) are updated.
- [x] CI is passing.

## Remark for PR creator

- Justfile is a task runner for the command line interface that allows you to run shell commands from a file named `justfile` in your project directory. You can use Justfile after [installing it](https://github.com/casey/just). Note that commands written in `justfile` of this repository are expected to be run in `bash`, not `cmd` or `powershell`. Running `just ...` commands in `cmd` or `powershell` will produce errors as the syntax is not compatible. On Windows, you can use `git bash` if you have Git installed.
- If fzyzcjy does not reply for a few days, maybe he just did not see it, so please ping him.
