### PR TITLE
Fix compile when install the newest version

### DIFF
--- a/frb_codegen/src/commands.rs
+++ b/frb_codegen/src/commands.rs
@@ -77,25 +77,23 @@ fn cbindgen(
         "execute cbindgen rust_crate_dir={} c_output_path={}",
         rust_crate_dir, c_output_path
     );
-    let config = cbindgen::Config {
-        language: cbindgen::Language::C,
-        sys_includes: vec![
-            "stdbool.h".to_string(),
-            "stdint.h".to_string(),
-            "stdlib.h".to_string(),
-        ],
-        no_includes: true,
-        // copied from: dart-sdk/dart_api.h
-        // used to convert Dart_Handle to Object.
-        after_includes: Some("typedef struct _Dart_Handle* Dart_Handle;".to_owned()),
-        export: cbindgen::ExportConfig {
-            include: c_struct_names
-                .iter()
-                .map(|name| format!("\"{name}\""))
-                .collect(),
-            exclude: exclude_symbols,
-            ..Default::default()
-        },
+    let mut config = cbindgen::Config::default();
+    config.language = cbindgen::Language::C;
+    config.sys_includes = vec![
+        "stdbool.h".to_string(),
+        "stdint.h".to_string(),
+        "stdlib.h".to_string(),
+    ];
+    config.no_includes = true;
+    // copied from: dart-sdk/dart_api.h
+    // used to convert Dart_Handle to Object.
+    config.after_includes = Some("typedef struct _Dart_Handle* Dart_Handle;".to_owned());
+    config.export = cbindgen::ExportConfig {
+        include: c_struct_names
+            .iter()
+            .map(|name| format!("\"{name}\""))
+            .collect(),
+        exclude: exclude_symbols,
         ..Default::default()
     };
 


### PR DESCRIPTION
cargo install flutter_rust_bridge_codegen v1.77.1
```
   Compiling flutter_rust_bridge_codegen v1.77.1
error[E0451]: field `config_path` of struct `Config` is private
   |
99 |         ..Default::default()
   |           ^^^^^^^^^^^^^^^^^^ field `config_path` is private

For more information about this error, try `rustc --explain E0451`.
error: could not compile `flutter_rust_bridge_codegen` due to previous error
warning: build failed, waiting for other jobs to finish...
error: failed to compile `flutter_rust_bridge_codegen v1.77.1`, intermediate artifacts can be found at
```