### PR TITLE
Warn user about using `lib.rs` as a Rust input.

### DIFF
--- a/frb_codegen/src/config/opts_parser.rs
+++ b/frb_codegen/src/config/opts_parser.rs
@@ -22,6 +22,12 @@ pub fn config_parse(mut raw: RawOpts) -> Vec<Opts> {
     use clap::error::ErrorKind;
     // rust input path(s)
     let rust_input_paths = get_valid_canon_paths(&raw.rust_input);
+    for rust_input in rust_input_paths.iter() {
+        if rust_input.contains("lib.rs") {
+            log::warn!("Do not use `lib.rs` as a Rust input. Please put code to be generated in an `api.rs` or similar.");
+            break;
+        }
+    }
 
     // dart output path(s)
     let dart_output_paths = get_valid_canon_paths(&raw.dart_output);


### PR DESCRIPTION
## Changes

Fixes #1191

Warns the user if a Rust input they provided contains "lib.rs". When generating code from a `lib.rs`, the `use` statement in `bridge_generated.rs` is incorrect because the convention is not followed.

## Checklist

- [x] An issue to be fixed by this PR is listed above.
- [ ] New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api.rs` and `dart/lib/main.dart`.
- [x] The code generator is run and the code is formatted (via `just precommit`).
- [ ] If this PR adds/changes features, documentations (in the `./book` folder) are updated.
- [x] CI is passing.

## Remark for PR creator

- Justfile is a task runner for the command line interface that allows you to run shell commands from a file named `justfile` in your project directory. You can use Justfile after [installing it](https://github.com/casey/just). Note that commands written in `justfile` of this repository are expected to be run in `bash`, not `cmd` or `powershell`. Running `just ...` commands in `cmd` or `powershell` will produce errors as the syntax is not compatible. On Windows, you can use `git bash` if you have Git installed.
- If fzyzcjy does not reply for a few days, maybe he just did not see it, so please ping him.
