### PR TITLE
feat: reinforce error handling, reduce panics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ flutter_rust_bridge_macros = { path = "frb_macros", version = "1" }
 flutter_rust_bridge = { path = "frb_rust", default-features = false, version = "1" }
 flutter_rust_bridge_codegen = { path = "frb_codegen", version = "1" }
 
-[profile.release]
+[profile.release.package.flutter_rust_bridge_codegen]
 strip = "debuginfo"
-lto = "thin"
 debug = 1 # preserves some debug information

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,4 @@ flutter_rust_bridge_codegen = { path = "frb_codegen", version = "1" }
 [profile.release]
 strip = "debuginfo"
 lto = "thin"
+debug = 1 # preserves some debug information

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ anyhow = "1.0.64"
 chrono = "0.4.23"
 lazy_static = "1.4.0"
 uuid = "1.1.2"
+thiserror = "1.0"
 
 flutter_rust_bridge_macros = { path = "frb_macros", version = "1" }
 flutter_rust_bridge = { path = "frb_rust", default-features = false, version = "1" }

--- a/book/src/help.txt
+++ b/book/src/help.txt
@@ -83,6 +83,9 @@ Options:
       --no-dart3
           Disable language features introduced in Dart 3
 
+      --keep-going
+          If set, the program will delay error reporting until all codegen operations have completed
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/frb_codegen/Cargo.toml
+++ b/frb_codegen/Cargo.toml
@@ -54,7 +54,7 @@ i686-pc-windows-msvc = {pkg-fmt = "zip"}
 x86_64-pc-windows-msvc = {pkg-fmt = "zip"}
 
 [features]
-default = ["chrono", "serde", "uuid"]
+default = ["chrono", "serde", "uuid", "anyhow/backtrace"]
 serde = []
 chrono = []
 uuid = []

--- a/frb_codegen/Cargo.toml
+++ b/frb_codegen/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = {workspace = true}
+thiserror = {workspace = true}
 cargo_metadata = "0.14.1"
 convert_case = "0.5.0"
 delegate = "0.8.0"
@@ -36,7 +37,6 @@ serde_yaml = "0.8"
 strum_macros = "0.24.3"
 syn = {version = "2.0.26", features = ["full", "extra-traits"]}
 tempfile = "3.2.0"
-thiserror = "1"
 toml = "0.5.8"
 topological-sort = "0.2.2"
 enum-iterator = "1.4.0"

--- a/frb_codegen/src/commands.rs
+++ b/frb_codegen/src/commands.rs
@@ -104,9 +104,7 @@ fn cbindgen(
 
     debug!("cbindgen config: {:#?}", config);
 
-    let canonical = Path::new(rust_crate_dir)
-        .canonicalize()
-        .expect("Could not canonicalize rust crate dir");
+    let canonical = Path::new(rust_crate_dir).canonicalize()?;
     let mut path = canonical.to_str().unwrap();
 
     // on windows get rid of the UNC path

--- a/frb_codegen/src/commands.rs
+++ b/frb_codegen/src/commands.rs
@@ -1,3 +1,4 @@
+use crate::Result;
 use cargo_metadata::VersionReq;
 use lazy_static::lazy_static;
 use std::fmt::Write;
@@ -6,10 +7,13 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use crate::command_run;
-use crate::error::{Error, Result};
 use crate::utils::command_runner::{call_shell, execute_command};
 use crate::utils::dart_repository::dart_repo::{DartDependencyMode, DartRepository};
 use log::{debug, info};
+
+mod error;
+pub use error::Error;
+pub(crate) type CommandResult<T = (), E = Error> = core::result::Result<T, E>;
 
 lazy_static! {
     pub(crate) static ref FFI_REQUIREMENT: VersionReq =
@@ -18,11 +22,10 @@ lazy_static! {
         VersionReq::parse(">= 8.0.0, < 9.0.0").unwrap();
 }
 
-pub fn ensure_tools_available(dart_root: &str, skip_deps_check: bool) -> Result {
-    let repo =
-        DartRepository::from_str(dart_root).map_err(|e| Error::StringError(e.to_string()))?;
+pub fn ensure_tools_available(dart_root: &str, skip_deps_check: bool) -> Result<(), Error> {
+    let repo = DartRepository::from_str(dart_root)?;
     if !repo.toolchain_available() {
-        return Err(Error::MissingExe(repo.toolchain.to_string()));
+        return Err(Error::MissingExe(repo.toolchain.to_string()))?;
     }
 
     if !skip_deps_check {
@@ -50,7 +53,7 @@ pub(crate) struct BindgenRustToDartArg<'a> {
 pub(crate) fn bindgen_rust_to_dart(
     arg: BindgenRustToDartArg,
     dart_root: &str,
-) -> anyhow::Result<()> {
+) -> CommandResult<()> {
     cbindgen(
         arg.rust_crate_dir,
         arg.c_output_path,
@@ -72,7 +75,7 @@ fn cbindgen(
     c_output_path: &str,
     c_struct_names: Vec<String>,
     exclude_symbols: Vec<String>,
-) -> anyhow::Result<()> {
+) -> CommandResult {
     debug!(
         "execute cbindgen rust_crate_dir={} c_output_path={}",
         rust_crate_dir, c_output_path
@@ -114,7 +117,7 @@ fn cbindgen(
     if cbindgen::generate_with_config(path, config)?.write_to_file(c_output_path) {
         Ok(())
     } else {
-        Err(Error::string("cbindgen failed writing file").into())
+        Err(anyhow::anyhow!("cbindgen failed writing file"))?
     }
 }
 
@@ -125,7 +128,7 @@ fn ffigen(
     llvm_path: &[String],
     llvm_compiler_opts: &str,
     dart_root: &str,
-) -> anyhow::Result<()> {
+) -> CommandResult {
     debug!(
         "execute ffigen c_path={} dart_path={} llvm_path={:?}",
         c_path, dart_path, llvm_path
@@ -184,9 +187,11 @@ fn ffigen(
         let out = String::from_utf8_lossy(&res.stdout);
         let pat = "Couldn't find dynamic library in default locations.";
         if err.contains(pat) || out.contains(pat) {
-            return Err(Error::FfigenLlvm.into());
+            return Err(Error::FfigenLlvm);
         }
-        return Err(Error::string(format!("ffigen failed:\nstderr: {err}\nstdout: {out}")).into());
+        Err(anyhow::anyhow!(
+            "ffigen failed:\nstderr: {err}\nstdout: {out}"
+        ))?;
     }
     Ok(())
 }
@@ -195,9 +200,7 @@ pub fn format_rust(path: &[PathBuf]) -> Result {
     debug!("execute format_rust path={:?}", path);
     let res = execute_command("rustfmt", path, None)?;
     if !res.status.success() {
-        return Err(Error::Rustfmt(
-            String::from_utf8_lossy(&res.stderr).to_string(),
-        ));
+        return Err(Error::Rustfmt(String::from_utf8_lossy(&res.stderr).to_string()).into());
     }
     Ok(())
 }
@@ -214,12 +217,11 @@ pub fn format_dart(path: &[PathBuf], line_length: u32) -> Result {
         "--line-length",
         line_length.to_string(),
         *path
-    )
-    .map_err(|err| Error::StringError(format!("{err}")))?;
+    )?;
     if !res.status.success() {
-        return Err(Error::Dartfmt(
+        Err(Error::Dartfmt(
             String::from_utf8_lossy(&res.stderr).to_string(),
-        ));
+        ))?;
     }
     Ok(())
 }
@@ -237,11 +239,11 @@ pub fn build_runner(dart_root: &str) -> Result {
         "--enable-experiment=class-modifiers",
     )?;
     if !out.status.success() {
-        return Err(Error::StringError(format!(
+        Err(anyhow::anyhow!(
             "Failed to run build_runner for {}: {}",
             dart_root,
             String::from_utf8_lossy(&out.stdout)
-        )));
+        ))?;
     }
     Ok(())
 }

--- a/frb_codegen/src/commands/error.rs
+++ b/frb_codegen/src/commands/error.rs
@@ -28,10 +28,10 @@ pub enum Error {
         manager: DartDependencyMode,
         requirement: String,
     },
-    #[error(transparent)]
-    Uncategorized(#[from] anyhow::Error),
     #[error("I/O failure.\n{0}")]
     Io(#[from] std::io::Error),
     #[error("Formatting failure.\n{0}")]
     Fmt(#[from] std::fmt::Error),
+    #[error(transparent)]
+    Uncategorized(#[from] anyhow::Error),
 }

--- a/frb_codegen/src/commands/error.rs
+++ b/frb_codegen/src/commands/error.rs
@@ -1,0 +1,37 @@
+use crate::utils::dart_repository::dart_repo::DartDependencyMode;
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("rustfmt failed: {0}")]
+    Rustfmt(String),
+    #[error("dart fmt failed: {0}")]
+    Dartfmt(String),
+    #[error(
+"ffigen could not find LLVM. Please supply --llvm-path to flutter_rust_bridge_codegen, e.g.:
+
+    flutter_rust_bridge_codegen .. --llvm-path <path_to_llvm>"
+    )]
+    FfigenLlvm,
+    #[error("{0} is not a command, or not executable.")]
+    MissingExe(String),
+    #[error(transparent)]
+    Cbindgen(#[from] cbindgen::Error),
+    #[error("Please add {name} to your {manager}. (version {requirement})")]
+    MissingDep {
+        name: String,
+        manager: DartDependencyMode,
+        requirement: String,
+    },
+    #[error("Please update version of {name} in your {manager}. (version {requirement})")]
+    InvalidDep {
+        name: String,
+        manager: DartDependencyMode,
+        requirement: String,
+    },
+    #[error(transparent)]
+    Uncategorized(#[from] anyhow::Error),
+    #[error("I/O failure.\n{0}")]
+    Io(#[from] std::io::Error),
+    #[error("Formatting failure.\n{0}")]
+    Fmt(#[from] std::fmt::Error),
+}

--- a/frb_codegen/src/config/error.rs
+++ b/frb_codegen/src/config/error.rs
@@ -1,0 +1,8 @@
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(
+        "build_runner configured to run, but Dart root could not be inferred.
+Please specify --dart-root, or disable build_runner with --no-build-runner."
+    )]
+    FailedInferDartRoot,
+}

--- a/frb_codegen/src/config/mod.rs
+++ b/frb_codegen/src/config/mod.rs
@@ -3,3 +3,7 @@ pub mod opts_parser;
 pub(crate) mod raw_opts;
 pub(crate) mod raw_opts_parser;
 pub(crate) mod refine_c_output;
+
+mod error;
+pub(crate) use error::Error;
+// pub(crate) type ConfigResult<T = (), E = Error> = core::result::Result<T, E>;

--- a/frb_codegen/src/config/opts.rs
+++ b/frb_codegen/src/config/opts.rs
@@ -1,7 +1,6 @@
 use crate::ir::IrFile;
-use crate::parser;
+use crate::parser::{self, ParserResult};
 use crate::utils::misc::BlockIndex;
-use anyhow::{Context, Result};
 use convert_case::{Case, Casing};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -31,26 +30,17 @@ pub struct Opts {
     pub bridge_in_method: bool,
     pub extra_headers: String,
     pub dart3: bool,
+    pub keep_going: bool,
 }
 
 impl Opts {
-    pub fn get_ir_file(&self) -> Result<IrFile> {
+    pub fn get_ir_file(&self) -> ParserResult<IrFile> {
         // info!("Phase: Parse source code to AST");
-        let source_rust_content = fs::read_to_string(&self.rust_input_path).with_context(|| {
-            format!(
-                "Failed to read rust input file \"{}\"",
-                self.rust_input_path
-            )
-        })?;
-        let file_ast = syn::parse_file(&source_rust_content).unwrap();
+        let source_rust_content = fs::read_to_string(&self.rust_input_path)?;
+        let file_ast = syn::parse_file(&source_rust_content)?;
 
         // info!("Phase: Parse AST to IR");
-
-        Ok(parser::parse(
-            &source_rust_content,
-            file_ast,
-            &self.manifest_path,
-        ))
+        parser::parse(&source_rust_content, file_ast, &self.manifest_path)
     }
 
     pub fn dart_api_class_name(&self) -> &str {

--- a/frb_codegen/src/config/opts_parser.rs
+++ b/frb_codegen/src/config/opts_parser.rs
@@ -309,7 +309,7 @@ pub(crate) fn format_fail_to_guess_error(name: &str) -> String {
 fn fallback_rust_crate_dir(rust_input_path: &str) -> Result<String> {
     let mut dir_curr = Path::new(rust_input_path)
         .parent()
-        .ok_or_else(|| anyhow!(""))?;
+        .context("Unexpected value for rust-crate-dir")?;
 
     loop {
         let path_cargo_toml = dir_curr.join("Cargo.toml");
@@ -318,7 +318,7 @@ fn fallback_rust_crate_dir(rust_input_path: &str) -> Result<String> {
             return Ok(dir_curr
                 .as_os_str()
                 .to_str()
-                .ok_or_else(|| anyhow!(""))?
+                .context("Not a UTF-8 path")?
                 .to_string());
         }
 
@@ -335,11 +335,9 @@ fn fallback_rust_crate_dir(rust_input_path: &str) -> Result<String> {
 
 fn fallback_rust_output_path(rust_input_path: &str) -> Result<String> {
     Ok(Path::new(rust_input_path)
-        .parent()
-        .ok_or_else(|| anyhow!(""))?
-        .join("bridge_generated.rs")
+        .with_file_name("bridge_generated.rs")
         .to_str()
-        .ok_or_else(|| anyhow!(""))?
+        .context("Not a UTF-8 path")?
         .to_string())
 }
 
@@ -350,7 +348,7 @@ fn fallback_dart_root(dart_output_path: &str) -> Result<String> {
             return res
                 .to_str()
                 .map(ToString::to_string)
-                .ok_or_else(|| anyhow!("Non-utf8 path"));
+                .context("Not a UTF-8 path");
         }
     }
     Err(anyhow!(
@@ -365,11 +363,11 @@ fn fallback_class_name(rust_crate_dir: &str) -> Result<String> {
     let cargo_toml_value = cargo_toml_content.parse::<Value>()?;
     let package_name = cargo_toml_value
         .get("package")
-        .ok_or_else(|| anyhow!("no `package` in Cargo.toml"))?
+        .context("no `package` in Cargo.toml")?
         .get("name")
-        .ok_or_else(|| anyhow!("no `name` in Cargo.toml"))?
+        .context("no `name` in Cargo.toml")?
         .as_str()
-        .ok_or_else(|| anyhow!(""))?;
+        .unwrap();
 
     Ok(package_name.to_case(Case::Pascal))
 }

--- a/frb_codegen/src/config/opts_parser.rs
+++ b/frb_codegen/src/config/opts_parser.rs
@@ -140,6 +140,7 @@ pub fn config_parse(mut raw: RawOpts) -> Vec<Opts> {
     let wasm = raw.wasm;
     let dart3 = raw.dart3;
     let inline_rust = raw.inline_rust;
+    let keep_going = raw.keep_going;
     let extra_headers = raw.extra_headers.unwrap_or({
         if raw.no_use_bridge_in_method {
             "import 'ffi.io.dart' if (dart.library.html) 'ffi.web.dart';".to_owned()
@@ -172,6 +173,7 @@ pub fn config_parse(mut raw: RawOpts) -> Vec<Opts> {
                 dart3,
                 inline_rust,
                 bridge_in_method,
+                keep_going,
                 extra_headers: extra_headers.clone(),
             }
         })
@@ -286,6 +288,7 @@ fn anchor_config(config: RawOpts, config_path: &str) -> RawOpts {
         skip_deps_check: config.skip_deps_check,
         no_use_bridge_in_method: config.no_use_bridge_in_method,
         extra_headers: config.extra_headers,
+        keep_going: config.keep_going,
         #[cfg(feature = "serde")]
         dump: config.dump,
     }

--- a/frb_codegen/src/config/raw_opts.rs
+++ b/frb_codegen/src/config/raw_opts.rs
@@ -122,6 +122,11 @@ pub struct RawOpts {
     #[arg(long = "no-dart3", action(ArgAction::SetFalse))]
     #[serde(default = "r#true")]
     pub dart3: bool,
+
+    /// If set, the program will delay error reporting until all codegen operations have completed.
+    #[arg(long)]
+    #[serde(default)]
+    pub keep_going: bool,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Deserialize, ValueEnum, enum_iterator::Sequence)]

--- a/frb_codegen/src/config/refine_c_output.rs
+++ b/frb_codegen/src/config/refine_c_output.rs
@@ -1,5 +1,5 @@
 use crate::config::opts_parser::{canon_path, format_fail_to_guess_error, raw_opts_bail};
-use anyhow::{anyhow, Result};
+use anyhow::{Context, Result};
 use std::path::Path;
 
 pub(crate) fn get_refined_c_output(
@@ -258,6 +258,6 @@ fn fallback_c_output_path() -> Result<String> {
     Ok(named_temp_file
         .path()
         .to_str()
-        .ok_or_else(|| anyhow!(""))?
+        .context("Not a UTF-8 path")?
         .to_string())
 }

--- a/frb_codegen/src/dump.rs
+++ b/frb_codegen/src/dump.rs
@@ -4,9 +4,10 @@ use std::collections::HashMap;
 
 use crate::config::opts::Opts;
 use crate::config::raw_opts::Dump;
+use crate::parser::ParserResult;
 use enum_iterator::all;
 
-pub fn dump_multi(configs: &[Opts], dump: Vec<Dump>) -> anyhow::Result<()> {
+pub fn dump_multi(configs: &[Opts], dump: Vec<Dump>) -> ParserResult {
     let dump = if dump.is_empty() {
         all().collect()
     } else {
@@ -24,7 +25,7 @@ pub fn dump_multi(configs: &[Opts], dump: Vec<Dump>) -> anyhow::Result<()> {
             }
             Ok(data)
         })
-        .collect::<anyhow::Result<Vec<_>>>()?;
+        .collect::<ParserResult<Vec<_>>>()?;
     let data = serde_yaml::to_string(&data)?;
     println!("{data}");
     Ok(())

--- a/frb_codegen/src/entrypoint/dart.rs
+++ b/frb_codegen/src/entrypoint/dart.rs
@@ -1,5 +1,4 @@
 use crate::commands::BindgenRustToDartArg;
-use crate::error::Error;
 use crate::others::{
     extract_dart_wire_content, modify_dart_wire_content, sanity_check, DartBasicCode,
     DUMMY_WIRE_CODE_FOR_BINDGEN, EXTRA_EXTERN_FUNC_NAMES,
@@ -19,7 +18,7 @@ pub(crate) fn generate_dart_code(
     ir_file: &ir::IrFile,
     generated_rust: generator::rust::Output,
     all_symbols: &[String],
-) -> anyhow::Result<()> {
+) -> crate::Result {
     let dart_root = config.dart_root_or_default();
     ensure_tools_available(&dart_root, config.skip_deps_check)?;
 
@@ -49,6 +48,7 @@ pub(crate) fn generate_dart_code(
                 },
                 &dart_root,
             )
+            .map_err(Into::into)
         },
     )?;
 
@@ -123,12 +123,9 @@ pub(crate) fn generate_dart_code(
     info!("Phase: Running build_runner");
     let dart_root = &config.dart_root;
     if generated_dart.needs_freezed && config.build_runner {
-        let dart_root = dart_root.as_ref().ok_or_else(|| {
-            Error::string(
-                "build_runner configured to run, but Dart root could not be inferred.
-        Please specify --dart-root, or disable build_runner with --no-build-runner.",
-            )
-        })?;
+        let dart_root = dart_root
+            .as_ref()
+            .ok_or(crate::config::Error::FailedInferDartRoot)?;
         commands::build_runner(dart_root)?;
     }
 
@@ -158,7 +155,7 @@ fn write_dart_decls(
     generated_dart: &crate::generator::dart::Output,
     generated_dart_decl_all: &DartBasicCode,
     generated_dart_impl_io_wire: &DartBasicCode,
-) -> anyhow::Result<()> {
+) -> crate::Result {
     let impl_import_decl = DartBasicCode {
         import: format!(
             "import \"{}\";",

--- a/frb_codegen/src/error.rs
+++ b/frb_codegen/src/error.rs
@@ -1,50 +1,36 @@
-use crate::utils::dart_repository::dart_repo::DartDependencyMode;
+use std::sync::Arc;
 use thiserror::Error;
 
-pub type Result<T = ()> = std::result::Result<T, Error>;
+pub type Result<T = (), E = Error> = core::result::Result<T, E>;
 
 #[derive(Error, Debug, Clone)]
-pub enum Error {
-    #[error("rustfmt failed: {0}")]
-    Rustfmt(String),
-    #[error("dart fmt failed: {0}")]
-    Dartfmt(String),
-    #[error(
-        "ffigen could not find LLVM.
-    Please supply --llvm-path to flutter_rust_bridge_codegen, e.g.:
-    
-        flutter_rust_bridge_codegen .. --llvm-path <path_to_llvm>"
-    )]
-    FfigenLlvm,
-    #[error("{0} is not a command, or not executable.")]
-    MissingExe(String),
-    #[error("{0}")]
-    StringError(String),
-    #[error("please add {name} to your {manager}. (version {requirement})")]
-    MissingDep {
-        name: String,
-        manager: DartDependencyMode,
-        requirement: String,
-    },
-    #[error("please update version of {name} in your {manager}. (version {requirement})")]
-    InvalidDep {
-        name: String,
-        manager: DartDependencyMode,
-        requirement: String,
-    },
+#[repr(transparent)]
+#[error(transparent)]
+pub struct Error(Arc<ErrorImpl>);
+
+#[derive(Error, Debug)]
+pub(crate) enum ErrorImpl {
+    #[error("External command failure.\n{0}")]
+    Command(#[from] crate::commands::Error),
+
+    #[error("Configuration error.\n{0}")]
+    Config(#[from] crate::config::Error),
+
+    #[error("Parser failure.\n{0}")]
+    Parser(#[from] crate::parser::Error),
+
+    #[error("I/O failure.\n{0}")]
+    Io(#[from] std::io::Error),
+
+    #[error(transparent)]
+    Uncategorized(#[from] anyhow::Error),
 }
 
-impl Error {
-    pub fn string<T: Into<String>>(msg: T) -> Self {
-        Self::StringError(msg.into())
-    }
-}
-
-impl From<anyhow::Error> for Error {
-    fn from(e: anyhow::Error) -> Self {
-        if let Some(e) = e.downcast_ref::<Self>() {
-            return e.clone();
-        }
-        Error::StringError(e.to_string())
+impl<E> From<E> for Error
+where
+    ErrorImpl: From<E>,
+{
+    fn from(value: E) -> Self {
+        Error(Arc::new(value.into()))
     }
 }

--- a/frb_codegen/src/lib.rs
+++ b/frb_codegen/src/lib.rs
@@ -8,24 +8,25 @@ pub use crate::config::raw_opts::RawOpts;
 pub use crate::logs::init_logger;
 pub use crate::utils::misc::get_symbols_if_no_duplicates;
 
-mod logs;
-#[macro_use]
-mod commands;
 pub mod config;
 pub mod dump;
+pub mod utils;
+
+mod commands;
 mod entrypoint;
 mod error;
 mod generator;
 mod ir;
+mod logs;
 mod others;
 mod parser;
 mod target;
 mod transformer;
-pub mod utils;
 
 use crate::entrypoint::dart::generate_dart_code;
 use crate::entrypoint::rust::generate_rust_code;
 use crate::utils::misc::BlockIndex;
+pub(crate) use error::Result;
 use log::info;
 
 /// When the API is only defined in 1 rust file(block), take this one for generation, where `config`

--- a/frb_codegen/src/main.rs
+++ b/frb_codegen/src/main.rs
@@ -32,15 +32,17 @@ fn main() -> anyhow::Result<()> {
                 errors.push((&config.rust_input_path, err));
                 continue;
             }
-            error!("fatal: {err}");
-            std::process::exit(1);
+            error!("Fatal error encountered. Rerun with RUST_BACKTRACE=1 or RUST_BACKTRACE=full for more details.");
+            return Err(err);
         }
     }
-    for (path, error) in &errors {
-        error!("Error running codegen for {path}:\n{error}");
-    }
     if !errors.is_empty() {
-        std::process::exit(1);
+        error!("Codegen failed with {} error(s).", errors.len());
+        for (path, error) in &errors {
+            error!("Error running codegen for {path}:\n{error}");
+        }
+        info!("Rerun with RUST_BACKTRACE=1 or RUST_BACKTRACE=full for more details.");
+        std::process::exit(1)
     }
 
     info!("Now go and use it :)");

--- a/frb_codegen/src/others.rs
+++ b/frb_codegen/src/others.rs
@@ -114,16 +114,12 @@ pub fn extract_dart_wire_content(content: &str) -> DartBasicCode {
     }
 }
 
-pub fn sanity_check(
-    generated_dart_wire_code: &str,
-    dart_wire_class_name: &str,
-) -> anyhow::Result<()> {
+pub fn sanity_check(generated_dart_wire_code: &str, dart_wire_class_name: &str) -> crate::Result {
     if !generated_dart_wire_code.contains(dart_wire_class_name) {
-        return Err(crate::error::Error::string(
+        Err(anyhow!(
             "Nothing is generated for dart wire class. \
             Maybe you forget to put code like `mod the_generated_bridge_code;` to your `lib.rs`?",
-        )
-        .into());
+        ))?;
     }
     Ok(())
 }

--- a/frb_codegen/src/parser/error.rs
+++ b/frb_codegen/src/parser/error.rs
@@ -1,0 +1,28 @@
+use std::sync::Arc;
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    #[error("No src/lib.rs or src/main.rs found for the specified/inferred Cargo.toml.")]
+    NoEntryPoint,
+
+    #[error("Parser bug: {0}")]
+    Syn(#[from] syn::Error),
+
+    #[error("(Bug) Unexpected pattern: {0}")]
+    UnexpectedPattern(Arc<str>),
+
+    #[error("(Bug) Unexpected parameter: {0}")]
+    UnexpectedSigInput(Arc<str>),
+
+    #[error("Mutating methods are not yet supported.")]
+    NoMutSelf,
+
+    #[error(transparent)]
+    SerdeYaml(#[from] serde_yaml::Error),
+
+    #[error(transparent)]
+    Uncategorized(#[from] anyhow::Error),
+}

--- a/frb_codegen/src/parser/mod.rs
+++ b/frb_codegen/src/parser/mod.rs
@@ -293,9 +293,9 @@ impl<'a> Parser<'a> {
         Ok(IrFunc {
             name: func_name,
             inputs,
-            output: output.expect("unsupported output"),
+            output: output.context("Unsupported output")?,
             fallible,
-            mode: mode.expect("missing mode"),
+            mode: mode.context("Missing mode")?,
             comments: extract_comments(&func.attrs),
         })
     }
@@ -324,7 +324,7 @@ fn extract_methods_from_file(file: &File) -> ParserResult<Vec<ItemFn>> {
                 if let ImplItem::Fn(item_method) = item {
                     if let Visibility::Public(_) = &item_method.vis {
                         let f = item_method_to_function(item_impl, item_method)?
-                            .expect("item implementation is unsupported");
+                            .context("Unsupported item implementation")?;
                         src_fns.push(f);
                     }
                 }

--- a/frb_codegen/src/parser/mod.rs
+++ b/frb_codegen/src/parser/mod.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 use std::default::Default as _;
 use std::string::String;
 
+use anyhow::Context;
 use log::debug;
 use quote::quote;
 use syn::parse::{Parse, ParseStream};
@@ -25,6 +26,10 @@ use crate::utils::method::FunctionName;
 use self::ty::convert_ident_str;
 
 const STREAM_SINK_IDENT: &str = "StreamSink";
+
+mod error;
+pub use error::Error;
+pub(crate) type ParserResult<T = (), E = Error> = core::result::Result<T, E>;
 
 pub(crate) fn topo_resolve(src: HashMap<String, Type>) -> HashMap<String, Type> {
     // Some types that cannot be Handled.
@@ -93,11 +98,11 @@ pub(crate) fn topo_resolve(src: HashMap<String, Type>) -> HashMap<String, Type> 
     ret
 }
 
-pub fn parse(source_rust_content: &str, file: File, manifest_path: &str) -> IrFile {
-    let crate_map = Crate::new(manifest_path);
+pub fn parse(source_rust_content: &str, file: File, manifest_path: &str) -> ParserResult<IrFile> {
+    let crate_map = Crate::new(manifest_path)?;
 
     let mut src_fns = extract_fns_from_file(&file);
-    src_fns.extend(extract_methods_from_file(&file));
+    src_fns.extend(extract_methods_from_file(&file)?);
     let src_structs = crate_map.root_module.collect_structs_to_vec();
     let src_enums = crate_map.root_module.collect_enums_to_vec();
     let src_types = crate_map.root_module.collect_types_to_pool();
@@ -118,19 +123,22 @@ impl<'a> Parser<'a> {
 }
 
 impl<'a> Parser<'a> {
-    fn parse(mut self, source_rust_content: &str, src_fns: Vec<ItemFn>) -> IrFile {
-        let funcs = src_fns.iter().map(|f| self.parse_function(f)).collect();
+    fn parse(mut self, source_rust_content: &str, src_fns: Vec<ItemFn>) -> ParserResult<IrFile> {
+        let funcs = src_fns
+            .iter()
+            .map(|f| self.parse_function(f))
+            .collect::<ParserResult<Vec<_>>>()?;
 
         let has_executor = source_rust_content.contains(HANDLER_NAME);
 
         let (struct_pool, enum_pool) = self.type_parser.consume();
 
-        IrFile {
+        Ok(IrFile {
             funcs,
             struct_pool,
             enum_pool,
             has_executor,
-        }
+        })
     }
 
     /// Attempts to parse the type from the return part of a function signature. There is a special
@@ -197,7 +205,7 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn parse_function(&mut self, func: &ItemFn) -> IrFunc {
+    fn parse_function(&mut self, func: &ItemFn) -> ParserResult<IrFunc> {
         debug!("parse_function function name: {:?}", func.sig.ident);
 
         let sig = &func.sig;
@@ -213,14 +221,17 @@ impl<'a> Parser<'a> {
                 let name = if let Pat::Ident(ref pat_ident) = *pat_type.pat {
                     format!("{}", pat_ident.ident)
                 } else {
-                    panic!("unexpected pat_type={:?}", pat_type)
+                    return Err(Error::UnexpectedPattern(
+                        quote::quote!(#pat_type).to_string().into(),
+                    ));
                 };
-                match self.try_parse_fn_arg_type(&pat_type.ty).unwrap_or_else(|| {
-                    panic!(
+                let arg_type = self.try_parse_fn_arg_type(&pat_type.ty).with_context(|| {
+                    format!(
                         "Failed to parse function argument type `{}`",
                         type_to_string(&pat_type.ty)
                     )
-                }) {
+                })?;
+                match arg_type {
                     IrFuncArg::StreamSinkType(ty) => {
                         output = Some(ty);
                         mode = Some(IrFuncMode::Stream { argument_index: i });
@@ -244,19 +255,22 @@ impl<'a> Parser<'a> {
                     }
                 }
             } else {
-                panic!("unexpected sig_input={:?}", sig_input);
+                return Err(Error::UnexpectedSigInput(
+                    quote::quote!(#sig_input).to_string().into(),
+                ));
             }
         }
 
         if output.is_none() {
             output = Some(match &sig.output {
                 ReturnType::Type(_, ty) => {
-                    match self.try_parse_fn_output_type(ty).unwrap_or_else(|| {
-                        panic!(
+                    let output_type = self.try_parse_fn_output_type(ty).with_context(|| {
+                        format!(
                             "Failed to parse function output type `{}`",
                             type_to_string(ty)
                         )
-                    }) {
+                    })?;
+                    match output_type {
                         IrFuncOutput::ResultType(ty) => ty,
                         IrFuncOutput::Type(ty) => {
                             fallible = false;
@@ -276,14 +290,14 @@ impl<'a> Parser<'a> {
             });
         }
 
-        IrFunc {
+        Ok(IrFunc {
             name: func_name,
             inputs,
             output: output.expect("unsupported output"),
             fallible,
             mode: mode.expect("missing mode"),
             comments: extract_comments(&func.attrs),
-        }
+        })
     }
 }
 
@@ -301,7 +315,7 @@ fn extract_fns_from_file(file: &File) -> Vec<ItemFn> {
     src_fns
 }
 
-fn extract_methods_from_file(file: &File) -> Vec<ItemFn> {
+fn extract_methods_from_file(file: &File) -> ParserResult<Vec<ItemFn>> {
     let mut src_fns = Vec::new();
 
     for item in file.items.iter() {
@@ -309,7 +323,7 @@ fn extract_methods_from_file(file: &File) -> Vec<ItemFn> {
             for item in &item_impl.items {
                 if let ImplItem::Fn(item_method) = item {
                     if let Visibility::Public(_) = &item_method.vis {
-                        let f = item_method_to_function(item_impl, item_method)
+                        let f = item_method_to_function(item_impl, item_method)?
                             .expect("item implementation is unsupported");
                         src_fns.push(f);
                     }
@@ -318,11 +332,14 @@ fn extract_methods_from_file(file: &File) -> Vec<ItemFn> {
         }
     }
 
-    src_fns
+    Ok(src_fns)
 }
 
 // Converts an item implementation (something like fn(&self, ...)) into a function where `&self` is a named parameter to `&Self`
-fn item_method_to_function(item_impl: &ItemImpl, item_method: &ImplItemFn) -> Option<ItemFn> {
+fn item_method_to_function(
+    item_impl: &ItemImpl,
+    item_method: &ImplItemFn,
+) -> ParserResult<Option<ItemFn>> {
     if let Type::Path(p) = item_impl.self_ty.as_ref() {
         let struct_name = p.path.segments.first().unwrap().ident.to_string();
         let span = item_method.sig.ident.span();
@@ -372,7 +389,7 @@ fn item_method_to_function(item_impl: &ItemImpl, item_method: &ImplItemFn) -> Op
             )
         };
 
-        Some(ItemFn {
+        Ok(Some(ItemFn {
             attrs: item_method.attrs.clone(),
             vis: item_method.vis.clone(),
             sig: Signature {
@@ -388,7 +405,7 @@ fn item_method_to_function(item_impl: &ItemImpl, item_method: &ImplItemFn) -> Op
                     .sig
                     .inputs
                     .iter()
-                    .map(|input| {
+                    .map(|input| -> ParserResult<_> {
                         if let FnArg::Receiver(Receiver { mutability, .. }) = input {
                             let mut segments = Punctuated::new();
                             segments.push(PathSegment {
@@ -396,9 +413,9 @@ fn item_method_to_function(item_impl: &ItemImpl, item_method: &ImplItemFn) -> Op
                                 arguments: PathArguments::None,
                             });
                             if mutability.is_some() {
-                                panic!("mutable methods are unsupported for safety reasons");
+                                return Err(Error::NoMutSelf);
                             }
-                            FnArg::Typed(PatType {
+                            Ok(FnArg::Typed(PatType {
                                 attrs: vec![],
                                 pat: Box::new(Pat::Ident(PatIdent {
                                     attrs: vec![],
@@ -415,19 +432,19 @@ fn item_method_to_function(item_impl: &ItemImpl, item_method: &ImplItemFn) -> Op
                                         segments,
                                     },
                                 })),
-                            })
+                            }))
                         } else {
-                            input.clone()
+                            Ok(input.clone())
                         }
                     })
-                    .collect::<Punctuated<_, _>>(),
+                    .collect::<ParserResult<Punctuated<_, _>>>()?,
                 variadic: None,
                 output: item_method.sig.output.clone(),
             },
             block: Box::new(item_method.block.clone()),
-        })
+        }))
     } else {
-        None
+        Ok(None)
     }
 }
 
@@ -462,7 +479,7 @@ pub struct NamedOption<K, V> {
 }
 
 impl<K: Parse + std::fmt::Debug, V: Parse> Parse for NamedOption<K, V> {
-    fn parse(input: ParseStream<'_>) -> Result<Self> {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
         let name: K = input.parse()?;
         let _: Token![=] = input.parse()?;
         let value = input.parse()?;
@@ -474,7 +491,7 @@ impl<K: Parse + std::fmt::Debug, V: Parse> Parse for NamedOption<K, V> {
 pub struct MirrorOption(Path);
 
 impl Parse for MirrorOption {
-    fn parse(input: ParseStream<'_>) -> Result<Self> {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
         let content;
         parenthesized!(content in input);
         let path: Path = content.parse()?;
@@ -486,7 +503,7 @@ impl Parse for MirrorOption {
 pub struct MetadataAnnotations(Vec<IrDartAnnotation>);
 
 impl Parse for IrDartAnnotation {
-    fn parse(input: ParseStream<'_>) -> Result<Self> {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
         let annotation: LitStr = input.parse()?;
         let library = if input.peek(frb_keyword::import) {
             let _ = input.parse::<frb_keyword::import>()?;
@@ -502,7 +519,7 @@ impl Parse for IrDartAnnotation {
     }
 }
 impl Parse for MetadataAnnotations {
-    fn parse(input: ParseStream<'_>) -> Result<Self> {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
         let content;
         parenthesized!(content in input);
         let annotations =
@@ -517,7 +534,7 @@ impl Parse for MetadataAnnotations {
 pub struct DartImports(Vec<IrDartImport>);
 
 impl Parse for IrDartImport {
-    fn parse(input: ParseStream<'_>) -> Result<Self> {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
         let uri: LitStr = input.parse()?;
         let alias: Option<String> = if input.peek(token::As) {
             let _ = input.parse::<token::As>()?;
@@ -533,7 +550,7 @@ impl Parse for IrDartImport {
     }
 }
 impl Parse for DartImports {
-    fn parse(input: ParseStream<'_>) -> Result<Self> {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
         let content;
         parenthesized!(content in input);
         let imports = Punctuated::<IrDartImport, syn::Token![,]>::parse_terminated(&content)?
@@ -551,7 +568,7 @@ enum FrbOption {
 }
 
 impl Parse for FrbOption {
-    fn parse(input: ParseStream<'_>) -> Result<Self> {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
         let lookahead = input.lookahead1();
         if lookahead.peek(frb_keyword::mirror) {
             input.parse().map(FrbOption::Mirror)
@@ -669,7 +686,7 @@ impl DefaultValues {
 }
 
 impl Parse for DefaultValues {
-    fn parse(input: ParseStream) -> Result<Self> {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
         let lh = input.lookahead1();
         if lh.peek(token::Bracket) {
             let inner;

--- a/frb_codegen/src/parser/ty.rs
+++ b/frb_codegen/src/parser/ty.rs
@@ -58,7 +58,7 @@ pub fn convert_ident_str(ty: &Type) -> Option<String> {
     None
 }
 
-#[cfg(all(feature = "chrono"))]
+#[cfg(feature = "chrono")]
 fn datetime_to_ir_type(args: &[IrType]) -> std::result::Result<IrType, String> {
     if let [Unencodable(IrTypeUnencodable { segments, .. })] = args {
         let mut segments = segments.clone();

--- a/frb_codegen/src/utils/command_runner.rs
+++ b/frb_codegen/src/utils/command_runner.rs
@@ -1,7 +1,8 @@
 use crate::commands::CommandResult;
 use anyhow::Context;
 use itertools::Itertools;
-use log::{debug, log_enabled, warn};
+use log::warn;
+use log::{debug, log_enabled};
 use std::path::PathBuf;
 use std::process::Command;
 use std::process::Output;
@@ -107,7 +108,7 @@ pub(crate) fn execute_command<'a>(
 
     let result = cmd
         .output()
-        .with_context(|| format!("\"{bin}\" \"{}\" failed", args_display))?;
+        .with_context(|| format!("\"{bin}\" \"{args_display}\" failed"))?;
 
     let stdout = String::from_utf8_lossy(&result.stdout);
     if result.status.success() {

--- a/frb_codegen/src/utils/misc.rs
+++ b/frb_codegen/src/utils/misc.rs
@@ -21,11 +21,11 @@ pub fn mod_from_rust_path(code_path: &str, crate_path: &str) -> String {
         .replace('/', "::")
 }
 
-pub fn with_changed_file<F: FnOnce() -> anyhow::Result<()>>(
+pub fn with_changed_file<F: FnOnce() -> crate::Result<()>>(
     path: &str,
     append_content: &str,
     f: F,
-) -> anyhow::Result<()> {
+) -> crate::Result<()> {
     let content_original = fs::read_to_string(path)?;
     fs::write(path, content_original.clone() + append_content)?;
 

--- a/frb_example/pure_dart/dart/pubspec.yaml
+++ b/frb_example/pure_dart/dart/pubspec.yaml
@@ -3,7 +3,7 @@ description: flutter rust bridge example
 version: 1.0.0
 publish_to: none
 environment:
-  sdk: '>=3.0.0 < 4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 dependencies:
   meta: ^1.8.0
   lints: ^2.0.1

--- a/frb_example/pure_dart/dart/pubspec.yaml.release
+++ b/frb_example/pure_dart/dart/pubspec.yaml.release
@@ -3,7 +3,7 @@ description: flutter rust bridge example
 version: 1.0.0
 publish_to: none
 environment:
-  sdk: '>=3.0.0 < 4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 dependencies:
   meta: ^1.8.0
   lints: ^2.0.0


### PR DESCRIPTION
## Changes

- Replace `anyhow::Error` with canonical error listings for library functions
  - Each module tries to manage its own error listing, rather than a single union of errors
- Allow `Err(anyhow!(..))?` as the new adhoc error syntax
  - Aim to reduce dependency on panicking as an error handling mechanism
- New flag `--keep-going` to delay error reporting to after codegen
- Use `anyhow::Context` where possible to make code concise and preserve backtraces

IR functions and methods are not included and should/may come in a separate PR.

The following public APIs have been changed:
- `ensure_tools_available` has opaque error type
- `dump::dump_multi` has opaque error type

## Checklist

- [ ] An issue to be fixed by this PR is listed above.
- [ ] New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api.rs` and `dart/lib/main.dart`.
- [x] The code generator is run and the code is formatted (via `just precommit`).
- [ ] If this PR adds/changes features, documentations (in the `./book` folder) are updated.
- [ ] CI is passing.

## Remark for PR creator

- Justfile is a task runner for the command line interface that allows you to run shell commands from a file named `justfile` in your project directory. You can use Justfile after [installing it](https://github.com/casey/just). Note that commands written in `justfile` of this repository are expected to be run in `bash`, not `cmd` or `powershell`. Running `just ...` commands in `cmd` or `powershell` will produce errors as the syntax is not compatible. On Windows, you can use `git bash` if you have Git installed.
- If fzyzcjy does not reply for a few days, maybe he just did not see it, so please ping him.
