### PR TITLE
fix: Bridge access for Rust opaques

### DIFF
--- a/frb_codegen/src/config/opts.rs
+++ b/frb_codegen/src/config/opts.rs
@@ -52,8 +52,8 @@ impl Opts {
         ))
     }
 
-    pub fn dart_api_class_name(&self) -> String {
-        self.class_name.clone()
+    pub fn dart_api_class_name(&self) -> &str {
+        &self.class_name
     }
 
     pub fn dart_api_impl_class_name(&self) -> String {

--- a/frb_codegen/src/generator/dart/mod.rs
+++ b/frb_codegen/src/generator/dart/mod.rs
@@ -140,7 +140,7 @@ impl DartApiSpec {
 
         let dart_wire2api_funcs = distinct_output_types
             .iter()
-            .map(|ty| generate_wire2api_func(ty, ir_file, &dart_api_class_name, config))
+            .map(|ty| generate_wire2api_func(ty, ir_file, dart_api_class_name, config))
             .collect::<Vec<_>>();
 
         let dart_opaque_funcs = distinct_output_types

--- a/frb_codegen/src/generator/dart/ty_rust_opaque.rs
+++ b/frb_codegen/src/generator/dart/ty_rust_opaque.rs
@@ -24,33 +24,37 @@ impl TypeDartGeneratorTrait for TypeRustOpaqueGenerator<'_> {
     }
 
     fn wire2api_body(&self) -> String {
+        let bridge = if self.context.config.bridge_in_method {
+            "this"
+        } else {
+            ""
+        };
         format!(
-            "return {0}.fromRaw(raw[0], raw[1], this);",
+            "return {0}.fromRaw(raw[0], raw[1], {bridge});",
             self.ir.dart_api_type()
         )
     }
 
     fn structs(&self) -> String {
-        let field_bridge = if self.context.config.bridge_in_method {
-            format!(
-                "final {} bridge;",
-                self.context.config.dart_api_class_name(),
-            )
+        let bridge = self.context.config.get_dart_api_bridge_name();
+        let bridge_class = self.context.config.dart_api_class_name();
+        let (field, param) = if self.context.config.bridge_in_method {
+            (format!("final {bridge_class} bridge;"), "this.bridge")
         } else {
-            String::new()
+            (String::new(), "")
         };
         format!(
             "@sealed class {0} extends FrbOpaque {{
-                {field_bridge}
-                    {0}.fromRaw(int ptr, int size, this.bridge) : super.unsafe(ptr, size);
-                    @override
-                    DropFnType get dropFn => bridge.dropOpaque{0};
-                    
-                    @override
-                    ShareFnType get shareFn => bridge.shareOpaque{0};
+                {field}
+                {0}.fromRaw(int ptr, int size, {param}) : super.unsafe(ptr, size);
+                @override
+                DropFnType get dropFn => {bridge}.dropOpaque{0};
+                
+                @override
+                ShareFnType get shareFn => {bridge}.shareOpaque{0};
 
-                    @override
-                    OpaqueTypeFinalizer get staticFinalizer => bridge.{0}Finalizer;
+                @override
+                OpaqueTypeFinalizer get staticFinalizer => {bridge}.{0}Finalizer;
             }}",
             self.ir.dart_api_type()
         )

--- a/frb_codegen/src/generator/dart/ty_struct.rs
+++ b/frb_codegen/src/generator/dart/ty_struct.rs
@@ -120,7 +120,7 @@ impl TypeDartGeneratorTrait for TypeStructRefGenerator<'_> {
                 generate_api_method(
                     func,
                     src,
-                    self.context.config.dart_api_class_name(),
+                    self.context.config.dart_api_class_name().to_string(),
                     self.context.config,
                 )
             })

--- a/frb_example/pure_dart/dart/lib/ffi.io.dart
+++ b/frb_example/pure_dart/dart/lib/ffi.io.dart
@@ -1,8 +1,12 @@
 import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
 
+import 'bridge_definitions.dart';
 import 'bridge_generated.dart';
 
-FlutterRustBridgeExampleSingleBlockTestImpl initializeExternalLibrary(String path) =>
-    FlutterRustBridgeExampleSingleBlockTestImpl(
-      loadLibForDart(path),
-    );
+FlutterRustBridgeExampleSingleBlockTestImpl initializeExternalLibrary(
+  String path,
+) =>
+    _api = FlutterRustBridgeExampleSingleBlockTestImpl(loadLibForDart(path));
+
+FlutterRustBridgeExampleSingleBlockTest? _api;
+FlutterRustBridgeExampleSingleBlockTest get api => _api ?? (throw Exception('API not yet initialized'));

--- a/frb_example/pure_dart/dart/lib/ffi.web.dart
+++ b/frb_example/pure_dart/dart/lib/ffi.web.dart
@@ -1,3 +1,4 @@
+import 'bridge_definitions.dart';
 import 'bridge_generated.web.dart';
 export 'bridge_generated.web.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
@@ -8,3 +9,6 @@ FlutterRustBridgeExampleSingleBlockTestImpl initializeExternalLibrary(void _) =>
     FlutterRustBridgeExampleSingleBlockTestImpl.wasm(
       WasmModule.initialize(kind: const Modules.noModules(root: root)),
     );
+
+FlutterRustBridgeExampleSingleBlockTest? _api;
+FlutterRustBridgeExampleSingleBlockTest get api => _api ?? (throw Exception('API not yet initialized'));


### PR DESCRIPTION
## Changes

Fix code generated for Rust opaques when `--no-use-bridge-in-method` is active (referencing a non-existent `bridge`)

## Checklist

- [ ] An issue to be fixed by this PR is listed above.
- [ ] New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api.rs` and `dart/lib/main.dart`.
- [x] The code generator is run and the code is formatted (via `just precommit`).
- [ ] If this PR adds/changes features, documentations (in the `./book` folder) are updated.
- [ ] CI is passing.

## Remark for PR creator

- Justfile is a task runner for the command line interface that allows you to run shell commands from a file named `justfile` in your project directory. You can use Justfile after [installing it](https://github.com/casey/just). Note that commands written in `justfile` of this repository are expected to be run in `bash`, not `cmd` or `powershell`. Running `just ...` commands in `cmd` or `powershell` will produce errors as the syntax is not compatible. On Windows, you can use `git bash` if you have Git installed.
- If fzyzcjy does not reply for a few days, maybe he just did not see it, so please ping him.
