### PR TITLE
fix: fix compile error when building `frb_codegen` w/o `serde` feature

### DIFF
--- a/frb_codegen/src/config/opts_parser.rs
+++ b/frb_codegen/src/config/opts_parser.rs
@@ -275,9 +275,10 @@ fn anchor_config(config: RawOpts, config_path: &str) -> RawOpts {
         wasm: config.wasm,
         inline_rust: config.inline_rust,
         skip_deps_check: config.skip_deps_check,
-        dump: config.dump,
         no_use_bridge_in_method: config.no_use_bridge_in_method,
         extra_headers: config.extra_headers,
+        #[cfg(feature = "serde")]
+        dump: config.dump,
     }
 }
 

--- a/frb_codegen/src/config/raw_opts_parser.rs
+++ b/frb_codegen/src/config/raw_opts_parser.rs
@@ -1,60 +1,71 @@
 use crate::config::raw_opts::RawOpts;
-use anyhow::Context;
 use clap::Parser;
-use std::fs;
 
 impl RawOpts {
     /// Parses options from arguments, or from a config file if no arguments are given.
     /// Terminates the program if argument validation fails.
-    #[cfg(feature = "serde")]
     pub fn try_parse_args_or_yaml() -> anyhow::Result<Self> {
-        const CONFIG_LOCATIONS: [&str; 3] = [
-            ".flutter_rust_bridge.yml",
-            ".flutter_rust_bridge.yaml",
-            ".flutter_rust_bridge.json",
-        ];
-        const PUBSPEC_LOCATIONS: [&str; 2] = ["pubspec.yaml", "pubspec.yml"];
+        #[cfg(not(feature = "serde"))]
+        {
+            Self::try_parse().map_err(|err| err.exit())
+        }
 
-        let has_args = std::env::args_os().len() > 1;
-        match Self::try_parse() {
-            Ok(opts) => Ok(opts),
-            Err(err) if has_args => err.exit(),
-            // Try to parse a command file, if exists
-            Err(err) => {
-                for location in CONFIG_LOCATIONS {
-                    if let Ok(file) = fs::File::open(location) {
-                        eprintln!("Found config file {location}");
-                        return serde_yaml::from_reader(file)
-                            .with_context(|| format!("Could not parse {location}"));
-                    }
-                }
+        #[cfg(feature = "serde")]
+        {
+            use anyhow::Context;
+            use std::fs;
 
-                let mut hint = "fill in .flutter_rust_bridge.yml with your config.".to_owned();
-                for location in PUBSPEC_LOCATIONS {
-                    if let Ok(pubspec) = fs::File::open(location) {
-                        #[derive(serde::Deserialize)]
-                        struct Needle {
-                            #[serde(rename = "flutter_rust_bridge")]
-                            data: Option<RawOpts>,
-                        }
-                        match serde_yaml::from_reader(pubspec) {
-                            Ok(Needle { data: Some(data) }) => return Ok(data),
-                            Ok(Needle { data: None }) => {
-                                hint = format!("create an entry called 'flutter_rust_bridge' in {location} with your config.");
-                            }
-                            Err(err) => {
-                                return Err(anyhow::Error::new(err).context(format!(
-                                    "Could not parse the 'flutter_rust_bridge' entry in {location}"
-                                )));
-                            }
-                        }
-                    }
-                }
+            const CONFIG_LOCATIONS: [&str; 3] = [
+                ".flutter_rust_bridge.yml",
+                ".flutter_rust_bridge.yaml",
+                ".flutter_rust_bridge.json",
+            ];
+            const PUBSPEC_LOCATIONS: [&str; 2] = ["pubspec.yaml", "pubspec.yml"];
 
-                _ = err.print();
-                eprintln!("Hint: To call flutter_rust_bridge_codegen with no arguments, {hint}");
-                std::process::exit(1)
+            let has_args = std::env::args_os().len() > 1;
+            let err = match Self::try_parse() {
+                Ok(opts) => return Ok(opts),
+                Err(err) => err,
+            };
+
+            if has_args {
+                err.exit();
             }
+
+            // Try to parse a command file, if exists
+            for location in CONFIG_LOCATIONS {
+                if let Ok(file) = fs::File::open(location) {
+                    eprintln!("Found config file {location}");
+                    return serde_yaml::from_reader(file)
+                        .with_context(|| format!("Could not parse {location}"));
+                }
+            }
+
+            let mut hint = "fill in .flutter_rust_bridge.yml with your config.".to_owned();
+            for location in PUBSPEC_LOCATIONS {
+                if let Ok(pubspec) = fs::File::open(location) {
+                    #[derive(serde::Deserialize)]
+                    struct Needle {
+                        #[serde(rename = "flutter_rust_bridge")]
+                        data: Option<RawOpts>,
+                    }
+                    match serde_yaml::from_reader(pubspec) {
+                        Ok(Needle { data: Some(data) }) => return Ok(data),
+                        Ok(Needle { data: None }) => {
+                            hint = format!("create an entry called 'flutter_rust_bridge' in {location} with your config.");
+                        }
+                        Err(err) => {
+                            return Err(anyhow::Error::new(err).context(format!(
+                                "Could not parse the 'flutter_rust_bridge' entry in {location}"
+                            )));
+                        }
+                    }
+                }
+            }
+
+            _ = err.print();
+            eprintln!("Hint: To call flutter_rust_bridge_codegen with no arguments, {hint}");
+            std::process::exit(1)
         }
     }
 }


### PR DESCRIPTION
This PR fixes a small issue preventing `frb_codegen` from building with `--no-default-features` (without the `serde` feature enabled).

### Before:

```rust
$ cargo check -p flutter_rust_bridge_codegen --no-default-features
    Checking flutter_rust_bridge_codegen v1.75.0
warning: unused import: `anyhow::Context`
 --> frb_codegen/src/config/raw_opts_parser.rs:2:5
  |
2 | use anyhow::Context;
  |     ^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: unused import: `clap::Parser`
 --> frb_codegen/src/config/raw_opts_parser.rs:3:5
  |
3 | use clap::Parser;
  |     ^^^^^^^^^^^^

warning: unused import: `std::fs`
 --> frb_codegen/src/config/raw_opts_parser.rs:4:5
  |
4 | use std::fs;
  |     ^^^^^^^

error[E0560]: struct `RawOpts` has no field named `dump`
   --> frb_codegen/src/config/opts_parser.rs:278:9
    |
278 |         dump: config.dump,
    |         ^^^^ `RawOpts` does not have this field
    |
    = note: available fields are: `rust_input`, `dart_output`, `config_file`, `dart_decl_output`, `c_output` ... and 17 others

error[E0609]: no field `dump` on type `RawOpts`
   --> frb_codegen/src/config/opts_parser.rs:278:22
    |
278 |         dump: config.dump,
    |                      ^^^^ unknown field
    |
    = note: available fields are: `rust_input`, `dart_output`, `config_file`, `dart_decl_output`, `c_output` ... and 17 others

Some errors have detailed explanations: E0560, E0609.
For more information about an error, try `rustc --explain E0560`.
warning: `flutter_rust_bridge_codegen` (lib) generated 3 warnings
error: could not compile `flutter_rust_bridge_codegen` due to 2 previous errors; 3 warnings emitted
```

## After:

```rust
$ cargo check -p flutter_rust_bridge_codegen --no-default-features
    Checking flutter_rust_bridge_codegen v1.75.0
    Finished dev [unoptimized + debuginfo] target(s) in 1.18s
```