### PR TITLE
fix: sync return with Freezed metadata

### DIFF
--- a/frb_codegen/src/generator/dart/mod.rs
+++ b/frb_codegen/src/generator/dart/mod.rs
@@ -170,7 +170,7 @@ impl DartApiSpec {
 
         let needs_freezed = distinct_types
             .iter()
-            .any(|ty| is_needs_freezed(ty, ir_file));
+            .any(|ty| needs_freezed(ty, ir_file));
 
         let import_array = distinct_types
             .iter()
@@ -599,15 +599,15 @@ fn dart_metadata(metadata: &[IrDartAnnotation]) -> String {
     metadata
 }
 
-fn is_needs_freezed(ty: &IrType, ir_file: &IrFile) -> bool {
+fn needs_freezed(ty: &IrType, ir_file: &IrFile) -> bool {
     match ty {
         EnumRef(_) => true,
         StructRef(st) => st.freezed,
         SyncReturn(sync_return) => {
             let mut need = false;
             sync_return.visit_children_types(
-                &mut |children| {
-                    need = is_needs_freezed(children, ir_file);
+                &mut |child| {
+                    need = needs_freezed(child, ir_file);
                     need
                 },
                 ir_file,

--- a/frb_codegen/src/generator/dart/mod.rs
+++ b/frb_codegen/src/generator/dart/mod.rs
@@ -168,11 +168,9 @@ impl DartApiSpec {
             generate_wasm_wire(exports, &dart_wire_class_name, &config.dart_wasm_module())
         });
 
-        let needs_freezed = distinct_types.iter().any(|ty| match ty {
-            EnumRef(_) => true,
-            StructRef(st) => st.freezed,
-            _ => false,
-        });
+        let needs_freezed = distinct_types
+            .iter()
+            .any(|ty| is_needs_freezed(ty, ir_file));
 
         let import_array = distinct_types
             .iter()
@@ -599,4 +597,24 @@ fn dart_metadata(metadata: &[IrDartAnnotation]) -> String {
         metadata.push('\n');
     }
     metadata
+}
+
+fn is_needs_freezed(ty: &IrType, ir_file: &IrFile) -> bool {
+    match ty {
+        EnumRef(_) => true,
+        StructRef(st) => st.freezed,
+        SyncReturn(sync_return) => {
+            let mut need = false;
+            sync_return.visit_children_types(
+                &mut |children| {
+                    need = is_needs_freezed(children, ir_file);
+                    need
+                },
+                ir_file,
+            );
+
+            need
+        }
+        _ => false,
+    }
 }

--- a/frb_example/pure_dart/dart/lib/bridge_definitions.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_definitions.dart
@@ -99,6 +99,10 @@ abstract class FlutterRustBridgeExampleSingleBlockTest {
 
   FlutterRustBridgeTaskConstMeta get kHandleStructSyncConstMeta;
 
+  MySizeFreezed handleStructSyncFreezed({required MySizeFreezed arg, required MySizeFreezed boxed, dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kHandleStructSyncFreezedConstMeta;
+
   Future<NewTypeInt> handleNewtype({required NewTypeInt arg, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleNewtypeConstMeta;
@@ -1417,6 +1421,14 @@ class MySize {
     required this.width,
     required this.height,
   });
+}
+
+@freezed
+class MySizeFreezed with _$MySizeFreezed {
+  const factory MySizeFreezed({
+    required int width,
+    required int height,
+  }) = _MySizeFreezed;
 }
 
 class MyStreamEntry {

--- a/frb_example/pure_dart/dart/lib/bridge_definitions.freezed.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_definitions.freezed.dart
@@ -4020,6 +4020,130 @@ abstract class Measure_Distance implements Measure {
 }
 
 /// @nodoc
+mixin _$MySizeFreezed {
+  int get width => throw _privateConstructorUsedError;
+  int get height => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $MySizeFreezedCopyWith<MySizeFreezed> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $MySizeFreezedCopyWith<$Res> {
+  factory $MySizeFreezedCopyWith(MySizeFreezed value, $Res Function(MySizeFreezed) then) =
+      _$MySizeFreezedCopyWithImpl<$Res, MySizeFreezed>;
+  @useResult
+  $Res call({int width, int height});
+}
+
+/// @nodoc
+class _$MySizeFreezedCopyWithImpl<$Res, $Val extends MySizeFreezed> implements $MySizeFreezedCopyWith<$Res> {
+  _$MySizeFreezedCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? width = null,
+    Object? height = null,
+  }) {
+    return _then(_value.copyWith(
+      width: null == width
+          ? _value.width
+          : width // ignore: cast_nullable_to_non_nullable
+              as int,
+      height: null == height
+          ? _value.height
+          : height // ignore: cast_nullable_to_non_nullable
+              as int,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_MySizeFreezedCopyWith<$Res> implements $MySizeFreezedCopyWith<$Res> {
+  factory _$$_MySizeFreezedCopyWith(_$_MySizeFreezed value, $Res Function(_$_MySizeFreezed) then) =
+      __$$_MySizeFreezedCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({int width, int height});
+}
+
+/// @nodoc
+class __$$_MySizeFreezedCopyWithImpl<$Res> extends _$MySizeFreezedCopyWithImpl<$Res, _$_MySizeFreezed>
+    implements _$$_MySizeFreezedCopyWith<$Res> {
+  __$$_MySizeFreezedCopyWithImpl(_$_MySizeFreezed _value, $Res Function(_$_MySizeFreezed) _then) : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? width = null,
+    Object? height = null,
+  }) {
+    return _then(_$_MySizeFreezed(
+      width: null == width
+          ? _value.width
+          : width // ignore: cast_nullable_to_non_nullable
+              as int,
+      height: null == height
+          ? _value.height
+          : height // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_MySizeFreezed implements _MySizeFreezed {
+  const _$_MySizeFreezed({required this.width, required this.height});
+
+  @override
+  final int width;
+  @override
+  final int height;
+
+  @override
+  String toString() {
+    return 'MySizeFreezed(width: $width, height: $height)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_MySizeFreezed &&
+            (identical(other.width, width) || other.width == width) &&
+            (identical(other.height, height) || other.height == height));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, width, height);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_MySizeFreezedCopyWith<_$_MySizeFreezed> get copyWith =>
+      __$$_MySizeFreezedCopyWithImpl<_$_MySizeFreezed>(this, _$identity);
+}
+
+abstract class _MySizeFreezed implements MySizeFreezed {
+  const factory _MySizeFreezed({required final int width, required final int height}) = _$_MySizeFreezed;
+
+  @override
+  int get width;
+  @override
+  int get height;
+  @override
+  @JsonKey(ignore: true)
+  _$$_MySizeFreezedCopyWith<_$_MySizeFreezed> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
 mixin _$RawStringEnumMirrored {
   Object get field0 => throw _privateConstructorUsedError;
   @optionalTypeArgs

--- a/frb_example/pure_dart/dart/lib/bridge_generated.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.dart
@@ -336,6 +336,23 @@ class FlutterRustBridgeExampleSingleBlockTestImpl implements FlutterRustBridgeEx
         argNames: ["arg", "boxed"],
       );
 
+  MySizeFreezed handleStructSyncFreezed({required MySizeFreezed arg, required MySizeFreezed boxed, dynamic hint}) {
+    var arg0 = _platform.api2wire_box_autoadd_my_size_freezed(arg);
+    var arg1 = _platform.api2wire_box_my_size_freezed(boxed);
+    return _platform.executeSync(FlutterRustBridgeSyncTask(
+      callFfi: () => _platform.inner.wire_handle_struct_sync_freezed(arg0, arg1),
+      parseSuccessData: _wire2api_my_size_freezed,
+      constMeta: kHandleStructSyncFreezedConstMeta,
+      argValues: [arg, boxed],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kHandleStructSyncFreezedConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "handle_struct_sync_freezed",
+        argNames: ["arg", "boxed"],
+      );
+
   Future<NewTypeInt> handleNewtype({required NewTypeInt arg, dynamic hint}) {
     var arg0 = _platform.api2wire_box_autoadd_new_type_int(arg);
     return _platform.executeNormal(FlutterRustBridgeTask(
@@ -3562,6 +3579,15 @@ class FlutterRustBridgeExampleSingleBlockTestImpl implements FlutterRustBridgeEx
     final arr = raw as List<dynamic>;
     if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return MySize(
+      width: _wire2api_i32(arr[0]),
+      height: _wire2api_i32(arr[1]),
+    );
+  }
+
+  MySizeFreezed _wire2api_my_size_freezed(dynamic raw) {
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return MySizeFreezed(
       width: _wire2api_i32(arr[0]),
       height: _wire2api_i32(arr[1]),
     );

--- a/frb_example/pure_dart/dart/lib/bridge_generated.io.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.io.dart
@@ -368,6 +368,13 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
   }
 
   @protected
+  ffi.Pointer<wire_MySizeFreezed> api2wire_box_autoadd_my_size_freezed(MySizeFreezed raw) {
+    final ptr = inner.new_box_autoadd_my_size_freezed_0();
+    _api_fill_to_wire_my_size_freezed(raw, ptr.ref);
+    return ptr;
+  }
+
+  @protected
   ffi.Pointer<wire_MyStruct> api2wire_box_autoadd_my_struct(MyStruct raw) {
     final ptr = inner.new_box_autoadd_my_struct_0();
     _api_fill_to_wire_my_struct(raw, ptr.ref);
@@ -501,6 +508,13 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
   ffi.Pointer<wire_MySize> api2wire_box_my_size(MySize raw) {
     final ptr = inner.new_box_my_size_0();
     _api_fill_to_wire_my_size(raw, ptr.ref);
+    return ptr;
+  }
+
+  @protected
+  ffi.Pointer<wire_MySizeFreezed> api2wire_box_my_size_freezed(MySizeFreezed raw) {
+    final ptr = inner.new_box_my_size_freezed_0();
+    _api_fill_to_wire_my_size_freezed(raw, ptr.ref);
     return ptr;
   }
 
@@ -1078,6 +1092,10 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
     _api_fill_to_wire_my_size(apiObj, wireObj.ref);
   }
 
+  void _api_fill_to_wire_box_autoadd_my_size_freezed(MySizeFreezed apiObj, ffi.Pointer<wire_MySizeFreezed> wireObj) {
+    _api_fill_to_wire_my_size_freezed(apiObj, wireObj.ref);
+  }
+
   void _api_fill_to_wire_box_autoadd_my_struct(MyStruct apiObj, ffi.Pointer<wire_MyStruct> wireObj) {
     _api_fill_to_wire_my_struct(apiObj, wireObj.ref);
   }
@@ -1140,6 +1158,10 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
 
   void _api_fill_to_wire_box_my_size(MySize apiObj, ffi.Pointer<wire_MySize> wireObj) {
     _api_fill_to_wire_my_size(apiObj, wireObj.ref);
+  }
+
+  void _api_fill_to_wire_box_my_size_freezed(MySizeFreezed apiObj, ffi.Pointer<wire_MySizeFreezed> wireObj) {
+    _api_fill_to_wire_my_size_freezed(apiObj, wireObj.ref);
   }
 
   void _api_fill_to_wire_box_speed(Speed apiObj, ffi.Pointer<wire_Speed> wireObj) {
@@ -1354,6 +1376,11 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
   }
 
   void _api_fill_to_wire_my_size(MySize apiObj, wire_MySize wireObj) {
+    wireObj.width = api2wire_i32(apiObj.width);
+    wireObj.height = api2wire_i32(apiObj.height);
+  }
+
+  void _api_fill_to_wire_my_size_freezed(MySizeFreezed apiObj, wire_MySizeFreezed wireObj) {
     wireObj.width = api2wire_i32(apiObj.width);
     wireObj.height = api2wire_i32(apiObj.height);
   }
@@ -1823,6 +1850,23 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
           'wire_handle_struct_sync');
   late final _wire_handle_struct_sync = _wire_handle_struct_syncPtr
       .asFunction<WireSyncReturn Function(ffi.Pointer<wire_MySize>, ffi.Pointer<wire_MySize>)>();
+
+  WireSyncReturn wire_handle_struct_sync_freezed(
+    ffi.Pointer<wire_MySizeFreezed> arg,
+    ffi.Pointer<wire_MySizeFreezed> boxed,
+  ) {
+    return _wire_handle_struct_sync_freezed(
+      arg,
+      boxed,
+    );
+  }
+
+  late final _wire_handle_struct_sync_freezedPtr = _lookup<
+      ffi.NativeFunction<
+          WireSyncReturn Function(
+              ffi.Pointer<wire_MySizeFreezed>, ffi.Pointer<wire_MySizeFreezed>)>>('wire_handle_struct_sync_freezed');
+  late final _wire_handle_struct_sync_freezed = _wire_handle_struct_sync_freezedPtr
+      .asFunction<WireSyncReturn Function(ffi.Pointer<wire_MySizeFreezed>, ffi.Pointer<wire_MySizeFreezed>)>();
 
   void wire_handle_newtype(
     int port_,
@@ -4310,6 +4354,15 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   late final _new_box_autoadd_my_size_0 =
       _new_box_autoadd_my_size_0Ptr.asFunction<ffi.Pointer<wire_MySize> Function()>();
 
+  ffi.Pointer<wire_MySizeFreezed> new_box_autoadd_my_size_freezed_0() {
+    return _new_box_autoadd_my_size_freezed_0();
+  }
+
+  late final _new_box_autoadd_my_size_freezed_0Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_MySizeFreezed> Function()>>('new_box_autoadd_my_size_freezed_0');
+  late final _new_box_autoadd_my_size_freezed_0 =
+      _new_box_autoadd_my_size_freezed_0Ptr.asFunction<ffi.Pointer<wire_MySizeFreezed> Function()>();
+
   ffi.Pointer<wire_MyStruct> new_box_autoadd_my_struct_0() {
     return _new_box_autoadd_my_struct_0();
   }
@@ -4507,6 +4560,15 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   late final _new_box_my_size_0Ptr =
       _lookup<ffi.NativeFunction<ffi.Pointer<wire_MySize> Function()>>('new_box_my_size_0');
   late final _new_box_my_size_0 = _new_box_my_size_0Ptr.asFunction<ffi.Pointer<wire_MySize> Function()>();
+
+  ffi.Pointer<wire_MySizeFreezed> new_box_my_size_freezed_0() {
+    return _new_box_my_size_freezed_0();
+  }
+
+  late final _new_box_my_size_freezed_0Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_MySizeFreezed> Function()>>('new_box_my_size_freezed_0');
+  late final _new_box_my_size_freezed_0 =
+      _new_box_my_size_freezed_0Ptr.asFunction<ffi.Pointer<wire_MySizeFreezed> Function()>();
 
   ffi.Pointer<wire_Speed> new_box_speed_0() {
     return _new_box_speed_0();
@@ -5166,6 +5228,14 @@ final class wire_uint_8_list extends ffi.Struct {
 }
 
 final class wire_MySize extends ffi.Struct {
+  @ffi.Int32()
+  external int width;
+
+  @ffi.Int32()
+  external int height;
+}
+
+final class wire_MySizeFreezed extends ffi.Struct {
   @ffi.Int32()
   external int width;
 

--- a/frb_example/pure_dart/dart/lib/bridge_generated.web.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.web.dart
@@ -360,6 +360,11 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
   }
 
   @protected
+  List<dynamic> api2wire_box_autoadd_my_size_freezed(MySizeFreezed raw) {
+    return api2wire_my_size_freezed(raw);
+  }
+
+  @protected
   List<dynamic> api2wire_box_autoadd_my_struct(MyStruct raw) {
     return api2wire_my_struct(raw);
   }
@@ -462,6 +467,11 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
   @protected
   List<dynamic> api2wire_box_my_size(MySize raw) {
     return api2wire_my_size(raw);
+  }
+
+  @protected
+  List<dynamic> api2wire_box_my_size_freezed(MySizeFreezed raw) {
+    return api2wire_my_size_freezed(raw);
   }
 
   @protected
@@ -737,6 +747,11 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
 
   @protected
   List<dynamic> api2wire_my_size(MySize raw) {
+    return [api2wire_i32(raw.width), api2wire_i32(raw.height)];
+  }
+
+  @protected
+  List<dynamic> api2wire_my_size_freezed(MySizeFreezed raw) {
     return [api2wire_i32(raw.width), api2wire_i32(raw.height)];
   }
 
@@ -1055,6 +1070,8 @@ class FlutterRustBridgeExampleSingleBlockTestWasmModule implements WasmModule {
   external dynamic /* void */ wire_handle_struct(NativePortType port_, List<dynamic> arg, List<dynamic> boxed);
 
   external dynamic /* List<dynamic> */ wire_handle_struct_sync(List<dynamic> arg, List<dynamic> boxed);
+
+  external dynamic /* List<dynamic> */ wire_handle_struct_sync_freezed(List<dynamic> arg, List<dynamic> boxed);
 
   external dynamic /* void */ wire_handle_newtype(NativePortType port_, List<dynamic> arg);
 
@@ -1453,6 +1470,9 @@ class FlutterRustBridgeExampleSingleBlockTestWire
 
   dynamic /* List<dynamic> */ wire_handle_struct_sync(List<dynamic> arg, List<dynamic> boxed) =>
       wasmModule.wire_handle_struct_sync(arg, boxed);
+
+  dynamic /* List<dynamic> */ wire_handle_struct_sync_freezed(List<dynamic> arg, List<dynamic> boxed) =>
+      wasmModule.wire_handle_struct_sync_freezed(arg, boxed);
 
   void wire_handle_newtype(NativePortType port_, List<dynamic> arg) => wasmModule.wire_handle_newtype(port_, arg);
 

--- a/frb_example/pure_dart/dart/lib/main.dart
+++ b/frb_example/pure_dart/dart/lib/main.dart
@@ -156,6 +156,15 @@ void main(List<String> args) async {
     expect(structResp.height, 100 + 10000);
   });
 
+  test('dart call handleStructSyncFreezed', () {
+    final structResp = api.handleStructSyncFreezed(
+        arg: MySizeFreezed(width: 42, height: 100), boxed: MySizeFreezed(width: 1000, height: 10000));
+    expect(structResp.width, 42 + 1000);
+    expect(structResp.height, 100 + 10000);
+    // Only freezed classes have copyWith
+    expect(structResp.copyWith, isNotNull);
+  });
+
   test('dart call handleNewtype', () async {
     final newtypeResp = await api.handleNewtype(arg: NewTypeInt(field0: 42));
     expect(newtypeResp.field0, 84);

--- a/frb_example/pure_dart/rust/c_output_path/c_output.h
+++ b/frb_example/pure_dart/rust/c_output_path/c_output.h
@@ -21,6 +21,11 @@ typedef struct wire_MySize {
   int32_t height;
 } wire_MySize;
 
+typedef struct wire_MySizeFreezed {
+  int32_t width;
+  int32_t height;
+} wire_MySizeFreezed;
+
 typedef struct wire_NewTypeInt {
   int64_t field0;
 } wire_NewTypeInt;
@@ -526,6 +531,9 @@ void wire_handle_struct(int64_t port_, struct wire_MySize *arg, struct wire_MySi
 
 WireSyncReturn wire_handle_struct_sync(struct wire_MySize *arg, struct wire_MySize *boxed);
 
+WireSyncReturn wire_handle_struct_sync_freezed(struct wire_MySizeFreezed *arg,
+                                               struct wire_MySizeFreezed *boxed);
+
 void wire_handle_newtype(int64_t port_, struct wire_NewTypeInt *arg);
 
 WireSyncReturn wire_handle_newtype_sync(struct wire_NewTypeInt *arg);
@@ -927,6 +935,8 @@ struct wire_MyNestedStruct *new_box_autoadd_my_nested_struct_0(void);
 
 struct wire_MySize *new_box_autoadd_my_size_0(void);
 
+struct wire_MySizeFreezed *new_box_autoadd_my_size_freezed_0(void);
+
 struct wire_MyStruct *new_box_autoadd_my_struct_0(void);
 
 struct wire_MyTreeNode *new_box_autoadd_my_tree_node_0(void);
@@ -968,6 +978,8 @@ int8_t *new_box_i8_0(int8_t value);
 struct wire_KitchenSink *new_box_kitchen_sink_0(void);
 
 struct wire_MySize *new_box_my_size_0(void);
+
+struct wire_MySizeFreezed *new_box_my_size_freezed_0(void);
 
 struct wire_Speed *new_box_speed_0(void);
 
@@ -1106,6 +1118,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_handle_zero_copy_vec_of_primitive_sync);
     dummy_var ^= ((int64_t) (void*) wire_handle_struct);
     dummy_var ^= ((int64_t) (void*) wire_handle_struct_sync);
+    dummy_var ^= ((int64_t) (void*) wire_handle_struct_sync_freezed);
     dummy_var ^= ((int64_t) (void*) wire_handle_newtype);
     dummy_var ^= ((int64_t) (void*) wire_handle_newtype_sync);
     dummy_var ^= ((int64_t) (void*) wire_handle_list_of_struct);
@@ -1296,6 +1309,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_message_id_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_my_nested_struct_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_my_size_0);
+    dummy_var ^= ((int64_t) (void*) new_box_autoadd_my_size_freezed_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_my_struct_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_my_tree_node_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_new_type_int_0);
@@ -1317,6 +1331,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) new_box_i8_0);
     dummy_var ^= ((int64_t) (void*) new_box_kitchen_sink_0);
     dummy_var ^= ((int64_t) (void*) new_box_my_size_0);
+    dummy_var ^= ((int64_t) (void*) new_box_my_size_freezed_0);
     dummy_var ^= ((int64_t) (void*) new_box_speed_0);
     dummy_var ^= ((int64_t) (void*) new_box_u8_0);
     dummy_var ^= ((int64_t) (void*) new_box_weekdays_0);

--- a/frb_example/pure_dart/rust/c_output_path_extra/c_output.h
+++ b/frb_example/pure_dart/rust/c_output_path_extra/c_output.h
@@ -21,6 +21,11 @@ typedef struct wire_MySize {
   int32_t height;
 } wire_MySize;
 
+typedef struct wire_MySizeFreezed {
+  int32_t width;
+  int32_t height;
+} wire_MySizeFreezed;
+
 typedef struct wire_NewTypeInt {
   int64_t field0;
 } wire_NewTypeInt;
@@ -526,6 +531,9 @@ void wire_handle_struct(int64_t port_, struct wire_MySize *arg, struct wire_MySi
 
 WireSyncReturn wire_handle_struct_sync(struct wire_MySize *arg, struct wire_MySize *boxed);
 
+WireSyncReturn wire_handle_struct_sync_freezed(struct wire_MySizeFreezed *arg,
+                                               struct wire_MySizeFreezed *boxed);
+
 void wire_handle_newtype(int64_t port_, struct wire_NewTypeInt *arg);
 
 WireSyncReturn wire_handle_newtype_sync(struct wire_NewTypeInt *arg);
@@ -927,6 +935,8 @@ struct wire_MyNestedStruct *new_box_autoadd_my_nested_struct_0(void);
 
 struct wire_MySize *new_box_autoadd_my_size_0(void);
 
+struct wire_MySizeFreezed *new_box_autoadd_my_size_freezed_0(void);
+
 struct wire_MyStruct *new_box_autoadd_my_struct_0(void);
 
 struct wire_MyTreeNode *new_box_autoadd_my_tree_node_0(void);
@@ -968,6 +978,8 @@ int8_t *new_box_i8_0(int8_t value);
 struct wire_KitchenSink *new_box_kitchen_sink_0(void);
 
 struct wire_MySize *new_box_my_size_0(void);
+
+struct wire_MySizeFreezed *new_box_my_size_freezed_0(void);
 
 struct wire_Speed *new_box_speed_0(void);
 
@@ -1106,6 +1118,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_handle_zero_copy_vec_of_primitive_sync);
     dummy_var ^= ((int64_t) (void*) wire_handle_struct);
     dummy_var ^= ((int64_t) (void*) wire_handle_struct_sync);
+    dummy_var ^= ((int64_t) (void*) wire_handle_struct_sync_freezed);
     dummy_var ^= ((int64_t) (void*) wire_handle_newtype);
     dummy_var ^= ((int64_t) (void*) wire_handle_newtype_sync);
     dummy_var ^= ((int64_t) (void*) wire_handle_list_of_struct);
@@ -1296,6 +1309,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_message_id_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_my_nested_struct_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_my_size_0);
+    dummy_var ^= ((int64_t) (void*) new_box_autoadd_my_size_freezed_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_my_struct_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_my_tree_node_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_new_type_int_0);
@@ -1317,6 +1331,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) new_box_i8_0);
     dummy_var ^= ((int64_t) (void*) new_box_kitchen_sink_0);
     dummy_var ^= ((int64_t) (void*) new_box_my_size_0);
+    dummy_var ^= ((int64_t) (void*) new_box_my_size_freezed_0);
     dummy_var ^= ((int64_t) (void*) new_box_speed_0);
     dummy_var ^= ((int64_t) (void*) new_box_u8_0);
     dummy_var ^= ((int64_t) (void*) new_box_weekdays_0);

--- a/frb_example/pure_dart/rust/src/api.rs
+++ b/frb_example/pure_dart/rust/src/api.rs
@@ -230,6 +230,13 @@ pub struct MySize {
     pub height: i32,
 }
 
+#[frb(dart_metadata = ("freezed"))]
+#[derive(Debug, Clone)]
+pub struct MySizeFreezed {
+    pub width: i32,
+    pub height: i32,
+}
+
 pub fn handle_struct(arg: MySize, boxed: Box<MySize>) -> MySize {
     info!("handle_struct({:?}, {:?})", &arg, &boxed);
     MySize {
@@ -241,6 +248,17 @@ pub fn handle_struct(arg: MySize, boxed: Box<MySize>) -> MySize {
 pub fn handle_struct_sync(arg: MySize, boxed: Box<MySize>) -> SyncReturn<MySize> {
     info!("handle_struct_sync({:?}, {:?})", &arg, &boxed);
     SyncReturn(MySize {
+        width: arg.width + boxed.width,
+        height: arg.height + boxed.height,
+    })
+}
+
+pub fn handle_struct_sync_freezed(
+    arg: MySizeFreezed,
+    boxed: Box<MySizeFreezed>,
+) -> SyncReturn<MySizeFreezed> {
+    info!("handle_struct_sync_freezed({:?}, {:?})", &arg, &boxed);
+    SyncReturn(MySizeFreezed {
         width: arg.width + boxed.width,
         height: arg.height + boxed.height,
     })

--- a/frb_example/pure_dart/rust/src/bridge_generated.io.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.io.rs
@@ -117,6 +117,14 @@ pub extern "C" fn wire_handle_struct_sync(
 }
 
 #[no_mangle]
+pub extern "C" fn wire_handle_struct_sync_freezed(
+    arg: *mut wire_MySizeFreezed,
+    boxed: *mut wire_MySizeFreezed,
+) -> support::WireSyncReturn {
+    wire_handle_struct_sync_freezed_impl(arg, boxed)
+}
+
+#[no_mangle]
 pub extern "C" fn wire_handle_newtype(port_: i64, arg: *mut wire_NewTypeInt) {
     wire_handle_newtype_impl(port_, arg)
 }
@@ -1128,6 +1136,11 @@ pub extern "C" fn new_box_autoadd_my_size_0() -> *mut wire_MySize {
 }
 
 #[no_mangle]
+pub extern "C" fn new_box_autoadd_my_size_freezed_0() -> *mut wire_MySizeFreezed {
+    support::new_leak_box_ptr(wire_MySizeFreezed::new_with_null_ptr())
+}
+
+#[no_mangle]
 pub extern "C" fn new_box_autoadd_my_struct_0() -> *mut wire_MyStruct {
     support::new_leak_box_ptr(wire_MyStruct::new_with_null_ptr())
 }
@@ -1230,6 +1243,11 @@ pub extern "C" fn new_box_kitchen_sink_0() -> *mut wire_KitchenSink {
 #[no_mangle]
 pub extern "C" fn new_box_my_size_0() -> *mut wire_MySize {
     support::new_leak_box_ptr(wire_MySize::new_with_null_ptr())
+}
+
+#[no_mangle]
+pub extern "C" fn new_box_my_size_freezed_0() -> *mut wire_MySizeFreezed {
+    support::new_leak_box_ptr(wire_MySizeFreezed::new_with_null_ptr())
 }
 
 #[no_mangle]
@@ -1913,6 +1931,12 @@ impl Wire2Api<MySize> for *mut wire_MySize {
         Wire2Api::<MySize>::wire2api(*wrap).into()
     }
 }
+impl Wire2Api<MySizeFreezed> for *mut wire_MySizeFreezed {
+    fn wire2api(self) -> MySizeFreezed {
+        let wrap = unsafe { support::box_from_leak_ptr(self) };
+        Wire2Api::<MySizeFreezed>::wire2api(*wrap).into()
+    }
+}
 impl Wire2Api<MyStruct> for *mut wire_MyStruct {
     fn wire2api(self) -> MyStruct {
         let wrap = unsafe { support::box_from_leak_ptr(self) };
@@ -2032,6 +2056,12 @@ impl Wire2Api<Box<MySize>> for *mut wire_MySize {
     fn wire2api(self) -> Box<MySize> {
         let wrap = unsafe { support::box_from_leak_ptr(self) };
         Wire2Api::<MySize>::wire2api(*wrap).into()
+    }
+}
+impl Wire2Api<Box<MySizeFreezed>> for *mut wire_MySizeFreezed {
+    fn wire2api(self) -> Box<MySizeFreezed> {
+        let wrap = unsafe { support::box_from_leak_ptr(self) };
+        Wire2Api::<MySizeFreezed>::wire2api(*wrap).into()
     }
 }
 impl Wire2Api<Box<Speed>> for *mut wire_Speed {
@@ -2420,6 +2450,14 @@ impl Wire2Api<MyNestedStruct> for wire_MyNestedStruct {
 impl Wire2Api<MySize> for wire_MySize {
     fn wire2api(self) -> MySize {
         MySize {
+            width: self.width.wire2api(),
+            height: self.height.wire2api(),
+        }
+    }
+}
+impl Wire2Api<MySizeFreezed> for wire_MySizeFreezed {
+    fn wire2api(self) -> MySizeFreezed {
+        MySizeFreezed {
             width: self.width.wire2api(),
             height: self.height.wire2api(),
         }
@@ -2854,6 +2892,13 @@ pub struct wire_MyNestedStruct {
 #[repr(C)]
 #[derive(Clone)]
 pub struct wire_MySize {
+    width: i32,
+    height: i32,
+}
+
+#[repr(C)]
+#[derive(Clone)]
+pub struct wire_MySizeFreezed {
     width: i32,
     height: i32,
 }
@@ -3823,6 +3868,21 @@ impl NewWithNullPtr for wire_MySize {
 }
 
 impl Default for wire_MySize {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
+
+impl NewWithNullPtr for wire_MySizeFreezed {
+    fn new_with_null_ptr() -> Self {
+        Self {
+            width: Default::default(),
+            height: Default::default(),
+        }
+    }
+}
+
+impl Default for wire_MySizeFreezed {
     fn default() -> Self {
         Self::new_with_null_ptr()
     }

--- a/frb_example/pure_dart/rust/src/bridge_generated.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.rs
@@ -340,6 +340,23 @@ fn wire_handle_struct_sync_impl(
         },
     )
 }
+fn wire_handle_struct_sync_freezed_impl(
+    arg: impl Wire2Api<MySizeFreezed> + UnwindSafe,
+    boxed: impl Wire2Api<Box<MySizeFreezed>> + UnwindSafe,
+) -> support::WireSyncReturn {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync(
+        WrapInfo {
+            debug_name: "handle_struct_sync_freezed",
+            port: None,
+            mode: FfiCallMode::Sync,
+        },
+        move || {
+            let api_arg = arg.wire2api();
+            let api_boxed = boxed.wire2api();
+            Ok(handle_struct_sync_freezed(api_arg, api_boxed))
+        },
+    )
+}
 fn wire_handle_newtype_impl(port_: MessagePort, arg: impl Wire2Api<NewTypeInt> + UnwindSafe) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, NewTypeInt>(
         WrapInfo {
@@ -3270,6 +3287,22 @@ impl support::IntoDart for MySize {
 }
 impl support::IntoDartExceptPrimitive for MySize {}
 impl rust2dart::IntoIntoDart<MySize> for MySize {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
+
+impl support::IntoDart for MySizeFreezed {
+    fn into_dart(self) -> support::DartAbi {
+        vec![
+            self.width.into_into_dart().into_dart(),
+            self.height.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl support::IntoDartExceptPrimitive for MySizeFreezed {}
+impl rust2dart::IntoIntoDart<MySizeFreezed> for MySizeFreezed {
     fn into_into_dart(self) -> Self {
         self
     }

--- a/frb_example/pure_dart/rust/src/bridge_generated.web.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.web.rs
@@ -114,6 +114,11 @@ pub fn wire_handle_struct_sync(arg: JsValue, boxed: JsValue) -> support::WireSyn
 }
 
 #[wasm_bindgen]
+pub fn wire_handle_struct_sync_freezed(arg: JsValue, boxed: JsValue) -> support::WireSyncReturn {
+    wire_handle_struct_sync_freezed_impl(arg, boxed)
+}
+
+#[wasm_bindgen]
 pub fn wire_handle_newtype(port_: MessagePort, arg: JsValue) {
     wire_handle_newtype_impl(port_, arg)
 }
@@ -1607,6 +1612,21 @@ impl Wire2Api<MySize> for JsValue {
         }
     }
 }
+impl Wire2Api<MySizeFreezed> for JsValue {
+    fn wire2api(self) -> MySizeFreezed {
+        let self_ = self.dyn_into::<JsArray>().unwrap();
+        assert_eq!(
+            self_.length(),
+            2,
+            "Expected 2 elements, got {}",
+            self_.length()
+        );
+        MySizeFreezed {
+            width: self_.get(0).wire2api(),
+            height: self_.get(1).wire2api(),
+        }
+    }
+}
 impl Wire2Api<MyStruct> for JsValue {
     fn wire2api(self) -> MyStruct {
         let self_ = self.dyn_into::<JsArray>().unwrap();
@@ -2100,6 +2120,11 @@ impl Wire2Api<Box<KitchenSink>> for JsValue {
 }
 impl Wire2Api<Box<MySize>> for JsValue {
     fn wire2api(self) -> Box<MySize> {
+        Box::new(self.wire2api())
+    }
+}
+impl Wire2Api<Box<MySizeFreezed>> for JsValue {
+    fn wire2api(self) -> Box<MySizeFreezed> {
         Box::new(self.wire2api())
     }
 }


### PR DESCRIPTION
## Changes
Check whether the children type of `SyncReturn` contains a `freezed` dart metadata in the frb macro.

## Checklist

- [x] An issue to be fixed by this PR is listed above.
- [x] New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api.rs` and `dart/lib/main.dart`.
- [x] The code generator is run and the code is formatted (via `just precommit`).
- [x] If this PR adds/changes features, documentations (in the `./book` folder) are updated.
- [ ] CI is passing.

## Remark for PR creator

- Justfile is a task runner for the command line interface that allows you to run shell commands from a file named `justfile` in your project directory. You can use Justfile after [installing it](https://github.com/casey/just). Note that commands written in `justfile` of this repository are expected to be run in `bash`, not `cmd` or `powershell`. Running `just ...` commands in `cmd` or `powershell` will produce errors as the syntax is not compatible. On Windows, you can use `git bash` if you have Git installed.
- If fzyzcjy does not reply for a few days, maybe he just did not see it, so please ping him.
