### PR TITLE
Adjust type constraints to allow mirror types in Streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn",
+ "syn 1.0.109",
  "tempfile",
  "toml",
 ]
@@ -256,7 +256,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -443,7 +443,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -460,7 +460,7 @@ checksum = "086c685979a698443656e5cf7856c95c642295a38599f12fb1ff76fb28d19892"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -480,7 +480,7 @@ checksum = "082a24a9967533dc5d743c602157637116fc1b52806d694a5a45e6f32567fcdd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -506,7 +506,7 @@ checksum = "355f93763ef7b0ae1c43c4d8eccc9d5848d84ad1a1d8ce61c421d1ac85a19d05"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -518,7 +518,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -664,7 +664,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "strum_macros",
- "syn",
+ "syn 2.0.26",
  "tempfile",
  "thiserror",
  "toml",
@@ -1197,7 +1197,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1221,7 +1221,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -1238,18 +1238,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "5fe8a65d69dd0808184ebb5f836ab526bb259db23c657efa38711b1072ee47f0"
 dependencies = [
  "proc-macro2",
 ]
@@ -1393,7 +1393,7 @@ checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1465,7 +1465,7 @@ dependencies = [
  "memchr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1484,7 +1484,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1492,6 +1492,17 @@ name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45c3457aacde3c65315de5031ec191ce46604304d2446e803d71ade03308d970"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1544,7 +1555,7 @@ checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1650,7 +1661,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
 
@@ -1684,7 +1695,7 @@ checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,6 +633,7 @@ dependencies = [
  "log",
  "parking_lot 0.12.1",
  "threadpool",
+ "type-equals",
  "uuid",
  "wasm-bindgen",
  "wasm-bindgen-test",
@@ -1592,6 +1593,12 @@ name = "topological-sort"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea68304e134ecd095ac6c3574494fc62b909f416c4fca77e440530221e549d3d"
+
+[[package]]
+name = "type-equals"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84e1896346ff3dc15668ce862ebcf159da02a836dde7e9ef0e0d2e8a10f1ceb"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,7 +633,6 @@ dependencies = [
  "log",
  "parking_lot 0.12.1",
  "threadpool",
- "type-equals",
  "uuid",
  "wasm-bindgen",
  "wasm-bindgen-test",
@@ -1593,12 +1592,6 @@ name = "topological-sort"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea68304e134ecd095ac6c3574494fc62b909f416c4fca77e440530221e549d3d"
-
-[[package]]
-name = "type-equals"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a84e1896346ff3dc15668ce862ebcf159da02a836dde7e9ef0e0d2e8a10f1ceb"
 
 [[package]]
 name = "unicode-ident"

--- a/book/src/feature/logging.md
+++ b/book/src/feature/logging.md
@@ -6,7 +6,7 @@ Since I have seen some questions asking how logging can be implemented with a Fl
 
 In my own app in production, I use the following strategy for Rust logging: Use normal Rust logging methods, such as `info!` and `debug!` macros. The logs are consumed in two places: They are printed via platform-specific methods (like android Logcat and iOS NSLog), and also use a Stream to send them to the Dart side such that my Dart code and further process it using the same pipeline as normal Dart logs (e.g. save to a file, send to server, etc).
 
-The _full_ code related to logging in my app can be seen here: [#486](https://github.com/fzyzcjy/flutter_rust_bridge/issues/486).
+The *full* code related to logging in my app can be seen here: [#486](https://github.com/fzyzcjy/flutter_rust_bridge/issues/486).
 
 ## Simple logger
 
@@ -34,6 +34,7 @@ pub fn create_log_stream(s: StreamSink<LogEntry>) {
 
 Now Rust will probably complain at you because `IntoDart` is not implemented for `LogEntry`. This is expected, because `flutter_rust_bridge` will generate this trait implementation for you.
 To fix this error you should just rerun `flutter_rust_bridge_codegen`.
+
 
 Generated Dart code:
 

--- a/book/src/feature/logging.md
+++ b/book/src/feature/logging.md
@@ -6,7 +6,7 @@ Since I have seen some questions asking how logging can be implemented with a Fl
 
 In my own app in production, I use the following strategy for Rust logging: Use normal Rust logging methods, such as `info!` and `debug!` macros. The logs are consumed in two places: They are printed via platform-specific methods (like android Logcat and iOS NSLog), and also use a Stream to send them to the Dart side such that my Dart code and further process it using the same pipeline as normal Dart logs (e.g. save to a file, send to server, etc).
 
-The *full* code related to logging in my app can be seen here: [#486](https://github.com/fzyzcjy/flutter_rust_bridge/issues/486).
+The _full_ code related to logging in my app can be seen here: [#486](https://github.com/fzyzcjy/flutter_rust_bridge/issues/486).
 
 ## Simple logger
 
@@ -34,7 +34,6 @@ pub fn create_log_stream(s: StreamSink<LogEntry>) {
 
 Now Rust will probably complain at you because `IntoDart` is not implemented for `LogEntry`. This is expected, because `flutter_rust_bridge` will generate this trait implementation for you.
 To fix this error you should just rerun `flutter_rust_bridge_codegen`.
-
 
 Generated Dart code:
 
@@ -68,7 +67,7 @@ Credits: [this](https://gist.github.com/Desdaemon/be5da0a1c6b4724f20093ef4349597
 use anyhow::Result;
 use std::{thread::sleep, time::Duration};
 
-use flutter_rust_bridge::{StreamSink,StreamSinkTrait};
+use flutter_rust_bridge::StreamSink;
 
 const ONE_SECOND: Duration = Duration::from_secs(1);
 

--- a/book/src/feature/logging.md
+++ b/book/src/feature/logging.md
@@ -68,7 +68,7 @@ Credits: [this](https://gist.github.com/Desdaemon/be5da0a1c6b4724f20093ef4349597
 use anyhow::Result;
 use std::{thread::sleep, time::Duration};
 
-use flutter_rust_bridge::StreamSink;
+use flutter_rust_bridge::{StreamSink,StreamSinkTrait};
 
 const ONE_SECOND: Duration = Duration::from_secs(1);
 

--- a/book/src/feature/stream.md
+++ b/book/src/feature/stream.md
@@ -8,7 +8,7 @@ For example, your Rust function may run computationally heavy algorithms, and fo
 
 As for the details, a Rust function with signature like `fn f(sink: StreamSink<T>, ..) -> Result<()>` is translated to a Dart function `Stream<T> f(..)`.
 
-Notice that, you can hold that `StreamSink` forever, and use it freely even _after the Rust function itself returns_. The logger example below also demonstrates this (the `create_log_stream` returns almost immediately, while you can use the `StreamSink` after, say, an hour).
+Notice that, you can hold that `StreamSink` forever, and use it freely even *after the Rust function itself returns*. The logger example below also demonstrates this (the `create_log_stream` returns almost immediately, while you can use the `StreamSink` after, say, an hour).
 
 The `StreamSink` can be placed at any location. For example, `fn f(a: i32, b: StreamSink<String>)` and `fn f(a: StreamSink<String>, b: i32)` are both valid.
 

--- a/book/src/feature/stream.md
+++ b/book/src/feature/stream.md
@@ -6,15 +6,38 @@ Flutter's [Stream](https://dart.dev/tutorials/language/streams) is a powerful ab
 
 For example, your Rust function may run computationally heavy algorithms, and for every hundreds of milliseconds, it finds out a new piece of the full solution. In this case, it can immediately give that piece to Flutter, then Flutter can render it to UI immediately. Therefore, users do not need to wait for the full algorithm to finish before he can see some partial results on the user interface.
 
-As for the details, a Rust function with signature like `fn f(sink: StreamSink<T>, ..) -> Result<()>` is translated to a Dart function  `Stream<T> f(..)`.
+As for the details, a Rust function with signature like `fn f(sink: StreamSink<T>, ..) -> Result<()>` is translated to a Dart function `Stream<T> f(..)`.
 
-Notice that, you can hold that `StreamSink` forever, and use it freely even *after the Rust function itself returns*. The logger example below also demonstrates this (the `create_log_stream` returns almost immediately, while you can use the `StreamSink` after, say, an hour).
+Notice that, you can hold that `StreamSink` forever, and use it freely even _after the Rust function itself returns_. The logger example below also demonstrates this (the `create_log_stream` returns almost immediately, while you can use the `StreamSink` after, say, an hour).
 
 The `StreamSink` can be placed at any location. For example, `fn f(a: i32, b: StreamSink<String>)` and `fn f(a: StreamSink<String>, b: i32)` are both valid.
 
 ## Examples
 
 See [logging examples](logging.md) which uses streams extensively.
+
+## Mirrored types in streams
+
+For mirrored types a Trait is generated that is used to implement the add method on the StreamSink. This trait is called `<T>StreamSink` where T is the type of the mirrored type. For example, if you have a mirrored type `MyType` then the trait is called `MyTypeStreamSink`. This trait has to be imported to be able to use a `StreamSink<MyType>`.
+The usage of the Sink doesn't change.
+
+Example:
+
+```rust,noplayground
+...
+pub use external_lib::MyType;
+use MyTypeStreamSink;
+
+#[frb(mirror(MyType))]
+_MyType{
+    ...
+}
+
+pub fn my_type_stream_sink_example(sink: StreamSink<MyType>) {
+    sink.add(MyType::new());
+}
+
+```
 
 ## What about streaming from Dart/Flutter to Rust?
 

--- a/book/src/feature/stream.md
+++ b/book/src/feature/stream.md
@@ -12,32 +12,11 @@ Notice that, you can hold that `StreamSink` forever, and use it freely even _aft
 
 The `StreamSink` can be placed at any location. For example, `fn f(a: i32, b: StreamSink<String>)` and `fn f(a: StreamSink<String>, b: i32)` are both valid.
 
+To use a `StreamSink` in Rust, you also have to import the `StreamSinkTrait`.
+
 ## Examples
 
 See [logging examples](logging.md) which uses streams extensively.
-
-## Mirrored types in streams
-
-For mirrored types a Trait is generated that is used to implement the add method on the StreamSink. This trait is called `<T>StreamSink` where T is the type of the mirrored type. For example, if you have a mirrored type `MyType` then the trait is called `MyTypeStreamSink`. This trait has to be imported to be able to use a `StreamSink<MyType>`.
-The usage of the Sink doesn't change.
-
-Example:
-
-```rust,noplayground
-...
-pub use external_lib::MyType;
-use MyTypeStreamSink;
-
-#[frb(mirror(MyType))]
-_MyType{
-    ...
-}
-
-pub fn my_type_stream_sink_example(sink: StreamSink<MyType>) {
-    sink.add(MyType::new());
-}
-
-```
 
 ## What about streaming from Dart/Flutter to Rust?
 

--- a/book/src/feature/stream.md
+++ b/book/src/feature/stream.md
@@ -12,8 +12,6 @@ Notice that, you can hold that `StreamSink` forever, and use it freely even _aft
 
 The `StreamSink` can be placed at any location. For example, `fn f(a: i32, b: StreamSink<String>)` and `fn f(a: StreamSink<String>, b: i32)` are both valid.
 
-To use a `StreamSink` in Rust, you also have to import the `StreamSinkTrait`.
-
 ## Examples
 
 See [logging examples](logging.md) which uses streams extensively.

--- a/frb_codegen/Cargo.toml
+++ b/frb_codegen/Cargo.toml
@@ -34,7 +34,7 @@ regex = "1.5.4"
 serde = {version = "1.0", features = ["derive"]}
 serde_yaml = "0.8"
 strum_macros = "0.24.3"
-syn = {version = "1.0.109", features = ["full", "extra-traits"]}
+syn = {version = "2.0.26", features = ["full", "extra-traits"]}
 tempfile = "3.2.0"
 thiserror = "1"
 toml = "0.5.8"

--- a/frb_codegen/src/generator/rust/mod.rs
+++ b/frb_codegen/src/generator/rust/mod.rs
@@ -309,7 +309,7 @@ impl<'a> Generator<'a> {
                 argument_index,
                 format!(
                     "task_callback.stream_sink::<_,{}>()",
-                    func.output.into_dart_type(ir_file)
+                    func.output.intodart_type(ir_file)
                 ),
             );
         }
@@ -342,10 +342,6 @@ impl<'a> Generator<'a> {
             } else {
                 panic!("{} is not a method, nor a static method.", func.name)
             };
-            let ret_type = match func.mode {
-                IrFuncMode::Stream { .. } => IrType::Primitive(IrTypePrimitive::Unit),
-                _ => func.output.clone(),
-            };
             format!(
                 r"{}::{}({})",
                 struct_name.unwrap(),
@@ -353,10 +349,6 @@ impl<'a> Generator<'a> {
                 inner_func_params.join(", ")
             )
         } else {
-            let ret_type = match func.mode {
-                IrFuncMode::Stream { .. } => IrType::Primitive(IrTypePrimitive::Unit),
-                _ => func.output.clone(),
-            };
             format!("{}({})", func.name, inner_func_params.join(", "))
         };
         let code_call_inner_func_result = if func.fallible {
@@ -375,7 +367,7 @@ impl<'a> Generator<'a> {
                 ),
             ),
             IrFuncMode::Normal => (
-                format!("wrap::<_,_,_,{}>", func.output.into_dart_type(ir_file)),
+                format!("wrap::<_,_,_,{}>", func.output.intodart_type(ir_file)),
                 None,
                 format!("{code_wire2api} move |task_callback| {code_call_inner_func_result}"),
             ),

--- a/frb_codegen/src/generator/rust/mod.rs
+++ b/frb_codegen/src/generator/rust/mod.rs
@@ -98,6 +98,7 @@ impl<'a> Generator<'a> {
         lines.push("use core::panic::UnwindSafe;".to_owned());
         lines.push("use std::sync::Arc;".to_owned());
         lines.push("use std::ffi::c_void;".to_owned());
+        lines.push("use flutter_rust_bridge::rust2dart::IntoIntoDart;".to_owned());
         lines.push(String::new());
 
         lines.push(self.section_header_comment("imports"));
@@ -156,7 +157,7 @@ impl<'a> Generator<'a> {
         lines.extend(
             distinct_output_types
                 .iter()
-                .map(|ty| self.generate_impl_intodart(ty, ir_file)),
+                .map(|ty| format!("//{:?}\n{}", ty, self.generate_impl_intodart(ty, ir_file))),
         );
 
         lines.push(self.section_header_comment("executor"));
@@ -673,7 +674,7 @@ pub fn get_into_into_dart(name: impl Display, wrapper_name: Option<impl Display>
             // case for types without mirror_ wrapper
             format!(
                 "impl rust2dart::IntoIntoDart<{name}> for {name} {{
-                fn into(self) -> Self {{
+                fn into_into_dart(self) -> Self {{
                     self
                 }}
             }}"
@@ -683,7 +684,7 @@ pub fn get_into_into_dart(name: impl Display, wrapper_name: Option<impl Display>
             // case for type with mirror_ wrapper
             format!(
                 "impl rust2dart::IntoIntoDart<{wrapper}> for {name} {{
-                fn into(self) -> {wrapper} {{
+                fn into_into_dart(self) -> {wrapper} {{
                     {wrapper}(self)
                 }}
             }}"

--- a/frb_codegen/src/generator/rust/mod.rs
+++ b/frb_codegen/src/generator/rust/mod.rs
@@ -346,24 +346,18 @@ impl<'a> Generator<'a> {
                 IrFuncMode::Stream { .. } => IrType::Primitive(IrTypePrimitive::Unit),
                 _ => func.output.clone(),
             };
-            TypeRustGenerator::new(ret_type, ir_file, self.config).wrap_obj(
-                format!(
-                    r"{}::{}({})",
-                    struct_name.unwrap(),
-                    method_name,
-                    inner_func_params.join(", ")
-                ),
-                func.fallible,
+            format!(
+                r"{}::{}({})",
+                struct_name.unwrap(),
+                method_name,
+                inner_func_params.join(", ")
             )
         } else {
             let ret_type = match func.mode {
                 IrFuncMode::Stream { .. } => IrType::Primitive(IrTypePrimitive::Unit),
                 _ => func.output.clone(),
             };
-            TypeRustGenerator::new(ret_type, ir_file, self.config).wrap_obj(
-                format!("{}({})", func.name, inner_func_params.join(", ")),
-                func.fallible,
-            )
+            format!("{}({})", func.name, inner_func_params.join(", "))
         };
         let code_call_inner_func_result = if func.fallible {
             code_call_inner_func

--- a/frb_codegen/src/generator/rust/mod.rs
+++ b/frb_codegen/src/generator/rust/mod.rs
@@ -366,16 +366,18 @@ impl<'a> Generator<'a> {
                     {code_call_inner_func_result}"
                 ),
             ),
-            IrFuncMode::Normal => (
-                format!("wrap::<_,_,_,{}>", func.output.intodart_type(ir_file)),
-                None,
-                format!("{code_wire2api} move |task_callback| {code_call_inner_func_result}"),
-            ),
-            IrFuncMode::Stream { .. } => (
-                String::from("wrap::<_,_,_,()>"),
-                None,
-                format!("{code_wire2api} move |task_callback| {code_call_inner_func_result}"),
-            ),
+            IrFuncMode::Normal | IrFuncMode::Stream { .. } => {
+                let output = if matches!(func.mode, IrFuncMode::Stream { .. }) {
+                    String::from("()")
+                } else {
+                    func.output.intodart_type(ir_file)
+                };
+                (
+                    format!("wrap::<_,_,_,{output}>"),
+                    None,
+                    format!("{code_wire2api} move |task_callback| {code_call_inner_func_result}"),
+                )
+            }
         };
 
         let body = format!(

--- a/frb_codegen/src/generator/rust/ty.rs
+++ b/frb_codegen/src/generator/rust/ty.rs
@@ -34,7 +34,7 @@ pub trait TypeRustGeneratorTrait {
     }
 
     fn convert_to_dart(&self, obj: String) -> String {
-        format!("{obj}.into_dart()")
+        format!("{obj}.into_into_dart().into_dart()")
     }
 
     fn structs(&self) -> String {

--- a/frb_codegen/src/generator/rust/ty.rs
+++ b/frb_codegen/src/generator/rust/ty.rs
@@ -29,10 +29,6 @@ pub trait TypeRustGeneratorTrait {
         obj
     }
 
-    fn wrap_obj(&self, obj: String, _wired_fallible_func: bool) -> String {
-        obj
-    }
-
     fn convert_to_dart(&self, obj: String) -> String {
         format!("{obj}.into_into_dart().into_dart()")
     }

--- a/frb_codegen/src/generator/rust/ty_boxed.rs
+++ b/frb_codegen/src/generator/rust/ty_boxed.rs
@@ -64,15 +64,6 @@ impl TypeRustGeneratorTrait for TypeBoxedGenerator<'_> {
         format!("(*{obj})")
     }
 
-    fn wrap_obj(&self, obj: String, wired_fallible_func: bool) -> String {
-        let src = TypeRustGenerator::new(
-            *self.ir.inner.clone(),
-            self.context.ir_file,
-            self.context.config,
-        );
-        src.wrap_obj(self.self_access(obj), wired_fallible_func)
-    }
-
     fn allocate_funcs(
         &self,
         collector: &mut ExternFuncCollector,

--- a/frb_codegen/src/generator/rust/ty_dart_opaque.rs
+++ b/frb_codegen/src/generator/rust/ty_dart_opaque.rs
@@ -67,10 +67,6 @@ impl TypeRustGeneratorTrait for TypeDartOpaqueGenerator<'_> {
         obj
     }
 
-    fn convert_to_dart(&self, obj: String) -> String {
-        format!("{obj}.into_dart()")
-    }
-
     fn structs(&self) -> String {
         "".to_owned()
     }

--- a/frb_codegen/src/generator/rust/ty_dart_opaque.rs
+++ b/frb_codegen/src/generator/rust/ty_dart_opaque.rs
@@ -63,10 +63,6 @@ impl TypeRustGeneratorTrait for TypeDartOpaqueGenerator<'_> {
         "".to_owned()
     }
 
-    fn wrap_obj(&self, obj: String, _wired_fallible_func: bool) -> String {
-        obj
-    }
-
     fn structs(&self) -> String {
         "".to_owned()
     }

--- a/frb_codegen/src/generator/rust/ty_delegate.rs
+++ b/frb_codegen/src/generator/rust/ty_delegate.rs
@@ -181,7 +181,12 @@ impl TypeRustGeneratorTrait for TypeDelegateGenerator<'_> {
                         }}.into_dart()
                     }}
                 }}
-                impl support::IntoDartExceptPrimitive for {name} {{}}"
+                impl support::IntoDartExceptPrimitive for {name} {{}}
+                impl rust2dart::IntoIntoDart<{name}> for {name} {{
+                    fn into_into_dart(self) -> Self {{
+                        self
+                    }}
+                }}"
             );
         }
         "".into()

--- a/frb_codegen/src/generator/rust/ty_delegate.rs
+++ b/frb_codegen/src/generator/rust/ty_delegate.rs
@@ -7,6 +7,8 @@ use crate::target::{Acc, Target};
 use crate::type_rust_generator_struct;
 use crate::utils::misc::BlockIndex;
 
+use super::get_into_into_dart;
+
 type_rust_generator_struct!(TypeDelegateGenerator, IrTypeDelegate);
 
 macro_rules! delegate_enum{
@@ -173,6 +175,7 @@ impl TypeRustGeneratorTrait for TypeDelegateGenerator<'_> {
                 .map(|(idx, variant)| format!("{}::{} => {},", self_path, variant.name, idx))
                 .collect::<Vec<_>>()
                 .join("\n");
+            let into_into_dart = get_into_into_dart(&src.name, src.wrapper_name.as_ref());
             return format!(
                 "impl support::IntoDart for {name} {{
                     fn into_dart(self) -> support::DartAbi {{
@@ -182,11 +185,8 @@ impl TypeRustGeneratorTrait for TypeDelegateGenerator<'_> {
                     }}
                 }}
                 impl support::IntoDartExceptPrimitive for {name} {{}}
-                impl rust2dart::IntoIntoDart<{name}> for {name} {{
-                    fn into_into_dart(self) -> Self {{
-                        self
-                    }}
-                }}"
+                {into_into_dart}
+                "
             );
         }
         "".into()
@@ -230,10 +230,6 @@ impl TypeRustGeneratorTrait for TypeDelegateGenerator<'_> {
 
     fn wrapper_struct(&self) -> Option<String> {
         delegate_enum!(self, wrapper_struct(), None)
-    }
-
-    fn wrap_obj(&self, obj: String, wired_fallible_func: bool) -> String {
-        delegate_enum!(self, wrap_obj(obj, wired_fallible_func), obj)
     }
 
     fn self_access(&self, obj: String) -> String {

--- a/frb_codegen/src/generator/rust/ty_enum.rs
+++ b/frb_codegen/src/generator/rust/ty_enum.rs
@@ -234,9 +234,7 @@ impl TypeRustGeneratorTrait for TypeEnumRefGenerator<'_> {
                                     self.context.config,
                                 );
 
-                                gen.convert_to_dart(
-                                    field.try_name_mirror(field.name.rust_style().to_owned()),
-                                )
+                                gen.convert_to_dart(field.name.rust_style().to_owned())
                             }))
                             .collect::<Vec<_>>();
                         let pattern = st

--- a/frb_codegen/src/generator/rust/ty_enum.rs
+++ b/frb_codegen/src/generator/rust/ty_enum.rs
@@ -1,5 +1,6 @@
 use itertools::Itertools;
 
+use crate::generator::rust::get_into_into_dart;
 use crate::generator::rust::ty::*;
 use crate::generator::rust::ExternFuncCollector;
 use crate::generator::rust::NO_PARAMS;
@@ -257,6 +258,8 @@ impl TypeRustGeneratorTrait for TypeEnumRefGenerator<'_> {
                 }
             })
             .collect::<Vec<_>>();
+
+        let into_into_dart = get_into_into_dart(&src.name, src.wrapper_name.as_ref());
         format!(
             "impl support::IntoDart for {} {{
                 fn into_dart(self) -> support::DartAbi {{
@@ -265,7 +268,9 @@ impl TypeRustGeneratorTrait for TypeEnumRefGenerator<'_> {
                     }}.into_dart()
                 }}
             }}
-            impl support::IntoDartExceptPrimitive for {0} {{}}",
+            impl support::IntoDartExceptPrimitive for {0} {{}}
+            {into_into_dart}
+            ",
             name,
             self_ref,
             variants.join("\n")

--- a/frb_codegen/src/generator/rust/ty_enum.rs
+++ b/frb_codegen/src/generator/rust/ty_enum.rs
@@ -199,13 +199,6 @@ impl TypeRustGeneratorTrait for TypeEnumRefGenerator<'_> {
         }
     }
 
-    fn wrap_obj(&self, obj: String, _wired_fallible_func: bool) -> String {
-        match self.wrapper_struct() {
-            Some(wrapper) => format!("{wrapper}({obj})"),
-            None => obj,
-        }
-    }
-
     fn impl_intodart(&self) -> String {
         let src = self.ir.get(self.context.ir_file);
 

--- a/frb_codegen/src/generator/rust/ty_general_list.rs
+++ b/frb_codegen/src/generator/rust/ty_general_list.rs
@@ -38,33 +38,6 @@ impl TypeRustGeneratorTrait for TypeGeneralListGenerator<'_> {
         ])
     }
 
-    fn wrap_obj(&self, obj: String, wired_fallible_func: bool) -> String {
-        let inner = TypeRustGenerator::new(
-            *self.ir.inner.clone(),
-            self.context.ir_file,
-            self.context.config,
-        );
-
-        inner
-            .wrapper_struct()
-            .map(|wrapper| {
-                let infallible_part = |name| {
-                    format!(
-                        "{}.into_iter().map(|v| {}({})).collect::<Vec<_>>()",
-                        name,
-                        wrapper,
-                        inner.self_access("v".to_owned())
-                    )
-                };
-                if wired_fallible_func {
-                    format!("{}.map(|s| {})", obj, infallible_part("s"))
-                } else {
-                    infallible_part(&obj)
-                }
-            })
-            .unwrap_or(obj)
-    }
-
     fn allocate_funcs(
         &self,
         collector: &mut ExternFuncCollector,
@@ -84,5 +57,14 @@ impl TypeRustGeneratorTrait for TypeGeneralListGenerator<'_> {
 
     fn imports(&self) -> Option<String> {
         generate_import(&self.ir.inner, self.context.ir_file, self.context.config)
+    }
+
+    fn convert_to_dart(&self, obj: String) -> String {
+        format!(
+            "{obj}.drain(0..)
+            .map(|e| e.into_into_dart().into_dart())
+            .collect::<Vec<_>>()
+            .into_dart(),"
+        )
     }
 }

--- a/frb_codegen/src/generator/rust/ty_general_list.rs
+++ b/frb_codegen/src/generator/rust/ty_general_list.rs
@@ -58,13 +58,4 @@ impl TypeRustGeneratorTrait for TypeGeneralListGenerator<'_> {
     fn imports(&self) -> Option<String> {
         generate_import(&self.ir.inner, self.context.ir_file, self.context.config)
     }
-
-    fn convert_to_dart(&self, obj: String) -> String {
-        format!(
-            "{obj}.drain(0..)
-            .map(|e| e.into_into_dart().into_dart())
-            .collect::<Vec<_>>()
-            .into_dart(),"
-        )
-    }
 }

--- a/frb_codegen/src/generator/rust/ty_record.rs
+++ b/frb_codegen/src/generator/rust/ty_record.rs
@@ -55,11 +55,6 @@ impl TypeRustGeneratorTrait for TypeRecordGenerator<'_> {
         self.as_struct_generator().wrapper_struct()
     }
 
-    fn wrap_obj(&self, obj: String, wired_fallible_func: bool) -> String {
-        self.as_struct_generator()
-            .wrap_obj(obj, wired_fallible_func)
-    }
-
     fn new_with_nullptr(&self, collector: &mut ExternFuncCollector) -> String {
         self.as_struct_generator().new_with_nullptr(collector)
     }

--- a/frb_codegen/src/generator/rust/ty_rust_opaque.rs
+++ b/frb_codegen/src/generator/rust/ty_rust_opaque.rs
@@ -55,10 +55,6 @@ impl TypeRustGeneratorTrait for TypeRustOpaqueGenerator<'_> {
         obj
     }
 
-    fn wrap_obj(&self, obj: String, _wired_fallible_func: bool) -> String {
-        obj
-    }
-
     fn convert_to_dart(&self, obj: String) -> String {
         format!("{obj}.into_dart()")
     }

--- a/frb_codegen/src/generator/rust/ty_struct.rs
+++ b/frb_codegen/src/generator/rust/ty_struct.rs
@@ -1,5 +1,4 @@
 use crate::generator::rust::get_into_into_dart;
-use crate::generator::rust::get_stream_sink_traits;
 use crate::generator::rust::ty::*;
 use crate::generator::rust::ExternFuncCollector;
 use crate::ir::*;
@@ -154,7 +153,6 @@ impl TypeRustGeneratorTrait for TypeStructRefGenerator<'_> {
         };
 
         let into_into_dart = get_into_into_dart(&src.name, src.wrapper_name.as_ref());
-        let stream_sink_traits = get_stream_sink_traits(&src.name, src.wrapper_name.as_ref());
         format!(
             "impl support::IntoDart for {name} {{
                 fn into_dart(self) -> support::DartAbi {{
@@ -163,7 +161,6 @@ impl TypeRustGeneratorTrait for TypeStructRefGenerator<'_> {
             }}
             impl support::IntoDartExceptPrimitive for {name} {{}}
             {into_into_dart}
-            {stream_sink_traits}
             "
         )
     }

--- a/frb_codegen/src/generator/rust/ty_struct.rs
+++ b/frb_codegen/src/generator/rust/ty_struct.rs
@@ -110,20 +110,6 @@ impl TypeRustGeneratorTrait for TypeStructRefGenerator<'_> {
         src.wrapper_name.as_ref().cloned()
     }
 
-    fn wrap_obj(&self, obj: String, wired_fallible_func: bool) -> String {
-        match self.wrapper_struct() {
-            Some(wrapper) => {
-                if wired_fallible_func {
-                    format!("Ok({wrapper}({obj}?))")
-                } else {
-                    format!("{wrapper}({obj})")
-                }
-            }
-
-            None => obj,
-        }
-    }
-
     fn impl_intodart(&self) -> String {
         let src = self.ir.get(self.context.ir_file);
 
@@ -148,10 +134,7 @@ impl TypeRustGeneratorTrait for TypeStructRefGenerator<'_> {
                 );
 
                 // wired_fallible is always false here, this parameter is only used for generate_wire_func
-                gen.convert_to_dart(gen.wrap_obj(
-                    field.try_name_mirror(format!("self{unwrap}.{field_ref}")),
-                    false,
-                ))
+                gen.convert_to_dart(gen.wrap_obj(format!("self{unwrap}.{field_ref}"), false))
             })
             .collect::<Vec<_>>()
             .join(",\n");

--- a/frb_codegen/src/generator/rust/ty_struct.rs
+++ b/frb_codegen/src/generator/rust/ty_struct.rs
@@ -133,8 +133,7 @@ impl TypeRustGeneratorTrait for TypeStructRefGenerator<'_> {
                     self.context.config,
                 );
 
-                // wired_fallible is always false here, this parameter is only used for generate_wire_func
-                gen.convert_to_dart(gen.wrap_obj(format!("self{unwrap}.{field_ref}"), false))
+                gen.convert_to_dart(format!("self{unwrap}.{field_ref}"))
             })
             .collect::<Vec<_>>()
             .join(",\n");

--- a/frb_codegen/src/generator/rust/ty_sync_return.rs
+++ b/frb_codegen/src/generator/rust/ty_sync_return.rs
@@ -34,7 +34,6 @@ impl<'a> TypeRustGeneratorTrait for TypeSyncReturnGenerator<'a> {
             fn static_checks(&self) -> Option<String>;
             fn wrapper_struct(&self) -> Option<String>;
             fn self_access(&self, obj: String) -> String;
-            fn wrap_obj(&self, obj: String, _wired_fallible_func: bool) -> String;
             fn convert_to_dart(&self, obj: String) -> String;
             fn structs(&self) -> String;
             fn allocate_funcs(

--- a/frb_codegen/src/ir/field.rs
+++ b/frb_codegen/src/ir/field.rs
@@ -72,16 +72,4 @@ impl IrField {
 
         format!("{enum_name}.{variant_name}")
     }
-
-    /// Takes the provided name and surrounds it with the `mirror_` prefix if the field is in a
-    /// mirrored enum.
-    /// This may be improved in the future: https://github.com/fzyzcjy/flutter_rust_bridge/pull/1144#issuecomment-1486569869
-    pub fn try_name_mirror(&self, name: String) -> String {
-        let mirrored_name = self.ty.mirrored_nested();
-        if self.settings.is_in_mirrored_enum && mirrored_name.is_some() {
-            format!("mirror_{}({})", mirrored_name.unwrap(), name)
-        } else {
-            name
-        }
-    }
 }

--- a/frb_codegen/src/ir/ty.rs
+++ b/frb_codegen/src/ir/ty.rs
@@ -143,6 +143,9 @@ pub trait IrTypeTrait {
     fn dart_wire_type(&self, target: Target) -> String;
     fn rust_api_type(&self) -> String;
     fn rust_wire_type(&self, target: Target) -> String;
+    fn into_dart_type(&self, _ir_file: &IrFile) -> String {
+        self.rust_api_type()
+    }
 
     fn rust_wire_modifier(&self, target: Target) -> String {
         if self.rust_wire_is_pointer(target) {

--- a/frb_codegen/src/ir/ty.rs
+++ b/frb_codegen/src/ir/ty.rs
@@ -143,7 +143,7 @@ pub trait IrTypeTrait {
     fn dart_wire_type(&self, target: Target) -> String;
     fn rust_api_type(&self) -> String;
     fn rust_wire_type(&self, target: Target) -> String;
-    fn into_dart_type(&self, _ir_file: &IrFile) -> String {
+    fn intodart_type(&self, _ir_file: &IrFile) -> String {
         self.rust_api_type()
     }
 

--- a/frb_codegen/src/ir/ty_boxed.rs
+++ b/frb_codegen/src/ir/ty_boxed.rs
@@ -74,4 +74,8 @@ impl IrTypeTrait for IrTypeBoxed {
         !target.is_wasm()
             || !self.inner.is_js_value() && !self.inner.is_array() && !self.inner.is_primitive()
     }
+
+    fn into_dart_type(&self, ir_file: &IrFile) -> String {
+        self.inner.into_dart_type(ir_file)
+    }
 }

--- a/frb_codegen/src/ir/ty_boxed.rs
+++ b/frb_codegen/src/ir/ty_boxed.rs
@@ -75,7 +75,7 @@ impl IrTypeTrait for IrTypeBoxed {
             || !self.inner.is_js_value() && !self.inner.is_array() && !self.inner.is_primitive()
     }
 
-    fn into_dart_type(&self, ir_file: &IrFile) -> String {
-        self.inner.into_dart_type(ir_file)
+    fn intodart_type(&self, ir_file: &IrFile) -> String {
+        self.inner.intodart_type(ir_file)
     }
 }

--- a/frb_codegen/src/ir/ty_enum.rs
+++ b/frb_codegen/src/ir/ty_enum.rs
@@ -55,8 +55,8 @@ impl IrTypeTrait for IrTypeEnumRef {
         }
     }
 
-    fn into_dart_type(&self, ir_file: &IrFile) -> String {
-        match &self.get(&ir_file).wrapper_name {
+    fn intodart_type(&self, ir_file: &IrFile) -> String {
+        match &self.get(ir_file).wrapper_name {
             Some(wrapper) => wrapper.clone(),
             None => self.dart_api_type(),
         }

--- a/frb_codegen/src/ir/ty_enum.rs
+++ b/frb_codegen/src/ir/ty_enum.rs
@@ -54,6 +54,13 @@ impl IrTypeTrait for IrTypeEnumRef {
             format!("wire_{}", self.name)
         }
     }
+
+    fn into_dart_type(&self, ir_file: &IrFile) -> String {
+        match &self.get(&ir_file).wrapper_name {
+            Some(wrapper) => wrapper.clone(),
+            None => self.dart_api_type(),
+        }
+    }
 }
 
 crate::ir! {

--- a/frb_codegen/src/ir/ty_general_list.rs
+++ b/frb_codegen/src/ir/ty_general_list.rs
@@ -46,4 +46,7 @@ impl IrTypeTrait for IrTypeGeneralList {
     fn rust_wire_is_pointer(&self, target: Target) -> bool {
         !target.is_wasm()
     }
+    fn into_dart_type(&self, ir_file: &IrFile) -> String {
+        format!("Vec<{}>", self.inner.into_dart_type(ir_file))
+    }
 }

--- a/frb_codegen/src/ir/ty_general_list.rs
+++ b/frb_codegen/src/ir/ty_general_list.rs
@@ -46,7 +46,7 @@ impl IrTypeTrait for IrTypeGeneralList {
     fn rust_wire_is_pointer(&self, target: Target) -> bool {
         !target.is_wasm()
     }
-    fn into_dart_type(&self, ir_file: &IrFile) -> String {
-        format!("Vec<{}>", self.inner.into_dart_type(ir_file))
+    fn intodart_type(&self, ir_file: &IrFile) -> String {
+        format!("Vec<{}>", self.inner.intodart_type(ir_file))
     }
 }

--- a/frb_codegen/src/ir/ty_primitive.rs
+++ b/frb_codegen/src/ir/ty_primitive.rs
@@ -77,7 +77,7 @@ impl IrTypeTrait for IrTypePrimitive {
         .to_string()
     }
 
-    fn into_dart_type(&self, _ir_file: &IrFile) -> String {
+    fn intodart_type(&self, _ir_file: &IrFile) -> String {
         match self {
             IrTypePrimitive::Unit => String::from("()"),
             _ => self.rust_api_type(),

--- a/frb_codegen/src/ir/ty_primitive.rs
+++ b/frb_codegen/src/ir/ty_primitive.rs
@@ -76,6 +76,13 @@ impl IrTypeTrait for IrTypePrimitive {
         }
         .to_string()
     }
+
+    fn into_dart_type(&self, _ir_file: &IrFile) -> String {
+        match self {
+            IrTypePrimitive::Unit => String::from("()"),
+            _ => self.rust_api_type(),
+        }
+    }
 }
 
 impl IrTypePrimitive {

--- a/frb_codegen/src/ir/ty_record.rs
+++ b/frb_codegen/src/ir/ty_record.rs
@@ -58,4 +58,14 @@ impl IrTypeTrait for IrTypeRecord {
             format!("wire_{}", self.safe_ident())
         }
     }
+
+    fn intodart_type(&self, ir_file: &IrFile) -> String {
+        let values = self
+            .values
+            .iter()
+            .map(|e| e.intodart_type(ir_file))
+            .collect::<Vec<_>>()
+            .join(",");
+        format!("({values},)")
+    }
 }

--- a/frb_codegen/src/ir/ty_struct.rs
+++ b/frb_codegen/src/ir/ty_struct.rs
@@ -47,6 +47,11 @@ impl IrTypeTrait for IrTypeStructRef {
             format!("wire_{}", self.name)
         }
     }
+
+    fn into_dart_type(&self, ir_file: &IrFile) -> String {
+        let wrapper = self.get(ir_file).wrapper_name.as_ref();
+        wrapper.unwrap_or(&self.rust_api_type()).clone()
+    }
 }
 
 crate::ir! {

--- a/frb_codegen/src/ir/ty_struct.rs
+++ b/frb_codegen/src/ir/ty_struct.rs
@@ -48,7 +48,7 @@ impl IrTypeTrait for IrTypeStructRef {
         }
     }
 
-    fn into_dart_type(&self, ir_file: &IrFile) -> String {
+    fn intodart_type(&self, ir_file: &IrFile) -> String {
         let wrapper = self.get(ir_file).wrapper_name.as_ref();
         wrapper.unwrap_or(&self.rust_api_type()).clone()
     }

--- a/frb_codegen/src/parser/markers.rs
+++ b/frb_codegen/src/parser/markers.rs
@@ -2,46 +2,38 @@ use syn::*;
 
 /// Extract a path from marker `#[frb(mirror(path), ..)]`
 pub fn extract_mirror_marker(attrs: &[Attribute]) -> Vec<Path> {
+    let mut paths = vec![];
     attrs
         .iter()
-        .filter(|attr| attr.path.is_ident("frb"))
-        .find_map(|attr| match attr.parse_meta() {
-            Ok(Meta::List(MetaList { nested, .. })) => nested.iter().find_map(|meta| match meta {
-                NestedMeta::Meta(Meta::List(MetaList {
-                    path,
-                    nested: mirror,
-                    ..
-                })) if path.is_ident("mirror") && !mirror.is_empty() => Some(
-                    mirror
-                        .into_iter()
-                        .filter_map(|label| {
-                            if let NestedMeta::Meta(Meta::Path(path)) = label {
-                                Some(path)
-                            } else {
-                                None
-                            }
-                        })
-                        .cloned()
-                        .collect::<Vec<_>>(),
-                ),
-                _ => None,
-            }),
-            _ => None,
-        })
-        .unwrap_or_default()
+        .filter(|attr| attr.path().is_ident("frb"))
+        .for_each(|attr| {
+            let _ = attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("mirror") {
+                    meta.parse_nested_meta(|path| {
+                        paths.push(path.path);
+                        Ok(())
+                    })
+                    .unwrap();
+                }
+                Ok(())
+            });
+        });
+    paths
 }
 
 /// Checks if the `#[frb(non_final)]` attribute is present.
 pub fn has_non_final(attrs: &[Attribute]) -> bool {
     attrs
         .iter()
-        .filter(|attr| attr.path.is_ident("frb"))
+        .filter(|attr| attr.path().is_ident("frb"))
         .any(|attr| {
-            match attr.parse_meta() {
-            Ok(Meta::List(MetaList { nested, .. })) => nested.iter().any(|meta| {
-                matches!(meta, NestedMeta::Meta(Meta::Path(path)) if path.is_ident("non_final"))
-            }),
-            _ => false,
-        }
+            let mut flag = false;
+            let _ = attr.parse_nested_meta(|arg| {
+                if arg.path.is_ident("non_final") {
+                    flag = true;
+                }
+                Ok(())
+            });
+            flag
         })
 }

--- a/frb_codegen/src/parser/source_graph.rs
+++ b/frb_codegen/src/parser/source_graph.rs
@@ -90,7 +90,6 @@ impl Crate {
 #[derive(Debug, Clone)]
 pub enum Visibility {
     Public,
-    Crate,
     Restricted, // Not supported
     Inherited,  // Usually means private
 }
@@ -98,7 +97,6 @@ pub enum Visibility {
 fn syn_vis_to_visibility(vis: &syn::Visibility) -> Visibility {
     match vis {
         syn::Visibility::Public(_) => Visibility::Public,
-        syn::Visibility::Crate(_) => Visibility::Crate,
         syn::Visibility::Restricted(_) => Visibility::Restricted,
         syn::Visibility::Inherited => Visibility::Inherited,
     }

--- a/frb_example/pure_dart/dart/lib/bridge_definitions.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_definitions.dart
@@ -223,6 +223,18 @@ abstract class FlutterRustBridgeExampleSingleBlockTest {
 
   FlutterRustBridgeTaskConstMeta get kIsAppEmbeddedConstMeta;
 
+  Stream<ApplicationSettings> appSettingsStream({dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kAppSettingsStreamConstMeta;
+
+  Stream<List<ApplicationSettings>> appSettingsVecStream({dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kAppSettingsVecStreamConstMeta;
+
+  Stream<MirrorStruct> mirrorStructStream({dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kMirrorStructStreamConstMeta;
+
   Future<ApplicationMessage> getMessage({dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kGetMessageConstMeta;
@@ -1347,6 +1359,20 @@ class MessageId {
 
   const MessageId({
     required this.field0,
+  });
+}
+
+class MirrorStruct {
+  final ApplicationSettings a;
+  final MyStruct b;
+  final List<MyEnum> c;
+  final List<ApplicationSettings> d;
+
+  const MirrorStruct({
+    required this.a,
+    required this.b,
+    required this.c,
+    required this.d,
   });
 }
 

--- a/frb_example/pure_dart/dart/lib/bridge_definitions.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_definitions.dart
@@ -235,6 +235,10 @@ abstract class FlutterRustBridgeExampleSingleBlockTest {
 
   FlutterRustBridgeTaskConstMeta get kMirrorStructStreamConstMeta;
 
+  Stream<(ApplicationSettings, RawStringEnumMirrored)> mirrorTupleStream({dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kMirrorTupleStreamConstMeta;
+
   Future<ApplicationMessage> getMessage({dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kGetMessageConstMeta;

--- a/frb_example/pure_dart/dart/lib/bridge_generated.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.dart
@@ -811,6 +811,51 @@ class FlutterRustBridgeExampleSingleBlockTestImpl implements FlutterRustBridgeEx
         argNames: ["appSettings"],
       );
 
+  Stream<ApplicationSettings> appSettingsStream({dynamic hint}) {
+    return _platform.executeStream(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_app_settings_stream(port_),
+      parseSuccessData: _wire2api_application_settings,
+      constMeta: kAppSettingsStreamConstMeta,
+      argValues: [],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kAppSettingsStreamConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "app_settings_stream",
+        argNames: [],
+      );
+
+  Stream<List<ApplicationSettings>> appSettingsVecStream({dynamic hint}) {
+    return _platform.executeStream(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_app_settings_vec_stream(port_),
+      parseSuccessData: _wire2api_list_application_settings,
+      constMeta: kAppSettingsVecStreamConstMeta,
+      argValues: [],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kAppSettingsVecStreamConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "app_settings_vec_stream",
+        argNames: [],
+      );
+
+  Stream<MirrorStruct> mirrorStructStream({dynamic hint}) {
+    return _platform.executeStream(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_mirror_struct_stream(port_),
+      parseSuccessData: _wire2api_mirror_struct,
+      constMeta: kMirrorStructStreamConstMeta,
+      argValues: [],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kMirrorStructStreamConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "mirror_struct_stream",
+        argNames: [],
+      );
+
   Future<ApplicationMessage> getMessage({dynamic hint}) {
     return _platform.executeNormal(FlutterRustBridgeTask(
       callFfi: (port_) => _platform.inner.wire_get_message(port_),
@@ -3346,6 +3391,10 @@ class FlutterRustBridgeExampleSingleBlockTestImpl implements FlutterRustBridgeEx
     return (raw as List<dynamic>).map(_wire2api_application_env_var).toList();
   }
 
+  List<ApplicationSettings> _wire2api_list_application_settings(dynamic raw) {
+    return (raw as List<dynamic>).map(_wire2api_application_settings).toList();
+  }
+
   List<Attribute> _wire2api_list_attribute(dynamic raw) {
     return (raw as List<dynamic>).map(_wire2api_attribute).toList();
   }
@@ -3356,6 +3405,10 @@ class FlutterRustBridgeExampleSingleBlockTestImpl implements FlutterRustBridgeEx
 
   List<EnumOpaque> _wire2api_list_enum_opaque(dynamic raw) {
     return (raw as List<dynamic>).map(_wire2api_enum_opaque).toList();
+  }
+
+  List<MyEnum> _wire2api_list_my_enum(dynamic raw) {
+    return (raw as List<dynamic>).map(_wire2api_my_enum).toList();
   }
 
   List<MySize> _wire2api_list_my_size(dynamic raw) {
@@ -3440,6 +3493,17 @@ class FlutterRustBridgeExampleSingleBlockTestImpl implements FlutterRustBridgeEx
     if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return MessageId(
       field0: _wire2api_u8_array_32(arr[0]),
+    );
+  }
+
+  MirrorStruct _wire2api_mirror_struct(dynamic raw) {
+    final arr = raw as List<dynamic>;
+    if (arr.length != 4) throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
+    return MirrorStruct(
+      a: _wire2api_application_settings(arr[0]),
+      b: _wire2api_my_struct(arr[1]),
+      c: _wire2api_list_my_enum(arr[2]),
+      d: _wire2api_list_application_settings(arr[3]),
     );
   }
 

--- a/frb_example/pure_dart/dart/lib/bridge_generated.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.dart
@@ -856,6 +856,21 @@ class FlutterRustBridgeExampleSingleBlockTestImpl implements FlutterRustBridgeEx
         argNames: [],
       );
 
+  Stream<(ApplicationSettings, RawStringEnumMirrored)> mirrorTupleStream({dynamic hint}) {
+    return _platform.executeStream(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_mirror_tuple_stream(port_),
+      parseSuccessData: _wire2api___record__application_settings_raw_string_enum_mirrored,
+      constMeta: kMirrorTupleStreamConstMeta,
+      argValues: [],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kMirrorTupleStreamConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "mirror_tuple_stream",
+        argNames: [],
+      );
+
   Future<ApplicationMessage> getMessage({dynamic hint}) {
     return _platform.executeNormal(FlutterRustBridgeTask(
       callFfi: (port_) => _platform.inner.wire_get_message(port_),
@@ -2900,6 +2915,18 @@ class FlutterRustBridgeExampleSingleBlockTestImpl implements FlutterRustBridgeEx
     return (
       _wire2api_String(arr[0]),
       _wire2api_i32(arr[1]),
+    );
+  }
+
+  (ApplicationSettings, RawStringEnumMirrored) _wire2api___record__application_settings_raw_string_enum_mirrored(
+      dynamic raw) {
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2) {
+      throw Exception('Expected 2 elements, got ${arr.length}');
+    }
+    return (
+      _wire2api_application_settings(arr[0]),
+      _wire2api_raw_string_enum_mirrored(arr[1]),
     );
   }
 

--- a/frb_example/pure_dart/dart/lib/bridge_generated.io.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.io.dart
@@ -2303,6 +2303,18 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_mirror_struct_stream');
   late final _wire_mirror_struct_stream = _wire_mirror_struct_streamPtr.asFunction<void Function(int)>();
 
+  void wire_mirror_tuple_stream(
+    int port_,
+  ) {
+    return _wire_mirror_tuple_stream(
+      port_,
+    );
+  }
+
+  late final _wire_mirror_tuple_streamPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_mirror_tuple_stream');
+  late final _wire_mirror_tuple_stream = _wire_mirror_tuple_streamPtr.asFunction<void Function(int)>();
+
   void wire_get_message(
     int port_,
   ) {

--- a/frb_example/pure_dart/dart/lib/bridge_generated.io.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.io.dart
@@ -2267,6 +2267,42 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   late final _wire_is_app_embedded =
       _wire_is_app_embeddedPtr.asFunction<void Function(int, ffi.Pointer<wire_ApplicationSettings>)>();
 
+  void wire_app_settings_stream(
+    int port_,
+  ) {
+    return _wire_app_settings_stream(
+      port_,
+    );
+  }
+
+  late final _wire_app_settings_streamPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_app_settings_stream');
+  late final _wire_app_settings_stream = _wire_app_settings_streamPtr.asFunction<void Function(int)>();
+
+  void wire_app_settings_vec_stream(
+    int port_,
+  ) {
+    return _wire_app_settings_vec_stream(
+      port_,
+    );
+  }
+
+  late final _wire_app_settings_vec_streamPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_app_settings_vec_stream');
+  late final _wire_app_settings_vec_stream = _wire_app_settings_vec_streamPtr.asFunction<void Function(int)>();
+
+  void wire_mirror_struct_stream(
+    int port_,
+  ) {
+    return _wire_mirror_struct_stream(
+      port_,
+    );
+  }
+
+  late final _wire_mirror_struct_streamPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_mirror_struct_stream');
+  late final _wire_mirror_struct_stream = _wire_mirror_struct_streamPtr.asFunction<void Function(int)>();
+
   void wire_get_message(
     int port_,
   ) {

--- a/frb_example/pure_dart/dart/lib/bridge_generated.web.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.web.dart
@@ -1115,6 +1115,12 @@ class FlutterRustBridgeExampleSingleBlockTestWasmModule implements WasmModule {
 
   external dynamic /* void */ wire_is_app_embedded(NativePortType port_, List<dynamic> app_settings);
 
+  external dynamic /* void */ wire_app_settings_stream(NativePortType port_);
+
+  external dynamic /* void */ wire_app_settings_vec_stream(NativePortType port_);
+
+  external dynamic /* void */ wire_mirror_struct_stream(NativePortType port_);
+
   external dynamic /* void */ wire_get_message(NativePortType port_);
 
   external dynamic /* void */ wire_repeat_number(NativePortType port_, int num, int times);
@@ -1521,6 +1527,12 @@ class FlutterRustBridgeExampleSingleBlockTestWire
 
   void wire_is_app_embedded(NativePortType port_, List<dynamic> app_settings) =>
       wasmModule.wire_is_app_embedded(port_, app_settings);
+
+  void wire_app_settings_stream(NativePortType port_) => wasmModule.wire_app_settings_stream(port_);
+
+  void wire_app_settings_vec_stream(NativePortType port_) => wasmModule.wire_app_settings_vec_stream(port_);
+
+  void wire_mirror_struct_stream(NativePortType port_) => wasmModule.wire_mirror_struct_stream(port_);
 
   void wire_get_message(NativePortType port_) => wasmModule.wire_get_message(port_);
 

--- a/frb_example/pure_dart/dart/lib/bridge_generated.web.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.web.dart
@@ -1121,6 +1121,8 @@ class FlutterRustBridgeExampleSingleBlockTestWasmModule implements WasmModule {
 
   external dynamic /* void */ wire_mirror_struct_stream(NativePortType port_);
 
+  external dynamic /* void */ wire_mirror_tuple_stream(NativePortType port_);
+
   external dynamic /* void */ wire_get_message(NativePortType port_);
 
   external dynamic /* void */ wire_repeat_number(NativePortType port_, int num, int times);
@@ -1533,6 +1535,8 @@ class FlutterRustBridgeExampleSingleBlockTestWire
   void wire_app_settings_vec_stream(NativePortType port_) => wasmModule.wire_app_settings_vec_stream(port_);
 
   void wire_mirror_struct_stream(NativePortType port_) => wasmModule.wire_mirror_struct_stream(port_);
+
+  void wire_mirror_tuple_stream(NativePortType port_) => wasmModule.wire_mirror_tuple_stream(port_);
 
   void wire_get_message(NativePortType port_) => wasmModule.wire_get_message(port_);
 

--- a/frb_example/pure_dart/dart/lib/main.dart
+++ b/frb_example/pure_dart/dart/lib/main.dart
@@ -303,7 +303,8 @@ void main(List<String> args) async {
   test('dart call mirror_tuple_stream', () async {
     final (settings, rawStringEnum) = await api.mirrorTupleStream().first;
     testAppSettings(settings);
-    expect(rawStringEnum, RawStringEnumMirrored.raw(RawStringMirrored(value: "test")));
+    expect(rawStringEnum is RawStringEnumMirrored_Raw, true);
+    expect((rawStringEnum as RawStringEnumMirrored_Raw).field0.value, "test");
   });
 
   test('dart call returnErr', () async {

--- a/frb_example/pure_dart/dart/lib/main.dart
+++ b/frb_example/pure_dart/dart/lib/main.dart
@@ -273,6 +273,39 @@ void main(List<String> args) async {
     testHandleStream(api.handleStreamSinkAt3);
   });
 
+  void testAppSettings(ApplicationSettings settings) {
+    expect(settings.version, "1.0.0-rc.1");
+    expect(settings.mode, ApplicationMode.standalone);
+    expect(settings.env.vars[0].field0, "myenv");
+  }
+
+  test('dart call app_settings_stream', () async {
+    final settings = await api.appSettingsStream().first;
+    testAppSettings(settings);
+  });
+
+  test('dart call app_settings_vec_stream', () async {
+    final settings = await api.appSettingsVecStream().first;
+    testAppSettings(settings[0]);
+    testAppSettings(settings[1]);
+  });
+
+  test('dart call mirror_struct_stream', () async {
+    final ret = await api.mirrorStructStream().first;
+    testAppSettings(ret.a);
+    expect(ret.b.content, true);
+    expect(ret.c[0], MyEnum.True);
+    expect(ret.c[1], MyEnum.False);
+    testAppSettings(ret.d[0]);
+    testAppSettings(ret.d[1]);
+  });
+
+  test('dart call mirror_tuple_stream', () async {
+    final (settings, rawStringEnum) = await api.mirrorTupleStream().first;
+    testAppSettings(settings);
+    expect(rawStringEnum, RawStringEnumMirrored.raw(RawStringMirrored(value: "test")));
+  });
+
   test('dart call returnErr', () async {
     try {
       await api.returnErr();

--- a/frb_example/pure_dart/rust/c_output_path/c_output.h
+++ b/frb_example/pure_dart/rust/c_output_path/c_output.h
@@ -597,6 +597,8 @@ void wire_app_settings_vec_stream(int64_t port_);
 
 void wire_mirror_struct_stream(int64_t port_);
 
+void wire_mirror_tuple_stream(int64_t port_);
+
 void wire_get_message(int64_t port_);
 
 void wire_repeat_number(int64_t port_, int32_t num, uintptr_t times);
@@ -1136,6 +1138,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_app_settings_stream);
     dummy_var ^= ((int64_t) (void*) wire_app_settings_vec_stream);
     dummy_var ^= ((int64_t) (void*) wire_mirror_struct_stream);
+    dummy_var ^= ((int64_t) (void*) wire_mirror_tuple_stream);
     dummy_var ^= ((int64_t) (void*) wire_get_message);
     dummy_var ^= ((int64_t) (void*) wire_repeat_number);
     dummy_var ^= ((int64_t) (void*) wire_repeat_sequence);

--- a/frb_example/pure_dart/rust/c_output_path/c_output.h
+++ b/frb_example/pure_dart/rust/c_output_path/c_output.h
@@ -591,6 +591,12 @@ void wire_get_fallible_app_settings(int64_t port_);
 
 void wire_is_app_embedded(int64_t port_, struct wire_ApplicationSettings *app_settings);
 
+void wire_app_settings_stream(int64_t port_);
+
+void wire_app_settings_vec_stream(int64_t port_);
+
+void wire_mirror_struct_stream(int64_t port_);
+
 void wire_get_message(int64_t port_);
 
 void wire_repeat_number(int64_t port_, int32_t num, uintptr_t times);
@@ -1127,6 +1133,9 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_get_app_settings);
     dummy_var ^= ((int64_t) (void*) wire_get_fallible_app_settings);
     dummy_var ^= ((int64_t) (void*) wire_is_app_embedded);
+    dummy_var ^= ((int64_t) (void*) wire_app_settings_stream);
+    dummy_var ^= ((int64_t) (void*) wire_app_settings_vec_stream);
+    dummy_var ^= ((int64_t) (void*) wire_mirror_struct_stream);
     dummy_var ^= ((int64_t) (void*) wire_get_message);
     dummy_var ^= ((int64_t) (void*) wire_repeat_number);
     dummy_var ^= ((int64_t) (void*) wire_repeat_sequence);

--- a/frb_example/pure_dart/rust/c_output_path_extra/c_output.h
+++ b/frb_example/pure_dart/rust/c_output_path_extra/c_output.h
@@ -597,6 +597,8 @@ void wire_app_settings_vec_stream(int64_t port_);
 
 void wire_mirror_struct_stream(int64_t port_);
 
+void wire_mirror_tuple_stream(int64_t port_);
+
 void wire_get_message(int64_t port_);
 
 void wire_repeat_number(int64_t port_, int32_t num, uintptr_t times);
@@ -1136,6 +1138,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_app_settings_stream);
     dummy_var ^= ((int64_t) (void*) wire_app_settings_vec_stream);
     dummy_var ^= ((int64_t) (void*) wire_mirror_struct_stream);
+    dummy_var ^= ((int64_t) (void*) wire_mirror_tuple_stream);
     dummy_var ^= ((int64_t) (void*) wire_get_message);
     dummy_var ^= ((int64_t) (void*) wire_repeat_number);
     dummy_var ^= ((int64_t) (void*) wire_repeat_sequence);

--- a/frb_example/pure_dart/rust/c_output_path_extra/c_output.h
+++ b/frb_example/pure_dart/rust/c_output_path_extra/c_output.h
@@ -591,6 +591,12 @@ void wire_get_fallible_app_settings(int64_t port_);
 
 void wire_is_app_embedded(int64_t port_, struct wire_ApplicationSettings *app_settings);
 
+void wire_app_settings_stream(int64_t port_);
+
+void wire_app_settings_vec_stream(int64_t port_);
+
+void wire_mirror_struct_stream(int64_t port_);
+
 void wire_get_message(int64_t port_);
 
 void wire_repeat_number(int64_t port_, int32_t num, uintptr_t times);
@@ -1127,6 +1133,9 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_get_app_settings);
     dummy_var ^= ((int64_t) (void*) wire_get_fallible_app_settings);
     dummy_var ^= ((int64_t) (void*) wire_is_app_embedded);
+    dummy_var ^= ((int64_t) (void*) wire_app_settings_stream);
+    dummy_var ^= ((int64_t) (void*) wire_app_settings_vec_stream);
+    dummy_var ^= ((int64_t) (void*) wire_mirror_struct_stream);
     dummy_var ^= ((int64_t) (void*) wire_get_message);
     dummy_var ^= ((int64_t) (void*) wire_repeat_number);
     dummy_var ^= ((int64_t) (void*) wire_repeat_sequence);

--- a/frb_example/pure_dart/rust/src/api.rs
+++ b/frb_example/pure_dart/rust/src/api.rs
@@ -689,6 +689,28 @@ pub fn is_app_embedded(app_settings: ApplicationSettings) -> bool {
     matches!(app_settings.mode, ApplicationMode::Embedded)
 }
 
+// use a stream of a mirrored type
+pub fn app_settings_stream(sink: StreamSink<ApplicationSettings>) {
+    let app_settings = external_lib::get_app_settings();
+    sink.add(app_settings.into());
+}
+
+// use a stream of a vec of mirrored type
+pub fn app_settings_vec_stream(sink: StreamSink<Vec<ApplicationSettings>>) {
+    let app_settings = vec![external_lib::get_app_settings()];
+    sink.add(mirror_ApplicationSettings::from(app_settings));
+}
+
+pub struct MirrorStruct {
+    pub a: mirror_ApplicationSettings,
+    pub b: MyStruct,
+    pub c: Vec<MyEnum>,
+    pub d: Vec<mirror_ApplicationSettings>,
+}
+
+// use a Struct consisting of mirror types as argument to a Stream
+pub fn mirror_struct_stream(sink: StreamSink<MirrorStruct>) {}
+
 #[frb(mirror(ApplicationMessage))]
 pub enum _ApplicationMessage {
     DisplayMessage(String),

--- a/frb_example/pure_dart/rust/src/api.rs
+++ b/frb_example/pure_dart/rust/src/api.rs
@@ -697,7 +697,10 @@ pub fn app_settings_stream(sink: StreamSink<ApplicationSettings>) {
 
 // use a stream of a vec of mirrored type
 pub fn app_settings_vec_stream(sink: StreamSink<Vec<ApplicationSettings>>) {
-    let app_settings = vec![external_lib::get_app_settings()];
+    let app_settings = vec![
+        external_lib::get_app_settings(),
+        external_lib::get_app_settings(),
+    ];
     sink.add(app_settings);
 }
 
@@ -709,7 +712,18 @@ pub struct MirrorStruct {
 }
 
 // use a Struct consisting of mirror types as argument to a Stream
-pub fn mirror_struct_stream(sink: StreamSink<MirrorStruct>) {}
+pub fn mirror_struct_stream(sink: StreamSink<MirrorStruct>) {
+    let val = MirrorStruct {
+        a: external_lib::get_app_settings(),
+        b: MyStruct { content: true },
+        c: vec![MyEnum::True, MyEnum::False],
+        d: vec![
+            external_lib::get_app_settings(),
+            external_lib::get_app_settings(),
+        ],
+    };
+    sink.add(val);
+}
 
 // usa a tuple of Mirror types for a StreamSink
 pub fn mirror_tuple_stream(sink: StreamSink<(ApplicationSettings, RawStringEnumMirrored)>) {

--- a/frb_example/pure_dart/rust/src/api.rs
+++ b/frb_example/pure_dart/rust/src/api.rs
@@ -13,6 +13,7 @@ use anyhow::{anyhow, Result};
 use flutter_rust_bridge::*;
 use lazy_static::lazy_static;
 
+use crate::bridge_generated::{ApplicationSettingsStreamSink, VecApplicationSettingsStreamSink};
 use crate::data::{EnumAlias, Id, MyEnum, MyStruct, StructAlias, UserIdAlias};
 pub use crate::data::{
     FrbOpaqueReturn, FrbOpaqueSyncReturn, HideData, NonCloneData, NonSendHideData,
@@ -692,20 +693,20 @@ pub fn is_app_embedded(app_settings: ApplicationSettings) -> bool {
 // use a stream of a mirrored type
 pub fn app_settings_stream(sink: StreamSink<ApplicationSettings>) {
     let app_settings = external_lib::get_app_settings();
-    sink.add(app_settings.into());
+    sink.add(app_settings);
 }
 
 // use a stream of a vec of mirrored type
 pub fn app_settings_vec_stream(sink: StreamSink<Vec<ApplicationSettings>>) {
     let app_settings = vec![external_lib::get_app_settings()];
-    sink.add(mirror_ApplicationSettings::from(app_settings));
+    sink.add(app_settings);
 }
 
 pub struct MirrorStruct {
-    pub a: mirror_ApplicationSettings,
+    pub a: ApplicationSettings,
     pub b: MyStruct,
     pub c: Vec<MyEnum>,
-    pub d: Vec<mirror_ApplicationSettings>,
+    pub d: Vec<ApplicationSettings>,
 }
 
 // use a Struct consisting of mirror types as argument to a Stream

--- a/frb_example/pure_dart/rust/src/api.rs
+++ b/frb_example/pure_dart/rust/src/api.rs
@@ -693,6 +693,7 @@ pub fn is_app_embedded(app_settings: ApplicationSettings) -> bool {
 pub fn app_settings_stream(sink: StreamSink<ApplicationSettings>) {
     let app_settings = external_lib::get_app_settings();
     sink.add(app_settings);
+    sink.close();
 }
 
 // use a stream of a vec of mirrored type
@@ -702,6 +703,7 @@ pub fn app_settings_vec_stream(sink: StreamSink<Vec<ApplicationSettings>>) {
         external_lib::get_app_settings(),
     ];
     sink.add(app_settings);
+    sink.close();
 }
 
 pub struct MirrorStruct {
@@ -723,6 +725,7 @@ pub fn mirror_struct_stream(sink: StreamSink<MirrorStruct>) {
         ],
     };
     sink.add(val);
+    sink.close();
 }
 
 // usa a tuple of Mirror types for a StreamSink
@@ -734,6 +737,7 @@ pub fn mirror_tuple_stream(sink: StreamSink<(ApplicationSettings, RawStringEnumM
         }),
     );
     sink.add(tuple);
+    sink.close();
 }
 
 #[frb(mirror(ApplicationMessage))]

--- a/frb_example/pure_dart/rust/src/api.rs
+++ b/frb_example/pure_dart/rust/src/api.rs
@@ -711,6 +711,17 @@ pub struct MirrorStruct {
 // use a Struct consisting of mirror types as argument to a Stream
 pub fn mirror_struct_stream(sink: StreamSink<MirrorStruct>) {}
 
+// usa a tuple of Mirror types for a StreamSink
+pub fn mirror_tuple_stream(sink: StreamSink<(ApplicationSettings, RawStringEnumMirrored)>) {
+    let tuple = (
+        external_lib::get_app_settings(),
+        RawStringEnumMirrored::Raw(RawStringMirrored {
+            value: String::from("test"),
+        }),
+    );
+    sink.add(tuple);
+}
+
 #[frb(mirror(ApplicationMessage))]
 pub enum _ApplicationMessage {
     DisplayMessage(String),

--- a/frb_example/pure_dart/rust/src/api.rs
+++ b/frb_example/pure_dart/rust/src/api.rs
@@ -13,7 +13,6 @@ use anyhow::{anyhow, Result};
 use flutter_rust_bridge::*;
 use lazy_static::lazy_static;
 
-use crate::bridge_generated::{ApplicationSettingsStreamSink, VecApplicationSettingsStreamSink};
 use crate::data::{EnumAlias, Id, MyEnum, MyStruct, StructAlias, UserIdAlias};
 pub use crate::data::{
     FrbOpaqueReturn, FrbOpaqueSyncReturn, HideData, NonCloneData, NonSendHideData,

--- a/frb_example/pure_dart/rust/src/bridge_generated.io.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.io.rs
@@ -294,6 +294,11 @@ pub extern "C" fn wire_mirror_struct_stream(port_: i64) {
 }
 
 #[no_mangle]
+pub extern "C" fn wire_mirror_tuple_stream(port_: i64) {
+    wire_mirror_tuple_stream_impl(port_)
+}
+
+#[no_mangle]
 pub extern "C" fn wire_get_message(port_: i64) {
     wire_get_message_impl(port_)
 }

--- a/frb_example/pure_dart/rust/src/bridge_generated.io.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.io.rs
@@ -279,6 +279,21 @@ pub extern "C" fn wire_is_app_embedded(port_: i64, app_settings: *mut wire_Appli
 }
 
 #[no_mangle]
+pub extern "C" fn wire_app_settings_stream(port_: i64) {
+    wire_app_settings_stream_impl(port_)
+}
+
+#[no_mangle]
+pub extern "C" fn wire_app_settings_vec_stream(port_: i64) {
+    wire_app_settings_vec_stream_impl(port_)
+}
+
+#[no_mangle]
+pub extern "C" fn wire_mirror_struct_stream(port_: i64) {
+    wire_mirror_struct_stream_impl(port_)
+}
+
+#[no_mangle]
 pub extern "C" fn wire_get_message(port_: i64) {
     wire_get_message_impl(port_)
 }

--- a/frb_example/pure_dart/rust/src/bridge_generated.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.rs
@@ -13,6 +13,7 @@
 
 use crate::api::*;
 use core::panic::UnwindSafe;
+use flutter_rust_bridge::rust2dart::IntoIntoDart;
 use flutter_rust_bridge::*;
 use std::ffi::c_void;
 use std::sync::Arc;
@@ -31,7 +32,7 @@ fn wire_simple_adder_impl(
     a: impl Wire2Api<i32> + UnwindSafe,
     b: impl Wire2Api<i32> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, i32>(
         WrapInfo {
             debug_name: "simple_adder",
             port: Some(port_),
@@ -68,7 +69,7 @@ fn wire_primitive_types_impl(
     my_f64: impl Wire2Api<f64> + UnwindSafe,
     my_bool: impl Wire2Api<bool> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, i32>(
         WrapInfo {
             debug_name: "primitive_types",
             port: Some(port_),
@@ -97,7 +98,7 @@ fn wire_primitive_optional_types_impl(
     my_f64: impl Wire2Api<Option<f64>> + UnwindSafe,
     my_bool: impl Wire2Api<Option<bool>> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, Option<i32>>(
         WrapInfo {
             debug_name: "primitive_optional_types",
             port: Some(port_),
@@ -146,7 +147,7 @@ fn wire_primitive_types_sync_impl(
     )
 }
 fn wire_primitive_u32_impl(port_: MessagePort, my_u32: impl Wire2Api<u32> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, u32>(
         WrapInfo {
             debug_name: "primitive_u32",
             port: Some(port_),
@@ -174,7 +175,7 @@ fn wire_primitive_u32_sync_impl(
     )
 }
 fn wire_handle_string_impl(port_: MessagePort, s: impl Wire2Api<String> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, String>(
         WrapInfo {
             debug_name: "handle_string",
             port: Some(port_),
@@ -200,7 +201,7 @@ fn wire_handle_string_sync_impl(s: impl Wire2Api<String> + UnwindSafe) -> suppor
     )
 }
 fn wire_handle_return_unit_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, ()>(
         WrapInfo {
             debug_name: "handle_return_unit",
             port: Some(port_),
@@ -220,7 +221,7 @@ fn wire_handle_return_unit_sync_impl() -> support::WireSyncReturn {
     )
 }
 fn wire_handle_vec_u8_impl(port_: MessagePort, v: impl Wire2Api<Vec<u8>> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, Vec<u8>>(
         WrapInfo {
             debug_name: "handle_vec_u8",
             port: Some(port_),
@@ -246,7 +247,7 @@ fn wire_handle_vec_u8_sync_impl(v: impl Wire2Api<Vec<u8>> + UnwindSafe) -> suppo
     )
 }
 fn wire_handle_vec_of_primitive_impl(port_: MessagePort, n: impl Wire2Api<i32> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, VecOfPrimitivePack>(
         WrapInfo {
             debug_name: "handle_vec_of_primitive",
             port: Some(port_),
@@ -277,7 +278,7 @@ fn wire_handle_zero_copy_vec_of_primitive_impl(
     port_: MessagePort,
     n: impl Wire2Api<i32> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, ZeroCopyVecOfPrimitivePack>(
         WrapInfo {
             debug_name: "handle_zero_copy_vec_of_primitive",
             port: Some(port_),
@@ -309,7 +310,7 @@ fn wire_handle_struct_impl(
     arg: impl Wire2Api<MySize> + UnwindSafe,
     boxed: impl Wire2Api<Box<MySize>> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, MySize>(
         WrapInfo {
             debug_name: "handle_struct",
             port: Some(port_),
@@ -340,7 +341,7 @@ fn wire_handle_struct_sync_impl(
     )
 }
 fn wire_handle_newtype_impl(port_: MessagePort, arg: impl Wire2Api<NewTypeInt> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, NewTypeInt>(
         WrapInfo {
             debug_name: "handle_newtype",
             port: Some(port_),
@@ -368,7 +369,7 @@ fn wire_handle_newtype_sync_impl(
     )
 }
 fn wire_handle_list_of_struct_impl(port_: MessagePort, l: impl Wire2Api<Vec<MySize>> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, Vec<MySize>>(
         WrapInfo {
             debug_name: "handle_list_of_struct",
             port: Some(port_),
@@ -399,7 +400,7 @@ fn wire_handle_string_list_impl(
     port_: MessagePort,
     names: impl Wire2Api<Vec<String>> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, Vec<String>>(
         WrapInfo {
             debug_name: "handle_string_list",
             port: Some(port_),
@@ -427,7 +428,7 @@ fn wire_handle_string_list_sync_impl(
     )
 }
 fn wire_handle_complex_struct_impl(port_: MessagePort, s: impl Wire2Api<MyTreeNode> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, MyTreeNode>(
         WrapInfo {
             debug_name: "handle_complex_struct",
             port: Some(port_),
@@ -458,7 +459,7 @@ fn wire_handle_nested_struct_impl(
     port_: MessagePort,
     s: impl Wire2Api<MyNestedStruct> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, MyNestedStruct>(
         WrapInfo {
             debug_name: "handle_nested_struct",
             port: Some(port_),
@@ -486,7 +487,7 @@ fn wire_handle_sync_return_impl(
     )
 }
 fn wire_handle_stream_impl(port_: MessagePort, arg: impl Wire2Api<String> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, ()>(
         WrapInfo {
             debug_name: "handle_stream",
             port: Some(port_),
@@ -494,22 +495,33 @@ fn wire_handle_stream_impl(port_: MessagePort, arg: impl Wire2Api<String> + Unwi
         },
         move || {
             let api_arg = arg.wire2api();
-            move |task_callback| Ok(handle_stream(task_callback.stream_sink(), api_arg))
+            move |task_callback| {
+                Ok(handle_stream(
+                    task_callback.stream_sink::<_, String>(),
+                    api_arg,
+                ))
+            }
         },
     )
 }
 fn wire_handle_stream_of_struct_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, ()>(
         WrapInfo {
             debug_name: "handle_stream_of_struct",
             port: Some(port_),
             mode: FfiCallMode::Stream,
         },
-        move || move |task_callback| Ok(handle_stream_of_struct(task_callback.stream_sink())),
+        move || {
+            move |task_callback| {
+                Ok(handle_stream_of_struct(
+                    task_callback.stream_sink::<_, MyStreamEntry>(),
+                ))
+            }
+        },
     )
 }
 fn wire_return_err_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, i32>(
         WrapInfo {
             debug_name: "return_err",
             port: Some(port_),
@@ -519,7 +531,7 @@ fn wire_return_err_impl(port_: MessagePort) {
     )
 }
 fn wire_return_panic_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, i32>(
         WrapInfo {
             debug_name: "return_panic",
             port: Some(port_),
@@ -533,7 +545,7 @@ fn wire_handle_optional_return_impl(
     left: impl Wire2Api<f64> + UnwindSafe,
     right: impl Wire2Api<f64> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, Option<f64>>(
         WrapInfo {
             debug_name: "handle_optional_return",
             port: Some(port_),
@@ -550,7 +562,7 @@ fn wire_handle_optional_struct_impl(
     port_: MessagePort,
     document: impl Wire2Api<Option<String>> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, Option<Element>>(
         WrapInfo {
             debug_name: "handle_optional_struct",
             port: Some(port_),
@@ -566,7 +578,7 @@ fn wire_handle_optional_increment_impl(
     port_: MessagePort,
     opt: impl Wire2Api<Option<ExoticOptionals>> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, Option<ExoticOptionals>>(
         WrapInfo {
             debug_name: "handle_optional_increment",
             port: Some(port_),
@@ -582,7 +594,7 @@ fn wire_handle_increment_boxed_optional_impl(
     port_: MessagePort,
     opt: impl Wire2Api<Option<Box<f64>>> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, f64>(
         WrapInfo {
             debug_name: "handle_increment_boxed_optional",
             port: Some(port_),
@@ -604,7 +616,7 @@ fn wire_handle_option_box_arguments_impl(
     boolbox: impl Wire2Api<Option<Box<bool>>> + UnwindSafe,
     structbox: impl Wire2Api<Option<Box<ExoticOptionals>>> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, String>(
         WrapInfo {
             debug_name: "handle_option_box_arguments",
             port: Some(port_),
@@ -633,7 +645,7 @@ fn wire_handle_option_box_arguments_impl(
     )
 }
 fn wire_print_note_impl(port_: MessagePort, note: impl Wire2Api<Note> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, ZeroCopyBuffer<Vec<u8>>>(
         WrapInfo {
             debug_name: "print_note",
             port: Some(port_),
@@ -646,7 +658,7 @@ fn wire_print_note_impl(port_: MessagePort, note: impl Wire2Api<Note> + UnwindSa
     )
 }
 fn wire_handle_return_enum_impl(port_: MessagePort, input: impl Wire2Api<String> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, Option<Weekdays>>(
         WrapInfo {
             debug_name: "handle_return_enum",
             port: Some(port_),
@@ -662,7 +674,7 @@ fn wire_handle_enum_parameter_impl(
     port_: MessagePort,
     weekday: impl Wire2Api<Weekdays> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, Weekdays>(
         WrapInfo {
             debug_name: "handle_enum_parameter",
             port: Some(port_),
@@ -678,7 +690,7 @@ fn wire_handle_customized_struct_impl(
     port_: MessagePort,
     val: impl Wire2Api<Customized> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, ()>(
         WrapInfo {
             debug_name: "handle_customized_struct",
             port: Some(port_),
@@ -691,7 +703,7 @@ fn wire_handle_customized_struct_impl(
     )
 }
 fn wire_handle_enum_struct_impl(port_: MessagePort, val: impl Wire2Api<KitchenSink> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, KitchenSink>(
         WrapInfo {
             debug_name: "handle_enum_struct",
             port: Some(port_),
@@ -707,7 +719,7 @@ fn wire_use_imported_struct_impl(
     port_: MessagePort,
     my_struct: impl Wire2Api<MyStruct> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, bool>(
         WrapInfo {
             debug_name: "use_imported_struct",
             port: Some(port_),
@@ -720,7 +732,7 @@ fn wire_use_imported_struct_impl(
     )
 }
 fn wire_use_imported_enum_impl(port_: MessagePort, my_enum: impl Wire2Api<MyEnum> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, bool>(
         WrapInfo {
             debug_name: "use_imported_enum",
             port: Some(port_),
@@ -733,30 +745,30 @@ fn wire_use_imported_enum_impl(port_: MessagePort, my_enum: impl Wire2Api<MyEnum
     )
 }
 fn wire_get_app_settings_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, mirror_ApplicationSettings>(
         WrapInfo {
             debug_name: "get_app_settings",
             port: Some(port_),
             mode: FfiCallMode::Normal,
         },
-        move || move |task_callback| Ok(mirror_ApplicationSettings(get_app_settings())),
+        move || move |task_callback| Ok(get_app_settings()),
     )
 }
 fn wire_get_fallible_app_settings_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, mirror_ApplicationSettings>(
         WrapInfo {
             debug_name: "get_fallible_app_settings",
             port: Some(port_),
             mode: FfiCallMode::Normal,
         },
-        move || move |task_callback| Ok(mirror_ApplicationSettings(get_fallible_app_settings()?)),
+        move || move |task_callback| get_fallible_app_settings(),
     )
 }
 fn wire_is_app_embedded_impl(
     port_: MessagePort,
     app_settings: impl Wire2Api<ApplicationSettings> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, bool>(
         WrapInfo {
             debug_name: "is_app_embedded",
             port: Some(port_),
@@ -768,14 +780,62 @@ fn wire_is_app_embedded_impl(
         },
     )
 }
+fn wire_app_settings_stream_impl(port_: MessagePort) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, ()>(
+        WrapInfo {
+            debug_name: "app_settings_stream",
+            port: Some(port_),
+            mode: FfiCallMode::Stream,
+        },
+        move || {
+            move |task_callback| {
+                Ok(app_settings_stream(
+                    task_callback.stream_sink::<_, mirror_ApplicationSettings>(),
+                ))
+            }
+        },
+    )
+}
+fn wire_app_settings_vec_stream_impl(port_: MessagePort) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, ()>(
+        WrapInfo {
+            debug_name: "app_settings_vec_stream",
+            port: Some(port_),
+            mode: FfiCallMode::Stream,
+        },
+        move || {
+            move |task_callback| {
+                Ok(app_settings_vec_stream(
+                    task_callback.stream_sink::<_, Vec<mirror_ApplicationSettings>>(),
+                ))
+            }
+        },
+    )
+}
+fn wire_mirror_struct_stream_impl(port_: MessagePort) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, ()>(
+        WrapInfo {
+            debug_name: "mirror_struct_stream",
+            port: Some(port_),
+            mode: FfiCallMode::Stream,
+        },
+        move || {
+            move |task_callback| {
+                Ok(mirror_struct_stream(
+                    task_callback.stream_sink::<_, MirrorStruct>(),
+                ))
+            }
+        },
+    )
+}
 fn wire_get_message_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, mirror_ApplicationMessage>(
         WrapInfo {
             debug_name: "get_message",
             port: Some(port_),
             mode: FfiCallMode::Normal,
         },
-        move || move |task_callback| Ok(mirror_ApplicationMessage(get_message())),
+        move || move |task_callback| Ok(get_message()),
     )
 }
 fn wire_repeat_number_impl(
@@ -783,7 +843,7 @@ fn wire_repeat_number_impl(
     num: impl Wire2Api<i32> + UnwindSafe,
     times: impl Wire2Api<usize> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, mirror_Numbers>(
         WrapInfo {
             debug_name: "repeat_number",
             port: Some(port_),
@@ -792,7 +852,7 @@ fn wire_repeat_number_impl(
         move || {
             let api_num = num.wire2api();
             let api_times = times.wire2api();
-            move |task_callback| Ok(mirror_Numbers(repeat_number(api_num, api_times)))
+            move |task_callback| Ok(repeat_number(api_num, api_times))
         },
     )
 }
@@ -801,7 +861,7 @@ fn wire_repeat_sequence_impl(
     seq: impl Wire2Api<i32> + UnwindSafe,
     times: impl Wire2Api<usize> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, mirror_Sequences>(
         WrapInfo {
             debug_name: "repeat_sequence",
             port: Some(port_),
@@ -810,12 +870,12 @@ fn wire_repeat_sequence_impl(
         move || {
             let api_seq = seq.wire2api();
             let api_times = times.wire2api();
-            move |task_callback| Ok(mirror_Sequences(repeat_sequence(api_seq, api_times)))
+            move |task_callback| Ok(repeat_sequence(api_seq, api_times))
         },
     )
 }
 fn wire_first_number_impl(port_: MessagePort, nums: impl Wire2Api<Numbers> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, Option<i32>>(
         WrapInfo {
             debug_name: "first_number",
             port: Some(port_),
@@ -828,7 +888,7 @@ fn wire_first_number_impl(port_: MessagePort, nums: impl Wire2Api<Numbers> + Unw
     )
 }
 fn wire_first_sequence_impl(port_: MessagePort, seqs: impl Wire2Api<Sequences> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, Option<i32>>(
         WrapInfo {
             debug_name: "first_sequence",
             port: Some(port_),
@@ -841,7 +901,7 @@ fn wire_first_sequence_impl(port_: MessagePort, seqs: impl Wire2Api<Sequences> +
     )
 }
 fn wire_get_array_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, [u8; 5]>(
         WrapInfo {
             debug_name: "get_array",
             port: Some(port_),
@@ -851,7 +911,7 @@ fn wire_get_array_impl(port_: MessagePort) {
     )
 }
 fn wire_get_complex_array_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, [Point; 2]>(
         WrapInfo {
             debug_name: "get_complex_array",
             port: Some(port_),
@@ -861,7 +921,7 @@ fn wire_get_complex_array_impl(port_: MessagePort) {
     )
 }
 fn wire_get_usize_impl(port_: MessagePort, u: impl Wire2Api<usize> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, usize>(
         WrapInfo {
             debug_name: "get_usize",
             port: Some(port_),
@@ -874,7 +934,7 @@ fn wire_get_usize_impl(port_: MessagePort, u: impl Wire2Api<usize> + UnwindSafe)
     )
 }
 fn wire_next_user_id_impl(port_: MessagePort, user_id: impl Wire2Api<UserId> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, UserId>(
         WrapInfo {
             debug_name: "next_user_id",
             port: Some(port_),
@@ -887,17 +947,19 @@ fn wire_next_user_id_impl(port_: MessagePort, user_id: impl Wire2Api<UserId> + U
     )
 }
 fn wire_register_event_listener_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, ()>(
         WrapInfo {
             debug_name: "register_event_listener",
             port: Some(port_),
             mode: FfiCallMode::Stream,
         },
-        move || move |task_callback| register_event_listener(task_callback.stream_sink()),
+        move || {
+            move |task_callback| register_event_listener(task_callback.stream_sink::<_, Event>())
+        },
     )
 }
 fn wire_close_event_listener_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, ()>(
         WrapInfo {
             debug_name: "close_event_listener",
             port: Some(port_),
@@ -911,7 +973,7 @@ fn wire_create_event_impl(
     address: impl Wire2Api<String> + UnwindSafe,
     payload: impl Wire2Api<String> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, ()>(
         WrapInfo {
             debug_name: "create_event",
             port: Some(port_),
@@ -929,7 +991,7 @@ fn wire_handle_stream_sink_at_1_impl(
     key: impl Wire2Api<u32> + UnwindSafe,
     max: impl Wire2Api<u32> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, ()>(
         WrapInfo {
             debug_name: "handle_stream_sink_at_1",
             port: Some(port_),
@@ -942,7 +1004,7 @@ fn wire_handle_stream_sink_at_1_impl(
                 Ok(handle_stream_sink_at_1(
                     api_key,
                     api_max,
-                    task_callback.stream_sink(),
+                    task_callback.stream_sink::<_, Log>(),
                 ))
             }
         },
@@ -953,7 +1015,7 @@ fn wire_handle_stream_sink_at_2_impl(
     key: impl Wire2Api<u32> + UnwindSafe,
     max: impl Wire2Api<u32> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, ()>(
         WrapInfo {
             debug_name: "handle_stream_sink_at_2",
             port: Some(port_),
@@ -965,7 +1027,7 @@ fn wire_handle_stream_sink_at_2_impl(
             move |task_callback| {
                 Ok(handle_stream_sink_at_2(
                     api_key,
-                    task_callback.stream_sink(),
+                    task_callback.stream_sink::<_, Log>(),
                     api_max,
                 ))
             }
@@ -977,7 +1039,7 @@ fn wire_handle_stream_sink_at_3_impl(
     key: impl Wire2Api<u32> + UnwindSafe,
     max: impl Wire2Api<u32> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, ()>(
         WrapInfo {
             debug_name: "handle_stream_sink_at_3",
             port: Some(port_),
@@ -988,7 +1050,7 @@ fn wire_handle_stream_sink_at_3_impl(
             let api_max = max.wire2api();
             move |task_callback| {
                 Ok(handle_stream_sink_at_3(
-                    task_callback.stream_sink(),
+                    task_callback.stream_sink::<_, Log>(),
                     api_key,
                     api_max,
                 ))
@@ -997,7 +1059,7 @@ fn wire_handle_stream_sink_at_3_impl(
     )
 }
 fn wire_get_sum_struct_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, SumWith>(
         WrapInfo {
             debug_name: "get_sum_struct",
             port: Some(port_),
@@ -1012,7 +1074,7 @@ fn wire_get_sum_array_impl(
     b: impl Wire2Api<u32> + UnwindSafe,
     c: impl Wire2Api<u32> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, [SumWith; 3]>(
         WrapInfo {
             debug_name: "get_sum_array",
             port: Some(port_),
@@ -1027,7 +1089,7 @@ fn wire_get_sum_array_impl(
     )
 }
 fn wire_multiply_by_ten_impl(port_: MessagePort, measure: impl Wire2Api<Measure> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, Option<Measure>>(
         WrapInfo {
             debug_name: "multiply_by_ten",
             port: Some(port_),
@@ -1040,7 +1102,7 @@ fn wire_multiply_by_ten_impl(port_: MessagePort, measure: impl Wire2Api<Measure>
     )
 }
 fn wire_call_old_module_system_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, OldSimpleStruct>(
         WrapInfo {
             debug_name: "call_old_module_system",
             port: Some(port_),
@@ -1050,7 +1112,7 @@ fn wire_call_old_module_system_impl(port_: MessagePort) {
     )
 }
 fn wire_call_new_module_system_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, NewSimpleStruct>(
         WrapInfo {
             debug_name: "call_new_module_system",
             port: Some(port_),
@@ -1060,7 +1122,7 @@ fn wire_call_new_module_system_impl(port_: MessagePort) {
     )
 }
 fn wire_handle_big_buffers_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, BigBuffers>(
         WrapInfo {
             debug_name: "handle_big_buffers",
             port: Some(port_),
@@ -1073,7 +1135,7 @@ fn wire_datetime_utc_impl(
     port_: MessagePort,
     d: impl Wire2Api<chrono::DateTime<chrono::Utc>> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, chrono::DateTime<chrono::Utc>>(
         WrapInfo {
             debug_name: "datetime_utc",
             port: Some(port_),
@@ -1089,7 +1151,7 @@ fn wire_datetime_local_impl(
     port_: MessagePort,
     d: impl Wire2Api<chrono::DateTime<chrono::Local>> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, chrono::DateTime<chrono::Local>>(
         WrapInfo {
             debug_name: "datetime_local",
             port: Some(port_),
@@ -1105,7 +1167,7 @@ fn wire_naivedatetime_impl(
     port_: MessagePort,
     d: impl Wire2Api<chrono::NaiveDateTime> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, chrono::NaiveDateTime>(
         WrapInfo {
             debug_name: "naivedatetime",
             port: Some(port_),
@@ -1121,7 +1183,7 @@ fn wire_optional_empty_datetime_utc_impl(
     port_: MessagePort,
     d: impl Wire2Api<Option<chrono::DateTime<chrono::Utc>>> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, Option<chrono::DateTime<chrono::Utc>>>(
         WrapInfo {
             debug_name: "optional_empty_datetime_utc",
             port: Some(port_),
@@ -1134,7 +1196,7 @@ fn wire_optional_empty_datetime_utc_impl(
     )
 }
 fn wire_duration_impl(port_: MessagePort, d: impl Wire2Api<chrono::Duration> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, chrono::Duration>(
         WrapInfo {
             debug_name: "duration",
             port: Some(port_),
@@ -1151,7 +1213,7 @@ fn wire_handle_timestamps_impl(
     timestamps: impl Wire2Api<Vec<chrono::NaiveDateTime>> + UnwindSafe,
     epoch: impl Wire2Api<chrono::NaiveDateTime> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, Vec<chrono::Duration>>(
         WrapInfo {
             debug_name: "handle_timestamps",
             port: Some(port_),
@@ -1169,7 +1231,7 @@ fn wire_handle_durations_impl(
     durations: impl Wire2Api<Vec<chrono::Duration>> + UnwindSafe,
     since: impl Wire2Api<chrono::DateTime<chrono::Local>> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, Vec<chrono::DateTime<chrono::Local>>>(
         WrapInfo {
             debug_name: "handle_durations",
             port: Some(port_),
@@ -1183,7 +1245,7 @@ fn wire_handle_durations_impl(
     )
 }
 fn wire_test_chrono_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, TestChrono>(
         WrapInfo {
             debug_name: "test_chrono",
             port: Some(port_),
@@ -1193,7 +1255,7 @@ fn wire_test_chrono_impl(port_: MessagePort) {
     )
 }
 fn wire_test_precise_chrono_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, TestChrono>(
         WrapInfo {
             debug_name: "test_precise_chrono",
             port: Some(port_),
@@ -1206,7 +1268,7 @@ fn wire_how_long_does_it_take_impl(
     port_: MessagePort,
     mine: impl Wire2Api<FeatureChrono> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, chrono::Duration>(
         WrapInfo {
             debug_name: "how_long_does_it_take",
             port: Some(port_),
@@ -1219,7 +1281,7 @@ fn wire_how_long_does_it_take_impl(
     )
 }
 fn wire_handle_uuid_impl(port_: MessagePort, id: impl Wire2Api<uuid::Uuid> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, uuid::Uuid>(
         WrapInfo {
             debug_name: "handle_uuid",
             port: Some(port_),
@@ -1232,7 +1294,7 @@ fn wire_handle_uuid_impl(port_: MessagePort, id: impl Wire2Api<uuid::Uuid> + Unw
     )
 }
 fn wire_handle_uuids_impl(port_: MessagePort, ids: impl Wire2Api<Vec<uuid::Uuid>> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, Vec<uuid::Uuid>>(
         WrapInfo {
             debug_name: "handle_uuids",
             port: Some(port_),
@@ -1245,7 +1307,7 @@ fn wire_handle_uuids_impl(port_: MessagePort, ids: impl Wire2Api<Vec<uuid::Uuid>
     )
 }
 fn wire_handle_nested_uuids_impl(port_: MessagePort, ids: impl Wire2Api<FeatureUuid> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, FeatureUuid>(
         WrapInfo {
             debug_name: "handle_nested_uuids",
             port: Some(port_),
@@ -1258,7 +1320,7 @@ fn wire_handle_nested_uuids_impl(port_: MessagePort, ids: impl Wire2Api<FeatureU
     )
 }
 fn wire_new_msgid_impl(port_: MessagePort, id: impl Wire2Api<[u8; 32]> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, MessageId>(
         WrapInfo {
             debug_name: "new_msgid",
             port: Some(port_),
@@ -1271,7 +1333,7 @@ fn wire_new_msgid_impl(port_: MessagePort, id: impl Wire2Api<[u8; 32]> + UnwindS
     )
 }
 fn wire_use_msgid_impl(port_: MessagePort, id: impl Wire2Api<MessageId> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, [u8; 32]>(
         WrapInfo {
             debug_name: "use_msgid",
             port: Some(port_),
@@ -1284,7 +1346,7 @@ fn wire_use_msgid_impl(port_: MessagePort, id: impl Wire2Api<MessageId> + Unwind
     )
 }
 fn wire_boxed_blob_impl(port_: MessagePort, blob: impl Wire2Api<Box<[u8; 1600]>> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, Blob>(
         WrapInfo {
             debug_name: "boxed_blob",
             port: Some(port_),
@@ -1297,7 +1359,7 @@ fn wire_boxed_blob_impl(port_: MessagePort, blob: impl Wire2Api<Box<[u8; 1600]>>
     )
 }
 fn wire_use_boxed_blob_impl(port_: MessagePort, blob: impl Wire2Api<Box<Blob>> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, [u8; 1600]>(
         WrapInfo {
             debug_name: "use_boxed_blob",
             port: Some(port_),
@@ -1310,7 +1372,7 @@ fn wire_use_boxed_blob_impl(port_: MessagePort, blob: impl Wire2Api<Box<Blob>> +
     )
 }
 fn wire_return_boxed_feed_id_impl(port_: MessagePort, id: impl Wire2Api<[u8; 8]> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, FeedId>(
         WrapInfo {
             debug_name: "return_boxed_feed_id",
             port: Some(port_),
@@ -1318,12 +1380,12 @@ fn wire_return_boxed_feed_id_impl(port_: MessagePort, id: impl Wire2Api<[u8; 8]>
         },
         move || {
             let api_id = id.wire2api();
-            move |task_callback| Ok((*return_boxed_feed_id(api_id)))
+            move |task_callback| Ok(return_boxed_feed_id(api_id))
         },
     )
 }
 fn wire_return_boxed_raw_feed_id_impl(port_: MessagePort, id: impl Wire2Api<FeedId> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, [u8; 8]>(
         WrapInfo {
             debug_name: "return_boxed_raw_feed_id",
             port: Some(port_),
@@ -1331,12 +1393,12 @@ fn wire_return_boxed_raw_feed_id_impl(port_: MessagePort, id: impl Wire2Api<Feed
         },
         move || {
             let api_id = id.wire2api();
-            move |task_callback| Ok((*return_boxed_raw_feed_id(api_id)))
+            move |task_callback| Ok(return_boxed_raw_feed_id(api_id))
         },
     )
 }
 fn wire_test_id_impl(port_: MessagePort, id: impl Wire2Api<TestId> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, TestId>(
         WrapInfo {
             debug_name: "test_id",
             port: Some(port_),
@@ -1349,7 +1411,7 @@ fn wire_test_id_impl(port_: MessagePort, id: impl Wire2Api<TestId> + UnwindSafe)
     )
 }
 fn wire_last_number_impl(port_: MessagePort, array: impl Wire2Api<[f64; 16]> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, f64>(
         WrapInfo {
             debug_name: "last_number",
             port: Some(port_),
@@ -1362,7 +1424,7 @@ fn wire_last_number_impl(port_: MessagePort, array: impl Wire2Api<[f64; 16]> + U
     )
 }
 fn wire_nested_id_impl(port_: MessagePort, id: impl Wire2Api<[TestId; 4]> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, [TestId; 2]>(
         WrapInfo {
             debug_name: "nested_id",
             port: Some(port_),
@@ -1393,7 +1455,7 @@ fn wire_async_accept_dart_opaque_impl(
     port_: MessagePort,
     opaque: impl Wire2Api<DartOpaque> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, String>(
         WrapInfo {
             debug_name: "async_accept_dart_opaque",
             port: Some(port_),
@@ -1406,7 +1468,7 @@ fn wire_async_accept_dart_opaque_impl(
     )
 }
 fn wire_loop_back_impl(port_: MessagePort, opaque: impl Wire2Api<DartOpaque> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, DartOpaque>(
         WrapInfo {
             debug_name: "loop_back",
             port: Some(port_),
@@ -1419,7 +1481,7 @@ fn wire_loop_back_impl(port_: MessagePort, opaque: impl Wire2Api<DartOpaque> + U
     )
 }
 fn wire_loop_back_option_impl(port_: MessagePort, opaque: impl Wire2Api<DartOpaque> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, Option<DartOpaque>>(
         WrapInfo {
             debug_name: "loop_back_option",
             port: Some(port_),
@@ -1432,7 +1494,7 @@ fn wire_loop_back_option_impl(port_: MessagePort, opaque: impl Wire2Api<DartOpaq
     )
 }
 fn wire_loop_back_array_impl(port_: MessagePort, opaque: impl Wire2Api<DartOpaque> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, [DartOpaque; 1]>(
         WrapInfo {
             debug_name: "loop_back_array",
             port: Some(port_),
@@ -1445,7 +1507,7 @@ fn wire_loop_back_array_impl(port_: MessagePort, opaque: impl Wire2Api<DartOpaqu
     )
 }
 fn wire_loop_back_vec_impl(port_: MessagePort, opaque: impl Wire2Api<DartOpaque> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, Vec<DartOpaque>>(
         WrapInfo {
             debug_name: "loop_back_vec",
             port: Some(port_),
@@ -1461,7 +1523,7 @@ fn wire_loop_back_option_get_impl(
     port_: MessagePort,
     opaque: impl Wire2Api<Option<DartOpaque>> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, ()>(
         WrapInfo {
             debug_name: "loop_back_option_get",
             port: Some(port_),
@@ -1477,7 +1539,7 @@ fn wire_loop_back_array_get_impl(
     port_: MessagePort,
     opaque: impl Wire2Api<[DartOpaque; 1]> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, ()>(
         WrapInfo {
             debug_name: "loop_back_array_get",
             port: Some(port_),
@@ -1493,7 +1555,7 @@ fn wire_loop_back_vec_get_impl(
     port_: MessagePort,
     opaque: impl Wire2Api<Vec<DartOpaque>> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, ()>(
         WrapInfo {
             debug_name: "loop_back_vec_get",
             port: Some(port_),
@@ -1524,7 +1586,7 @@ fn wire_panic_unwrap_dart_opaque_impl(
     port_: MessagePort,
     opaque: impl Wire2Api<DartOpaque> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, ()>(
         WrapInfo {
             debug_name: "panic_unwrap_dart_opaque",
             port: Some(port_),
@@ -1537,7 +1599,7 @@ fn wire_panic_unwrap_dart_opaque_impl(
     )
 }
 fn wire_create_opaque_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, RustOpaque<HideData>>(
         WrapInfo {
             debug_name: "create_opaque",
             port: Some(port_),
@@ -1550,7 +1612,7 @@ fn wire_create_option_opaque_impl(
     port_: MessagePort,
     opaque: impl Wire2Api<Option<RustOpaque<HideData>>> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, Option<RustOpaque<HideData>>>(
         WrapInfo {
             debug_name: "create_option_opaque",
             port: Some(port_),
@@ -1573,7 +1635,7 @@ fn wire_sync_create_opaque_impl() -> support::WireSyncReturn {
     )
 }
 fn wire_create_array_opaque_enum_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, [EnumOpaque; 5]>(
         WrapInfo {
             debug_name: "create_array_opaque_enum",
             port: Some(port_),
@@ -1583,7 +1645,7 @@ fn wire_create_array_opaque_enum_impl(port_: MessagePort) {
     )
 }
 fn wire_run_enum_opaque_impl(port_: MessagePort, opaque: impl Wire2Api<EnumOpaque> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, String>(
         WrapInfo {
             debug_name: "run_enum_opaque",
             port: Some(port_),
@@ -1599,7 +1661,7 @@ fn wire_run_opaque_impl(
     port_: MessagePort,
     opaque: impl Wire2Api<RustOpaque<HideData>> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, String>(
         WrapInfo {
             debug_name: "run_opaque",
             port: Some(port_),
@@ -1615,7 +1677,7 @@ fn wire_run_opaque_with_delay_impl(
     port_: MessagePort,
     opaque: impl Wire2Api<RustOpaque<HideData>> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, String>(
         WrapInfo {
             debug_name: "run_opaque_with_delay",
             port: Some(port_),
@@ -1628,7 +1690,7 @@ fn wire_run_opaque_with_delay_impl(
     )
 }
 fn wire_opaque_array_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, [RustOpaque<HideData>; 2]>(
         WrapInfo {
             debug_name: "opaque_array",
             port: Some(port_),
@@ -1651,7 +1713,7 @@ fn wire_run_non_clone_impl(
     port_: MessagePort,
     clone: impl Wire2Api<RustOpaque<NonCloneData>> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, String>(
         WrapInfo {
             debug_name: "run_non_clone",
             port: Some(port_),
@@ -1664,7 +1726,7 @@ fn wire_run_non_clone_impl(
     )
 }
 fn wire_create_sync_opaque_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, RustOpaque<NonSendHideData>>(
         WrapInfo {
             debug_name: "create_sync_opaque",
             port: Some(port_),
@@ -1702,7 +1764,7 @@ fn wire_opaque_array_run_impl(
     port_: MessagePort,
     data: impl Wire2Api<[RustOpaque<HideData>; 2]> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, ()>(
         WrapInfo {
             debug_name: "opaque_array_run",
             port: Some(port_),
@@ -1715,7 +1777,7 @@ fn wire_opaque_array_run_impl(
     )
 }
 fn wire_opaque_vec_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, Vec<RustOpaque<HideData>>>(
         WrapInfo {
             debug_name: "opaque_vec",
             port: Some(port_),
@@ -1728,7 +1790,7 @@ fn wire_opaque_vec_run_impl(
     port_: MessagePort,
     data: impl Wire2Api<Vec<RustOpaque<HideData>>> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, ()>(
         WrapInfo {
             debug_name: "opaque_vec_run",
             port: Some(port_),
@@ -1741,7 +1803,7 @@ fn wire_opaque_vec_run_impl(
     )
 }
 fn wire_create_nested_opaque_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, OpaqueNested>(
         WrapInfo {
             debug_name: "create_nested_opaque",
             port: Some(port_),
@@ -1839,7 +1901,7 @@ fn wire_run_nested_opaque_impl(
     port_: MessagePort,
     opaque: impl Wire2Api<OpaqueNested> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, ()>(
         WrapInfo {
             debug_name: "run_nested_opaque",
             port: Some(port_),
@@ -1856,7 +1918,7 @@ fn wire_create_nested_dart_opaque_impl(
     opaque1: impl Wire2Api<DartOpaque> + UnwindSafe,
     opaque2: impl Wire2Api<DartOpaque> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, DartOpaqueNested>(
         WrapInfo {
             debug_name: "create_nested_dart_opaque",
             port: Some(port_),
@@ -1873,7 +1935,7 @@ fn wire_get_nested_dart_opaque_impl(
     port_: MessagePort,
     opaque: impl Wire2Api<DartOpaqueNested> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, ()>(
         WrapInfo {
             debug_name: "get_nested_dart_opaque",
             port: Some(port_),
@@ -1889,7 +1951,7 @@ fn wire_create_enum_dart_opaque_impl(
     port_: MessagePort,
     opaque: impl Wire2Api<DartOpaque> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, EnumDartOpaque>(
         WrapInfo {
             debug_name: "create_enum_dart_opaque",
             port: Some(port_),
@@ -1905,7 +1967,7 @@ fn wire_get_enum_dart_opaque_impl(
     port_: MessagePort,
     opaque: impl Wire2Api<EnumDartOpaque> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, ()>(
         WrapInfo {
             debug_name: "get_enum_dart_opaque",
             port: Some(port_),
@@ -1921,7 +1983,7 @@ fn wire_set_static_dart_opaque_impl(
     port_: MessagePort,
     opaque: impl Wire2Api<DartOpaque> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, ()>(
         WrapInfo {
             debug_name: "set_static_dart_opaque",
             port: Some(port_),
@@ -1934,7 +1996,7 @@ fn wire_set_static_dart_opaque_impl(
     )
 }
 fn wire_drop_static_dart_opaque_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, ()>(
         WrapInfo {
             debug_name: "drop_static_dart_opaque",
             port: Some(port_),
@@ -1947,7 +2009,7 @@ fn wire_unwrap_rust_opaque_impl(
     port_: MessagePort,
     opaque: impl Wire2Api<RustOpaque<HideData>> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, String>(
         WrapInfo {
             debug_name: "unwrap_rust_opaque",
             port: Some(port_),
@@ -1975,7 +2037,7 @@ fn wire_return_non_droppable_dart_opaque_impl(
     )
 }
 fn wire_frb_generator_test_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, RustOpaque<FrbOpaqueReturn>>(
         WrapInfo {
             debug_name: "frb_generator_test",
             port: Some(port_),
@@ -1995,7 +2057,7 @@ fn wire_frb_sync_generator_test_impl() -> support::WireSyncReturn {
     )
 }
 fn wire_handle_type_alias_id_impl(port_: MessagePort, input: impl Wire2Api<u64> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, u64>(
         WrapInfo {
             debug_name: "handle_type_alias_id",
             port: Some(port_),
@@ -2008,7 +2070,7 @@ fn wire_handle_type_alias_id_impl(port_: MessagePort, input: impl Wire2Api<u64> 
     )
 }
 fn wire_handle_type_nest_alias_id_impl(port_: MessagePort, input: impl Wire2Api<u64> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, u64>(
         WrapInfo {
             debug_name: "handle_type_nest_alias_id",
             port: Some(port_),
@@ -2021,7 +2083,7 @@ fn wire_handle_type_nest_alias_id_impl(port_: MessagePort, input: impl Wire2Api<
     )
 }
 fn wire_handle_type_alias_model_impl(port_: MessagePort, input: impl Wire2Api<u64> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, TestModel>(
         WrapInfo {
             debug_name: "handle_type_alias_model",
             port: Some(port_),
@@ -2034,7 +2096,7 @@ fn wire_handle_type_alias_model_impl(port_: MessagePort, input: impl Wire2Api<u6
     )
 }
 fn wire_empty_struct_impl(port_: MessagePort, empty: impl Wire2Api<Empty> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, Empty>(
         WrapInfo {
             debug_name: "empty_struct",
             port: Some(port_),
@@ -2047,7 +2109,7 @@ fn wire_empty_struct_impl(port_: MessagePort, empty: impl Wire2Api<Empty> + Unwi
     )
 }
 fn wire_return_dart_dynamic_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, flutter_rust_bridge::DartAbi>(
         WrapInfo {
             debug_name: "return_dart_dynamic",
             port: Some(port_),
@@ -2057,7 +2119,7 @@ fn wire_return_dart_dynamic_impl(port_: MessagePort) {
     )
 }
 fn wire_test_raw_string_item_struct_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, RawStringItemStruct>(
         WrapInfo {
             debug_name: "test_raw_string_item_struct",
             port: Some(port_),
@@ -2067,7 +2129,7 @@ fn wire_test_raw_string_item_struct_impl(port_: MessagePort) {
     )
 }
 fn wire_test_more_than_just_one_raw_string_struct_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, MoreThanJustOneRawStringStruct>(
         WrapInfo {
             debug_name: "test_more_than_just_one_raw_string_struct",
             port: Some(port_),
@@ -2077,36 +2139,30 @@ fn wire_test_more_than_just_one_raw_string_struct_impl(port_: MessagePort) {
     )
 }
 fn wire_test_raw_string_mirrored_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, mirror_RawStringMirrored>(
         WrapInfo {
             debug_name: "test_raw_string_mirrored",
             port: Some(port_),
             mode: FfiCallMode::Normal,
         },
-        move || move |task_callback| Ok(mirror_RawStringMirrored(test_raw_string_mirrored())),
+        move || move |task_callback| Ok(test_raw_string_mirrored()),
     )
 }
 fn wire_test_nested_raw_string_mirrored_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, mirror_NestedRawStringMirrored>(
         WrapInfo {
             debug_name: "test_nested_raw_string_mirrored",
             port: Some(port_),
             mode: FfiCallMode::Normal,
         },
-        move || {
-            move |task_callback| {
-                Ok(mirror_NestedRawStringMirrored(
-                    test_nested_raw_string_mirrored(),
-                ))
-            }
-        },
+        move || move |task_callback| Ok(test_nested_raw_string_mirrored()),
     )
 }
 fn wire_test_raw_string_enum_mirrored_impl(
     port_: MessagePort,
     nested: impl Wire2Api<bool> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, mirror_RawStringEnumMirrored>(
         WrapInfo {
             debug_name: "test_raw_string_enum_mirrored",
             port: Some(port_),
@@ -2114,53 +2170,35 @@ fn wire_test_raw_string_enum_mirrored_impl(
         },
         move || {
             let api_nested = nested.wire2api();
-            move |task_callback| {
-                Ok(mirror_RawStringEnumMirrored(test_raw_string_enum_mirrored(
-                    api_nested,
-                )))
-            }
+            move |task_callback| Ok(test_raw_string_enum_mirrored(api_nested))
         },
     )
 }
 fn wire_test_list_of_raw_nested_string_mirrored_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, mirror_ListOfNestedRawStringMirrored>(
         WrapInfo {
             debug_name: "test_list_of_raw_nested_string_mirrored",
             port: Some(port_),
             mode: FfiCallMode::Normal,
         },
-        move || {
-            move |task_callback| {
-                Ok(mirror_ListOfNestedRawStringMirrored(
-                    test_list_of_raw_nested_string_mirrored(),
-                ))
-            }
-        },
+        move || move |task_callback| Ok(test_list_of_raw_nested_string_mirrored()),
     )
 }
 fn wire_test_fallible_of_raw_string_mirrored_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, Vec<mirror_RawStringMirrored>>(
         WrapInfo {
             debug_name: "test_fallible_of_raw_string_mirrored",
             port: Some(port_),
             mode: FfiCallMode::Normal,
         },
-        move || {
-            move |task_callback| {
-                test_fallible_of_raw_string_mirrored().map(|s| {
-                    s.into_iter()
-                        .map(|v| mirror_RawStringMirrored(v))
-                        .collect::<Vec<_>>()
-                })
-            }
-        },
+        move || move |task_callback| test_fallible_of_raw_string_mirrored(),
     )
 }
 fn wire_list_of_primitive_enums_impl(
     port_: MessagePort,
     weekdays: impl Wire2Api<Vec<Weekdays>> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, Vec<Weekdays>>(
         WrapInfo {
             debug_name: "list_of_primitive_enums",
             port: Some(port_),
@@ -2173,7 +2211,7 @@ fn wire_list_of_primitive_enums_impl(
     )
 }
 fn wire_test_abc_enum_impl(port_: MessagePort, abc: impl Wire2Api<Abc> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, Abc>(
         WrapInfo {
             debug_name: "test_abc_enum",
             port: Some(port_),
@@ -2186,7 +2224,7 @@ fn wire_test_abc_enum_impl(port_: MessagePort, abc: impl Wire2Api<Abc> + UnwindS
     )
 }
 fn wire_test_contains_mirrored_sub_struct_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, ContainsMirroredSubStruct>(
         WrapInfo {
             debug_name: "test_contains_mirrored_sub_struct",
             port: Some(port_),
@@ -2199,7 +2237,7 @@ fn wire_test_struct_with_enum_impl(
     port_: MessagePort,
     se: impl Wire2Api<StructWithEnum> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, StructWithEnum>(
         WrapInfo {
             debug_name: "test_struct_with_enum",
             port: Some(port_),
@@ -2215,7 +2253,7 @@ fn wire_test_tuple_impl(
     port_: MessagePort,
     value: impl Wire2Api<Option<(String, i32)>> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, (String, i32)>(
         WrapInfo {
             debug_name: "test_tuple",
             port: Some(port_),
@@ -2231,7 +2269,7 @@ fn wire_test_tuple_2_impl(
     port_: MessagePort,
     value: impl Wire2Api<Vec<(String, i32)>> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, ()>(
         WrapInfo {
             debug_name: "test_tuple_2",
             port: Some(port_),
@@ -2244,7 +2282,7 @@ fn wire_test_tuple_2_impl(
     )
 }
 fn wire_as_string__method__Event_impl(port_: MessagePort, that: impl Wire2Api<Event> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, String>(
         WrapInfo {
             debug_name: "as_string__method__Event",
             port: Some(port_),
@@ -2262,7 +2300,7 @@ fn wire_sum__method__SumWith_impl(
     y: impl Wire2Api<u32> + UnwindSafe,
     z: impl Wire2Api<u32> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, u32>(
         WrapInfo {
             debug_name: "sum__method__SumWith",
             port: Some(port_),
@@ -2280,7 +2318,7 @@ fn wire_new__static_method__ConcatenateWith_impl(
     port_: MessagePort,
     a: impl Wire2Api<String> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, ConcatenateWith>(
         WrapInfo {
             debug_name: "new__static_method__ConcatenateWith",
             port: Some(port_),
@@ -2297,7 +2335,7 @@ fn wire_concatenate__method__ConcatenateWith_impl(
     that: impl Wire2Api<ConcatenateWith> + UnwindSafe,
     b: impl Wire2Api<String> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, String>(
         WrapInfo {
             debug_name: "concatenate__method__ConcatenateWith",
             port: Some(port_),
@@ -2315,7 +2353,7 @@ fn wire_concatenate_static__static_method__ConcatenateWith_impl(
     a: impl Wire2Api<String> + UnwindSafe,
     b: impl Wire2Api<String> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, String>(
         WrapInfo {
             debug_name: "concatenate_static__static_method__ConcatenateWith",
             port: Some(port_),
@@ -2334,7 +2372,7 @@ fn wire_handle_some_stream_sink__method__ConcatenateWith_impl(
     key: impl Wire2Api<u32> + UnwindSafe,
     max: impl Wire2Api<u32> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, ()>(
         WrapInfo {
             debug_name: "handle_some_stream_sink__method__ConcatenateWith",
             port: Some(port_),
@@ -2349,7 +2387,7 @@ fn wire_handle_some_stream_sink__method__ConcatenateWith_impl(
                     &api_that,
                     api_key,
                     api_max,
-                    task_callback.stream_sink(),
+                    task_callback.stream_sink::<_, Log2>(),
                 ))
             }
         },
@@ -2359,7 +2397,7 @@ fn wire_handle_some_stream_sink_at_1__method__ConcatenateWith_impl(
     port_: MessagePort,
     that: impl Wire2Api<ConcatenateWith> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, ()>(
         WrapInfo {
             debug_name: "handle_some_stream_sink_at_1__method__ConcatenateWith",
             port: Some(port_),
@@ -2370,7 +2408,7 @@ fn wire_handle_some_stream_sink_at_1__method__ConcatenateWith_impl(
             move |task_callback| {
                 Ok(ConcatenateWith::handle_some_stream_sink_at_1(
                     &api_that,
-                    task_callback.stream_sink(),
+                    task_callback.stream_sink::<_, u32>(),
                 ))
             }
         },
@@ -2381,7 +2419,7 @@ fn wire_handle_some_static_stream_sink__static_method__ConcatenateWith_impl(
     key: impl Wire2Api<u32> + UnwindSafe,
     max: impl Wire2Api<u32> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, ()>(
         WrapInfo {
             debug_name: "handle_some_static_stream_sink__static_method__ConcatenateWith",
             port: Some(port_),
@@ -2394,7 +2432,7 @@ fn wire_handle_some_static_stream_sink__static_method__ConcatenateWith_impl(
                 Ok(ConcatenateWith::handle_some_static_stream_sink(
                     api_key,
                     api_max,
-                    task_callback.stream_sink(),
+                    task_callback.stream_sink::<_, Log2>(),
                 ))
             }
         },
@@ -2403,7 +2441,7 @@ fn wire_handle_some_static_stream_sink__static_method__ConcatenateWith_impl(
 fn wire_handle_some_static_stream_sink_single_arg__static_method__ConcatenateWith_impl(
     port_: MessagePort,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, ()>(
         WrapInfo {
             debug_name: "handle_some_static_stream_sink_single_arg__static_method__ConcatenateWith",
             port: Some(port_),
@@ -2412,7 +2450,7 @@ fn wire_handle_some_static_stream_sink_single_arg__static_method__ConcatenateWit
         move || {
             move |task_callback| {
                 Ok(ConcatenateWith::handle_some_static_stream_sink_single_arg(
-                    task_callback.stream_sink(),
+                    task_callback.stream_sink::<_, u32>(),
                 ))
             }
         },
@@ -2657,59 +2695,199 @@ impl Wire2Api<Weekdays> for i32 {
 }
 // Section: impl IntoDart
 
+//RustOpaque(IrTypeRustOpaque { inner_rust: "Box<dyn DartDebug>", inner_dart: "BoxDartDebug" })
+
+//Delegate(Time(Duration))
+
+//Delegate(TimeList(Duration))
+
+//Delegate(Time(Local))
+
+//Delegate(TimeList(Local))
+
+//Delegate(Time(Naive))
+
+//Delegate(Time(Utc))
+
+//DartOpaque(IrTypeDartOpaque)
+
+//Delegate(Array(GeneralArray { length: 5, general: EnumRef(IrTypeEnumRef { name: "EnumOpaque" }) }))
+
+//RustOpaque(IrTypeRustOpaque { inner_rust: "FrbOpaqueReturn", inner_dart: "FrbOpaqueReturn" })
+
+//SyncReturn(IrTypeSyncReturn(RustOpaque(IrTypeRustOpaque { inner_rust: "FrbOpaqueSyncReturn", inner_dart: "FrbOpaqueSyncReturn" })))
+
+//RustOpaque(IrTypeRustOpaque { inner_rust: "HideData", inner_dart: "HideData" })
+
+//Delegate(Array(GeneralArray { length: 2, general: RustOpaque(IrTypeRustOpaque { inner_rust: "HideData", inner_dart: "HideData" }) }))
+
+//RustOpaque(IrTypeRustOpaque { inner_rust: "i32", inner_dart: "I32" })
+
+//RustOpaque(IrTypeRustOpaque { inner_rust: "Mutex < HideData >", inner_dart: "MutexHideData" })
+
+//SyncReturn(IrTypeSyncReturn(RustOpaque(IrTypeRustOpaque { inner_rust: "NonCloneData", inner_dart: "NonCloneData" })))
+
+//RustOpaque(IrTypeRustOpaque { inner_rust: "NonSendHideData", inner_dart: "NonSendHideData" })
+
+//Delegate(Array(GeneralArray { length: 1, general: DartOpaque(IrTypeDartOpaque) }))
+
+//Delegate(Array(GeneralArray { length: 2, general: StructRef(IrTypeStructRef { name: "Point", freezed: false, empty: false }) }))
+
+//RustOpaque(IrTypeRustOpaque { inner_rust: "RwLock < HideData >", inner_dart: "RwLockHideData" })
+
+//Delegate(String)
+
+//Delegate(StringList)
+
+//Delegate(Array(GeneralArray { length: 3, general: StructRef(IrTypeStructRef { name: "SumWith", freezed: false, empty: false }) }))
+
+//Delegate(Array(GeneralArray { length: 2, general: StructRef(IrTypeStructRef { name: "TestId", freezed: false, empty: false }) }))
+
+//Delegate(Uuid)
+
+//Delegate(Uuids)
+
+//Delegate(ZeroCopyBufferVecPrimitive(F32))
+
+//Delegate(ZeroCopyBufferVecPrimitive(F64))
+
+//Delegate(ZeroCopyBufferVecPrimitive(I16))
+
+//Delegate(ZeroCopyBufferVecPrimitive(I32))
+
+//Delegate(ZeroCopyBufferVecPrimitive(I64))
+
+//Delegate(ZeroCopyBufferVecPrimitive(I8))
+
+//Delegate(ZeroCopyBufferVecPrimitive(U16))
+
+//Delegate(ZeroCopyBufferVecPrimitive(U32))
+
+//Delegate(ZeroCopyBufferVecPrimitive(U64))
+
+//Delegate(ZeroCopyBufferVecPrimitive(U8))
+
+//Record(IrTypeRecord { inner: IrTypeStructRef { name: "__record__String_i32", freezed: false, empty: false }, values: [Delegate(String), Primitive(I32)] })
+
+//StructRef(IrTypeStructRef { name: "A", freezed: false, empty: false })
 impl support::IntoDart for A {
     fn into_dart(self) -> support::DartAbi {
-        vec![self.a.into_dart()].into_dart()
+        vec![self.a.into_into_dart().into_dart()].into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for A {}
+impl rust2dart::IntoIntoDart<A> for A {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//EnumRef(IrTypeEnumRef { name: "Abc" })
 impl support::IntoDart for Abc {
     fn into_dart(self) -> support::DartAbi {
         match self {
-            Self::A(field0) => vec![0.into_dart(), field0.into_dart()],
-            Self::B(field0) => vec![1.into_dart(), field0.into_dart()],
-            Self::C(field0) => vec![2.into_dart(), field0.into_dart()],
-            Self::JustInt(field0) => vec![3.into_dart(), field0.into_dart()],
+            Self::A(field0) => vec![0.into_dart(), field0.into_into_dart().into_dart()],
+            Self::B(field0) => vec![1.into_dart(), field0.into_into_dart().into_dart()],
+            Self::C(field0) => vec![2.into_dart(), field0.into_into_dart().into_dart()],
+            Self::JustInt(field0) => vec![3.into_dart(), field0.into_into_dart().into_dart()],
         }
         .into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for Abc {}
+impl rust2dart::IntoIntoDart<Abc> for Abc {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
+
+//StructRef(IrTypeStructRef { name: "ApplicationEnv", freezed: false, empty: false })
 impl support::IntoDart for mirror_ApplicationEnv {
     fn into_dart(self) -> support::DartAbi {
-        vec![self
-            .0
-            .vars
-            .into_iter()
-            .map(|v| mirror_ApplicationEnvVar(v))
-            .collect::<Vec<_>>()
-            .into_dart()]
-        .into_dart()
+        vec![self.0.vars.into_into_dart().into_dart()].into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for mirror_ApplicationEnv {}
+impl rust2dart::IntoIntoDart<mirror_ApplicationEnv> for ApplicationEnv {
+    fn into_into_dart(self) -> mirror_ApplicationEnv {
+        mirror_ApplicationEnv(self)
+    }
+}
+pub trait ApplicationEnvStreamSink {
+    fn add(&self, val: ApplicationEnv) -> bool;
+}
+impl ApplicationEnvStreamSink for StreamSink<ApplicationEnv> {
+    fn add(&self, val: ApplicationEnv) -> bool {
+        self.add_inner::<_, mirror_ApplicationEnv>(val)
+    }
+}
+pub trait VecApplicationEnvStreamSink {
+    fn add(&self, val: Vec<ApplicationEnv>) -> bool;
+}
+impl VecApplicationEnvStreamSink for StreamSink<Vec<ApplicationEnv>> {
+    fn add(&self, val: Vec<ApplicationEnv>) -> bool {
+        self.add_inner::<_, Vec<mirror_ApplicationEnv>>(val)
+    }
+}
 
+//StructRef(IrTypeStructRef { name: "ApplicationEnvVar", freezed: false, empty: false })
 impl support::IntoDart for mirror_ApplicationEnvVar {
     fn into_dart(self) -> support::DartAbi {
-        vec![self.0 .0.into_dart(), self.0 .1.into_dart()].into_dart()
+        vec![
+            self.0 .0.into_into_dart().into_dart(),
+            self.0 .1.into_into_dart().into_dart(),
+        ]
+        .into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for mirror_ApplicationEnvVar {}
+impl rust2dart::IntoIntoDart<mirror_ApplicationEnvVar> for ApplicationEnvVar {
+    fn into_into_dart(self) -> mirror_ApplicationEnvVar {
+        mirror_ApplicationEnvVar(self)
+    }
+}
+pub trait ApplicationEnvVarStreamSink {
+    fn add(&self, val: ApplicationEnvVar) -> bool;
+}
+impl ApplicationEnvVarStreamSink for StreamSink<ApplicationEnvVar> {
+    fn add(&self, val: ApplicationEnvVar) -> bool {
+        self.add_inner::<_, mirror_ApplicationEnvVar>(val)
+    }
+}
+pub trait VecApplicationEnvVarStreamSink {
+    fn add(&self, val: Vec<ApplicationEnvVar>) -> bool;
+}
+impl VecApplicationEnvVarStreamSink for StreamSink<Vec<ApplicationEnvVar>> {
+    fn add(&self, val: Vec<ApplicationEnvVar>) -> bool {
+        self.add_inner::<_, Vec<mirror_ApplicationEnvVar>>(val)
+    }
+}
 
+//EnumRef(IrTypeEnumRef { name: "ApplicationMessage" })
 impl support::IntoDart for mirror_ApplicationMessage {
     fn into_dart(self) -> support::DartAbi {
         match self.0 {
-            ApplicationMessage::DisplayMessage(field0) => vec![0.into_dart(), field0.into_dart()],
-            ApplicationMessage::RenderPixel { x, y } => {
-                vec![1.into_dart(), x.into_dart(), y.into_dart()]
+            ApplicationMessage::DisplayMessage(field0) => {
+                vec![0.into_dart(), field0.into_into_dart().into_dart()]
             }
+            ApplicationMessage::RenderPixel { x, y } => vec![
+                1.into_dart(),
+                x.into_into_dart().into_dart(),
+                y.into_into_dart().into_dart(),
+            ],
             ApplicationMessage::Exit => vec![2.into_dart()],
         }
         .into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for mirror_ApplicationMessage {}
+impl rust2dart::IntoIntoDart<mirror_ApplicationMessage> for ApplicationMessage {
+    fn into_into_dart(self) -> mirror_ApplicationMessage {
+        mirror_ApplicationMessage(self)
+    }
+}
+
+//Delegate(PrimitiveEnum { ir: IrTypeEnumRef { name: "ApplicationMode" }, repr: I32 })
 impl support::IntoDart for mirror_ApplicationMode {
     fn into_dart(self) -> support::DartAbi {
         match self.0 {
@@ -2720,13 +2898,20 @@ impl support::IntoDart for mirror_ApplicationMode {
     }
 }
 impl support::IntoDartExceptPrimitive for mirror_ApplicationMode {}
+impl rust2dart::IntoIntoDart<mirror_ApplicationMode> for ApplicationMode {
+    fn into_into_dart(self) -> mirror_ApplicationMode {
+        mirror_ApplicationMode(self)
+    }
+}
+
+//StructRef(IrTypeStructRef { name: "ApplicationSettings", freezed: false, empty: false })
 impl support::IntoDart for mirror_ApplicationSettings {
     fn into_dart(self) -> support::DartAbi {
         vec![
-            self.0.name.into_dart(),
-            self.0.version.into_dart(),
-            mirror_ApplicationMode(self.0.mode).into_dart(),
-            mirror_ApplicationEnv((*self.0.env)).into_dart(),
+            self.0.name.into_into_dart().into_dart(),
+            self.0.version.into_into_dart().into_dart(),
+            self.0.mode.into_into_dart().into_dart(),
+            self.0.env.into_into_dart().into_dart(),
             self.0
                 .env_optional
                 .map(|v| mirror_ApplicationEnv(v))
@@ -2736,77 +2921,226 @@ impl support::IntoDart for mirror_ApplicationSettings {
     }
 }
 impl support::IntoDartExceptPrimitive for mirror_ApplicationSettings {}
+impl rust2dart::IntoIntoDart<mirror_ApplicationSettings> for ApplicationSettings {
+    fn into_into_dart(self) -> mirror_ApplicationSettings {
+        mirror_ApplicationSettings(self)
+    }
+}
+pub trait ApplicationSettingsStreamSink {
+    fn add(&self, val: ApplicationSettings) -> bool;
+}
+impl ApplicationSettingsStreamSink for StreamSink<ApplicationSettings> {
+    fn add(&self, val: ApplicationSettings) -> bool {
+        self.add_inner::<_, mirror_ApplicationSettings>(val)
+    }
+}
+pub trait VecApplicationSettingsStreamSink {
+    fn add(&self, val: Vec<ApplicationSettings>) -> bool;
+}
+impl VecApplicationSettingsStreamSink for StreamSink<Vec<ApplicationSettings>> {
+    fn add(&self, val: Vec<ApplicationSettings>) -> bool {
+        self.add_inner::<_, Vec<mirror_ApplicationSettings>>(val)
+    }
+}
 
+//StructRef(IrTypeStructRef { name: "Attribute", freezed: false, empty: false })
 impl support::IntoDart for Attribute {
     fn into_dart(self) -> support::DartAbi {
-        vec![self.key.into_dart(), self.value.into_dart()].into_dart()
+        vec![
+            self.key.into_into_dart().into_dart(),
+            self.value.into_into_dart().into_dart(),
+        ]
+        .into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for Attribute {}
+impl rust2dart::IntoIntoDart<Attribute> for Attribute {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//StructRef(IrTypeStructRef { name: "B", freezed: false, empty: false })
 impl support::IntoDart for B {
     fn into_dart(self) -> support::DartAbi {
-        vec![self.b.into_dart()].into_dart()
+        vec![self.b.into_into_dart().into_dart()].into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for B {}
+impl rust2dart::IntoIntoDart<B> for B {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//StructRef(IrTypeStructRef { name: "BigBuffers", freezed: false, empty: false })
 impl support::IntoDart for BigBuffers {
     fn into_dart(self) -> support::DartAbi {
-        vec![self.int64.into_dart(), self.uint64.into_dart()].into_dart()
+        vec![
+            self.int64.into_into_dart().into_dart(),
+            self.uint64.into_into_dart().into_dart(),
+        ]
+        .into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for BigBuffers {}
+impl rust2dart::IntoIntoDart<BigBuffers> for BigBuffers {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//StructRef(IrTypeStructRef { name: "Blob", freezed: false, empty: false })
 impl support::IntoDart for Blob {
     fn into_dart(self) -> support::DartAbi {
-        vec![self.0.into_dart()].into_dart()
+        vec![self.0.into_into_dart().into_dart()].into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for Blob {}
+impl rust2dart::IntoIntoDart<Blob> for Blob {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//Primitive(Bool)
+
+//Boxed(IrTypeBoxed { exist_in_real_api: true, inner: StructRef(IrTypeStructRef { name: "ApplicationEnv", freezed: false, empty: false }) })
+
+//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: Delegate(Time(Duration)) })
+
+//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: Delegate(Time(Naive)) })
+
+//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: Delegate(Time(Utc)) })
+
+//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: DartOpaque(IrTypeDartOpaque) })
+
+//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: RustOpaque(IrTypeRustOpaque { inner_rust: "HideData", inner_dart: "HideData" }) })
+
+//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: StructRef(IrTypeStructRef { name: "A", freezed: false, empty: false }) })
+
+//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: StructRef(IrTypeStructRef { name: "ApplicationEnv", freezed: false, empty: false }) })
+
+//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: StructRef(IrTypeStructRef { name: "Attribute", freezed: false, empty: false }) })
+
+//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: StructRef(IrTypeStructRef { name: "B", freezed: false, empty: false }) })
+
+//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: Primitive(Bool) })
+
+//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: StructRef(IrTypeStructRef { name: "C", freezed: false, empty: false }) })
+
+//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: StructRef(IrTypeStructRef { name: "Element", freezed: false, empty: false }) })
+
+//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: StructRef(IrTypeStructRef { name: "ExoticOptionals", freezed: false, empty: false }) })
+
+//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: Primitive(F64) })
+
+//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: Primitive(I32) })
+
+//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: Primitive(I64) })
+
+//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: StructRef(IrTypeStructRef { name: "ListOfNestedRawStringMirrored", freezed: false, empty: false }) })
+
+//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: EnumRef(IrTypeEnumRef { name: "Measure" }) })
+
+//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: StructRef(IrTypeStructRef { name: "NestedRawStringMirrored", freezed: false, empty: false }) })
+
+//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: StructRef(IrTypeStructRef { name: "NewTypeInt", freezed: false, empty: false }) })
+
+//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: StructRef(IrTypeStructRef { name: "RawStringMirrored", freezed: false, empty: false }) })
+
+//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: Delegate(PrimitiveEnum { ir: IrTypeEnumRef { name: "Weekdays" }, repr: I32 }) })
+
+//Boxed(IrTypeBoxed { exist_in_real_api: true, inner: EnumRef(IrTypeEnumRef { name: "Distance" }) })
+
+//Boxed(IrTypeBoxed { exist_in_real_api: true, inner: StructRef(IrTypeStructRef { name: "FeedId", freezed: false, empty: false }) })
+
+//Boxed(IrTypeBoxed { exist_in_real_api: true, inner: EnumRef(IrTypeEnumRef { name: "KitchenSink" }) })
+
+//Boxed(IrTypeBoxed { exist_in_real_api: true, inner: EnumRef(IrTypeEnumRef { name: "Speed" }) })
+
+//Boxed(IrTypeBoxed { exist_in_real_api: true, inner: Delegate(Array(PrimitiveArray { length: 8, primitive: U8 })) })
+
+//StructRef(IrTypeStructRef { name: "C", freezed: false, empty: false })
 impl support::IntoDart for C {
     fn into_dart(self) -> support::DartAbi {
-        vec![self.c.into_dart()].into_dart()
+        vec![self.c.into_into_dart().into_dart()].into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for C {}
+impl rust2dart::IntoIntoDart<C> for C {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//StructRef(IrTypeStructRef { name: "ConcatenateWith", freezed: false, empty: false })
 impl support::IntoDart for ConcatenateWith {
     fn into_dart(self) -> support::DartAbi {
-        vec![self.a.into_dart()].into_dart()
+        vec![self.a.into_into_dart().into_dart()].into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for ConcatenateWith {}
+impl rust2dart::IntoIntoDart<ConcatenateWith> for ConcatenateWith {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//StructRef(IrTypeStructRef { name: "ContainsMirroredSubStruct", freezed: false, empty: false })
 impl support::IntoDart for ContainsMirroredSubStruct {
     fn into_dart(self) -> support::DartAbi {
         vec![
-            mirror_RawStringMirrored(self.test).into_dart(),
-            self.test2.into_dart(),
+            self.test.into_into_dart().into_dart(),
+            self.test2.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for ContainsMirroredSubStruct {}
+impl rust2dart::IntoIntoDart<ContainsMirroredSubStruct> for ContainsMirroredSubStruct {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//StructRef(IrTypeStructRef { name: "DartOpaqueNested", freezed: false, empty: false })
 impl support::IntoDart for DartOpaqueNested {
     fn into_dart(self) -> support::DartAbi {
-        vec![self.first.into_dart(), self.second.into_dart()].into_dart()
+        vec![
+            self.first.into_into_dart().into_dart(),
+            self.second.into_into_dart().into_dart(),
+        ]
+        .into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for DartOpaqueNested {}
+impl rust2dart::IntoIntoDart<DartOpaqueNested> for DartOpaqueNested {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//Dynamic(IrTypeDynamic)
+
+//EnumRef(IrTypeEnumRef { name: "Distance" })
 impl support::IntoDart for Distance {
     fn into_dart(self) -> support::DartAbi {
         match self {
             Self::Unknown => vec![0.into_dart()],
-            Self::Map(field0) => vec![1.into_dart(), field0.into_dart()],
+            Self::Map(field0) => vec![1.into_dart(), field0.into_into_dart().into_dart()],
         }
         .into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for Distance {}
+impl rust2dart::IntoIntoDart<Distance> for Distance {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
+
+//StructRef(IrTypeStructRef { name: "Element", freezed: false, empty: false })
 impl support::IntoDart for Element {
     fn into_dart(self) -> support::DartAbi {
         vec![
@@ -2819,24 +3153,43 @@ impl support::IntoDart for Element {
     }
 }
 impl support::IntoDartExceptPrimitive for Element {}
+impl rust2dart::IntoIntoDart<Element> for Element {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//StructRef(IrTypeStructRef { name: "Empty", freezed: false, empty: true })
 impl support::IntoDart for Empty {
     fn into_dart(self) -> support::DartAbi {
         Vec::<u8>::new().into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for Empty {}
+impl rust2dart::IntoIntoDart<Empty> for Empty {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//EnumRef(IrTypeEnumRef { name: "EnumDartOpaque" })
 impl support::IntoDart for EnumDartOpaque {
     fn into_dart(self) -> support::DartAbi {
         match self {
-            Self::Primitive(field0) => vec![0.into_dart(), field0.into_dart()],
-            Self::Opaque(field0) => vec![1.into_dart(), field0.into_dart()],
+            Self::Primitive(field0) => vec![0.into_dart(), field0.into_into_dart().into_dart()],
+            Self::Opaque(field0) => vec![1.into_dart(), field0.into_into_dart().into_dart()],
         }
         .into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for EnumDartOpaque {}
+impl rust2dart::IntoIntoDart<EnumDartOpaque> for EnumDartOpaque {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
+
+//EnumRef(IrTypeEnumRef { name: "EnumOpaque" })
 impl support::IntoDart for EnumOpaque {
     fn into_dart(self) -> support::DartAbi {
         match self {
@@ -2850,13 +3203,30 @@ impl support::IntoDart for EnumOpaque {
     }
 }
 impl support::IntoDartExceptPrimitive for EnumOpaque {}
+impl rust2dart::IntoIntoDart<EnumOpaque> for EnumOpaque {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
+
+//StructRef(IrTypeStructRef { name: "Event", freezed: true, empty: false })
 impl support::IntoDart for Event {
     fn into_dart(self) -> support::DartAbi {
-        vec![self.address.into_dart(), self.payload.into_dart()].into_dart()
+        vec![
+            self.address.into_into_dart().into_dart(),
+            self.payload.into_into_dart().into_dart(),
+        ]
+        .into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for Event {}
+impl rust2dart::IntoIntoDart<Event> for Event {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//StructRef(IrTypeStructRef { name: "ExoticOptionals", freezed: false, empty: false })
 impl support::IntoDart for ExoticOptionals {
     fn into_dart(self) -> support::DartAbi {
         vec![
@@ -2871,7 +3241,7 @@ impl support::IntoDart for ExoticOptionals {
             self.float32list.into_dart(),
             self.float64list.into_dart(),
             self.attributes.into_dart(),
-            self.attributes_nullable.into_dart(),
+            self.attributes_nullable.into_into_dart().into_dart(),
             self.nullable_attributes.into_dart(),
             self.newtypeint.into_dart(),
         ]
@@ -2879,21 +3249,69 @@ impl support::IntoDart for ExoticOptionals {
     }
 }
 impl support::IntoDartExceptPrimitive for ExoticOptionals {}
+impl rust2dart::IntoIntoDart<ExoticOptionals> for ExoticOptionals {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//Primitive(F32)
+
+//Primitive(F64)
+
+//StructRef(IrTypeStructRef { name: "FeatureUuid", freezed: false, empty: false })
 impl support::IntoDart for FeatureUuid {
     fn into_dart(self) -> support::DartAbi {
-        vec![self.one.into_dart(), self.many.into_dart()].into_dart()
+        vec![
+            self.one.into_into_dart().into_dart(),
+            self.many.into_into_dart().into_dart(),
+        ]
+        .into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for FeatureUuid {}
+impl rust2dart::IntoIntoDart<FeatureUuid> for FeatureUuid {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//StructRef(IrTypeStructRef { name: "FeedId", freezed: false, empty: false })
 impl support::IntoDart for FeedId {
     fn into_dart(self) -> support::DartAbi {
-        vec![self.0.into_dart()].into_dart()
+        vec![self.0.into_into_dart().into_dart()].into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for FeedId {}
+impl rust2dart::IntoIntoDart<FeedId> for FeedId {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//PrimitiveList(IrTypePrimitiveList { primitive: F32 })
+
+//PrimitiveList(IrTypePrimitiveList { primitive: F64 })
+
+//Primitive(I16)
+
+//Primitive(I32)
+
+//Delegate(Array(PrimitiveArray { length: 2, primitive: I32 }))
+
+//Primitive(I64)
+
+//Primitive(I8)
+
+//PrimitiveList(IrTypePrimitiveList { primitive: I16 })
+
+//PrimitiveList(IrTypePrimitiveList { primitive: I32 })
+
+//PrimitiveList(IrTypePrimitiveList { primitive: I64 })
+
+//PrimitiveList(IrTypePrimitiveList { primitive: I8 })
+
+//EnumRef(IrTypeEnumRef { name: "KitchenSink" })
 impl support::IntoDart for KitchenSink {
     fn into_dart(self) -> support::DartAbi {
         match self {
@@ -2904,82 +3322,199 @@ impl support::IntoDart for KitchenSink {
                 boolean,
             } => vec![
                 1.into_dart(),
-                int32.into_dart(),
-                float64.into_dart(),
-                boolean.into_dart(),
+                int32.into_into_dart().into_dart(),
+                float64.into_into_dart().into_dart(),
+                boolean.into_into_dart().into_dart(),
             ],
-            Self::Nested(field0, field1) => {
-                vec![2.into_dart(), field0.into_dart(), field1.into_dart()]
-            }
+            Self::Nested(field0, field1) => vec![
+                2.into_dart(),
+                field0.into_into_dart().into_dart(),
+                field1.into_into_dart().into_dart(),
+            ],
             Self::Optional(field0, field1) => {
                 vec![3.into_dart(), field0.into_dart(), field1.into_dart()]
             }
-            Self::Buffer(field0) => vec![4.into_dart(), field0.into_dart()],
-            Self::Enums(field0) => vec![5.into_dart(), field0.into_dart()],
+            Self::Buffer(field0) => vec![4.into_dart(), field0.into_into_dart().into_dart()],
+            Self::Enums(field0) => vec![5.into_dart(), field0.into_into_dart().into_dart()],
         }
         .into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for KitchenSink {}
+impl rust2dart::IntoIntoDart<KitchenSink> for KitchenSink {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//GeneralList(IrTypeGeneralList { inner: DartOpaque(IrTypeDartOpaque) })
+
+//GeneralList(IrTypeGeneralList { inner: RustOpaque(IrTypeRustOpaque { inner_rust: "HideData", inner_dart: "HideData" }) })
+
+//GeneralList(IrTypeGeneralList { inner: StructRef(IrTypeStructRef { name: "ApplicationEnvVar", freezed: false, empty: false }) })
+
+//GeneralList(IrTypeGeneralList { inner: StructRef(IrTypeStructRef { name: "ApplicationSettings", freezed: false, empty: false }) })
+
+//GeneralList(IrTypeGeneralList { inner: StructRef(IrTypeStructRef { name: "Attribute", freezed: false, empty: false }) })
+
+//GeneralList(IrTypeGeneralList { inner: StructRef(IrTypeStructRef { name: "Element", freezed: false, empty: false }) })
+
+//GeneralList(IrTypeGeneralList { inner: EnumRef(IrTypeEnumRef { name: "EnumOpaque" }) })
+
+//GeneralList(IrTypeGeneralList { inner: Delegate(PrimitiveEnum { ir: IrTypeEnumRef { name: "MyEnum" }, repr: I32 }) })
+
+//GeneralList(IrTypeGeneralList { inner: StructRef(IrTypeStructRef { name: "MySize", freezed: false, empty: false }) })
+
+//GeneralList(IrTypeGeneralList { inner: StructRef(IrTypeStructRef { name: "MyTreeNode", freezed: false, empty: false }) })
+
+//GeneralList(IrTypeGeneralList { inner: StructRef(IrTypeStructRef { name: "NestedRawStringMirrored", freezed: false, empty: false }) })
+
+//StructRef(IrTypeStructRef { name: "ListOfNestedRawStringMirrored", freezed: false, empty: false })
 impl support::IntoDart for mirror_ListOfNestedRawStringMirrored {
     fn into_dart(self) -> support::DartAbi {
-        vec![self
-            .0
-            .raw
-            .into_iter()
-            .map(|v| mirror_NestedRawStringMirrored(v))
-            .collect::<Vec<_>>()
-            .into_dart()]
-        .into_dart()
+        vec![self.0.raw.into_into_dart().into_dart()].into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for mirror_ListOfNestedRawStringMirrored {}
+impl rust2dart::IntoIntoDart<mirror_ListOfNestedRawStringMirrored>
+    for ListOfNestedRawStringMirrored
+{
+    fn into_into_dart(self) -> mirror_ListOfNestedRawStringMirrored {
+        mirror_ListOfNestedRawStringMirrored(self)
+    }
+}
+pub trait ListOfNestedRawStringMirroredStreamSink {
+    fn add(&self, val: ListOfNestedRawStringMirrored) -> bool;
+}
+impl ListOfNestedRawStringMirroredStreamSink for StreamSink<ListOfNestedRawStringMirrored> {
+    fn add(&self, val: ListOfNestedRawStringMirrored) -> bool {
+        self.add_inner::<_, mirror_ListOfNestedRawStringMirrored>(val)
+    }
+}
+pub trait VecListOfNestedRawStringMirroredStreamSink {
+    fn add(&self, val: Vec<ListOfNestedRawStringMirrored>) -> bool;
+}
+impl VecListOfNestedRawStringMirroredStreamSink for StreamSink<Vec<ListOfNestedRawStringMirrored>> {
+    fn add(&self, val: Vec<ListOfNestedRawStringMirrored>) -> bool {
+        self.add_inner::<_, Vec<mirror_ListOfNestedRawStringMirrored>>(val)
+    }
+}
 
+//GeneralList(IrTypeGeneralList { inner: Optional(IrTypeOptional { inner: Boxed(IrTypeBoxed { exist_in_real_api: false, inner: StructRef(IrTypeStructRef { name: "Attribute", freezed: false, empty: false }) }) }) })
+
+//GeneralList(IrTypeGeneralList { inner: StructRef(IrTypeStructRef { name: "Point", freezed: false, empty: false }) })
+
+//GeneralList(IrTypeGeneralList { inner: StructRef(IrTypeStructRef { name: "RawStringMirrored", freezed: false, empty: false }) })
+
+//GeneralList(IrTypeGeneralList { inner: StructRef(IrTypeStructRef { name: "SumWith", freezed: false, empty: false }) })
+
+//GeneralList(IrTypeGeneralList { inner: StructRef(IrTypeStructRef { name: "TestId", freezed: false, empty: false }) })
+
+//GeneralList(IrTypeGeneralList { inner: Delegate(PrimitiveEnum { ir: IrTypeEnumRef { name: "Weekdays" }, repr: I32 }) })
+
+//StructRef(IrTypeStructRef { name: "Log", freezed: false, empty: false })
 impl support::IntoDart for Log {
     fn into_dart(self) -> support::DartAbi {
-        vec![self.key.into_dart(), self.value.into_dart()].into_dart()
+        vec![
+            self.key.into_into_dart().into_dart(),
+            self.value.into_into_dart().into_dart(),
+        ]
+        .into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for Log {}
+impl rust2dart::IntoIntoDart<Log> for Log {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//StructRef(IrTypeStructRef { name: "Log2", freezed: false, empty: false })
 impl support::IntoDart for Log2 {
     fn into_dart(self) -> support::DartAbi {
-        vec![self.key.into_dart(), self.value.into_dart()].into_dart()
+        vec![
+            self.key.into_into_dart().into_dart(),
+            self.value.into_into_dart().into_dart(),
+        ]
+        .into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for Log2 {}
+impl rust2dart::IntoIntoDart<Log2> for Log2 {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//EnumRef(IrTypeEnumRef { name: "Measure" })
 impl support::IntoDart for Measure {
     fn into_dart(self) -> support::DartAbi {
         match self {
-            Self::Speed(field0) => vec![0.into_dart(), field0.into_dart()],
-            Self::Distance(field0) => vec![1.into_dart(), field0.into_dart()],
+            Self::Speed(field0) => vec![0.into_dart(), field0.into_into_dart().into_dart()],
+            Self::Distance(field0) => vec![1.into_dart(), field0.into_into_dart().into_dart()],
         }
         .into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for Measure {}
+impl rust2dart::IntoIntoDart<Measure> for Measure {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
+
+//StructRef(IrTypeStructRef { name: "MessageId", freezed: false, empty: false })
 impl support::IntoDart for MessageId {
     fn into_dart(self) -> support::DartAbi {
-        vec![self.0.into_dart()].into_dart()
+        vec![self.0.into_into_dart().into_dart()].into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for MessageId {}
+impl rust2dart::IntoIntoDart<MessageId> for MessageId {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//StructRef(IrTypeStructRef { name: "MirrorStruct", freezed: false, empty: false })
+impl support::IntoDart for MirrorStruct {
+    fn into_dart(self) -> support::DartAbi {
+        vec![
+            self.a.into_into_dart().into_dart(),
+            self.b.into_into_dart().into_dart(),
+            self.c.into_into_dart().into_dart(),
+            self.d.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl support::IntoDartExceptPrimitive for MirrorStruct {}
+impl rust2dart::IntoIntoDart<MirrorStruct> for MirrorStruct {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
+
+//StructRef(IrTypeStructRef { name: "MoreThanJustOneRawStringStruct", freezed: false, empty: false })
 impl support::IntoDart for MoreThanJustOneRawStringStruct {
     fn into_dart(self) -> support::DartAbi {
         vec![
-            self.regular.into_dart(),
-            self.r#type.into_dart(),
-            self.r#async.into_dart(),
-            self.another.into_dart(),
+            self.regular.into_into_dart().into_dart(),
+            self.r#type.into_into_dart().into_dart(),
+            self.r#async.into_into_dart().into_dart(),
+            self.another.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for MoreThanJustOneRawStringStruct {}
+impl rust2dart::IntoIntoDart<MoreThanJustOneRawStringStruct> for MoreThanJustOneRawStringStruct {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//Delegate(PrimitiveEnum { ir: IrTypeEnumRef { name: "MyEnum" }, repr: I32 })
 impl support::IntoDart for MyEnum {
     fn into_dart(self) -> support::DartAbi {
         match self {
@@ -2990,160 +3525,413 @@ impl support::IntoDart for MyEnum {
     }
 }
 impl support::IntoDartExceptPrimitive for MyEnum {}
+impl rust2dart::IntoIntoDart<MyEnum> for MyEnum {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
+
+//StructRef(IrTypeStructRef { name: "MyNestedStruct", freezed: false, empty: false })
 impl support::IntoDart for MyNestedStruct {
     fn into_dart(self) -> support::DartAbi {
-        vec![self.tree_node.into_dart(), self.weekday.into_dart()].into_dart()
+        vec![
+            self.tree_node.into_into_dart().into_dart(),
+            self.weekday.into_into_dart().into_dart(),
+        ]
+        .into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for MyNestedStruct {}
+impl rust2dart::IntoIntoDart<MyNestedStruct> for MyNestedStruct {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//StructRef(IrTypeStructRef { name: "MySize", freezed: false, empty: false })
 impl support::IntoDart for MySize {
     fn into_dart(self) -> support::DartAbi {
-        vec![self.width.into_dart(), self.height.into_dart()].into_dart()
+        vec![
+            self.width.into_into_dart().into_dart(),
+            self.height.into_into_dart().into_dart(),
+        ]
+        .into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for MySize {}
+impl rust2dart::IntoIntoDart<MySize> for MySize {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//StructRef(IrTypeStructRef { name: "MyStreamEntry", freezed: false, empty: false })
 impl support::IntoDart for MyStreamEntry {
     fn into_dart(self) -> support::DartAbi {
-        vec![self.hello.into_dart()].into_dart()
+        vec![self.hello.into_into_dart().into_dart()].into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for MyStreamEntry {}
+impl rust2dart::IntoIntoDart<MyStreamEntry> for MyStreamEntry {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//StructRef(IrTypeStructRef { name: "MyStruct", freezed: false, empty: false })
 impl support::IntoDart for MyStruct {
     fn into_dart(self) -> support::DartAbi {
-        vec![self.content.into_dart()].into_dart()
+        vec![self.content.into_into_dart().into_dart()].into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for MyStruct {}
+impl rust2dart::IntoIntoDart<MyStruct> for MyStruct {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//StructRef(IrTypeStructRef { name: "MyTreeNode", freezed: false, empty: false })
 impl support::IntoDart for MyTreeNode {
     fn into_dart(self) -> support::DartAbi {
         vec![
-            self.value_i32.into_dart(),
-            self.value_vec_u8.into_dart(),
-            self.value_boolean.into_dart(),
-            self.children.into_dart(),
+            self.value_i32.into_into_dart().into_dart(),
+            self.value_vec_u8.into_into_dart().into_dart(),
+            self.value_boolean.into_into_dart().into_dart(),
+            self.children.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for MyTreeNode {}
+impl rust2dart::IntoIntoDart<MyTreeNode> for MyTreeNode {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//StructRef(IrTypeStructRef { name: "NestedRawStringMirrored", freezed: false, empty: false })
 impl support::IntoDart for mirror_NestedRawStringMirrored {
     fn into_dart(self) -> support::DartAbi {
-        vec![mirror_RawStringMirrored(self.0.raw).into_dart()].into_dart()
+        vec![self.0.raw.into_into_dart().into_dart()].into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for mirror_NestedRawStringMirrored {}
+impl rust2dart::IntoIntoDart<mirror_NestedRawStringMirrored> for NestedRawStringMirrored {
+    fn into_into_dart(self) -> mirror_NestedRawStringMirrored {
+        mirror_NestedRawStringMirrored(self)
+    }
+}
+pub trait NestedRawStringMirroredStreamSink {
+    fn add(&self, val: NestedRawStringMirrored) -> bool;
+}
+impl NestedRawStringMirroredStreamSink for StreamSink<NestedRawStringMirrored> {
+    fn add(&self, val: NestedRawStringMirrored) -> bool {
+        self.add_inner::<_, mirror_NestedRawStringMirrored>(val)
+    }
+}
+pub trait VecNestedRawStringMirroredStreamSink {
+    fn add(&self, val: Vec<NestedRawStringMirrored>) -> bool;
+}
+impl VecNestedRawStringMirroredStreamSink for StreamSink<Vec<NestedRawStringMirrored>> {
+    fn add(&self, val: Vec<NestedRawStringMirrored>) -> bool {
+        self.add_inner::<_, Vec<mirror_NestedRawStringMirrored>>(val)
+    }
+}
 
+//StructRef(IrTypeStructRef { name: "NewSimpleStruct", freezed: false, empty: false })
 impl support::IntoDart for NewSimpleStruct {
     fn into_dart(self) -> support::DartAbi {
-        vec![self.field.into_dart()].into_dart()
+        vec![self.field.into_into_dart().into_dart()].into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for NewSimpleStruct {}
+impl rust2dart::IntoIntoDart<NewSimpleStruct> for NewSimpleStruct {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//StructRef(IrTypeStructRef { name: "NewTypeInt", freezed: false, empty: false })
 impl support::IntoDart for NewTypeInt {
     fn into_dart(self) -> support::DartAbi {
-        vec![self.0.into_dart()].into_dart()
+        vec![self.0.into_into_dart().into_dart()].into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for NewTypeInt {}
+impl rust2dart::IntoIntoDart<NewTypeInt> for NewTypeInt {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//StructRef(IrTypeStructRef { name: "Numbers", freezed: false, empty: false })
 impl support::IntoDart for mirror_Numbers {
     fn into_dart(self) -> support::DartAbi {
-        vec![self.0 .0.into_dart()].into_dart()
+        vec![self.0 .0.into_into_dart().into_dart()].into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for mirror_Numbers {}
+impl rust2dart::IntoIntoDart<mirror_Numbers> for Numbers {
+    fn into_into_dart(self) -> mirror_Numbers {
+        mirror_Numbers(self)
+    }
+}
+pub trait NumbersStreamSink {
+    fn add(&self, val: Numbers) -> bool;
+}
+impl NumbersStreamSink for StreamSink<Numbers> {
+    fn add(&self, val: Numbers) -> bool {
+        self.add_inner::<_, mirror_Numbers>(val)
+    }
+}
+pub trait VecNumbersStreamSink {
+    fn add(&self, val: Vec<Numbers>) -> bool;
+}
+impl VecNumbersStreamSink for StreamSink<Vec<Numbers>> {
+    fn add(&self, val: Vec<Numbers>) -> bool {
+        self.add_inner::<_, Vec<mirror_Numbers>>(val)
+    }
+}
 
+//StructRef(IrTypeStructRef { name: "OldSimpleStruct", freezed: false, empty: false })
 impl support::IntoDart for OldSimpleStruct {
     fn into_dart(self) -> support::DartAbi {
-        vec![self.field.into_dart()].into_dart()
+        vec![self.field.into_into_dart().into_dart()].into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for OldSimpleStruct {}
+impl rust2dart::IntoIntoDart<OldSimpleStruct> for OldSimpleStruct {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//StructRef(IrTypeStructRef { name: "OpaqueNested", freezed: false, empty: false })
 impl support::IntoDart for OpaqueNested {
     fn into_dart(self) -> support::DartAbi {
         vec![self.first.into_dart(), self.second.into_dart()].into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for OpaqueNested {}
+impl rust2dart::IntoIntoDart<OpaqueNested> for OpaqueNested {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//Optional(IrTypeOptional { inner: Delegate(String) })
+
+//Optional(IrTypeOptional { inner: Delegate(ZeroCopyBufferVecPrimitive(U8)) })
+
+//Optional(IrTypeOptional { inner: Boxed(IrTypeBoxed { exist_in_real_api: false, inner: Delegate(Time(Duration)) }) })
+
+//Optional(IrTypeOptional { inner: Boxed(IrTypeBoxed { exist_in_real_api: false, inner: Delegate(Time(Naive)) }) })
+
+//Optional(IrTypeOptional { inner: Boxed(IrTypeBoxed { exist_in_real_api: false, inner: Delegate(Time(Utc)) }) })
+
+//Optional(IrTypeOptional { inner: Boxed(IrTypeBoxed { exist_in_real_api: false, inner: DartOpaque(IrTypeDartOpaque) }) })
+
+//Optional(IrTypeOptional { inner: Boxed(IrTypeBoxed { exist_in_real_api: false, inner: RustOpaque(IrTypeRustOpaque { inner_rust: "HideData", inner_dart: "HideData" }) }) })
+
+//Optional(IrTypeOptional { inner: Boxed(IrTypeBoxed { exist_in_real_api: false, inner: StructRef(IrTypeStructRef { name: "ApplicationEnv", freezed: false, empty: false }) }) })
+
+//Optional(IrTypeOptional { inner: Boxed(IrTypeBoxed { exist_in_real_api: false, inner: StructRef(IrTypeStructRef { name: "Attribute", freezed: false, empty: false }) }) })
+
+//Optional(IrTypeOptional { inner: Boxed(IrTypeBoxed { exist_in_real_api: false, inner: Primitive(Bool) }) })
+
+//Optional(IrTypeOptional { inner: Boxed(IrTypeBoxed { exist_in_real_api: false, inner: StructRef(IrTypeStructRef { name: "Element", freezed: false, empty: false }) }) })
+
+//Optional(IrTypeOptional { inner: Boxed(IrTypeBoxed { exist_in_real_api: false, inner: StructRef(IrTypeStructRef { name: "ExoticOptionals", freezed: false, empty: false }) }) })
+
+//Optional(IrTypeOptional { inner: Boxed(IrTypeBoxed { exist_in_real_api: false, inner: Primitive(F64) }) })
+
+//Optional(IrTypeOptional { inner: Boxed(IrTypeBoxed { exist_in_real_api: false, inner: Primitive(I32) }) })
+
+//Optional(IrTypeOptional { inner: Boxed(IrTypeBoxed { exist_in_real_api: false, inner: Primitive(I64) }) })
+
+//Optional(IrTypeOptional { inner: Boxed(IrTypeBoxed { exist_in_real_api: false, inner: EnumRef(IrTypeEnumRef { name: "Measure" }) }) })
+
+//Optional(IrTypeOptional { inner: Boxed(IrTypeBoxed { exist_in_real_api: false, inner: StructRef(IrTypeStructRef { name: "NewTypeInt", freezed: false, empty: false }) }) })
+
+//Optional(IrTypeOptional { inner: Boxed(IrTypeBoxed { exist_in_real_api: false, inner: Delegate(PrimitiveEnum { ir: IrTypeEnumRef { name: "Weekdays" }, repr: I32 }) }) })
+
+//Optional(IrTypeOptional { inner: PrimitiveList(IrTypePrimitiveList { primitive: F32 }) })
+
+//Optional(IrTypeOptional { inner: PrimitiveList(IrTypePrimitiveList { primitive: F64 }) })
+
+//Optional(IrTypeOptional { inner: PrimitiveList(IrTypePrimitiveList { primitive: I32 }) })
+
+//Optional(IrTypeOptional { inner: PrimitiveList(IrTypePrimitiveList { primitive: I8 }) })
+
+//Optional(IrTypeOptional { inner: GeneralList(IrTypeGeneralList { inner: StructRef(IrTypeStructRef { name: "Attribute", freezed: false, empty: false }) }) })
+
+//Optional(IrTypeOptional { inner: GeneralList(IrTypeGeneralList { inner: StructRef(IrTypeStructRef { name: "Element", freezed: false, empty: false }) }) })
+
+//Optional(IrTypeOptional { inner: GeneralList(IrTypeGeneralList { inner: Optional(IrTypeOptional { inner: Boxed(IrTypeBoxed { exist_in_real_api: false, inner: StructRef(IrTypeStructRef { name: "Attribute", freezed: false, empty: false }) }) }) }) })
+
+//Optional(IrTypeOptional { inner: PrimitiveList(IrTypePrimitiveList { primitive: U8 }) })
+
+//StructRef(IrTypeStructRef { name: "Point", freezed: false, empty: false })
 impl support::IntoDart for Point {
     fn into_dart(self) -> support::DartAbi {
-        vec![self.x.into_dart(), self.y.into_dart()].into_dart()
+        vec![
+            self.x.into_into_dart().into_dart(),
+            self.y.into_into_dart().into_dart(),
+        ]
+        .into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for Point {}
+impl rust2dart::IntoIntoDart<Point> for Point {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//EnumRef(IrTypeEnumRef { name: "RawStringEnumMirrored" })
 impl support::IntoDart for mirror_RawStringEnumMirrored {
     fn into_dart(self) -> support::DartAbi {
         match self.0 {
             RawStringEnumMirrored::Raw(field0) => {
-                vec![0.into_dart(), mirror_RawStringMirrored(field0).into_dart()]
+                vec![0.into_dart(), field0.into_into_dart().into_dart()]
             }
-            RawStringEnumMirrored::Nested(field0) => vec![
-                1.into_dart(),
-                mirror_NestedRawStringMirrored(field0).into_dart(),
-            ],
-            RawStringEnumMirrored::ListOfNested(field0) => vec![
-                2.into_dart(),
-                mirror_ListOfNestedRawStringMirrored(field0).into_dart(),
-            ],
+            RawStringEnumMirrored::Nested(field0) => {
+                vec![1.into_dart(), field0.into_into_dart().into_dart()]
+            }
+            RawStringEnumMirrored::ListOfNested(field0) => {
+                vec![2.into_dart(), field0.into_into_dart().into_dart()]
+            }
         }
         .into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for mirror_RawStringEnumMirrored {}
+impl rust2dart::IntoIntoDart<mirror_RawStringEnumMirrored> for RawStringEnumMirrored {
+    fn into_into_dart(self) -> mirror_RawStringEnumMirrored {
+        mirror_RawStringEnumMirrored(self)
+    }
+}
+
+//StructRef(IrTypeStructRef { name: "RawStringItemStruct", freezed: false, empty: false })
 impl support::IntoDart for RawStringItemStruct {
     fn into_dart(self) -> support::DartAbi {
-        vec![self.r#type.into_dart()].into_dart()
+        vec![self.r#type.into_into_dart().into_dart()].into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for RawStringItemStruct {}
+impl rust2dart::IntoIntoDart<RawStringItemStruct> for RawStringItemStruct {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//StructRef(IrTypeStructRef { name: "RawStringMirrored", freezed: false, empty: false })
 impl support::IntoDart for mirror_RawStringMirrored {
     fn into_dart(self) -> support::DartAbi {
-        vec![self.0.r#value.into_dart()].into_dart()
+        vec![self.0.r#value.into_into_dart().into_dart()].into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for mirror_RawStringMirrored {}
+impl rust2dart::IntoIntoDart<mirror_RawStringMirrored> for RawStringMirrored {
+    fn into_into_dart(self) -> mirror_RawStringMirrored {
+        mirror_RawStringMirrored(self)
+    }
+}
+pub trait RawStringMirroredStreamSink {
+    fn add(&self, val: RawStringMirrored) -> bool;
+}
+impl RawStringMirroredStreamSink for StreamSink<RawStringMirrored> {
+    fn add(&self, val: RawStringMirrored) -> bool {
+        self.add_inner::<_, mirror_RawStringMirrored>(val)
+    }
+}
+pub trait VecRawStringMirroredStreamSink {
+    fn add(&self, val: Vec<RawStringMirrored>) -> bool;
+}
+impl VecRawStringMirroredStreamSink for StreamSink<Vec<RawStringMirrored>> {
+    fn add(&self, val: Vec<RawStringMirrored>) -> bool {
+        self.add_inner::<_, Vec<mirror_RawStringMirrored>>(val)
+    }
+}
 
+//StructRef(IrTypeStructRef { name: "Sequences", freezed: false, empty: false })
 impl support::IntoDart for mirror_Sequences {
     fn into_dart(self) -> support::DartAbi {
-        vec![self.0 .0.into_dart()].into_dart()
+        vec![self.0 .0.into_into_dart().into_dart()].into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for mirror_Sequences {}
+impl rust2dart::IntoIntoDart<mirror_Sequences> for Sequences {
+    fn into_into_dart(self) -> mirror_Sequences {
+        mirror_Sequences(self)
+    }
+}
+pub trait SequencesStreamSink {
+    fn add(&self, val: Sequences) -> bool;
+}
+impl SequencesStreamSink for StreamSink<Sequences> {
+    fn add(&self, val: Sequences) -> bool {
+        self.add_inner::<_, mirror_Sequences>(val)
+    }
+}
+pub trait VecSequencesStreamSink {
+    fn add(&self, val: Vec<Sequences>) -> bool;
+}
+impl VecSequencesStreamSink for StreamSink<Vec<Sequences>> {
+    fn add(&self, val: Vec<Sequences>) -> bool {
+        self.add_inner::<_, Vec<mirror_Sequences>>(val)
+    }
+}
 
+//EnumRef(IrTypeEnumRef { name: "Speed" })
 impl support::IntoDart for Speed {
     fn into_dart(self) -> support::DartAbi {
         match self {
             Self::Unknown => vec![0.into_dart()],
-            Self::GPS(field0) => vec![1.into_dart(), field0.into_dart()],
+            Self::GPS(field0) => vec![1.into_dart(), field0.into_into_dart().into_dart()],
         }
         .into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for Speed {}
+impl rust2dart::IntoIntoDart<Speed> for Speed {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
+
+//StructRef(IrTypeStructRef { name: "StructWithEnum", freezed: false, empty: false })
 impl support::IntoDart for StructWithEnum {
     fn into_dart(self) -> support::DartAbi {
-        vec![self.abc1.into_dart(), self.abc2.into_dart()].into_dart()
+        vec![
+            self.abc1.into_into_dart().into_dart(),
+            self.abc2.into_into_dart().into_dart(),
+        ]
+        .into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for StructWithEnum {}
+impl rust2dart::IntoIntoDart<StructWithEnum> for StructWithEnum {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//StructRef(IrTypeStructRef { name: "SumWith", freezed: false, empty: false })
 impl support::IntoDart for SumWith {
     fn into_dart(self) -> support::DartAbi {
-        vec![self.x.into_dart()].into_dart()
+        vec![self.x.into_into_dart().into_dart()].into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for SumWith {}
+impl rust2dart::IntoIntoDart<SumWith> for SumWith {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//StructRef(IrTypeStructRef { name: "TestChrono", freezed: false, empty: false })
 impl support::IntoDart for TestChrono {
     fn into_dart(self) -> support::DartAbi {
         vec![
@@ -3155,53 +3943,111 @@ impl support::IntoDart for TestChrono {
     }
 }
 impl support::IntoDartExceptPrimitive for TestChrono {}
+impl rust2dart::IntoIntoDart<TestChrono> for TestChrono {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//StructRef(IrTypeStructRef { name: "TestId", freezed: false, empty: false })
 impl support::IntoDart for TestId {
     fn into_dart(self) -> support::DartAbi {
-        vec![self.0.into_dart()].into_dart()
+        vec![self.0.into_into_dart().into_dart()].into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for TestId {}
+impl rust2dart::IntoIntoDart<TestId> for TestId {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//StructRef(IrTypeStructRef { name: "TestModel", freezed: false, empty: false })
 impl support::IntoDart for TestModel {
     fn into_dart(self) -> support::DartAbi {
         vec![
-            self.id.into_dart(),
-            self.name.into_dart(),
-            self.alias_enum.into_dart(),
-            self.alias_struct.into_dart(),
+            self.id.into_into_dart().into_dart(),
+            self.name.into_into_dart().into_dart(),
+            self.alias_enum.into_into_dart().into_dart(),
+            self.alias_struct.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for TestModel {}
+impl rust2dart::IntoIntoDart<TestModel> for TestModel {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//Primitive(U16)
+
+//Primitive(U32)
+
+//Primitive(U64)
+
+//Primitive(U8)
+
+//Delegate(Array(PrimitiveArray { length: 1600, primitive: U8 }))
+
+//Delegate(Array(PrimitiveArray { length: 32, primitive: U8 }))
+
+//Delegate(Array(PrimitiveArray { length: 5, primitive: U8 }))
+
+//Delegate(Array(PrimitiveArray { length: 8, primitive: U8 }))
+
+//PrimitiveList(IrTypePrimitiveList { primitive: U16 })
+
+//PrimitiveList(IrTypePrimitiveList { primitive: U32 })
+
+//PrimitiveList(IrTypePrimitiveList { primitive: U64 })
+
+//PrimitiveList(IrTypePrimitiveList { primitive: U8 })
+
+//Primitive(Unit)
+
+//StructRef(IrTypeStructRef { name: "UserId", freezed: true, empty: false })
 impl support::IntoDart for UserId {
     fn into_dart(self) -> support::DartAbi {
-        vec![self.value.into_dart()].into_dart()
+        vec![self.value.into_into_dart().into_dart()].into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for UserId {}
+impl rust2dart::IntoIntoDart<UserId> for UserId {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//Primitive(Usize)
+
+//StructRef(IrTypeStructRef { name: "VecOfPrimitivePack", freezed: false, empty: false })
 impl support::IntoDart for VecOfPrimitivePack {
     fn into_dart(self) -> support::DartAbi {
         vec![
-            self.int8list.into_dart(),
-            self.uint8list.into_dart(),
-            self.int16list.into_dart(),
-            self.uint16list.into_dart(),
-            self.uint32list.into_dart(),
-            self.int32list.into_dart(),
-            self.uint64list.into_dart(),
-            self.int64list.into_dart(),
-            self.float32list.into_dart(),
-            self.float64list.into_dart(),
+            self.int8list.into_into_dart().into_dart(),
+            self.uint8list.into_into_dart().into_dart(),
+            self.int16list.into_into_dart().into_dart(),
+            self.uint16list.into_into_dart().into_dart(),
+            self.uint32list.into_into_dart().into_dart(),
+            self.int32list.into_into_dart().into_dart(),
+            self.uint64list.into_into_dart().into_dart(),
+            self.int64list.into_into_dart().into_dart(),
+            self.float32list.into_into_dart().into_dart(),
+            self.float64list.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for VecOfPrimitivePack {}
+impl rust2dart::IntoIntoDart<VecOfPrimitivePack> for VecOfPrimitivePack {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//Delegate(PrimitiveEnum { ir: IrTypeEnumRef { name: "Weekdays" }, repr: I32 })
 impl support::IntoDart for Weekdays {
     fn into_dart(self) -> support::DartAbi {
         match self {
@@ -3217,24 +4063,36 @@ impl support::IntoDart for Weekdays {
     }
 }
 impl support::IntoDartExceptPrimitive for Weekdays {}
+impl rust2dart::IntoIntoDart<Weekdays> for Weekdays {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
+
+//StructRef(IrTypeStructRef { name: "ZeroCopyVecOfPrimitivePack", freezed: false, empty: false })
 impl support::IntoDart for ZeroCopyVecOfPrimitivePack {
     fn into_dart(self) -> support::DartAbi {
         vec![
-            self.int8list.into_dart(),
-            self.uint8list.into_dart(),
-            self.int16list.into_dart(),
-            self.uint16list.into_dart(),
-            self.uint32list.into_dart(),
-            self.int32list.into_dart(),
-            self.uint64list.into_dart(),
-            self.int64list.into_dart(),
-            self.float32list.into_dart(),
-            self.float64list.into_dart(),
+            self.int8list.into_into_dart().into_dart(),
+            self.uint8list.into_into_dart().into_dart(),
+            self.int16list.into_into_dart().into_dart(),
+            self.uint16list.into_into_dart().into_dart(),
+            self.uint32list.into_into_dart().into_dart(),
+            self.int32list.into_into_dart().into_dart(),
+            self.uint64list.into_into_dart().into_dart(),
+            self.int64list.into_into_dart().into_dart(),
+            self.float32list.into_into_dart().into_dart(),
+            self.float64list.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for ZeroCopyVecOfPrimitivePack {}
+impl rust2dart::IntoIntoDart<ZeroCopyVecOfPrimitivePack> for ZeroCopyVecOfPrimitivePack {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
 // Section: executor
 

--- a/frb_example/pure_dart/rust/src/bridge_generated.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.rs
@@ -828,6 +828,9 @@ fn wire_mirror_struct_stream_impl(port_: MessagePort) {
         },
     )
 }
+fn wire_mirror_tuple_stream_impl(port_: MessagePort) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_,_,_,()>(WrapInfo{ debug_name: "mirror_tuple_stream", port: Some(port_), mode: FfiCallMode::Stream }, move || {  move |task_callback| Ok(mirror_tuple_stream(task_callback.stream_sink::<_,(mirror_ApplicationSettings,mirror_RawStringEnumMirrored,)>())) })
+}
 fn wire_get_message_impl(port_: MessagePort) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, mirror_ApplicationMessage>(
         WrapInfo {

--- a/frb_example/pure_dart/rust/src/bridge_generated.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.rs
@@ -2459,37 +2459,37 @@ fn wire_handle_some_static_stream_sink_single_arg__static_method__ConcatenateWit
 // Section: wrapper structs
 
 #[derive(Clone)]
-struct mirror_ApplicationEnv(ApplicationEnv);
+pub struct mirror_ApplicationEnv(ApplicationEnv);
 
 #[derive(Clone)]
-struct mirror_ApplicationEnvVar(ApplicationEnvVar);
+pub struct mirror_ApplicationEnvVar(ApplicationEnvVar);
 
 #[derive(Clone)]
-struct mirror_ApplicationMessage(ApplicationMessage);
+pub struct mirror_ApplicationMessage(ApplicationMessage);
 
 #[derive(Clone)]
-struct mirror_ApplicationMode(ApplicationMode);
+pub struct mirror_ApplicationMode(ApplicationMode);
 
 #[derive(Clone)]
-struct mirror_ApplicationSettings(ApplicationSettings);
+pub struct mirror_ApplicationSettings(ApplicationSettings);
 
 #[derive(Clone)]
-struct mirror_ListOfNestedRawStringMirrored(ListOfNestedRawStringMirrored);
+pub struct mirror_ListOfNestedRawStringMirrored(ListOfNestedRawStringMirrored);
 
 #[derive(Clone)]
-struct mirror_NestedRawStringMirrored(NestedRawStringMirrored);
+pub struct mirror_NestedRawStringMirrored(NestedRawStringMirrored);
 
 #[derive(Clone)]
-struct mirror_Numbers(Numbers);
+pub struct mirror_Numbers(Numbers);
 
 #[derive(Clone)]
-struct mirror_RawStringEnumMirrored(RawStringEnumMirrored);
+pub struct mirror_RawStringEnumMirrored(RawStringEnumMirrored);
 
 #[derive(Clone)]
-struct mirror_RawStringMirrored(RawStringMirrored);
+pub struct mirror_RawStringMirrored(RawStringMirrored);
 
 #[derive(Clone)]
-struct mirror_Sequences(Sequences);
+pub struct mirror_Sequences(Sequences);
 
 // Section: static checks
 
@@ -2695,81 +2695,6 @@ impl Wire2Api<Weekdays> for i32 {
 }
 // Section: impl IntoDart
 
-//RustOpaque(IrTypeRustOpaque { inner_rust: "Box<dyn DartDebug>", inner_dart: "BoxDartDebug" })
-
-//Delegate(Time(Duration))
-
-//Delegate(TimeList(Duration))
-
-//Delegate(Time(Local))
-
-//Delegate(TimeList(Local))
-
-//Delegate(Time(Naive))
-
-//Delegate(Time(Utc))
-
-//DartOpaque(IrTypeDartOpaque)
-
-//Delegate(Array(GeneralArray { length: 5, general: EnumRef(IrTypeEnumRef { name: "EnumOpaque" }) }))
-
-//RustOpaque(IrTypeRustOpaque { inner_rust: "FrbOpaqueReturn", inner_dart: "FrbOpaqueReturn" })
-
-//SyncReturn(IrTypeSyncReturn(RustOpaque(IrTypeRustOpaque { inner_rust: "FrbOpaqueSyncReturn", inner_dart: "FrbOpaqueSyncReturn" })))
-
-//RustOpaque(IrTypeRustOpaque { inner_rust: "HideData", inner_dart: "HideData" })
-
-//Delegate(Array(GeneralArray { length: 2, general: RustOpaque(IrTypeRustOpaque { inner_rust: "HideData", inner_dart: "HideData" }) }))
-
-//RustOpaque(IrTypeRustOpaque { inner_rust: "i32", inner_dart: "I32" })
-
-//RustOpaque(IrTypeRustOpaque { inner_rust: "Mutex < HideData >", inner_dart: "MutexHideData" })
-
-//SyncReturn(IrTypeSyncReturn(RustOpaque(IrTypeRustOpaque { inner_rust: "NonCloneData", inner_dart: "NonCloneData" })))
-
-//RustOpaque(IrTypeRustOpaque { inner_rust: "NonSendHideData", inner_dart: "NonSendHideData" })
-
-//Delegate(Array(GeneralArray { length: 1, general: DartOpaque(IrTypeDartOpaque) }))
-
-//Delegate(Array(GeneralArray { length: 2, general: StructRef(IrTypeStructRef { name: "Point", freezed: false, empty: false }) }))
-
-//RustOpaque(IrTypeRustOpaque { inner_rust: "RwLock < HideData >", inner_dart: "RwLockHideData" })
-
-//Delegate(String)
-
-//Delegate(StringList)
-
-//Delegate(Array(GeneralArray { length: 3, general: StructRef(IrTypeStructRef { name: "SumWith", freezed: false, empty: false }) }))
-
-//Delegate(Array(GeneralArray { length: 2, general: StructRef(IrTypeStructRef { name: "TestId", freezed: false, empty: false }) }))
-
-//Delegate(Uuid)
-
-//Delegate(Uuids)
-
-//Delegate(ZeroCopyBufferVecPrimitive(F32))
-
-//Delegate(ZeroCopyBufferVecPrimitive(F64))
-
-//Delegate(ZeroCopyBufferVecPrimitive(I16))
-
-//Delegate(ZeroCopyBufferVecPrimitive(I32))
-
-//Delegate(ZeroCopyBufferVecPrimitive(I64))
-
-//Delegate(ZeroCopyBufferVecPrimitive(I8))
-
-//Delegate(ZeroCopyBufferVecPrimitive(U16))
-
-//Delegate(ZeroCopyBufferVecPrimitive(U32))
-
-//Delegate(ZeroCopyBufferVecPrimitive(U64))
-
-//Delegate(ZeroCopyBufferVecPrimitive(U8))
-
-//Record(IrTypeRecord { inner: IrTypeStructRef { name: "__record__String_i32", freezed: false, empty: false }, values: [Delegate(String), Primitive(I32)] })
-
-//StructRef(IrTypeStructRef { name: "A", freezed: false, empty: false })
 impl support::IntoDart for A {
     fn into_dart(self) -> support::DartAbi {
         vec![self.a.into_into_dart().into_dart()].into_dart()
@@ -2782,7 +2707,6 @@ impl rust2dart::IntoIntoDart<A> for A {
     }
 }
 
-//EnumRef(IrTypeEnumRef { name: "Abc" })
 impl support::IntoDart for Abc {
     fn into_dart(self) -> support::DartAbi {
         match self {
@@ -2801,7 +2725,6 @@ impl rust2dart::IntoIntoDart<Abc> for Abc {
     }
 }
 
-//StructRef(IrTypeStructRef { name: "ApplicationEnv", freezed: false, empty: false })
 impl support::IntoDart for mirror_ApplicationEnv {
     fn into_dart(self) -> support::DartAbi {
         vec![self.0.vars.into_into_dart().into_dart()].into_dart()
@@ -2813,24 +2736,7 @@ impl rust2dart::IntoIntoDart<mirror_ApplicationEnv> for ApplicationEnv {
         mirror_ApplicationEnv(self)
     }
 }
-pub trait ApplicationEnvStreamSink {
-    fn add(&self, val: ApplicationEnv) -> bool;
-}
-impl ApplicationEnvStreamSink for StreamSink<ApplicationEnv> {
-    fn add(&self, val: ApplicationEnv) -> bool {
-        self.add_inner::<_, mirror_ApplicationEnv>(val)
-    }
-}
-pub trait VecApplicationEnvStreamSink {
-    fn add(&self, val: Vec<ApplicationEnv>) -> bool;
-}
-impl VecApplicationEnvStreamSink for StreamSink<Vec<ApplicationEnv>> {
-    fn add(&self, val: Vec<ApplicationEnv>) -> bool {
-        self.add_inner::<_, Vec<mirror_ApplicationEnv>>(val)
-    }
-}
 
-//StructRef(IrTypeStructRef { name: "ApplicationEnvVar", freezed: false, empty: false })
 impl support::IntoDart for mirror_ApplicationEnvVar {
     fn into_dart(self) -> support::DartAbi {
         vec![
@@ -2846,24 +2752,7 @@ impl rust2dart::IntoIntoDart<mirror_ApplicationEnvVar> for ApplicationEnvVar {
         mirror_ApplicationEnvVar(self)
     }
 }
-pub trait ApplicationEnvVarStreamSink {
-    fn add(&self, val: ApplicationEnvVar) -> bool;
-}
-impl ApplicationEnvVarStreamSink for StreamSink<ApplicationEnvVar> {
-    fn add(&self, val: ApplicationEnvVar) -> bool {
-        self.add_inner::<_, mirror_ApplicationEnvVar>(val)
-    }
-}
-pub trait VecApplicationEnvVarStreamSink {
-    fn add(&self, val: Vec<ApplicationEnvVar>) -> bool;
-}
-impl VecApplicationEnvVarStreamSink for StreamSink<Vec<ApplicationEnvVar>> {
-    fn add(&self, val: Vec<ApplicationEnvVar>) -> bool {
-        self.add_inner::<_, Vec<mirror_ApplicationEnvVar>>(val)
-    }
-}
 
-//EnumRef(IrTypeEnumRef { name: "ApplicationMessage" })
 impl support::IntoDart for mirror_ApplicationMessage {
     fn into_dart(self) -> support::DartAbi {
         match self.0 {
@@ -2887,7 +2776,6 @@ impl rust2dart::IntoIntoDart<mirror_ApplicationMessage> for ApplicationMessage {
     }
 }
 
-//Delegate(PrimitiveEnum { ir: IrTypeEnumRef { name: "ApplicationMode" }, repr: I32 })
 impl support::IntoDart for mirror_ApplicationMode {
     fn into_dart(self) -> support::DartAbi {
         match self.0 {
@@ -2904,7 +2792,6 @@ impl rust2dart::IntoIntoDart<mirror_ApplicationMode> for ApplicationMode {
     }
 }
 
-//StructRef(IrTypeStructRef { name: "ApplicationSettings", freezed: false, empty: false })
 impl support::IntoDart for mirror_ApplicationSettings {
     fn into_dart(self) -> support::DartAbi {
         vec![
@@ -2926,24 +2813,7 @@ impl rust2dart::IntoIntoDart<mirror_ApplicationSettings> for ApplicationSettings
         mirror_ApplicationSettings(self)
     }
 }
-pub trait ApplicationSettingsStreamSink {
-    fn add(&self, val: ApplicationSettings) -> bool;
-}
-impl ApplicationSettingsStreamSink for StreamSink<ApplicationSettings> {
-    fn add(&self, val: ApplicationSettings) -> bool {
-        self.add_inner::<_, mirror_ApplicationSettings>(val)
-    }
-}
-pub trait VecApplicationSettingsStreamSink {
-    fn add(&self, val: Vec<ApplicationSettings>) -> bool;
-}
-impl VecApplicationSettingsStreamSink for StreamSink<Vec<ApplicationSettings>> {
-    fn add(&self, val: Vec<ApplicationSettings>) -> bool {
-        self.add_inner::<_, Vec<mirror_ApplicationSettings>>(val)
-    }
-}
 
-//StructRef(IrTypeStructRef { name: "Attribute", freezed: false, empty: false })
 impl support::IntoDart for Attribute {
     fn into_dart(self) -> support::DartAbi {
         vec![
@@ -2960,7 +2830,6 @@ impl rust2dart::IntoIntoDart<Attribute> for Attribute {
     }
 }
 
-//StructRef(IrTypeStructRef { name: "B", freezed: false, empty: false })
 impl support::IntoDart for B {
     fn into_dart(self) -> support::DartAbi {
         vec![self.b.into_into_dart().into_dart()].into_dart()
@@ -2973,7 +2842,6 @@ impl rust2dart::IntoIntoDart<B> for B {
     }
 }
 
-//StructRef(IrTypeStructRef { name: "BigBuffers", freezed: false, empty: false })
 impl support::IntoDart for BigBuffers {
     fn into_dart(self) -> support::DartAbi {
         vec![
@@ -2990,7 +2858,6 @@ impl rust2dart::IntoIntoDart<BigBuffers> for BigBuffers {
     }
 }
 
-//StructRef(IrTypeStructRef { name: "Blob", freezed: false, empty: false })
 impl support::IntoDart for Blob {
     fn into_dart(self) -> support::DartAbi {
         vec![self.0.into_into_dart().into_dart()].into_dart()
@@ -3003,65 +2870,6 @@ impl rust2dart::IntoIntoDart<Blob> for Blob {
     }
 }
 
-//Primitive(Bool)
-
-//Boxed(IrTypeBoxed { exist_in_real_api: true, inner: StructRef(IrTypeStructRef { name: "ApplicationEnv", freezed: false, empty: false }) })
-
-//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: Delegate(Time(Duration)) })
-
-//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: Delegate(Time(Naive)) })
-
-//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: Delegate(Time(Utc)) })
-
-//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: DartOpaque(IrTypeDartOpaque) })
-
-//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: RustOpaque(IrTypeRustOpaque { inner_rust: "HideData", inner_dart: "HideData" }) })
-
-//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: StructRef(IrTypeStructRef { name: "A", freezed: false, empty: false }) })
-
-//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: StructRef(IrTypeStructRef { name: "ApplicationEnv", freezed: false, empty: false }) })
-
-//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: StructRef(IrTypeStructRef { name: "Attribute", freezed: false, empty: false }) })
-
-//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: StructRef(IrTypeStructRef { name: "B", freezed: false, empty: false }) })
-
-//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: Primitive(Bool) })
-
-//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: StructRef(IrTypeStructRef { name: "C", freezed: false, empty: false }) })
-
-//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: StructRef(IrTypeStructRef { name: "Element", freezed: false, empty: false }) })
-
-//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: StructRef(IrTypeStructRef { name: "ExoticOptionals", freezed: false, empty: false }) })
-
-//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: Primitive(F64) })
-
-//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: Primitive(I32) })
-
-//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: Primitive(I64) })
-
-//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: StructRef(IrTypeStructRef { name: "ListOfNestedRawStringMirrored", freezed: false, empty: false }) })
-
-//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: EnumRef(IrTypeEnumRef { name: "Measure" }) })
-
-//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: StructRef(IrTypeStructRef { name: "NestedRawStringMirrored", freezed: false, empty: false }) })
-
-//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: StructRef(IrTypeStructRef { name: "NewTypeInt", freezed: false, empty: false }) })
-
-//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: StructRef(IrTypeStructRef { name: "RawStringMirrored", freezed: false, empty: false }) })
-
-//Boxed(IrTypeBoxed { exist_in_real_api: false, inner: Delegate(PrimitiveEnum { ir: IrTypeEnumRef { name: "Weekdays" }, repr: I32 }) })
-
-//Boxed(IrTypeBoxed { exist_in_real_api: true, inner: EnumRef(IrTypeEnumRef { name: "Distance" }) })
-
-//Boxed(IrTypeBoxed { exist_in_real_api: true, inner: StructRef(IrTypeStructRef { name: "FeedId", freezed: false, empty: false }) })
-
-//Boxed(IrTypeBoxed { exist_in_real_api: true, inner: EnumRef(IrTypeEnumRef { name: "KitchenSink" }) })
-
-//Boxed(IrTypeBoxed { exist_in_real_api: true, inner: EnumRef(IrTypeEnumRef { name: "Speed" }) })
-
-//Boxed(IrTypeBoxed { exist_in_real_api: true, inner: Delegate(Array(PrimitiveArray { length: 8, primitive: U8 })) })
-
-//StructRef(IrTypeStructRef { name: "C", freezed: false, empty: false })
 impl support::IntoDart for C {
     fn into_dart(self) -> support::DartAbi {
         vec![self.c.into_into_dart().into_dart()].into_dart()
@@ -3074,7 +2882,6 @@ impl rust2dart::IntoIntoDart<C> for C {
     }
 }
 
-//StructRef(IrTypeStructRef { name: "ConcatenateWith", freezed: false, empty: false })
 impl support::IntoDart for ConcatenateWith {
     fn into_dart(self) -> support::DartAbi {
         vec![self.a.into_into_dart().into_dart()].into_dart()
@@ -3087,7 +2894,6 @@ impl rust2dart::IntoIntoDart<ConcatenateWith> for ConcatenateWith {
     }
 }
 
-//StructRef(IrTypeStructRef { name: "ContainsMirroredSubStruct", freezed: false, empty: false })
 impl support::IntoDart for ContainsMirroredSubStruct {
     fn into_dart(self) -> support::DartAbi {
         vec![
@@ -3104,7 +2910,6 @@ impl rust2dart::IntoIntoDart<ContainsMirroredSubStruct> for ContainsMirroredSubS
     }
 }
 
-//StructRef(IrTypeStructRef { name: "DartOpaqueNested", freezed: false, empty: false })
 impl support::IntoDart for DartOpaqueNested {
     fn into_dart(self) -> support::DartAbi {
         vec![
@@ -3121,9 +2926,6 @@ impl rust2dart::IntoIntoDart<DartOpaqueNested> for DartOpaqueNested {
     }
 }
 
-//Dynamic(IrTypeDynamic)
-
-//EnumRef(IrTypeEnumRef { name: "Distance" })
 impl support::IntoDart for Distance {
     fn into_dart(self) -> support::DartAbi {
         match self {
@@ -3140,7 +2942,6 @@ impl rust2dart::IntoIntoDart<Distance> for Distance {
     }
 }
 
-//StructRef(IrTypeStructRef { name: "Element", freezed: false, empty: false })
 impl support::IntoDart for Element {
     fn into_dart(self) -> support::DartAbi {
         vec![
@@ -3159,7 +2960,6 @@ impl rust2dart::IntoIntoDart<Element> for Element {
     }
 }
 
-//StructRef(IrTypeStructRef { name: "Empty", freezed: false, empty: true })
 impl support::IntoDart for Empty {
     fn into_dart(self) -> support::DartAbi {
         Vec::<u8>::new().into_dart()
@@ -3172,7 +2972,6 @@ impl rust2dart::IntoIntoDart<Empty> for Empty {
     }
 }
 
-//EnumRef(IrTypeEnumRef { name: "EnumDartOpaque" })
 impl support::IntoDart for EnumDartOpaque {
     fn into_dart(self) -> support::DartAbi {
         match self {
@@ -3189,7 +2988,6 @@ impl rust2dart::IntoIntoDart<EnumDartOpaque> for EnumDartOpaque {
     }
 }
 
-//EnumRef(IrTypeEnumRef { name: "EnumOpaque" })
 impl support::IntoDart for EnumOpaque {
     fn into_dart(self) -> support::DartAbi {
         match self {
@@ -3209,7 +3007,6 @@ impl rust2dart::IntoIntoDart<EnumOpaque> for EnumOpaque {
     }
 }
 
-//StructRef(IrTypeStructRef { name: "Event", freezed: true, empty: false })
 impl support::IntoDart for Event {
     fn into_dart(self) -> support::DartAbi {
         vec![
@@ -3226,7 +3023,6 @@ impl rust2dart::IntoIntoDart<Event> for Event {
     }
 }
 
-//StructRef(IrTypeStructRef { name: "ExoticOptionals", freezed: false, empty: false })
 impl support::IntoDart for ExoticOptionals {
     fn into_dart(self) -> support::DartAbi {
         vec![
@@ -3255,11 +3051,6 @@ impl rust2dart::IntoIntoDart<ExoticOptionals> for ExoticOptionals {
     }
 }
 
-//Primitive(F32)
-
-//Primitive(F64)
-
-//StructRef(IrTypeStructRef { name: "FeatureUuid", freezed: false, empty: false })
 impl support::IntoDart for FeatureUuid {
     fn into_dart(self) -> support::DartAbi {
         vec![
@@ -3276,7 +3067,6 @@ impl rust2dart::IntoIntoDart<FeatureUuid> for FeatureUuid {
     }
 }
 
-//StructRef(IrTypeStructRef { name: "FeedId", freezed: false, empty: false })
 impl support::IntoDart for FeedId {
     fn into_dart(self) -> support::DartAbi {
         vec![self.0.into_into_dart().into_dart()].into_dart()
@@ -3289,29 +3079,6 @@ impl rust2dart::IntoIntoDart<FeedId> for FeedId {
     }
 }
 
-//PrimitiveList(IrTypePrimitiveList { primitive: F32 })
-
-//PrimitiveList(IrTypePrimitiveList { primitive: F64 })
-
-//Primitive(I16)
-
-//Primitive(I32)
-
-//Delegate(Array(PrimitiveArray { length: 2, primitive: I32 }))
-
-//Primitive(I64)
-
-//Primitive(I8)
-
-//PrimitiveList(IrTypePrimitiveList { primitive: I16 })
-
-//PrimitiveList(IrTypePrimitiveList { primitive: I32 })
-
-//PrimitiveList(IrTypePrimitiveList { primitive: I64 })
-
-//PrimitiveList(IrTypePrimitiveList { primitive: I8 })
-
-//EnumRef(IrTypeEnumRef { name: "KitchenSink" })
 impl support::IntoDart for KitchenSink {
     fn into_dart(self) -> support::DartAbi {
         match self {
@@ -3347,29 +3114,6 @@ impl rust2dart::IntoIntoDart<KitchenSink> for KitchenSink {
     }
 }
 
-//GeneralList(IrTypeGeneralList { inner: DartOpaque(IrTypeDartOpaque) })
-
-//GeneralList(IrTypeGeneralList { inner: RustOpaque(IrTypeRustOpaque { inner_rust: "HideData", inner_dart: "HideData" }) })
-
-//GeneralList(IrTypeGeneralList { inner: StructRef(IrTypeStructRef { name: "ApplicationEnvVar", freezed: false, empty: false }) })
-
-//GeneralList(IrTypeGeneralList { inner: StructRef(IrTypeStructRef { name: "ApplicationSettings", freezed: false, empty: false }) })
-
-//GeneralList(IrTypeGeneralList { inner: StructRef(IrTypeStructRef { name: "Attribute", freezed: false, empty: false }) })
-
-//GeneralList(IrTypeGeneralList { inner: StructRef(IrTypeStructRef { name: "Element", freezed: false, empty: false }) })
-
-//GeneralList(IrTypeGeneralList { inner: EnumRef(IrTypeEnumRef { name: "EnumOpaque" }) })
-
-//GeneralList(IrTypeGeneralList { inner: Delegate(PrimitiveEnum { ir: IrTypeEnumRef { name: "MyEnum" }, repr: I32 }) })
-
-//GeneralList(IrTypeGeneralList { inner: StructRef(IrTypeStructRef { name: "MySize", freezed: false, empty: false }) })
-
-//GeneralList(IrTypeGeneralList { inner: StructRef(IrTypeStructRef { name: "MyTreeNode", freezed: false, empty: false }) })
-
-//GeneralList(IrTypeGeneralList { inner: StructRef(IrTypeStructRef { name: "NestedRawStringMirrored", freezed: false, empty: false }) })
-
-//StructRef(IrTypeStructRef { name: "ListOfNestedRawStringMirrored", freezed: false, empty: false })
 impl support::IntoDart for mirror_ListOfNestedRawStringMirrored {
     fn into_dart(self) -> support::DartAbi {
         vec![self.0.raw.into_into_dart().into_dart()].into_dart()
@@ -3383,36 +3127,7 @@ impl rust2dart::IntoIntoDart<mirror_ListOfNestedRawStringMirrored>
         mirror_ListOfNestedRawStringMirrored(self)
     }
 }
-pub trait ListOfNestedRawStringMirroredStreamSink {
-    fn add(&self, val: ListOfNestedRawStringMirrored) -> bool;
-}
-impl ListOfNestedRawStringMirroredStreamSink for StreamSink<ListOfNestedRawStringMirrored> {
-    fn add(&self, val: ListOfNestedRawStringMirrored) -> bool {
-        self.add_inner::<_, mirror_ListOfNestedRawStringMirrored>(val)
-    }
-}
-pub trait VecListOfNestedRawStringMirroredStreamSink {
-    fn add(&self, val: Vec<ListOfNestedRawStringMirrored>) -> bool;
-}
-impl VecListOfNestedRawStringMirroredStreamSink for StreamSink<Vec<ListOfNestedRawStringMirrored>> {
-    fn add(&self, val: Vec<ListOfNestedRawStringMirrored>) -> bool {
-        self.add_inner::<_, Vec<mirror_ListOfNestedRawStringMirrored>>(val)
-    }
-}
 
-//GeneralList(IrTypeGeneralList { inner: Optional(IrTypeOptional { inner: Boxed(IrTypeBoxed { exist_in_real_api: false, inner: StructRef(IrTypeStructRef { name: "Attribute", freezed: false, empty: false }) }) }) })
-
-//GeneralList(IrTypeGeneralList { inner: StructRef(IrTypeStructRef { name: "Point", freezed: false, empty: false }) })
-
-//GeneralList(IrTypeGeneralList { inner: StructRef(IrTypeStructRef { name: "RawStringMirrored", freezed: false, empty: false }) })
-
-//GeneralList(IrTypeGeneralList { inner: StructRef(IrTypeStructRef { name: "SumWith", freezed: false, empty: false }) })
-
-//GeneralList(IrTypeGeneralList { inner: StructRef(IrTypeStructRef { name: "TestId", freezed: false, empty: false }) })
-
-//GeneralList(IrTypeGeneralList { inner: Delegate(PrimitiveEnum { ir: IrTypeEnumRef { name: "Weekdays" }, repr: I32 }) })
-
-//StructRef(IrTypeStructRef { name: "Log", freezed: false, empty: false })
 impl support::IntoDart for Log {
     fn into_dart(self) -> support::DartAbi {
         vec![
@@ -3429,7 +3144,6 @@ impl rust2dart::IntoIntoDart<Log> for Log {
     }
 }
 
-//StructRef(IrTypeStructRef { name: "Log2", freezed: false, empty: false })
 impl support::IntoDart for Log2 {
     fn into_dart(self) -> support::DartAbi {
         vec![
@@ -3446,7 +3160,6 @@ impl rust2dart::IntoIntoDart<Log2> for Log2 {
     }
 }
 
-//EnumRef(IrTypeEnumRef { name: "Measure" })
 impl support::IntoDart for Measure {
     fn into_dart(self) -> support::DartAbi {
         match self {
@@ -3463,7 +3176,6 @@ impl rust2dart::IntoIntoDart<Measure> for Measure {
     }
 }
 
-//StructRef(IrTypeStructRef { name: "MessageId", freezed: false, empty: false })
 impl support::IntoDart for MessageId {
     fn into_dart(self) -> support::DartAbi {
         vec![self.0.into_into_dart().into_dart()].into_dart()
@@ -3476,7 +3188,6 @@ impl rust2dart::IntoIntoDart<MessageId> for MessageId {
     }
 }
 
-//StructRef(IrTypeStructRef { name: "MirrorStruct", freezed: false, empty: false })
 impl support::IntoDart for MirrorStruct {
     fn into_dart(self) -> support::DartAbi {
         vec![
@@ -3495,7 +3206,6 @@ impl rust2dart::IntoIntoDart<MirrorStruct> for MirrorStruct {
     }
 }
 
-//StructRef(IrTypeStructRef { name: "MoreThanJustOneRawStringStruct", freezed: false, empty: false })
 impl support::IntoDart for MoreThanJustOneRawStringStruct {
     fn into_dart(self) -> support::DartAbi {
         vec![
@@ -3514,7 +3224,6 @@ impl rust2dart::IntoIntoDart<MoreThanJustOneRawStringStruct> for MoreThanJustOne
     }
 }
 
-//Delegate(PrimitiveEnum { ir: IrTypeEnumRef { name: "MyEnum" }, repr: I32 })
 impl support::IntoDart for MyEnum {
     fn into_dart(self) -> support::DartAbi {
         match self {
@@ -3531,7 +3240,6 @@ impl rust2dart::IntoIntoDart<MyEnum> for MyEnum {
     }
 }
 
-//StructRef(IrTypeStructRef { name: "MyNestedStruct", freezed: false, empty: false })
 impl support::IntoDart for MyNestedStruct {
     fn into_dart(self) -> support::DartAbi {
         vec![
@@ -3548,7 +3256,6 @@ impl rust2dart::IntoIntoDart<MyNestedStruct> for MyNestedStruct {
     }
 }
 
-//StructRef(IrTypeStructRef { name: "MySize", freezed: false, empty: false })
 impl support::IntoDart for MySize {
     fn into_dart(self) -> support::DartAbi {
         vec![
@@ -3565,7 +3272,6 @@ impl rust2dart::IntoIntoDart<MySize> for MySize {
     }
 }
 
-//StructRef(IrTypeStructRef { name: "MyStreamEntry", freezed: false, empty: false })
 impl support::IntoDart for MyStreamEntry {
     fn into_dart(self) -> support::DartAbi {
         vec![self.hello.into_into_dart().into_dart()].into_dart()
@@ -3578,7 +3284,6 @@ impl rust2dart::IntoIntoDart<MyStreamEntry> for MyStreamEntry {
     }
 }
 
-//StructRef(IrTypeStructRef { name: "MyStruct", freezed: false, empty: false })
 impl support::IntoDart for MyStruct {
     fn into_dart(self) -> support::DartAbi {
         vec![self.content.into_into_dart().into_dart()].into_dart()
@@ -3591,7 +3296,6 @@ impl rust2dart::IntoIntoDart<MyStruct> for MyStruct {
     }
 }
 
-//StructRef(IrTypeStructRef { name: "MyTreeNode", freezed: false, empty: false })
 impl support::IntoDart for MyTreeNode {
     fn into_dart(self) -> support::DartAbi {
         vec![
@@ -3610,7 +3314,6 @@ impl rust2dart::IntoIntoDart<MyTreeNode> for MyTreeNode {
     }
 }
 
-//StructRef(IrTypeStructRef { name: "NestedRawStringMirrored", freezed: false, empty: false })
 impl support::IntoDart for mirror_NestedRawStringMirrored {
     fn into_dart(self) -> support::DartAbi {
         vec![self.0.raw.into_into_dart().into_dart()].into_dart()
@@ -3622,24 +3325,7 @@ impl rust2dart::IntoIntoDart<mirror_NestedRawStringMirrored> for NestedRawString
         mirror_NestedRawStringMirrored(self)
     }
 }
-pub trait NestedRawStringMirroredStreamSink {
-    fn add(&self, val: NestedRawStringMirrored) -> bool;
-}
-impl NestedRawStringMirroredStreamSink for StreamSink<NestedRawStringMirrored> {
-    fn add(&self, val: NestedRawStringMirrored) -> bool {
-        self.add_inner::<_, mirror_NestedRawStringMirrored>(val)
-    }
-}
-pub trait VecNestedRawStringMirroredStreamSink {
-    fn add(&self, val: Vec<NestedRawStringMirrored>) -> bool;
-}
-impl VecNestedRawStringMirroredStreamSink for StreamSink<Vec<NestedRawStringMirrored>> {
-    fn add(&self, val: Vec<NestedRawStringMirrored>) -> bool {
-        self.add_inner::<_, Vec<mirror_NestedRawStringMirrored>>(val)
-    }
-}
 
-//StructRef(IrTypeStructRef { name: "NewSimpleStruct", freezed: false, empty: false })
 impl support::IntoDart for NewSimpleStruct {
     fn into_dart(self) -> support::DartAbi {
         vec![self.field.into_into_dart().into_dart()].into_dart()
@@ -3652,7 +3338,6 @@ impl rust2dart::IntoIntoDart<NewSimpleStruct> for NewSimpleStruct {
     }
 }
 
-//StructRef(IrTypeStructRef { name: "NewTypeInt", freezed: false, empty: false })
 impl support::IntoDart for NewTypeInt {
     fn into_dart(self) -> support::DartAbi {
         vec![self.0.into_into_dart().into_dart()].into_dart()
@@ -3665,7 +3350,6 @@ impl rust2dart::IntoIntoDart<NewTypeInt> for NewTypeInt {
     }
 }
 
-//StructRef(IrTypeStructRef { name: "Numbers", freezed: false, empty: false })
 impl support::IntoDart for mirror_Numbers {
     fn into_dart(self) -> support::DartAbi {
         vec![self.0 .0.into_into_dart().into_dart()].into_dart()
@@ -3677,24 +3361,7 @@ impl rust2dart::IntoIntoDart<mirror_Numbers> for Numbers {
         mirror_Numbers(self)
     }
 }
-pub trait NumbersStreamSink {
-    fn add(&self, val: Numbers) -> bool;
-}
-impl NumbersStreamSink for StreamSink<Numbers> {
-    fn add(&self, val: Numbers) -> bool {
-        self.add_inner::<_, mirror_Numbers>(val)
-    }
-}
-pub trait VecNumbersStreamSink {
-    fn add(&self, val: Vec<Numbers>) -> bool;
-}
-impl VecNumbersStreamSink for StreamSink<Vec<Numbers>> {
-    fn add(&self, val: Vec<Numbers>) -> bool {
-        self.add_inner::<_, Vec<mirror_Numbers>>(val)
-    }
-}
 
-//StructRef(IrTypeStructRef { name: "OldSimpleStruct", freezed: false, empty: false })
 impl support::IntoDart for OldSimpleStruct {
     fn into_dart(self) -> support::DartAbi {
         vec![self.field.into_into_dart().into_dart()].into_dart()
@@ -3707,7 +3374,6 @@ impl rust2dart::IntoIntoDart<OldSimpleStruct> for OldSimpleStruct {
     }
 }
 
-//StructRef(IrTypeStructRef { name: "OpaqueNested", freezed: false, empty: false })
 impl support::IntoDart for OpaqueNested {
     fn into_dart(self) -> support::DartAbi {
         vec![self.first.into_dart(), self.second.into_dart()].into_dart()
@@ -3720,59 +3386,6 @@ impl rust2dart::IntoIntoDart<OpaqueNested> for OpaqueNested {
     }
 }
 
-//Optional(IrTypeOptional { inner: Delegate(String) })
-
-//Optional(IrTypeOptional { inner: Delegate(ZeroCopyBufferVecPrimitive(U8)) })
-
-//Optional(IrTypeOptional { inner: Boxed(IrTypeBoxed { exist_in_real_api: false, inner: Delegate(Time(Duration)) }) })
-
-//Optional(IrTypeOptional { inner: Boxed(IrTypeBoxed { exist_in_real_api: false, inner: Delegate(Time(Naive)) }) })
-
-//Optional(IrTypeOptional { inner: Boxed(IrTypeBoxed { exist_in_real_api: false, inner: Delegate(Time(Utc)) }) })
-
-//Optional(IrTypeOptional { inner: Boxed(IrTypeBoxed { exist_in_real_api: false, inner: DartOpaque(IrTypeDartOpaque) }) })
-
-//Optional(IrTypeOptional { inner: Boxed(IrTypeBoxed { exist_in_real_api: false, inner: RustOpaque(IrTypeRustOpaque { inner_rust: "HideData", inner_dart: "HideData" }) }) })
-
-//Optional(IrTypeOptional { inner: Boxed(IrTypeBoxed { exist_in_real_api: false, inner: StructRef(IrTypeStructRef { name: "ApplicationEnv", freezed: false, empty: false }) }) })
-
-//Optional(IrTypeOptional { inner: Boxed(IrTypeBoxed { exist_in_real_api: false, inner: StructRef(IrTypeStructRef { name: "Attribute", freezed: false, empty: false }) }) })
-
-//Optional(IrTypeOptional { inner: Boxed(IrTypeBoxed { exist_in_real_api: false, inner: Primitive(Bool) }) })
-
-//Optional(IrTypeOptional { inner: Boxed(IrTypeBoxed { exist_in_real_api: false, inner: StructRef(IrTypeStructRef { name: "Element", freezed: false, empty: false }) }) })
-
-//Optional(IrTypeOptional { inner: Boxed(IrTypeBoxed { exist_in_real_api: false, inner: StructRef(IrTypeStructRef { name: "ExoticOptionals", freezed: false, empty: false }) }) })
-
-//Optional(IrTypeOptional { inner: Boxed(IrTypeBoxed { exist_in_real_api: false, inner: Primitive(F64) }) })
-
-//Optional(IrTypeOptional { inner: Boxed(IrTypeBoxed { exist_in_real_api: false, inner: Primitive(I32) }) })
-
-//Optional(IrTypeOptional { inner: Boxed(IrTypeBoxed { exist_in_real_api: false, inner: Primitive(I64) }) })
-
-//Optional(IrTypeOptional { inner: Boxed(IrTypeBoxed { exist_in_real_api: false, inner: EnumRef(IrTypeEnumRef { name: "Measure" }) }) })
-
-//Optional(IrTypeOptional { inner: Boxed(IrTypeBoxed { exist_in_real_api: false, inner: StructRef(IrTypeStructRef { name: "NewTypeInt", freezed: false, empty: false }) }) })
-
-//Optional(IrTypeOptional { inner: Boxed(IrTypeBoxed { exist_in_real_api: false, inner: Delegate(PrimitiveEnum { ir: IrTypeEnumRef { name: "Weekdays" }, repr: I32 }) }) })
-
-//Optional(IrTypeOptional { inner: PrimitiveList(IrTypePrimitiveList { primitive: F32 }) })
-
-//Optional(IrTypeOptional { inner: PrimitiveList(IrTypePrimitiveList { primitive: F64 }) })
-
-//Optional(IrTypeOptional { inner: PrimitiveList(IrTypePrimitiveList { primitive: I32 }) })
-
-//Optional(IrTypeOptional { inner: PrimitiveList(IrTypePrimitiveList { primitive: I8 }) })
-
-//Optional(IrTypeOptional { inner: GeneralList(IrTypeGeneralList { inner: StructRef(IrTypeStructRef { name: "Attribute", freezed: false, empty: false }) }) })
-
-//Optional(IrTypeOptional { inner: GeneralList(IrTypeGeneralList { inner: StructRef(IrTypeStructRef { name: "Element", freezed: false, empty: false }) }) })
-
-//Optional(IrTypeOptional { inner: GeneralList(IrTypeGeneralList { inner: Optional(IrTypeOptional { inner: Boxed(IrTypeBoxed { exist_in_real_api: false, inner: StructRef(IrTypeStructRef { name: "Attribute", freezed: false, empty: false }) }) }) }) })
-
-//Optional(IrTypeOptional { inner: PrimitiveList(IrTypePrimitiveList { primitive: U8 }) })
-
-//StructRef(IrTypeStructRef { name: "Point", freezed: false, empty: false })
 impl support::IntoDart for Point {
     fn into_dart(self) -> support::DartAbi {
         vec![
@@ -3789,7 +3402,6 @@ impl rust2dart::IntoIntoDart<Point> for Point {
     }
 }
 
-//EnumRef(IrTypeEnumRef { name: "RawStringEnumMirrored" })
 impl support::IntoDart for mirror_RawStringEnumMirrored {
     fn into_dart(self) -> support::DartAbi {
         match self.0 {
@@ -3813,7 +3425,6 @@ impl rust2dart::IntoIntoDart<mirror_RawStringEnumMirrored> for RawStringEnumMirr
     }
 }
 
-//StructRef(IrTypeStructRef { name: "RawStringItemStruct", freezed: false, empty: false })
 impl support::IntoDart for RawStringItemStruct {
     fn into_dart(self) -> support::DartAbi {
         vec![self.r#type.into_into_dart().into_dart()].into_dart()
@@ -3826,7 +3437,6 @@ impl rust2dart::IntoIntoDart<RawStringItemStruct> for RawStringItemStruct {
     }
 }
 
-//StructRef(IrTypeStructRef { name: "RawStringMirrored", freezed: false, empty: false })
 impl support::IntoDart for mirror_RawStringMirrored {
     fn into_dart(self) -> support::DartAbi {
         vec![self.0.r#value.into_into_dart().into_dart()].into_dart()
@@ -3838,24 +3448,7 @@ impl rust2dart::IntoIntoDart<mirror_RawStringMirrored> for RawStringMirrored {
         mirror_RawStringMirrored(self)
     }
 }
-pub trait RawStringMirroredStreamSink {
-    fn add(&self, val: RawStringMirrored) -> bool;
-}
-impl RawStringMirroredStreamSink for StreamSink<RawStringMirrored> {
-    fn add(&self, val: RawStringMirrored) -> bool {
-        self.add_inner::<_, mirror_RawStringMirrored>(val)
-    }
-}
-pub trait VecRawStringMirroredStreamSink {
-    fn add(&self, val: Vec<RawStringMirrored>) -> bool;
-}
-impl VecRawStringMirroredStreamSink for StreamSink<Vec<RawStringMirrored>> {
-    fn add(&self, val: Vec<RawStringMirrored>) -> bool {
-        self.add_inner::<_, Vec<mirror_RawStringMirrored>>(val)
-    }
-}
 
-//StructRef(IrTypeStructRef { name: "Sequences", freezed: false, empty: false })
 impl support::IntoDart for mirror_Sequences {
     fn into_dart(self) -> support::DartAbi {
         vec![self.0 .0.into_into_dart().into_dart()].into_dart()
@@ -3867,24 +3460,7 @@ impl rust2dart::IntoIntoDart<mirror_Sequences> for Sequences {
         mirror_Sequences(self)
     }
 }
-pub trait SequencesStreamSink {
-    fn add(&self, val: Sequences) -> bool;
-}
-impl SequencesStreamSink for StreamSink<Sequences> {
-    fn add(&self, val: Sequences) -> bool {
-        self.add_inner::<_, mirror_Sequences>(val)
-    }
-}
-pub trait VecSequencesStreamSink {
-    fn add(&self, val: Vec<Sequences>) -> bool;
-}
-impl VecSequencesStreamSink for StreamSink<Vec<Sequences>> {
-    fn add(&self, val: Vec<Sequences>) -> bool {
-        self.add_inner::<_, Vec<mirror_Sequences>>(val)
-    }
-}
 
-//EnumRef(IrTypeEnumRef { name: "Speed" })
 impl support::IntoDart for Speed {
     fn into_dart(self) -> support::DartAbi {
         match self {
@@ -3901,7 +3477,6 @@ impl rust2dart::IntoIntoDart<Speed> for Speed {
     }
 }
 
-//StructRef(IrTypeStructRef { name: "StructWithEnum", freezed: false, empty: false })
 impl support::IntoDart for StructWithEnum {
     fn into_dart(self) -> support::DartAbi {
         vec![
@@ -3918,7 +3493,6 @@ impl rust2dart::IntoIntoDart<StructWithEnum> for StructWithEnum {
     }
 }
 
-//StructRef(IrTypeStructRef { name: "SumWith", freezed: false, empty: false })
 impl support::IntoDart for SumWith {
     fn into_dart(self) -> support::DartAbi {
         vec![self.x.into_into_dart().into_dart()].into_dart()
@@ -3931,7 +3505,6 @@ impl rust2dart::IntoIntoDart<SumWith> for SumWith {
     }
 }
 
-//StructRef(IrTypeStructRef { name: "TestChrono", freezed: false, empty: false })
 impl support::IntoDart for TestChrono {
     fn into_dart(self) -> support::DartAbi {
         vec![
@@ -3949,7 +3522,6 @@ impl rust2dart::IntoIntoDart<TestChrono> for TestChrono {
     }
 }
 
-//StructRef(IrTypeStructRef { name: "TestId", freezed: false, empty: false })
 impl support::IntoDart for TestId {
     fn into_dart(self) -> support::DartAbi {
         vec![self.0.into_into_dart().into_dart()].into_dart()
@@ -3962,7 +3534,6 @@ impl rust2dart::IntoIntoDart<TestId> for TestId {
     }
 }
 
-//StructRef(IrTypeStructRef { name: "TestModel", freezed: false, empty: false })
 impl support::IntoDart for TestModel {
     fn into_dart(self) -> support::DartAbi {
         vec![
@@ -3981,33 +3552,6 @@ impl rust2dart::IntoIntoDart<TestModel> for TestModel {
     }
 }
 
-//Primitive(U16)
-
-//Primitive(U32)
-
-//Primitive(U64)
-
-//Primitive(U8)
-
-//Delegate(Array(PrimitiveArray { length: 1600, primitive: U8 }))
-
-//Delegate(Array(PrimitiveArray { length: 32, primitive: U8 }))
-
-//Delegate(Array(PrimitiveArray { length: 5, primitive: U8 }))
-
-//Delegate(Array(PrimitiveArray { length: 8, primitive: U8 }))
-
-//PrimitiveList(IrTypePrimitiveList { primitive: U16 })
-
-//PrimitiveList(IrTypePrimitiveList { primitive: U32 })
-
-//PrimitiveList(IrTypePrimitiveList { primitive: U64 })
-
-//PrimitiveList(IrTypePrimitiveList { primitive: U8 })
-
-//Primitive(Unit)
-
-//StructRef(IrTypeStructRef { name: "UserId", freezed: true, empty: false })
 impl support::IntoDart for UserId {
     fn into_dart(self) -> support::DartAbi {
         vec![self.value.into_into_dart().into_dart()].into_dart()
@@ -4020,9 +3564,6 @@ impl rust2dart::IntoIntoDart<UserId> for UserId {
     }
 }
 
-//Primitive(Usize)
-
-//StructRef(IrTypeStructRef { name: "VecOfPrimitivePack", freezed: false, empty: false })
 impl support::IntoDart for VecOfPrimitivePack {
     fn into_dart(self) -> support::DartAbi {
         vec![
@@ -4047,7 +3588,6 @@ impl rust2dart::IntoIntoDart<VecOfPrimitivePack> for VecOfPrimitivePack {
     }
 }
 
-//Delegate(PrimitiveEnum { ir: IrTypeEnumRef { name: "Weekdays" }, repr: I32 })
 impl support::IntoDart for Weekdays {
     fn into_dart(self) -> support::DartAbi {
         match self {
@@ -4069,7 +3609,6 @@ impl rust2dart::IntoIntoDart<Weekdays> for Weekdays {
     }
 }
 
-//StructRef(IrTypeStructRef { name: "ZeroCopyVecOfPrimitivePack", freezed: false, empty: false })
 impl support::IntoDart for ZeroCopyVecOfPrimitivePack {
     fn into_dart(self) -> support::DartAbi {
         vec![

--- a/frb_example/pure_dart/rust/src/bridge_generated.web.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.web.rs
@@ -270,6 +270,21 @@ pub fn wire_is_app_embedded(port_: MessagePort, app_settings: JsValue) {
 }
 
 #[wasm_bindgen]
+pub fn wire_app_settings_stream(port_: MessagePort) {
+    wire_app_settings_stream_impl(port_)
+}
+
+#[wasm_bindgen]
+pub fn wire_app_settings_vec_stream(port_: MessagePort) {
+    wire_app_settings_vec_stream_impl(port_)
+}
+
+#[wasm_bindgen]
+pub fn wire_mirror_struct_stream(port_: MessagePort) {
+    wire_mirror_struct_stream_impl(port_)
+}
+
+#[wasm_bindgen]
 pub fn wire_get_message(port_: MessagePort) {
     wire_get_message_impl(port_)
 }

--- a/frb_example/pure_dart/rust/src/bridge_generated.web.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.web.rs
@@ -285,6 +285,11 @@ pub fn wire_mirror_struct_stream(port_: MessagePort) {
 }
 
 #[wasm_bindgen]
+pub fn wire_mirror_tuple_stream(port_: MessagePort) {
+    wire_mirror_tuple_stream_impl(port_)
+}
+
+#[wasm_bindgen]
 pub fn wire_get_message(port_: MessagePort) {
     wire_get_message_impl(port_)
 }

--- a/frb_example/pure_dart_multi/rust/src/generated_api_1.rs
+++ b/frb_example/pure_dart_multi/rust/src/generated_api_1.rs
@@ -69,8 +69,6 @@ impl Wire2Api<i32> for i32 {
 }
 // Section: impl IntoDart
 
-//Primitive(I32)
-
 // Section: executor
 
 support::lazy_static! {

--- a/frb_example/pure_dart_multi/rust/src/generated_api_1.rs
+++ b/frb_example/pure_dart_multi/rust/src/generated_api_1.rs
@@ -13,6 +13,7 @@
 
 use crate::api_1::*;
 use core::panic::UnwindSafe;
+use flutter_rust_bridge::rust2dart::IntoIntoDart;
 use flutter_rust_bridge::*;
 use std::ffi::c_void;
 use std::sync::Arc;
@@ -26,7 +27,7 @@ fn wire_simple_adder_1_impl(
     a: impl Wire2Api<i32> + UnwindSafe,
     b: impl Wire2Api<i32> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, i32>(
         WrapInfo {
             debug_name: "simple_adder_1",
             port: Some(port_),
@@ -67,6 +68,8 @@ impl Wire2Api<i32> for i32 {
     }
 }
 // Section: impl IntoDart
+
+//Primitive(I32)
 
 // Section: executor
 

--- a/frb_example/pure_dart_multi/rust/src/generated_api_2.rs
+++ b/frb_example/pure_dart_multi/rust/src/generated_api_2.rs
@@ -69,8 +69,6 @@ impl Wire2Api<i32> for i32 {
 }
 // Section: impl IntoDart
 
-//Primitive(I32)
-
 // Section: executor
 
 support::lazy_static! {

--- a/frb_example/pure_dart_multi/rust/src/generated_api_2.rs
+++ b/frb_example/pure_dart_multi/rust/src/generated_api_2.rs
@@ -13,6 +13,7 @@
 
 use crate::api_2::*;
 use core::panic::UnwindSafe;
+use flutter_rust_bridge::rust2dart::IntoIntoDart;
 use flutter_rust_bridge::*;
 use std::ffi::c_void;
 use std::sync::Arc;
@@ -26,7 +27,7 @@ fn wire_simple_adder_2_impl(
     a: impl Wire2Api<i32> + UnwindSafe,
     b: impl Wire2Api<i32> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, i32>(
         WrapInfo {
             debug_name: "simple_adder_2",
             port: Some(port_),
@@ -67,6 +68,8 @@ impl Wire2Api<i32> for i32 {
     }
 }
 // Section: impl IntoDart
+
+//Primitive(I32)
 
 // Section: executor
 

--- a/frb_example/with_flutter/rust/src/bridge_generated.rs
+++ b/frb_example/with_flutter/rust/src/bridge_generated.rs
@@ -13,6 +13,7 @@
 
 use crate::api::*;
 use core::panic::UnwindSafe;
+use flutter_rust_bridge::rust2dart::IntoIntoDart;
 use flutter_rust_bridge::*;
 use std::ffi::c_void;
 use std::sync::Arc;
@@ -28,7 +29,7 @@ fn wire_draw_mandelbrot_impl(
     scale: impl Wire2Api<f64> + UnwindSafe,
     num_threads: impl Wire2Api<i32> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, ZeroCopyBuffer<Vec<u8>>>(
         WrapInfo {
             debug_name: "draw_mandelbrot",
             port: Some(port_),
@@ -49,7 +50,7 @@ fn wire_passing_complex_structs_impl(
     port_: MessagePort,
     root: impl Wire2Api<TreeNode> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, String>(
         WrapInfo {
             debug_name: "passing_complex_structs",
             port: Some(port_),
@@ -62,7 +63,7 @@ fn wire_passing_complex_structs_impl(
     )
 }
 fn wire_returning_structs_with_boxed_fields_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, BoxedPoint>(
         WrapInfo {
             debug_name: "returning_structs_with_boxed_fields",
             port: Some(port_),
@@ -75,7 +76,7 @@ fn wire_off_topic_memory_test_input_array_impl(
     port_: MessagePort,
     input: impl Wire2Api<Vec<u8>> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, i32>(
         WrapInfo {
             debug_name: "off_topic_memory_test_input_array",
             port: Some(port_),
@@ -91,7 +92,7 @@ fn wire_off_topic_memory_test_output_zero_copy_buffer_impl(
     port_: MessagePort,
     len: impl Wire2Api<i32> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, ZeroCopyBuffer<Vec<u8>>>(
         WrapInfo {
             debug_name: "off_topic_memory_test_output_zero_copy_buffer",
             port: Some(port_),
@@ -107,7 +108,7 @@ fn wire_off_topic_memory_test_output_vec_u8_impl(
     port_: MessagePort,
     len: impl Wire2Api<i32> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, Vec<u8>>(
         WrapInfo {
             debug_name: "off_topic_memory_test_output_vec_u8",
             port: Some(port_),
@@ -123,7 +124,7 @@ fn wire_off_topic_memory_test_input_vec_of_object_impl(
     port_: MessagePort,
     input: impl Wire2Api<Vec<Size>> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, i32>(
         WrapInfo {
             debug_name: "off_topic_memory_test_input_vec_of_object",
             port: Some(port_),
@@ -139,7 +140,7 @@ fn wire_off_topic_memory_test_output_vec_of_object_impl(
     port_: MessagePort,
     len: impl Wire2Api<i32> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, Vec<Size>>(
         WrapInfo {
             debug_name: "off_topic_memory_test_output_vec_of_object",
             port: Some(port_),
@@ -155,7 +156,7 @@ fn wire_off_topic_memory_test_input_complex_struct_impl(
     port_: MessagePort,
     input: impl Wire2Api<TreeNode> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, i32>(
         WrapInfo {
             debug_name: "off_topic_memory_test_input_complex_struct",
             port: Some(port_),
@@ -171,7 +172,7 @@ fn wire_off_topic_memory_test_output_complex_struct_impl(
     port_: MessagePort,
     len: impl Wire2Api<i32> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, TreeNode>(
         WrapInfo {
             debug_name: "off_topic_memory_test_output_complex_struct",
             port: Some(port_),
@@ -184,7 +185,7 @@ fn wire_off_topic_memory_test_output_complex_struct_impl(
     )
 }
 fn wire_off_topic_deliberately_return_error_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, i32>(
         WrapInfo {
             debug_name: "off_topic_deliberately_return_error",
             port: Some(port_),
@@ -194,7 +195,7 @@ fn wire_off_topic_deliberately_return_error_impl(port_: MessagePort) {
     )
 }
 fn wire_off_topic_deliberately_panic_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, i32>(
         WrapInfo {
             debug_name: "off_topic_deliberately_panic",
             port: Some(port_),
@@ -204,7 +205,7 @@ fn wire_off_topic_deliberately_panic_impl(port_: MessagePort) {
     )
 }
 fn wire_next_user_id_impl(port_: MessagePort, user_id: impl Wire2Api<UserId> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, UserId>(
         WrapInfo {
             debug_name: "next_user_id",
             port: Some(port_),
@@ -220,7 +221,7 @@ fn wire_test_method__method__BoxedPoint_impl(
     port_: MessagePort,
     that: impl Wire2Api<BoxedPoint> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, ()>(
         WrapInfo {
             debug_name: "test_method__method__BoxedPoint",
             port: Some(port_),
@@ -237,7 +238,7 @@ fn wire_sum__method__SumWith_impl(
     that: impl Wire2Api<SumWith> + UnwindSafe,
     y: impl Wire2Api<u32> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, u32>(
         WrapInfo {
             debug_name: "sum__method__SumWith",
             port: Some(port_),
@@ -255,7 +256,7 @@ fn wire_sum_static__static_method__SumWith_impl(
     x: impl Wire2Api<u32> + UnwindSafe,
     y: impl Wire2Api<u32> + UnwindSafe,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, u32>(
         WrapInfo {
             debug_name: "sum_static__static_method__SumWith",
             port: Some(port_),
@@ -315,40 +316,104 @@ impl Wire2Api<u8> for u8 {
 
 // Section: impl IntoDart
 
+//Delegate(String)
+
+//Delegate(ZeroCopyBufferVecPrimitive(U8))
+
+//Boxed(IrTypeBoxed { exist_in_real_api: true, inner: StructRef(IrTypeStructRef { name: "Point", freezed: false, empty: false }) })
+
+//StructRef(IrTypeStructRef { name: "BoxedPoint", freezed: false, empty: false })
 impl support::IntoDart for BoxedPoint {
     fn into_dart(self) -> support::DartAbi {
-        vec![(*self.point).into_dart()].into_dart()
+        vec![self.point.into_into_dart().into_dart()].into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for BoxedPoint {}
+impl rust2dart::IntoIntoDart<BoxedPoint> for BoxedPoint {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//Primitive(F64)
+
+//Primitive(I32)
+
+//GeneralList(IrTypeGeneralList { inner: StructRef(IrTypeStructRef { name: "Size", freezed: false, empty: false }) })
+
+//GeneralList(IrTypeGeneralList { inner: StructRef(IrTypeStructRef { name: "TreeNode", freezed: false, empty: false }) })
+
+//StructRef(IrTypeStructRef { name: "Point", freezed: false, empty: false })
 impl support::IntoDart for Point {
     fn into_dart(self) -> support::DartAbi {
-        vec![self.x.into_dart(), self.y.into_dart()].into_dart()
+        vec![
+            self.x.into_into_dart().into_dart(),
+            self.y.into_into_dart().into_dart(),
+        ]
+        .into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for Point {}
+impl rust2dart::IntoIntoDart<Point> for Point {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//StructRef(IrTypeStructRef { name: "Size", freezed: false, empty: false })
 impl support::IntoDart for Size {
     fn into_dart(self) -> support::DartAbi {
-        vec![self.width.into_dart(), self.height.into_dart()].into_dart()
+        vec![
+            self.width.into_into_dart().into_dart(),
+            self.height.into_into_dart().into_dart(),
+        ]
+        .into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for Size {}
+impl rust2dart::IntoIntoDart<Size> for Size {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//StructRef(IrTypeStructRef { name: "TreeNode", freezed: false, empty: false })
 impl support::IntoDart for TreeNode {
     fn into_dart(self) -> support::DartAbi {
-        vec![self.name.into_dart(), self.children.into_dart()].into_dart()
+        vec![
+            self.name.into_into_dart().into_dart(),
+            self.children.into_into_dart().into_dart(),
+        ]
+        .into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for TreeNode {}
+impl rust2dart::IntoIntoDart<TreeNode> for TreeNode {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
+//Primitive(U32)
+
+//Primitive(U8)
+
+//PrimitiveList(IrTypePrimitiveList { primitive: U8 })
+
+//Primitive(Unit)
+
+//StructRef(IrTypeStructRef { name: "UserId", freezed: true, empty: false })
 impl support::IntoDart for UserId {
     fn into_dart(self) -> support::DartAbi {
-        vec![self.value.into_dart()].into_dart()
+        vec![self.value.into_into_dart().into_dart()].into_dart()
     }
 }
 impl support::IntoDartExceptPrimitive for UserId {}
+impl rust2dart::IntoIntoDart<UserId> for UserId {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
 
 // Section: executor
 

--- a/frb_example/with_flutter/rust/src/bridge_generated.rs
+++ b/frb_example/with_flutter/rust/src/bridge_generated.rs
@@ -316,13 +316,6 @@ impl Wire2Api<u8> for u8 {
 
 // Section: impl IntoDart
 
-//Delegate(String)
-
-//Delegate(ZeroCopyBufferVecPrimitive(U8))
-
-//Boxed(IrTypeBoxed { exist_in_real_api: true, inner: StructRef(IrTypeStructRef { name: "Point", freezed: false, empty: false }) })
-
-//StructRef(IrTypeStructRef { name: "BoxedPoint", freezed: false, empty: false })
 impl support::IntoDart for BoxedPoint {
     fn into_dart(self) -> support::DartAbi {
         vec![self.point.into_into_dart().into_dart()].into_dart()
@@ -335,15 +328,6 @@ impl rust2dart::IntoIntoDart<BoxedPoint> for BoxedPoint {
     }
 }
 
-//Primitive(F64)
-
-//Primitive(I32)
-
-//GeneralList(IrTypeGeneralList { inner: StructRef(IrTypeStructRef { name: "Size", freezed: false, empty: false }) })
-
-//GeneralList(IrTypeGeneralList { inner: StructRef(IrTypeStructRef { name: "TreeNode", freezed: false, empty: false }) })
-
-//StructRef(IrTypeStructRef { name: "Point", freezed: false, empty: false })
 impl support::IntoDart for Point {
     fn into_dart(self) -> support::DartAbi {
         vec![
@@ -360,7 +344,6 @@ impl rust2dart::IntoIntoDart<Point> for Point {
     }
 }
 
-//StructRef(IrTypeStructRef { name: "Size", freezed: false, empty: false })
 impl support::IntoDart for Size {
     fn into_dart(self) -> support::DartAbi {
         vec![
@@ -377,7 +360,6 @@ impl rust2dart::IntoIntoDart<Size> for Size {
     }
 }
 
-//StructRef(IrTypeStructRef { name: "TreeNode", freezed: false, empty: false })
 impl support::IntoDart for TreeNode {
     fn into_dart(self) -> support::DartAbi {
         vec![
@@ -394,15 +376,6 @@ impl rust2dart::IntoIntoDart<TreeNode> for TreeNode {
     }
 }
 
-//Primitive(U32)
-
-//Primitive(U8)
-
-//PrimitiveList(IrTypePrimitiveList { primitive: U8 })
-
-//Primitive(Unit)
-
-//StructRef(IrTypeStructRef { name: "UserId", freezed: true, empty: false })
 impl support::IntoDart for UserId {
     fn into_dart(self) -> support::DartAbi {
         vec![self.value.into_into_dart().into_dart()].into_dart()

--- a/frb_rust/Cargo.toml
+++ b/frb_rust/Cargo.toml
@@ -18,7 +18,6 @@ parking_lot = "0.12.1"
 flutter_rust_bridge_macros = { workspace = true }
 uuid = { workspace = true, optional = true }
 log = "0.4"
-type-equals = "0.1.0"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 allo-isolate = { workspace = true }

--- a/frb_rust/Cargo.toml
+++ b/frb_rust/Cargo.toml
@@ -18,6 +18,7 @@ parking_lot = "0.12.1"
 flutter_rust_bridge_macros = { workspace = true }
 uuid = { workspace = true, optional = true }
 log = "0.4"
+type-equals = "0.1.0"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 allo-isolate = { workspace = true }

--- a/frb_rust/src/handler.rs
+++ b/frb_rust/src/handler.rs
@@ -204,7 +204,8 @@ impl<EH: ErrorHandler> Executor for ThreadPoolExecutor<EH> {
                 #[allow(clippy::clone_on_copy)]
                 let rust2dart = Rust2Dart::new(port2.clone());
 
-                let ret = task(TaskCallback::new(rust2dart.clone())).map(|e| e.into().into_dart());
+                let ret = task(TaskCallback::new(rust2dart.clone()))
+                    .map(|e| e.into_into_dart().into_dart());
 
                 match ret {
                     Ok(result) => {

--- a/frb_rust/src/into_into_dart.rs
+++ b/frb_rust/src/into_into_dart.rs
@@ -5,13 +5,15 @@ use crate::{ffi::*, DartSafe};
 /// These blanket implementations allow us to accept external types in various places.
 /// The initial reason for this was to allow mirrored types in StreamSink<>.
 /// See also [PR 1285](https://github.com/fzyzcjy/flutter_rust_bridge/pull/1285)
-pub trait IntoIntoDart<D> {
+pub trait IntoIntoDart<D: IntoDart> {
     fn into_into_dart(self) -> D;
 }
 
 impl<T, D> IntoIntoDart<Vec<D>> for Vec<T>
 where
     T: IntoIntoDart<D>,
+    Vec<D>: IntoDart,
+    D: IntoDart,
 {
     fn into_into_dart(self) -> Vec<D> {
         self.into_iter().map(|e| e.into_into_dart()).collect()
@@ -21,6 +23,7 @@ where
 impl<T, D> IntoIntoDart<Option<D>> for Option<T>
 where
     T: IntoIntoDart<D>,
+    D: IntoDart,
 {
     fn into_into_dart(self) -> Option<D> {
         self.map(|e| e.into_into_dart())
@@ -39,6 +42,8 @@ where
 impl<T, D> IntoIntoDart<ZeroCopyBuffer<D>> for ZeroCopyBuffer<T>
 where
     T: IntoIntoDart<D>,
+    D: IntoDart,
+    ZeroCopyBuffer<D>: IntoDart,
 {
     fn into_into_dart(self) -> ZeroCopyBuffer<D> {
         ZeroCopyBuffer(self.0.into_into_dart())
@@ -48,6 +53,7 @@ where
 impl<T, const C: usize> IntoIntoDart<[T; C]> for [T; C]
 where
     T: IntoDart,
+    [T; C]: IntoDart,
 {
     fn into_into_dart(self) -> [T; C] {
         self
@@ -67,7 +73,9 @@ where
 impl<A, AD, B, BD> IntoIntoDart<(AD, BD)> for (A, B)
 where
     A: IntoIntoDart<AD>,
+    AD: IntoDart,
     B: IntoIntoDart<BD>,
+    BD: IntoDart,
 {
     fn into_into_dart(self) -> (AD, BD) {
         (self.0.into_into_dart(), self.1.into_into_dart())
@@ -76,8 +84,11 @@ where
 impl<A, AD, B, BD, C, CD> IntoIntoDart<(AD, BD, CD)> for (A, B, C)
 where
     A: IntoIntoDart<AD>,
+    AD: IntoDart,
     B: IntoIntoDart<BD>,
+    BD: IntoDart,
     C: IntoIntoDart<CD>,
+    CD: IntoDart,
 {
     fn into_into_dart(self) -> (AD, BD, CD) {
         (
@@ -90,9 +101,13 @@ where
 impl<A, AD, B, BD, C, CD, D, DD> IntoIntoDart<(AD, BD, CD, DD)> for (A, B, C, D)
 where
     A: IntoIntoDart<AD>,
+    AD: IntoDart,
     B: IntoIntoDart<BD>,
+    BD: IntoDart,
     C: IntoIntoDart<CD>,
+    CD: IntoDart,
     D: IntoIntoDart<DD>,
+    DD: IntoDart,
 {
     fn into_into_dart(self) -> (AD, BD, CD, DD) {
         (
@@ -106,10 +121,15 @@ where
 impl<A, AD, B, BD, C, CD, D, DD, E, ED> IntoIntoDart<(AD, BD, CD, DD, ED)> for (A, B, C, D, E)
 where
     A: IntoIntoDart<AD>,
+    AD: IntoDart,
     B: IntoIntoDart<BD>,
+    BD: IntoDart,
     C: IntoIntoDart<CD>,
+    CD: IntoDart,
     D: IntoIntoDart<DD>,
+    DD: IntoDart,
     E: IntoIntoDart<ED>,
+    ED: IntoDart,
 {
     fn into_into_dart(self) -> (AD, BD, CD, DD, ED) {
         (
@@ -151,7 +171,6 @@ impl_into_into_dart!(f64);
 impl_into_into_dart!(bool);
 impl_into_into_dart!(());
 impl_into_into_dart!(usize);
-impl_into_into_dart!(isize);
 impl_into_into_dart!(String);
 impl_into_into_dart!(DartOpaque);
 #[cfg(not(target_family = "wasm"))]

--- a/frb_rust/src/into_into_dart.rs
+++ b/frb_rust/src/into_into_dart.rs
@@ -175,7 +175,8 @@ impl_into_into_dart!(String);
 impl_into_into_dart!(DartOpaque);
 #[cfg(not(target_family = "wasm"))]
 impl_into_into_dart!(allo_isolate::ffi::DartCObject);
-
+#[cfg(target_family = "wasm")]
+impl_into_into_dart!(crate::JsValue);
 #[cfg(feature = "uuid")]
 impl_into_into_dart!(uuid::Uuid);
 

--- a/frb_rust/src/into_into_dart.rs
+++ b/frb_rust/src/into_into_dart.rs
@@ -1,0 +1,172 @@
+use crate::{ffi::*, DartSafe};
+
+/// Basically the Into trait.
+/// We need this separate trait because we need to implement it for Vec<T> etc.
+/// These blanket implementations allow us to accept external types in various places.
+/// The initial reason for this was to allow mirrored types in StreamSink<>.
+/// See also [PR 1285](https://github.com/fzyzcjy/flutter_rust_bridge/pull/1285)
+pub trait IntoIntoDart<D> {
+    fn into_into_dart(self) -> D;
+}
+
+impl<T, D> IntoIntoDart<Vec<D>> for Vec<T>
+where
+    T: IntoIntoDart<D>,
+{
+    fn into_into_dart(self) -> Vec<D> {
+        self.into_iter().map(|e| e.into_into_dart()).collect()
+    }
+}
+
+impl<T, D> IntoIntoDart<Option<D>> for Option<T>
+where
+    T: IntoIntoDart<D>,
+{
+    fn into_into_dart(self) -> Option<D> {
+        self.map(|e| e.into_into_dart())
+    }
+}
+
+impl<T> IntoIntoDart<RustOpaque<T>> for RustOpaque<T>
+where
+    T: DartSafe,
+{
+    fn into_into_dart(self) -> RustOpaque<T> {
+        self
+    }
+}
+
+impl<T, D> IntoIntoDart<ZeroCopyBuffer<D>> for ZeroCopyBuffer<T>
+where
+    T: IntoIntoDart<D>,
+{
+    fn into_into_dart(self) -> ZeroCopyBuffer<D> {
+        ZeroCopyBuffer(self.0.into_into_dart())
+    }
+}
+
+impl<T, const C: usize> IntoIntoDart<[T; C]> for [T; C]
+where
+    T: IntoDart,
+{
+    fn into_into_dart(self) -> [T; C] {
+        self
+    }
+}
+
+impl<T> IntoIntoDart<T> for Box<T>
+where
+    T: IntoDart,
+{
+    fn into_into_dart(self) -> T {
+        *self
+    }
+}
+
+// These tuple impls should probably be a macro, but that is not easily possible with macro_rules because of the field access
+impl<A, AD, B, BD> IntoIntoDart<(AD, BD)> for (A, B)
+where
+    A: IntoIntoDart<AD>,
+    B: IntoIntoDart<BD>,
+{
+    fn into_into_dart(self) -> (AD, BD) {
+        (self.0.into_into_dart(), self.1.into_into_dart())
+    }
+}
+impl<A, AD, B, BD, C, CD> IntoIntoDart<(AD, BD, CD)> for (A, B, C)
+where
+    A: IntoIntoDart<AD>,
+    B: IntoIntoDart<BD>,
+    C: IntoIntoDart<CD>,
+{
+    fn into_into_dart(self) -> (AD, BD, CD) {
+        (
+            self.0.into_into_dart(),
+            self.1.into_into_dart(),
+            self.2.into_into_dart(),
+        )
+    }
+}
+impl<A, AD, B, BD, C, CD, D, DD> IntoIntoDart<(AD, BD, CD, DD)> for (A, B, C, D)
+where
+    A: IntoIntoDart<AD>,
+    B: IntoIntoDart<BD>,
+    C: IntoIntoDart<CD>,
+    D: IntoIntoDart<DD>,
+{
+    fn into_into_dart(self) -> (AD, BD, CD, DD) {
+        (
+            self.0.into_into_dart(),
+            self.1.into_into_dart(),
+            self.2.into_into_dart(),
+            self.3.into_into_dart(),
+        )
+    }
+}
+impl<A, AD, B, BD, C, CD, D, DD, E, ED> IntoIntoDart<(AD, BD, CD, DD, ED)> for (A, B, C, D, E)
+where
+    A: IntoIntoDart<AD>,
+    B: IntoIntoDart<BD>,
+    C: IntoIntoDart<CD>,
+    D: IntoIntoDart<DD>,
+    E: IntoIntoDart<ED>,
+{
+    fn into_into_dart(self) -> (AD, BD, CD, DD, ED) {
+        (
+            self.0.into_into_dart(),
+            self.1.into_into_dart(),
+            self.2.into_into_dart(),
+            self.3.into_into_dart(),
+            self.4.into_into_dart(),
+        )
+    }
+}
+
+// more generic impls do not work because they crate possibly conflicting trait impls
+// this is why here are some more specific impls
+
+// Implementations for simple types
+macro_rules! impl_into_into_dart {
+    ($t:ty) => {
+        impl IntoIntoDart<$t> for $t {
+            fn into_into_dart(self) -> $t {
+                self
+            }
+        }
+    };
+}
+
+// Impls for primitive types are taken from the IntoDart trait
+
+impl_into_into_dart!(u8);
+impl_into_into_dart!(i8);
+impl_into_into_dart!(u16);
+impl_into_into_dart!(i16);
+impl_into_into_dart!(u32);
+impl_into_into_dart!(i32);
+impl_into_into_dart!(u64);
+impl_into_into_dart!(i64);
+impl_into_into_dart!(f32);
+impl_into_into_dart!(f64);
+impl_into_into_dart!(bool);
+impl_into_into_dart!(());
+impl_into_into_dart!(usize);
+impl_into_into_dart!(isize);
+impl_into_into_dart!(String);
+impl_into_into_dart!(DartOpaque);
+#[cfg(not(target_family = "wasm"))]
+impl_into_into_dart!(allo_isolate::ffi::DartCObject);
+
+#[cfg(feature = "uuid")]
+impl_into_into_dart!(uuid::Uuid);
+
+#[cfg(feature = "chrono")]
+mod chrono_impls {
+    use chrono::{Local, Utc};
+
+    use super::IntoIntoDart;
+    impl_into_into_dart!(chrono::Duration);
+    impl_into_into_dart!(chrono::NaiveDateTime);
+    impl_into_into_dart!(chrono::DateTime<Local>);
+    impl_into_into_dart!(chrono::DateTime<Utc>);
+}

--- a/frb_rust/src/lib.rs
+++ b/frb_rust/src/lib.rs
@@ -2,7 +2,7 @@ use std::panic::{RefUnwindSafe, UnwindSafe};
 
 pub use flutter_rust_bridge_macros::frb;
 pub use handler::{FfiCallMode, Handler, WrapInfo};
-pub use rust2dart::{StreamSink, StreamSinkTrait};
+pub use rust2dart::StreamSink;
 
 pub mod ffi;
 pub use ffi::*;

--- a/frb_rust/src/lib.rs
+++ b/frb_rust/src/lib.rs
@@ -2,7 +2,7 @@ use std::panic::{RefUnwindSafe, UnwindSafe};
 
 pub use flutter_rust_bridge_macros::frb;
 pub use handler::{FfiCallMode, Handler, WrapInfo};
-pub use rust2dart::StreamSink;
+pub use rust2dart::{StreamSink, StreamSinkTrait};
 
 pub mod ffi;
 pub use ffi::*;

--- a/frb_rust/src/lib.rs
+++ b/frb_rust/src/lib.rs
@@ -12,6 +12,7 @@ pub mod thread;
 pub mod handler;
 #[macro_use]
 mod macros;
+mod into_into_dart;
 pub mod rust2dart;
 pub mod support;
 

--- a/frb_rust/src/rust2dart.rs
+++ b/frb_rust/src/rust2dart.rs
@@ -258,8 +258,9 @@ impl_into_into_dart!(());
 impl_into_into_dart!(usize);
 impl_into_into_dart!(isize);
 impl_into_into_dart!(String);
-impl_into_into_dart!(allo_isolate::ffi::DartCObject);
 impl_into_into_dart!(DartOpaque);
+#[cfg(not(target_family = "wasm"))]
+impl_into_into_dart!(allo_isolate::ffi::DartCObject);
 
 #[cfg(feature = "uuid")]
 impl_into_into_dart!(uuid::Uuid);

--- a/frb_rust/src/rust2dart.rs
+++ b/frb_rust/src/rust2dart.rs
@@ -145,14 +145,15 @@ impl<T> StreamSink<T> {
     }
 }
 
-pub trait StreamSinkTrait<T> {
+pub trait StreamSinkTrait<T, D> {
     fn add(&self, value: T) -> bool;
 }
 
 // all the simple types without additional Conversions
-impl<T> StreamSinkTrait<T> for StreamSink<T>
+impl<T, D> StreamSinkTrait<T, D> for StreamSink<T>
 where
-    T: IntoIntoDart<T> + IntoDart,
+    T: IntoIntoDart<D>,
+    D: IntoDart,
 {
     fn add(&self, value: T) -> bool {
         self.add_inner(value)

--- a/frb_rust/src/rust2dart.rs
+++ b/frb_rust/src/rust2dart.rs
@@ -211,6 +211,24 @@ where
     }
 }
 
+impl<T, const C: usize> IntoIntoDart<[T; C]> for [T; C]
+where
+    T: IntoDart,
+{
+    fn into_into_dart(self) -> [T; C] {
+        self
+    }
+}
+
+impl<T> IntoIntoDart<T> for Box<T>
+where
+    T: IntoDart,
+{
+    fn into_into_dart(self) -> T {
+        *self
+    }
+}
+
 // more generic impls do not work because they crate possibly conflicting trait impls
 // this is why here are some more specific impls
 
@@ -240,3 +258,19 @@ impl_into_into_dart!(());
 impl_into_into_dart!(usize);
 impl_into_into_dart!(isize);
 impl_into_into_dart!(String);
+impl_into_into_dart!(allo_isolate::ffi::DartCObject);
+impl_into_into_dart!(DartOpaque);
+
+#[cfg(feature = "uuid")]
+impl_into_into_dart!(uuid::Uuid);
+
+#[cfg(feature = "chrono")]
+mod chrono_impls {
+    use chrono::{Local, Utc};
+
+    use super::IntoIntoDart;
+    impl_into_into_dart!(chrono::Duration);
+    impl_into_into_dart!(chrono::NaiveDateTime);
+    impl_into_into_dart!(chrono::DateTime<Local>);
+    impl_into_into_dart!(chrono::DateTime<Utc>);
+}

--- a/frb_rust/src/rust2dart.rs
+++ b/frb_rust/src/rust2dart.rs
@@ -1,6 +1,7 @@
 //! Manages receiving and sending values across the FFI boundary.
 
 use std::marker::PhantomData;
+use type_equals::TypeEquals;
 
 /// The representation of a Dart object outside of the Dart heap.
 ///
@@ -134,7 +135,7 @@ impl<T> StreamSink<T> {
 
     /// Add data to the stream. Returns false when data could not be sent,
     /// or the stream has been closed.
-    pub fn add_inner<V: IntoIntoDart<D>, D: IntoDart>(&self, value: V) -> bool {
+    pub fn add<V: IntoIntoDart<D> + TypeEquals<Other = T>, D: IntoDart>(&self, value: V) -> bool {
         self.rust2dart().success(value.into_into_dart().into_dart())
     }
 
@@ -142,21 +143,6 @@ impl<T> StreamSink<T> {
     /// the stream could not be closed, or when it has already been closed.
     pub fn close(&self) -> bool {
         self.rust2dart().close_stream()
-    }
-}
-
-pub trait StreamSinkTrait<T, D> {
-    fn add(&self, value: T) -> bool;
-}
-
-// all the simple types without additional Conversions
-impl<T, D> StreamSinkTrait<T, D> for StreamSink<T>
-where
-    T: IntoIntoDart<D>,
-    D: IntoDart,
-{
-    fn add(&self, value: T) -> bool {
-        self.add_inner(value)
     }
 }
 

--- a/frb_rust/src/rust2dart.rs
+++ b/frb_rust/src/rust2dart.rs
@@ -150,9 +150,9 @@ pub trait IntoIntoDart<D> {
 
 impl<T, D> IntoIntoDart<Vec<D>> for Vec<T>
 where
-    T: Clone + IntoIntoDart<D>,
+    T: IntoIntoDart<D>,
 {
-    fn into(self) -> Vec<D> {
-        self.iter().map(|e| e.clone().into()).collect()
+    fn into(mut self) -> Vec<D> {
+        self.drain(0..).map(|e| e.into()).collect()
     }
 }


### PR DESCRIPTION
## Changes

The basic idea is to crate a trait IntoIntoDart that can be used to convert a type to another type that then implements IntoDart. This can then be used as constraint for StreamSink to allow a type that converts to a mirror_type that then implements IntoDart.

I have some local changes that I didn't commit  yet. With some more generic impls and adjustments in the generator this removes explicit wrapping into mirror types basically everywhere, also in the generated code.

Fixes #1275 

## Checklist

- [x] An issue to be fixed by this PR is listed above.
- [x] New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api.rs` and `dart/lib/main.dart`.
- [x] The code generator is run and the code is formatted (via `just precommit`).
- [x] If this PR adds/changes features, documentations (in the `./book` folder) are updated.
- [x] CI is passing.
