### PR TITLE
Add crucial info on macOS integration in docs

### DIFF
--- a/book/src/integrate/ios_headers.md
+++ b/book/src/integrate/ios_headers.md
@@ -8,8 +8,8 @@ Add `ios/Runner/bridge_generated.h` (or `macos/Runner/bridge_generated.h`)
 to the project, either by dragging it onto the project tree or
 via the **Add Files to "Runner"...** menu option.
 
-Switch to the **Build Phases** tab and drag the **bridge_generated.h** file over
-to the **Copy Bundle Resources** phase, if it isn't already present.
+Switch to the **Build Phases** tab and drag the `bridge_generated.h` file over
+to the **Copy Bundle Resources** section, if it isn't already present.
 
 ## iOS
 
@@ -43,12 +43,13 @@ If you release your app through App Store, the steps above might not be sufficie
 
 Ref: https://docs.flutter.dev/development/platform-integration/ios/c-interop#stripping-ios-symbols
 
-
 ## MacOS
 
 Flutter on MacOS does not use headers by default, so let's go ahead
 and add one ourselves. In the **Build Settings** tab, set the
 **Objective-C Bridging Header** to be **Runner/bridge_generated.h**.
+
+Also, head over to the **Build Phases** tab, **Bundle Framework** section and add your `$crate.dylib` by clicking the plus button. This includes your dynamic library file in your app package.
 
 Finally, use `dummy_method_to_enforce_bundling` somewhere within
 `macos/Runner/AppDelegate.swift`, as long as Xcode does not consider it dead code.

--- a/book/src/integrate/ios_proj.md
+++ b/book/src/integrate/ios_proj.md
@@ -28,4 +28,4 @@ cargo xcode
 This will generate a `$crate/$crate.xcodeproj` that can be imported into other Xcode projects.
 You only have to do this once per crate.
 
-Now, open up that `$crate/$crate.xcodeproj` file with Xcode and select the root item at the left pane. The item's name will be identical to your crate's name. In the **Build Settings** tab, search for `Dynamic Library Install Name Base` and change the value into `@executable_path/../Frameworks/`. This is [required by cargo-xcode](https://lib.rs/crates/cargo-xcode#:~:text=DYLIB_INSTALL_NAME_BASE) to enable macOS apps to properly locate `.dylib` library files .
+Now, open up that `$crate/$crate.xcodeproj` file with Xcode and select the root item at the left pane. The item's name will be identical to your crate's name. In the **Build Settings** tab, search for `Dynamic Library Install Name Base` and change the value into `@executable_path/../Frameworks/`. This is [required by cargo-xcode](https://lib.rs/crates/cargo-xcode#:~:text=DYLIB_INSTALL_NAME_BASE) to enable macOS executable to properly locate `.dylib` library files in the package.

--- a/book/src/integrate/ios_proj.md
+++ b/book/src/integrate/ios_proj.md
@@ -14,6 +14,7 @@ crate-type = ["lib", "staticlib", "cdylib"]
 ```
 
 where
+
 - `lib` is required for non-library targets, such as tests and benchmarks
 - `staticlib` is required for iOS
 - `cdylib` for all other platforms
@@ -26,4 +27,5 @@ cargo xcode
 
 This will generate a `$crate/$crate.xcodeproj` that can be imported into other Xcode projects.
 You only have to do this once per crate.
-Don't open the project yet; we need to configure it through the parent projects first.
+
+Now, open up that `$crate/$crate.xcodeproj` file with Xcode and select the root item at the left pane. The item's name will be identical to your crate's name. In the **Build Settings** tab, search for `Dynamic Library Install Name Base` and change the value into `@executable_path/../Frameworks/`. This is [required by cargo-xcode](https://lib.rs/crates/cargo-xcode#:~:text=DYLIB_INSTALL_NAME_BASE) to enable macOS apps to properly locate `.dylib` library files .


### PR DESCRIPTION
## Changes

This PR adds crucial information about macOS integration. The docs were almost there, but few steps were missing to make the integration work.

As described in #870, many people seemed to be using `staticlib` for macOS apps, not `dylib`. This was because dynamic libraries were not being included in the `Frameworks` folder of the macOS app package and thus the executable was not able to find the `dylib` file.

This PR adds documentation about how to include the `dylib` file and locate it from the executable. The solution was inspired from #870 and https://crates.io/crates/cargo-xcode docs. I confirmed on my macbook that it works.
<img width="453" alt="image" src="https://github.com/fzyzcjy/flutter_rust_bridge/assets/66480156/cc519af8-cada-45f4-a45e-c43fc03e8ca7">


## Checklist

- [x] An issue to be fixed by this PR is listed above.
- [x] New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api.rs` and `dart/lib/main.dart`.
- [x] The code generator is run and the code is formatted (via `just precommit`).
- [x] If this PR adds/changes features, documentations (in the `./book` folder) are updated.
- [x] CI is passing.

## Remark for PR creator

- Justfile is a task runner for the command line interface that allows you to run shell commands from a file named `justfile` in your project directory. You can use Justfile after [installing it](https://github.com/casey/just). Note that commands written in `justfile` of this repository are expected to be run in `bash`, not `cmd` or `powershell`. Running `just ...` commands in `cmd` or `powershell` will produce errors as the syntax is not compatible. On Windows, you can use `git bash` if you have Git installed.
- If fzyzcjy does not reply for a few days, maybe he just did not see it, so please ping him.
