### PR TITLE
Do not wrap function calls using stream in mirror

### DIFF
--- a/book/src/feature/stream.md
+++ b/book/src/feature/stream.md
@@ -6,9 +6,9 @@ Flutter's [Stream](https://dart.dev/tutorials/language/streams) is a powerful ab
 
 For example, your Rust function may run computationally heavy algorithms, and for every hundreds of milliseconds, it finds out a new piece of the full solution. In this case, it can immediately give that piece to Flutter, then Flutter can render it to UI immediately. Therefore, users do not need to wait for the full algorithm to finish before he can see some partial results on the user interface.
 
-As for the details, a Rust function with signature like `fn f(sink: StreamSink<T>, ..) -> Result<()>` is translated to a Dart function  `Stream<T> f(..)`.
+As for the details, a Rust function with signature like `fn f(sink: StreamSink<T>, ..) -> Result<()>` is translated to a Dart function `Stream<T> f(..)`.
 
-Notice that, you can hold that `StreamSink` forever, and use it freely even *after the Rust function itself returns*. The logger example below also demonstrates this (the `create_log_stream` returns almost immediately, while you can use the `StreamSink` after, say, an hour).
+Notice that, you can hold that `StreamSink` forever, and use it freely even _after the Rust function itself returns_. The logger example below also demonstrates this (the `create_log_stream` returns almost immediately, while you can use the `StreamSink` after, say, an hour).
 
 The `StreamSink` can be placed at any location. For example, `fn f(a: i32, b: StreamSink<String>)` and `fn f(a: StreamSink<String>, b: i32)` are both valid.
 
@@ -19,3 +19,36 @@ See [logging examples](logging.md) which uses streams extensively.
 ## What about streaming from Dart/Flutter to Rust?
 
 This is not currently supported. As a workaround, consider iterating through your Dart stream and calling a normal Rust function for each item.
+
+## Streaming external types (mirror)
+
+When using mirrored external types in a StreamSink you have to specify the generated `mirror_..` type in the StreamSink. This is because the generated code can not implement the necessary interfaces on a struct from a different crate. The generated `mirror_struct` implements `From<struct>` so you can use your normal types and just call `.into()` before passing them to the StreamSink.
+
+### For example:
+
+```rust,noplayground
+pub use external_crate::MyStruct;
+
+pub fn sink_function(sink: StreamSink<mirror_MyStruct>) {
+    sink.add(MyStruct::new().into());
+}
+
+// for vectors you have to call mirror_struct::from(vec) instead of vec.into()
+pub fn vec_sink_function(sink: StreamSink<Vec<mirror_MyStruct>>>){
+    let vector = vec![MyStruct::new(), MyStruct::new()];
+    sink.add(mirror_MyStruct::from(vector));
+}
+
+// mirror types in structs work directly
+#[derive(Default)]
+pub struct MirrorStruct {
+    pub my_struct: mirror_MyStruct,
+}
+
+pub fn struct_sink_function(sink: StreamSink<MyStructWrapper>) {
+    let mirror_struct = MyStruct::default();
+    sink.add(MyStructWrapper {
+        my_struct: MyStruct::new().into(),
+    });
+}
+```

--- a/frb_codegen/src/generator/rust/mod.rs
+++ b/frb_codegen/src/generator/rust/mod.rs
@@ -324,6 +324,11 @@ impl<'a> Generator<'a> {
             .collect::<Vec<_>>()
             .join("");
 
+        // Stream functions do not have a return value on the rust side
+        let output = match func.mode {
+            IrFuncMode::Stream { .. } => IrType::Primitive(IrTypePrimitive::Unit),
+            _ => func.output.clone(),
+        };
         let code_call_inner_func = if f.is_non_static_method() || f.is_static_method() {
             let method_name = if f.is_non_static_method() {
                 inner_func_params[0] = format!("&{}", inner_func_params[0]);
@@ -335,7 +340,7 @@ impl<'a> Generator<'a> {
             } else {
                 panic!("{} is not a method, nor a static method.", func.name)
             };
-            TypeRustGenerator::new(func.output.clone(), ir_file, self.config).wrap_obj(
+            TypeRustGenerator::new(output, ir_file, self.config).wrap_obj(
                 format!(
                     r"{}::{}({})",
                     struct_name.unwrap(),
@@ -345,7 +350,7 @@ impl<'a> Generator<'a> {
                 func.fallible,
             )
         } else {
-            TypeRustGenerator::new(func.output.clone(), ir_file, self.config).wrap_obj(
+            TypeRustGenerator::new(output, ir_file, self.config).wrap_obj(
                 format!("{}({})", func.name, inner_func_params.join(", ")),
                 func.fallible,
             )

--- a/frb_codegen/src/generator/rust/mod.rs
+++ b/frb_codegen/src/generator/rust/mod.rs
@@ -497,10 +497,15 @@ impl<'a> Generator<'a> {
                         format!(
                             r###"
                             #[derive(Clone)]
-                            struct {}({});
+                            pub struct {w}({i});
+                            impl From<{i}> for {w} {{
+                                fn from(inner: {i}) -> Self {{
+                                    Self(inner)
+                                }}
+                            }} 
                             "###,
-                            wrapper,
-                            ty.rust_api_type(),
+                            w = wrapper,
+                            i = ty.rust_api_type(),
                         )
                     })
             }

--- a/frb_codegen/src/generator/rust/mod.rs
+++ b/frb_codegen/src/generator/rust/mod.rs
@@ -502,7 +502,17 @@ impl<'a> Generator<'a> {
                                 fn from(inner: {i}) -> Self {{
                                     Self(inner)
                                 }}
-                            }} 
+                            }}
+                            impl From<&{i}> for {w} {{
+                                fn from(inner: &{i}) -> Self {{
+                                    Self(inner.clone())
+                                }}
+                            }}
+                            impl {w} {{
+                                pub fn from(inner: Vec<{i}>) -> Vec<Self> {{
+                                    inner.iter().map(|x| x.into()).collect()
+                                }}
+                            }}
                             "###,
                             w = wrapper,
                             i = ty.rust_api_type(),

--- a/frb_codegen/src/generator/rust/ty_struct.rs
+++ b/frb_codegen/src/generator/rust/ty_struct.rs
@@ -104,6 +104,9 @@ impl TypeRustGeneratorTrait for TypeStructRefGenerator<'_> {
     }
 
     fn wrapper_struct(&self) -> Option<String> {
+        if self.ir.mirror {
+            return None;
+        }
         let src = self.ir.get(self.context.ir_file);
         src.wrapper_name.as_ref().cloned()
     }

--- a/frb_codegen/src/ir/file.rs
+++ b/frb_codegen/src/ir/file.rs
@@ -59,6 +59,13 @@ impl IrFile {
         let mut ans = Vec::new();
         self.visit_types(
             &mut |ty| {
+                // ignore mirror types that already come from generated code
+                // used e.g. in StreamSink<..>
+                if let IrType::StructRef(ty) = ty {
+                    if ty.name.starts_with("mirror_") {
+                        return false;
+                    }
+                }
                 let ident = ty.safe_ident();
                 let contains = seen_idents.contains(&ident);
                 if !contains {

--- a/frb_codegen/src/ir/file.rs
+++ b/frb_codegen/src/ir/file.rs
@@ -59,13 +59,6 @@ impl IrFile {
         let mut ans = Vec::new();
         self.visit_types(
             &mut |ty| {
-                // ignore mirror types that already come from generated code
-                // used e.g. in StreamSink<..>
-                if let IrType::StructRef(ty) = ty {
-                    if ty.name.starts_with("mirror_") {
-                        return false;
-                    }
-                }
                 let ident = ty.safe_ident();
                 let contains = seen_idents.contains(&ident);
                 if !contains {
@@ -80,7 +73,6 @@ impl IrFile {
 
         // make the output change less when input change
         ans.sort_by_key(|ty| ty.safe_ident());
-
         ans
     }
 

--- a/frb_codegen/src/ir/func.rs
+++ b/frb_codegen/src/ir/func.rs
@@ -91,7 +91,9 @@ impl IrFuncMode {
         match self {
             Self::Normal => format!("Future<{inner}>"),
             Self::Sync => inner.to_string(),
-            Self::Stream { .. } => format!("Stream<{inner}>"),
+            Self::Stream { .. } => {
+                format!("Stream<{}>", inner.strip_prefix("mirror_").unwrap_or(inner))
+            }
         }
     }
 

--- a/frb_codegen/src/ir/func.rs
+++ b/frb_codegen/src/ir/func.rs
@@ -92,7 +92,7 @@ impl IrFuncMode {
             Self::Normal => format!("Future<{inner}>"),
             Self::Sync => inner.to_string(),
             Self::Stream { .. } => {
-                format!("Stream<{}>", inner.strip_prefix("mirror_").unwrap_or(inner))
+                format!("Stream<{inner}>")
             }
         }
     }

--- a/frb_codegen/src/ir/ty_struct.rs
+++ b/frb_codegen/src/ir/ty_struct.rs
@@ -7,6 +7,7 @@ pub struct IrTypeStructRef {
     pub name: String,
     pub freezed: bool,
     pub empty: bool,
+    pub mirror: bool,
 }
 }
 impl IrTypeStructRef {

--- a/frb_codegen/src/ir/ty_struct.rs
+++ b/frb_codegen/src/ir/ty_struct.rs
@@ -26,7 +26,10 @@ impl IrTypeTrait for IrTypeStructRef {
         self.dart_api_type().to_case(Case::Snake)
     }
     fn dart_api_type(&self) -> String {
-        self.name.to_string()
+        self.name
+            .strip_prefix("mirror_")
+            .unwrap_or(&self.name)
+            .to_string()
     }
     fn dart_wire_type(&self, target: Target) -> String {
         if target.is_wasm() {

--- a/frb_codegen/src/ir/ty_struct.rs
+++ b/frb_codegen/src/ir/ty_struct.rs
@@ -26,10 +26,7 @@ impl IrTypeTrait for IrTypeStructRef {
         self.dart_api_type().to_case(Case::Snake)
     }
     fn dart_api_type(&self) -> String {
-        self.name
-            .strip_prefix("mirror_")
-            .unwrap_or(&self.name)
-            .to_string()
+        self.name.clone()
     }
     fn dart_wire_type(&self, target: Target) -> String {
         if target.is_wasm() {

--- a/frb_codegen/src/parser/ty.rs
+++ b/frb_codegen/src/parser/ty.rs
@@ -305,8 +305,20 @@ impl<'a> TypeParser<'a> {
                         Ok(Primitive(IrTypePrimitive::try_from_rust_str(name).unwrap()))
                     }
 
-                    [(name, None)] if self.src_structs.contains_key(&name.to_string()) => {
-                        let ident_string = name.to_string();
+                    [(name, None)]
+                        if self.src_structs.contains_key(
+                            &name
+                                .strip_prefix("mirror_")
+                                .or(Some(name))
+                                .expect("can not be None")
+                                .to_string(),
+                        ) =>
+                    {
+                        let ident_string = name
+                            .strip_prefix("mirror_")
+                            .or(Some(name))
+                            .expect("can not be None")
+                            .to_string();
                         if !self.parsing_or_parsed_struct_names.contains(&ident_string) {
                             self.parsing_or_parsed_struct_names
                                 .insert(ident_string.to_owned());

--- a/frb_codegen/src/parser/ty.rs
+++ b/frb_codegen/src/parser/ty.rs
@@ -343,6 +343,7 @@ impl<'a> TypeParser<'a> {
                                 .get(&ident_string)
                                 .map(IrStruct::is_empty)
                                 .unwrap_or(false),
+                            mirror: name.starts_with("mirror_"),
                         }))
                     }
 
@@ -537,6 +538,7 @@ impl<'a> TypeParser<'a> {
                 name: safe_ident,
                 freezed: false,
                 empty: false,
+                mirror: false,
             },
             values: values.into_boxed_slice(),
         })

--- a/frb_example/pure_dart/dart/lib/bridge_definitions.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_definitions.dart
@@ -223,6 +223,10 @@ abstract class FlutterRustBridgeExampleSingleBlockTest {
 
   FlutterRustBridgeTaskConstMeta get kIsAppEmbeddedConstMeta;
 
+  Stream<ApplicationSettings> appSettingsStream({dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kAppSettingsStreamConstMeta;
+
   Future<ApplicationMessage> getMessage({dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kGetMessageConstMeta;

--- a/frb_example/pure_dart/dart/lib/bridge_definitions.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_definitions.dart
@@ -227,6 +227,10 @@ abstract class FlutterRustBridgeExampleSingleBlockTest {
 
   FlutterRustBridgeTaskConstMeta get kAppSettingsStreamConstMeta;
 
+  Stream<List<ApplicationSettings>> appSettingsVecStream({dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kAppSettingsVecStreamConstMeta;
+
   Future<ApplicationMessage> getMessage({dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kGetMessageConstMeta;

--- a/frb_example/pure_dart/dart/lib/bridge_definitions.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_definitions.dart
@@ -231,6 +231,10 @@ abstract class FlutterRustBridgeExampleSingleBlockTest {
 
   FlutterRustBridgeTaskConstMeta get kAppSettingsVecStreamConstMeta;
 
+  Stream<MirrorStruct> mirrorStructStream({dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kMirrorStructStreamConstMeta;
+
   Future<ApplicationMessage> getMessage({dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kGetMessageConstMeta;
@@ -1355,6 +1359,20 @@ class MessageId {
 
   const MessageId({
     required this.field0,
+  });
+}
+
+class MirrorStruct {
+  final ApplicationSettings a;
+  final MyStruct b;
+  final List<MyEnum> c;
+  final List<ApplicationSettings> d;
+
+  const MirrorStruct({
+    required this.a,
+    required this.b,
+    required this.c,
+    required this.d,
   });
 }
 

--- a/frb_example/pure_dart/dart/lib/bridge_generated.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.dart
@@ -811,6 +811,21 @@ class FlutterRustBridgeExampleSingleBlockTestImpl implements FlutterRustBridgeEx
         argNames: ["appSettings"],
       );
 
+  Stream<ApplicationSettings> appSettingsStream({dynamic hint}) {
+    return _platform.executeStream(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_app_settings_stream(port_),
+      parseSuccessData: _wire2api_application_settings,
+      constMeta: kAppSettingsStreamConstMeta,
+      argValues: [],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kAppSettingsStreamConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "app_settings_stream",
+        argNames: [],
+      );
+
   Future<ApplicationMessage> getMessage({dynamic hint}) {
     return _platform.executeNormal(FlutterRustBridgeTask(
       callFfi: (port_) => _platform.inner.wire_get_message(port_),

--- a/frb_example/pure_dart/dart/lib/bridge_generated.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.dart
@@ -841,6 +841,21 @@ class FlutterRustBridgeExampleSingleBlockTestImpl implements FlutterRustBridgeEx
         argNames: [],
       );
 
+  Stream<MirrorStruct> mirrorStructStream({dynamic hint}) {
+    return _platform.executeStream(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_mirror_struct_stream(port_),
+      parseSuccessData: _wire2api_mirror_struct,
+      constMeta: kMirrorStructStreamConstMeta,
+      argValues: [],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kMirrorStructStreamConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "mirror_struct_stream",
+        argNames: [],
+      );
+
   Future<ApplicationMessage> getMessage({dynamic hint}) {
     return _platform.executeNormal(FlutterRustBridgeTask(
       callFfi: (port_) => _platform.inner.wire_get_message(port_),
@@ -3392,6 +3407,10 @@ class FlutterRustBridgeExampleSingleBlockTestImpl implements FlutterRustBridgeEx
     return (raw as List<dynamic>).map(_wire2api_enum_opaque).toList();
   }
 
+  List<MyEnum> _wire2api_list_my_enum(dynamic raw) {
+    return (raw as List<dynamic>).map(_wire2api_my_enum).toList();
+  }
+
   List<MySize> _wire2api_list_my_size(dynamic raw) {
     return (raw as List<dynamic>).map(_wire2api_my_size).toList();
   }
@@ -3474,6 +3493,17 @@ class FlutterRustBridgeExampleSingleBlockTestImpl implements FlutterRustBridgeEx
     if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return MessageId(
       field0: _wire2api_u8_array_32(arr[0]),
+    );
+  }
+
+  MirrorStruct _wire2api_mirror_struct(dynamic raw) {
+    final arr = raw as List<dynamic>;
+    if (arr.length != 4) throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
+    return MirrorStruct(
+      a: _wire2api_application_settings(arr[0]),
+      b: _wire2api_my_struct(arr[1]),
+      c: _wire2api_list_my_enum(arr[2]),
+      d: _wire2api_list_application_settings(arr[3]),
     );
   }
 

--- a/frb_example/pure_dart/dart/lib/bridge_generated.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.dart
@@ -826,6 +826,21 @@ class FlutterRustBridgeExampleSingleBlockTestImpl implements FlutterRustBridgeEx
         argNames: [],
       );
 
+  Stream<List<ApplicationSettings>> appSettingsVecStream({dynamic hint}) {
+    return _platform.executeStream(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_app_settings_vec_stream(port_),
+      parseSuccessData: _wire2api_list_application_settings,
+      constMeta: kAppSettingsVecStreamConstMeta,
+      argValues: [],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kAppSettingsVecStreamConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "app_settings_vec_stream",
+        argNames: [],
+      );
+
   Future<ApplicationMessage> getMessage({dynamic hint}) {
     return _platform.executeNormal(FlutterRustBridgeTask(
       callFfi: (port_) => _platform.inner.wire_get_message(port_),
@@ -3359,6 +3374,10 @@ class FlutterRustBridgeExampleSingleBlockTestImpl implements FlutterRustBridgeEx
 
   List<ApplicationEnvVar> _wire2api_list_application_env_var(dynamic raw) {
     return (raw as List<dynamic>).map(_wire2api_application_env_var).toList();
+  }
+
+  List<ApplicationSettings> _wire2api_list_application_settings(dynamic raw) {
+    return (raw as List<dynamic>).map(_wire2api_application_settings).toList();
   }
 
   List<Attribute> _wire2api_list_attribute(dynamic raw) {

--- a/frb_example/pure_dart/dart/lib/bridge_generated.io.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.io.dart
@@ -2267,6 +2267,18 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   late final _wire_is_app_embedded =
       _wire_is_app_embeddedPtr.asFunction<void Function(int, ffi.Pointer<wire_ApplicationSettings>)>();
 
+  void wire_app_settings_stream(
+    int port_,
+  ) {
+    return _wire_app_settings_stream(
+      port_,
+    );
+  }
+
+  late final _wire_app_settings_streamPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_app_settings_stream');
+  late final _wire_app_settings_stream = _wire_app_settings_streamPtr.asFunction<void Function(int)>();
+
   void wire_get_message(
     int port_,
   ) {

--- a/frb_example/pure_dart/dart/lib/bridge_generated.io.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.io.dart
@@ -2279,6 +2279,18 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_app_settings_stream');
   late final _wire_app_settings_stream = _wire_app_settings_streamPtr.asFunction<void Function(int)>();
 
+  void wire_app_settings_vec_stream(
+    int port_,
+  ) {
+    return _wire_app_settings_vec_stream(
+      port_,
+    );
+  }
+
+  late final _wire_app_settings_vec_streamPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_app_settings_vec_stream');
+  late final _wire_app_settings_vec_stream = _wire_app_settings_vec_streamPtr.asFunction<void Function(int)>();
+
   void wire_get_message(
     int port_,
   ) {

--- a/frb_example/pure_dart/dart/lib/bridge_generated.io.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.io.dart
@@ -2291,6 +2291,18 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_app_settings_vec_stream');
   late final _wire_app_settings_vec_stream = _wire_app_settings_vec_streamPtr.asFunction<void Function(int)>();
 
+  void wire_mirror_struct_stream(
+    int port_,
+  ) {
+    return _wire_mirror_struct_stream(
+      port_,
+    );
+  }
+
+  late final _wire_mirror_struct_streamPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_mirror_struct_stream');
+  late final _wire_mirror_struct_stream = _wire_mirror_struct_streamPtr.asFunction<void Function(int)>();
+
   void wire_get_message(
     int port_,
   ) {

--- a/frb_example/pure_dart/dart/lib/bridge_generated.web.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.web.dart
@@ -1115,6 +1115,8 @@ class FlutterRustBridgeExampleSingleBlockTestWasmModule implements WasmModule {
 
   external dynamic /* void */ wire_is_app_embedded(NativePortType port_, List<dynamic> app_settings);
 
+  external dynamic /* void */ wire_app_settings_stream(NativePortType port_);
+
   external dynamic /* void */ wire_get_message(NativePortType port_);
 
   external dynamic /* void */ wire_repeat_number(NativePortType port_, int num, int times);
@@ -1521,6 +1523,8 @@ class FlutterRustBridgeExampleSingleBlockTestWire
 
   void wire_is_app_embedded(NativePortType port_, List<dynamic> app_settings) =>
       wasmModule.wire_is_app_embedded(port_, app_settings);
+
+  void wire_app_settings_stream(NativePortType port_) => wasmModule.wire_app_settings_stream(port_);
 
   void wire_get_message(NativePortType port_) => wasmModule.wire_get_message(port_);
 

--- a/frb_example/pure_dart/dart/lib/bridge_generated.web.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.web.dart
@@ -1119,6 +1119,8 @@ class FlutterRustBridgeExampleSingleBlockTestWasmModule implements WasmModule {
 
   external dynamic /* void */ wire_app_settings_vec_stream(NativePortType port_);
 
+  external dynamic /* void */ wire_mirror_struct_stream(NativePortType port_);
+
   external dynamic /* void */ wire_get_message(NativePortType port_);
 
   external dynamic /* void */ wire_repeat_number(NativePortType port_, int num, int times);
@@ -1529,6 +1531,8 @@ class FlutterRustBridgeExampleSingleBlockTestWire
   void wire_app_settings_stream(NativePortType port_) => wasmModule.wire_app_settings_stream(port_);
 
   void wire_app_settings_vec_stream(NativePortType port_) => wasmModule.wire_app_settings_vec_stream(port_);
+
+  void wire_mirror_struct_stream(NativePortType port_) => wasmModule.wire_mirror_struct_stream(port_);
 
   void wire_get_message(NativePortType port_) => wasmModule.wire_get_message(port_);
 

--- a/frb_example/pure_dart/dart/lib/bridge_generated.web.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.web.dart
@@ -1117,6 +1117,8 @@ class FlutterRustBridgeExampleSingleBlockTestWasmModule implements WasmModule {
 
   external dynamic /* void */ wire_app_settings_stream(NativePortType port_);
 
+  external dynamic /* void */ wire_app_settings_vec_stream(NativePortType port_);
+
   external dynamic /* void */ wire_get_message(NativePortType port_);
 
   external dynamic /* void */ wire_repeat_number(NativePortType port_, int num, int times);
@@ -1525,6 +1527,8 @@ class FlutterRustBridgeExampleSingleBlockTestWire
       wasmModule.wire_is_app_embedded(port_, app_settings);
 
   void wire_app_settings_stream(NativePortType port_) => wasmModule.wire_app_settings_stream(port_);
+
+  void wire_app_settings_vec_stream(NativePortType port_) => wasmModule.wire_app_settings_vec_stream(port_);
 
   void wire_get_message(NativePortType port_) => wasmModule.wire_get_message(port_);
 

--- a/frb_example/pure_dart/rust/c_output_path/c_output.h
+++ b/frb_example/pure_dart/rust/c_output_path/c_output.h
@@ -595,6 +595,8 @@ void wire_app_settings_stream(int64_t port_);
 
 void wire_app_settings_vec_stream(int64_t port_);
 
+void wire_mirror_struct_stream(int64_t port_);
+
 void wire_get_message(int64_t port_);
 
 void wire_repeat_number(int64_t port_, int32_t num, uintptr_t times);
@@ -1133,6 +1135,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_is_app_embedded);
     dummy_var ^= ((int64_t) (void*) wire_app_settings_stream);
     dummy_var ^= ((int64_t) (void*) wire_app_settings_vec_stream);
+    dummy_var ^= ((int64_t) (void*) wire_mirror_struct_stream);
     dummy_var ^= ((int64_t) (void*) wire_get_message);
     dummy_var ^= ((int64_t) (void*) wire_repeat_number);
     dummy_var ^= ((int64_t) (void*) wire_repeat_sequence);

--- a/frb_example/pure_dart/rust/c_output_path/c_output.h
+++ b/frb_example/pure_dart/rust/c_output_path/c_output.h
@@ -591,6 +591,8 @@ void wire_get_fallible_app_settings(int64_t port_);
 
 void wire_is_app_embedded(int64_t port_, struct wire_ApplicationSettings *app_settings);
 
+void wire_app_settings_stream(int64_t port_);
+
 void wire_get_message(int64_t port_);
 
 void wire_repeat_number(int64_t port_, int32_t num, uintptr_t times);
@@ -1127,6 +1129,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_get_app_settings);
     dummy_var ^= ((int64_t) (void*) wire_get_fallible_app_settings);
     dummy_var ^= ((int64_t) (void*) wire_is_app_embedded);
+    dummy_var ^= ((int64_t) (void*) wire_app_settings_stream);
     dummy_var ^= ((int64_t) (void*) wire_get_message);
     dummy_var ^= ((int64_t) (void*) wire_repeat_number);
     dummy_var ^= ((int64_t) (void*) wire_repeat_sequence);

--- a/frb_example/pure_dart/rust/c_output_path/c_output.h
+++ b/frb_example/pure_dart/rust/c_output_path/c_output.h
@@ -593,6 +593,8 @@ void wire_is_app_embedded(int64_t port_, struct wire_ApplicationSettings *app_se
 
 void wire_app_settings_stream(int64_t port_);
 
+void wire_app_settings_vec_stream(int64_t port_);
+
 void wire_get_message(int64_t port_);
 
 void wire_repeat_number(int64_t port_, int32_t num, uintptr_t times);
@@ -1130,6 +1132,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_get_fallible_app_settings);
     dummy_var ^= ((int64_t) (void*) wire_is_app_embedded);
     dummy_var ^= ((int64_t) (void*) wire_app_settings_stream);
+    dummy_var ^= ((int64_t) (void*) wire_app_settings_vec_stream);
     dummy_var ^= ((int64_t) (void*) wire_get_message);
     dummy_var ^= ((int64_t) (void*) wire_repeat_number);
     dummy_var ^= ((int64_t) (void*) wire_repeat_sequence);

--- a/frb_example/pure_dart/rust/c_output_path_extra/c_output.h
+++ b/frb_example/pure_dart/rust/c_output_path_extra/c_output.h
@@ -595,6 +595,8 @@ void wire_app_settings_stream(int64_t port_);
 
 void wire_app_settings_vec_stream(int64_t port_);
 
+void wire_mirror_struct_stream(int64_t port_);
+
 void wire_get_message(int64_t port_);
 
 void wire_repeat_number(int64_t port_, int32_t num, uintptr_t times);
@@ -1133,6 +1135,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_is_app_embedded);
     dummy_var ^= ((int64_t) (void*) wire_app_settings_stream);
     dummy_var ^= ((int64_t) (void*) wire_app_settings_vec_stream);
+    dummy_var ^= ((int64_t) (void*) wire_mirror_struct_stream);
     dummy_var ^= ((int64_t) (void*) wire_get_message);
     dummy_var ^= ((int64_t) (void*) wire_repeat_number);
     dummy_var ^= ((int64_t) (void*) wire_repeat_sequence);

--- a/frb_example/pure_dart/rust/c_output_path_extra/c_output.h
+++ b/frb_example/pure_dart/rust/c_output_path_extra/c_output.h
@@ -591,6 +591,8 @@ void wire_get_fallible_app_settings(int64_t port_);
 
 void wire_is_app_embedded(int64_t port_, struct wire_ApplicationSettings *app_settings);
 
+void wire_app_settings_stream(int64_t port_);
+
 void wire_get_message(int64_t port_);
 
 void wire_repeat_number(int64_t port_, int32_t num, uintptr_t times);
@@ -1127,6 +1129,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_get_app_settings);
     dummy_var ^= ((int64_t) (void*) wire_get_fallible_app_settings);
     dummy_var ^= ((int64_t) (void*) wire_is_app_embedded);
+    dummy_var ^= ((int64_t) (void*) wire_app_settings_stream);
     dummy_var ^= ((int64_t) (void*) wire_get_message);
     dummy_var ^= ((int64_t) (void*) wire_repeat_number);
     dummy_var ^= ((int64_t) (void*) wire_repeat_sequence);

--- a/frb_example/pure_dart/rust/c_output_path_extra/c_output.h
+++ b/frb_example/pure_dart/rust/c_output_path_extra/c_output.h
@@ -593,6 +593,8 @@ void wire_is_app_embedded(int64_t port_, struct wire_ApplicationSettings *app_se
 
 void wire_app_settings_stream(int64_t port_);
 
+void wire_app_settings_vec_stream(int64_t port_);
+
 void wire_get_message(int64_t port_);
 
 void wire_repeat_number(int64_t port_, int32_t num, uintptr_t times);
@@ -1130,6 +1132,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_get_fallible_app_settings);
     dummy_var ^= ((int64_t) (void*) wire_is_app_embedded);
     dummy_var ^= ((int64_t) (void*) wire_app_settings_stream);
+    dummy_var ^= ((int64_t) (void*) wire_app_settings_vec_stream);
     dummy_var ^= ((int64_t) (void*) wire_get_message);
     dummy_var ^= ((int64_t) (void*) wire_repeat_number);
     dummy_var ^= ((int64_t) (void*) wire_repeat_sequence);

--- a/frb_example/pure_dart/rust/src/api.rs
+++ b/frb_example/pure_dart/rust/src/api.rs
@@ -699,14 +699,18 @@ pub fn app_settings_stream(sink: StreamSink<mirror_ApplicationSettings>) {
 // use a stream of a vec of mirrored type
 pub fn app_settings_vec_stream(sink: StreamSink<Vec<mirror_ApplicationSettings>>) {
     let app_settings = vec![external_lib::get_app_settings()];
-    sink.add(
-        app_settings
-            .iter()
-            .map(|e| e.to_owned().into())
-            .collect::<Vec<_>>()
-            .into(),
-    );
+    sink.add(mirror_ApplicationSettings::from(app_settings));
 }
+
+pub struct MirrorStruct {
+    pub a: mirror_ApplicationSettings,
+    pub b: MyStruct,
+    pub c: Vec<MyEnum>,
+    pub d: Vec<mirror_ApplicationSettings>,
+}
+
+// use a Struct consisting of mirror types as argument to a Stream
+pub fn mirror_struct_stream(sink: StreamSink<MirrorStruct>) {}
 
 #[frb(mirror(ApplicationMessage))]
 pub enum _ApplicationMessage {

--- a/frb_example/pure_dart/rust/src/api.rs
+++ b/frb_example/pure_dart/rust/src/api.rs
@@ -696,6 +696,18 @@ pub fn app_settings_stream(sink: StreamSink<mirror_ApplicationSettings>) {
     sink.add(app_settings.into());
 }
 
+// use a stream of a vec of mirrored type
+pub fn app_settings_vec_stream(sink: StreamSink<Vec<mirror_ApplicationSettings>>) {
+    let app_settings = vec![external_lib::get_app_settings()];
+    sink.add(
+        app_settings
+            .iter()
+            .map(|e| e.to_owned().into())
+            .collect::<Vec<_>>()
+            .into(),
+    );
+}
+
 #[frb(mirror(ApplicationMessage))]
 pub enum _ApplicationMessage {
     DisplayMessage(String),

--- a/frb_example/pure_dart/rust/src/api.rs
+++ b/frb_example/pure_dart/rust/src/api.rs
@@ -13,6 +13,7 @@ use anyhow::{anyhow, Result};
 use flutter_rust_bridge::*;
 use lazy_static::lazy_static;
 
+use crate::bridge_generated::mirror_ApplicationSettings;
 use crate::data::{EnumAlias, Id, MyEnum, MyStruct, StructAlias, UserIdAlias};
 pub use crate::data::{
     FrbOpaqueReturn, FrbOpaqueSyncReturn, HideData, NonCloneData, NonSendHideData,
@@ -690,7 +691,10 @@ pub fn is_app_embedded(app_settings: ApplicationSettings) -> bool {
 }
 
 // use a stream of a mirrored type
-pub fn app_settings_stream(sink: StreamSink<ApplicationSettings>) {}
+pub fn app_settings_stream(sink: StreamSink<mirror_ApplicationSettings>) {
+    let app_settings = external_lib::get_app_settings();
+    sink.add(app_settings.into());
+}
 
 #[frb(mirror(ApplicationMessage))]
 pub enum _ApplicationMessage {

--- a/frb_example/pure_dart/rust/src/api.rs
+++ b/frb_example/pure_dart/rust/src/api.rs
@@ -689,6 +689,9 @@ pub fn is_app_embedded(app_settings: ApplicationSettings) -> bool {
     matches!(app_settings.mode, ApplicationMode::Embedded)
 }
 
+// use a stream of a mirrored type
+pub fn app_settings_stream(sink: StreamSink<ApplicationSettings>) {}
+
 #[frb(mirror(ApplicationMessage))]
 pub enum _ApplicationMessage {
     DisplayMessage(String),

--- a/frb_example/pure_dart/rust/src/bridge_generated.io.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.io.rs
@@ -289,6 +289,11 @@ pub extern "C" fn wire_app_settings_vec_stream(port_: i64) {
 }
 
 #[no_mangle]
+pub extern "C" fn wire_mirror_struct_stream(port_: i64) {
+    wire_mirror_struct_stream_impl(port_)
+}
+
+#[no_mangle]
 pub extern "C" fn wire_get_message(port_: i64) {
     wire_get_message_impl(port_)
 }

--- a/frb_example/pure_dart/rust/src/bridge_generated.io.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.io.rs
@@ -279,6 +279,11 @@ pub extern "C" fn wire_is_app_embedded(port_: i64, app_settings: *mut wire_Appli
 }
 
 #[no_mangle]
+pub extern "C" fn wire_app_settings_stream(port_: i64) {
+    wire_app_settings_stream_impl(port_)
+}
+
+#[no_mangle]
 pub extern "C" fn wire_get_message(port_: i64) {
     wire_get_message_impl(port_)
 }

--- a/frb_example/pure_dart/rust/src/bridge_generated.io.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.io.rs
@@ -284,6 +284,11 @@ pub extern "C" fn wire_app_settings_stream(port_: i64) {
 }
 
 #[no_mangle]
+pub extern "C" fn wire_app_settings_vec_stream(port_: i64) {
+    wire_app_settings_vec_stream_impl(port_)
+}
+
+#[no_mangle]
 pub extern "C" fn wire_get_message(port_: i64) {
     wire_get_message_impl(port_)
 }

--- a/frb_example/pure_dart/rust/src/bridge_generated.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.rs
@@ -778,6 +778,16 @@ fn wire_app_settings_stream_impl(port_: MessagePort) {
         move || move |task_callback| Ok(app_settings_stream(task_callback.stream_sink())),
     )
 }
+fn wire_app_settings_vec_stream_impl(port_: MessagePort) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+        WrapInfo {
+            debug_name: "app_settings_vec_stream",
+            port: Some(port_),
+            mode: FfiCallMode::Stream,
+        },
+        move || move |task_callback| Ok(app_settings_vec_stream(task_callback.stream_sink())),
+    )
+}
 fn wire_get_message_impl(port_: MessagePort) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {

--- a/frb_example/pure_dart/rust/src/bridge_generated.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.rs
@@ -768,6 +768,16 @@ fn wire_is_app_embedded_impl(
         },
     )
 }
+fn wire_app_settings_stream_impl(port_: MessagePort) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+        WrapInfo {
+            debug_name: "app_settings_stream",
+            port: Some(port_),
+            mode: FfiCallMode::Stream,
+        },
+        move || move |task_callback| Ok(app_settings_stream(task_callback.stream_sink())),
+    )
+}
 fn wire_get_message_impl(port_: MessagePort) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {

--- a/frb_example/pure_dart/rust/src/bridge_generated.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.rs
@@ -2431,37 +2431,92 @@ fn wire_handle_some_static_stream_sink_single_arg__static_method__ConcatenateWit
 // Section: wrapper structs
 
 #[derive(Clone)]
-struct mirror_ApplicationEnv(ApplicationEnv);
+pub struct mirror_ApplicationEnv(ApplicationEnv);
+impl From<ApplicationEnv> for mirror_ApplicationEnv {
+    fn from(inner: ApplicationEnv) -> Self {
+        Self(inner)
+    }
+}
 
 #[derive(Clone)]
-struct mirror_ApplicationEnvVar(ApplicationEnvVar);
+pub struct mirror_ApplicationEnvVar(ApplicationEnvVar);
+impl From<ApplicationEnvVar> for mirror_ApplicationEnvVar {
+    fn from(inner: ApplicationEnvVar) -> Self {
+        Self(inner)
+    }
+}
 
 #[derive(Clone)]
-struct mirror_ApplicationMessage(ApplicationMessage);
+pub struct mirror_ApplicationMessage(ApplicationMessage);
+impl From<ApplicationMessage> for mirror_ApplicationMessage {
+    fn from(inner: ApplicationMessage) -> Self {
+        Self(inner)
+    }
+}
 
 #[derive(Clone)]
-struct mirror_ApplicationMode(ApplicationMode);
+pub struct mirror_ApplicationMode(ApplicationMode);
+impl From<ApplicationMode> for mirror_ApplicationMode {
+    fn from(inner: ApplicationMode) -> Self {
+        Self(inner)
+    }
+}
 
 #[derive(Clone)]
-struct mirror_ApplicationSettings(ApplicationSettings);
+pub struct mirror_ApplicationSettings(ApplicationSettings);
+impl From<ApplicationSettings> for mirror_ApplicationSettings {
+    fn from(inner: ApplicationSettings) -> Self {
+        Self(inner)
+    }
+}
 
 #[derive(Clone)]
-struct mirror_ListOfNestedRawStringMirrored(ListOfNestedRawStringMirrored);
+pub struct mirror_ListOfNestedRawStringMirrored(ListOfNestedRawStringMirrored);
+impl From<ListOfNestedRawStringMirrored> for mirror_ListOfNestedRawStringMirrored {
+    fn from(inner: ListOfNestedRawStringMirrored) -> Self {
+        Self(inner)
+    }
+}
 
 #[derive(Clone)]
-struct mirror_NestedRawStringMirrored(NestedRawStringMirrored);
+pub struct mirror_NestedRawStringMirrored(NestedRawStringMirrored);
+impl From<NestedRawStringMirrored> for mirror_NestedRawStringMirrored {
+    fn from(inner: NestedRawStringMirrored) -> Self {
+        Self(inner)
+    }
+}
 
 #[derive(Clone)]
-struct mirror_Numbers(Numbers);
+pub struct mirror_Numbers(Numbers);
+impl From<Numbers> for mirror_Numbers {
+    fn from(inner: Numbers) -> Self {
+        Self(inner)
+    }
+}
 
 #[derive(Clone)]
-struct mirror_RawStringEnumMirrored(RawStringEnumMirrored);
+pub struct mirror_RawStringEnumMirrored(RawStringEnumMirrored);
+impl From<RawStringEnumMirrored> for mirror_RawStringEnumMirrored {
+    fn from(inner: RawStringEnumMirrored) -> Self {
+        Self(inner)
+    }
+}
 
 #[derive(Clone)]
-struct mirror_RawStringMirrored(RawStringMirrored);
+pub struct mirror_RawStringMirrored(RawStringMirrored);
+impl From<RawStringMirrored> for mirror_RawStringMirrored {
+    fn from(inner: RawStringMirrored) -> Self {
+        Self(inner)
+    }
+}
 
 #[derive(Clone)]
-struct mirror_Sequences(Sequences);
+pub struct mirror_Sequences(Sequences);
+impl From<Sequences> for mirror_Sequences {
+    fn from(inner: Sequences) -> Self {
+        Self(inner)
+    }
+}
 
 // Section: static checks
 

--- a/frb_example/pure_dart/rust/src/bridge_generated.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.rs
@@ -788,6 +788,16 @@ fn wire_app_settings_vec_stream_impl(port_: MessagePort) {
         move || move |task_callback| Ok(app_settings_vec_stream(task_callback.stream_sink())),
     )
 }
+fn wire_mirror_struct_stream_impl(port_: MessagePort) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+        WrapInfo {
+            debug_name: "mirror_struct_stream",
+            port: Some(port_),
+            mode: FfiCallMode::Stream,
+        },
+        move || move |task_callback| Ok(mirror_struct_stream(task_callback.stream_sink())),
+    )
+}
 fn wire_get_message_impl(port_: MessagePort) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {
@@ -2447,12 +2457,32 @@ impl From<ApplicationEnv> for mirror_ApplicationEnv {
         Self(inner)
     }
 }
+impl From<&ApplicationEnv> for mirror_ApplicationEnv {
+    fn from(inner: &ApplicationEnv) -> Self {
+        Self(inner.clone())
+    }
+}
+impl mirror_ApplicationEnv {
+    pub fn from(inner: Vec<ApplicationEnv>) -> Vec<Self> {
+        inner.iter().map(|x| x.into()).collect()
+    }
+}
 
 #[derive(Clone)]
 pub struct mirror_ApplicationEnvVar(ApplicationEnvVar);
 impl From<ApplicationEnvVar> for mirror_ApplicationEnvVar {
     fn from(inner: ApplicationEnvVar) -> Self {
         Self(inner)
+    }
+}
+impl From<&ApplicationEnvVar> for mirror_ApplicationEnvVar {
+    fn from(inner: &ApplicationEnvVar) -> Self {
+        Self(inner.clone())
+    }
+}
+impl mirror_ApplicationEnvVar {
+    pub fn from(inner: Vec<ApplicationEnvVar>) -> Vec<Self> {
+        inner.iter().map(|x| x.into()).collect()
     }
 }
 
@@ -2463,12 +2493,32 @@ impl From<ApplicationMessage> for mirror_ApplicationMessage {
         Self(inner)
     }
 }
+impl From<&ApplicationMessage> for mirror_ApplicationMessage {
+    fn from(inner: &ApplicationMessage) -> Self {
+        Self(inner.clone())
+    }
+}
+impl mirror_ApplicationMessage {
+    pub fn from(inner: Vec<ApplicationMessage>) -> Vec<Self> {
+        inner.iter().map(|x| x.into()).collect()
+    }
+}
 
 #[derive(Clone)]
 pub struct mirror_ApplicationMode(ApplicationMode);
 impl From<ApplicationMode> for mirror_ApplicationMode {
     fn from(inner: ApplicationMode) -> Self {
         Self(inner)
+    }
+}
+impl From<&ApplicationMode> for mirror_ApplicationMode {
+    fn from(inner: &ApplicationMode) -> Self {
+        Self(inner.clone())
+    }
+}
+impl mirror_ApplicationMode {
+    pub fn from(inner: Vec<ApplicationMode>) -> Vec<Self> {
+        inner.iter().map(|x| x.into()).collect()
     }
 }
 
@@ -2479,12 +2529,32 @@ impl From<ApplicationSettings> for mirror_ApplicationSettings {
         Self(inner)
     }
 }
+impl From<&ApplicationSettings> for mirror_ApplicationSettings {
+    fn from(inner: &ApplicationSettings) -> Self {
+        Self(inner.clone())
+    }
+}
+impl mirror_ApplicationSettings {
+    pub fn from(inner: Vec<ApplicationSettings>) -> Vec<Self> {
+        inner.iter().map(|x| x.into()).collect()
+    }
+}
 
 #[derive(Clone)]
 pub struct mirror_ListOfNestedRawStringMirrored(ListOfNestedRawStringMirrored);
 impl From<ListOfNestedRawStringMirrored> for mirror_ListOfNestedRawStringMirrored {
     fn from(inner: ListOfNestedRawStringMirrored) -> Self {
         Self(inner)
+    }
+}
+impl From<&ListOfNestedRawStringMirrored> for mirror_ListOfNestedRawStringMirrored {
+    fn from(inner: &ListOfNestedRawStringMirrored) -> Self {
+        Self(inner.clone())
+    }
+}
+impl mirror_ListOfNestedRawStringMirrored {
+    pub fn from(inner: Vec<ListOfNestedRawStringMirrored>) -> Vec<Self> {
+        inner.iter().map(|x| x.into()).collect()
     }
 }
 
@@ -2495,12 +2565,32 @@ impl From<NestedRawStringMirrored> for mirror_NestedRawStringMirrored {
         Self(inner)
     }
 }
+impl From<&NestedRawStringMirrored> for mirror_NestedRawStringMirrored {
+    fn from(inner: &NestedRawStringMirrored) -> Self {
+        Self(inner.clone())
+    }
+}
+impl mirror_NestedRawStringMirrored {
+    pub fn from(inner: Vec<NestedRawStringMirrored>) -> Vec<Self> {
+        inner.iter().map(|x| x.into()).collect()
+    }
+}
 
 #[derive(Clone)]
 pub struct mirror_Numbers(Numbers);
 impl From<Numbers> for mirror_Numbers {
     fn from(inner: Numbers) -> Self {
         Self(inner)
+    }
+}
+impl From<&Numbers> for mirror_Numbers {
+    fn from(inner: &Numbers) -> Self {
+        Self(inner.clone())
+    }
+}
+impl mirror_Numbers {
+    pub fn from(inner: Vec<Numbers>) -> Vec<Self> {
+        inner.iter().map(|x| x.into()).collect()
     }
 }
 
@@ -2511,6 +2601,16 @@ impl From<RawStringEnumMirrored> for mirror_RawStringEnumMirrored {
         Self(inner)
     }
 }
+impl From<&RawStringEnumMirrored> for mirror_RawStringEnumMirrored {
+    fn from(inner: &RawStringEnumMirrored) -> Self {
+        Self(inner.clone())
+    }
+}
+impl mirror_RawStringEnumMirrored {
+    pub fn from(inner: Vec<RawStringEnumMirrored>) -> Vec<Self> {
+        inner.iter().map(|x| x.into()).collect()
+    }
+}
 
 #[derive(Clone)]
 pub struct mirror_RawStringMirrored(RawStringMirrored);
@@ -2519,12 +2619,32 @@ impl From<RawStringMirrored> for mirror_RawStringMirrored {
         Self(inner)
     }
 }
+impl From<&RawStringMirrored> for mirror_RawStringMirrored {
+    fn from(inner: &RawStringMirrored) -> Self {
+        Self(inner.clone())
+    }
+}
+impl mirror_RawStringMirrored {
+    pub fn from(inner: Vec<RawStringMirrored>) -> Vec<Self> {
+        inner.iter().map(|x| x.into()).collect()
+    }
+}
 
 #[derive(Clone)]
 pub struct mirror_Sequences(Sequences);
 impl From<Sequences> for mirror_Sequences {
     fn from(inner: Sequences) -> Self {
         Self(inner)
+    }
+}
+impl From<&Sequences> for mirror_Sequences {
+    fn from(inner: &Sequences) -> Self {
+        Self(inner.clone())
+    }
+}
+impl mirror_Sequences {
+    pub fn from(inner: Vec<Sequences>) -> Vec<Self> {
+        inner.iter().map(|x| x.into()).collect()
     }
 }
 
@@ -3041,6 +3161,19 @@ impl support::IntoDart for MessageId {
     }
 }
 impl support::IntoDartExceptPrimitive for MessageId {}
+
+impl support::IntoDart for MirrorStruct {
+    fn into_dart(self) -> support::DartAbi {
+        vec![
+            self.a.into_dart(),
+            self.b.into_dart(),
+            self.c.into_dart(),
+            self.d.into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl support::IntoDartExceptPrimitive for MirrorStruct {}
 
 impl support::IntoDart for MoreThanJustOneRawStringStruct {
     fn into_dart(self) -> support::DartAbi {

--- a/frb_example/pure_dart/rust/src/bridge_generated.web.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.web.rs
@@ -280,6 +280,11 @@ pub fn wire_app_settings_vec_stream(port_: MessagePort) {
 }
 
 #[wasm_bindgen]
+pub fn wire_mirror_struct_stream(port_: MessagePort) {
+    wire_mirror_struct_stream_impl(port_)
+}
+
+#[wasm_bindgen]
 pub fn wire_get_message(port_: MessagePort) {
     wire_get_message_impl(port_)
 }

--- a/frb_example/pure_dart/rust/src/bridge_generated.web.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.web.rs
@@ -275,6 +275,11 @@ pub fn wire_app_settings_stream(port_: MessagePort) {
 }
 
 #[wasm_bindgen]
+pub fn wire_app_settings_vec_stream(port_: MessagePort) {
+    wire_app_settings_vec_stream_impl(port_)
+}
+
+#[wasm_bindgen]
 pub fn wire_get_message(port_: MessagePort) {
     wire_get_message_impl(port_)
 }

--- a/frb_example/pure_dart/rust/src/bridge_generated.web.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.web.rs
@@ -270,6 +270,11 @@ pub fn wire_is_app_embedded(port_: MessagePort, app_settings: JsValue) {
 }
 
 #[wasm_bindgen]
+pub fn wire_app_settings_stream(port_: MessagePort) {
+    wire_app_settings_stream_impl(port_)
+}
+
+#[wasm_bindgen]
 pub fn wire_get_message(port_: MessagePort) {
     wire_get_message_impl(port_)
 }

--- a/frb_example/pure_dart/rust/src/data.rs
+++ b/frb_example/pure_dart/rust/src/data.rs
@@ -1,6 +1,8 @@
 #![allow(dead_code)]
 
 use std::rc::Rc;
+
+#[derive(Default)]
 pub struct MyStruct {
     pub content: bool,
 }


### PR DESCRIPTION
## Changes

When using a mirrored stuct as type in a StreamSink, do not wrap the function call in mirror_<struct>() in the generated rust code. Fixes #1275.

At the moment there is the problem that the mirrored types have to manually implement intoDart for the StreamSink to work. I have no good idea how we could change that because we cant implement a trait on structs from another crate.
Any ideas on how to fix this? I just created this pull-request at this point to discuss this problem. Obviously this needs to be fixed before merging

I added a test that is failing at this point. If there is no good way around manually implementing intoDart i can do that for a test. 

## Checklist

- [x] An issue to be fixed by this PR is listed above.
- [x] New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api.rs` and `dart/lib/main.dart`.
- [ ] The code generator is run and the code is formatted (via `just precommit`).
- [ ] If this PR adds/changes features, documentations (in the `./book` folder) are updated.
- [ ] CI is passing.
