### PR TITLE
fix: better check for whether the file need to generate freezed structs/enums

### DIFF
--- a/frb_codegen/src/generator/dart/mod.rs
+++ b/frb_codegen/src/generator/dart/mod.rs
@@ -601,17 +601,9 @@ fn needs_freezed(ty: &IrType, ir_file: &IrFile) -> bool {
     match ty {
         EnumRef(_) => true,
         StructRef(st) => st.freezed,
-        SyncReturn(sync_return) => {
-            let mut need = false;
-            sync_return.visit_children_types(
-                &mut |child| {
-                    need = needs_freezed(child, ir_file);
-                    need
-                },
-                ir_file,
-            );
-
-            need
+        SyncReturn(sync) => {
+            let types = sync.clone().into_inner().distinct_types(ir_file);
+            types.iter().any(|child| needs_freezed(child, ir_file))
         }
         _ => false,
     }

--- a/frb_example/pure_dart/dart/lib/bridge_definitions.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_definitions.dart
@@ -199,6 +199,10 @@ abstract class FlutterRustBridgeExampleSingleBlockTest {
 
   FlutterRustBridgeTaskConstMeta get kHandleEnumParameterConstMeta;
 
+  MyEnumFreezed handleEnumSyncFreezed({required MyEnumFreezed value, dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kHandleEnumSyncFreezedConstMeta;
+
   Future<void> handleCustomizedStruct({required Customized val, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kHandleCustomizedStructConstMeta;
@@ -1401,6 +1405,16 @@ class MoreThanJustOneRawStringStruct {
 enum MyEnum {
   False,
   True,
+}
+
+@freezed
+sealed class MyEnumFreezed with _$MyEnumFreezed {
+  const factory MyEnumFreezed.a(
+    int field0,
+  ) = MyEnumFreezed_A;
+  const factory MyEnumFreezed.b(
+    String field0,
+  ) = MyEnumFreezed_B;
 }
 
 class MyNestedStruct {

--- a/frb_example/pure_dart/dart/lib/bridge_definitions.freezed.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_definitions.freezed.dart
@@ -4020,6 +4020,325 @@ abstract class Measure_Distance implements Measure {
 }
 
 /// @nodoc
+mixin _$MyEnumFreezed {
+  Object get field0 => throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(int field0) a,
+    required TResult Function(String field0) b,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(int field0)? a,
+    TResult? Function(String field0)? b,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(int field0)? a,
+    TResult Function(String field0)? b,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(MyEnumFreezed_A value) a,
+    required TResult Function(MyEnumFreezed_B value) b,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(MyEnumFreezed_A value)? a,
+    TResult? Function(MyEnumFreezed_B value)? b,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(MyEnumFreezed_A value)? a,
+    TResult Function(MyEnumFreezed_B value)? b,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $MyEnumFreezedCopyWith<$Res> {
+  factory $MyEnumFreezedCopyWith(MyEnumFreezed value, $Res Function(MyEnumFreezed) then) =
+      _$MyEnumFreezedCopyWithImpl<$Res, MyEnumFreezed>;
+}
+
+/// @nodoc
+class _$MyEnumFreezedCopyWithImpl<$Res, $Val extends MyEnumFreezed> implements $MyEnumFreezedCopyWith<$Res> {
+  _$MyEnumFreezedCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+}
+
+/// @nodoc
+abstract class _$$MyEnumFreezed_ACopyWith<$Res> {
+  factory _$$MyEnumFreezed_ACopyWith(_$MyEnumFreezed_A value, $Res Function(_$MyEnumFreezed_A) then) =
+      __$$MyEnumFreezed_ACopyWithImpl<$Res>;
+  @useResult
+  $Res call({int field0});
+}
+
+/// @nodoc
+class __$$MyEnumFreezed_ACopyWithImpl<$Res> extends _$MyEnumFreezedCopyWithImpl<$Res, _$MyEnumFreezed_A>
+    implements _$$MyEnumFreezed_ACopyWith<$Res> {
+  __$$MyEnumFreezed_ACopyWithImpl(_$MyEnumFreezed_A _value, $Res Function(_$MyEnumFreezed_A) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? field0 = null,
+  }) {
+    return _then(_$MyEnumFreezed_A(
+      null == field0
+          ? _value.field0
+          : field0 // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$MyEnumFreezed_A implements MyEnumFreezed_A {
+  const _$MyEnumFreezed_A(this.field0);
+
+  @override
+  final int field0;
+
+  @override
+  String toString() {
+    return 'MyEnumFreezed.a(field0: $field0)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$MyEnumFreezed_A &&
+            (identical(other.field0, field0) || other.field0 == field0));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, field0);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$MyEnumFreezed_ACopyWith<_$MyEnumFreezed_A> get copyWith =>
+      __$$MyEnumFreezed_ACopyWithImpl<_$MyEnumFreezed_A>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(int field0) a,
+    required TResult Function(String field0) b,
+  }) {
+    return a(field0);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(int field0)? a,
+    TResult? Function(String field0)? b,
+  }) {
+    return a?.call(field0);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(int field0)? a,
+    TResult Function(String field0)? b,
+    required TResult orElse(),
+  }) {
+    if (a != null) {
+      return a(field0);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(MyEnumFreezed_A value) a,
+    required TResult Function(MyEnumFreezed_B value) b,
+  }) {
+    return a(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(MyEnumFreezed_A value)? a,
+    TResult? Function(MyEnumFreezed_B value)? b,
+  }) {
+    return a?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(MyEnumFreezed_A value)? a,
+    TResult Function(MyEnumFreezed_B value)? b,
+    required TResult orElse(),
+  }) {
+    if (a != null) {
+      return a(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class MyEnumFreezed_A implements MyEnumFreezed {
+  const factory MyEnumFreezed_A(final int field0) = _$MyEnumFreezed_A;
+
+  @override
+  int get field0;
+  @JsonKey(ignore: true)
+  _$$MyEnumFreezed_ACopyWith<_$MyEnumFreezed_A> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$MyEnumFreezed_BCopyWith<$Res> {
+  factory _$$MyEnumFreezed_BCopyWith(_$MyEnumFreezed_B value, $Res Function(_$MyEnumFreezed_B) then) =
+      __$$MyEnumFreezed_BCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String field0});
+}
+
+/// @nodoc
+class __$$MyEnumFreezed_BCopyWithImpl<$Res> extends _$MyEnumFreezedCopyWithImpl<$Res, _$MyEnumFreezed_B>
+    implements _$$MyEnumFreezed_BCopyWith<$Res> {
+  __$$MyEnumFreezed_BCopyWithImpl(_$MyEnumFreezed_B _value, $Res Function(_$MyEnumFreezed_B) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? field0 = null,
+  }) {
+    return _then(_$MyEnumFreezed_B(
+      null == field0
+          ? _value.field0
+          : field0 // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$MyEnumFreezed_B implements MyEnumFreezed_B {
+  const _$MyEnumFreezed_B(this.field0);
+
+  @override
+  final String field0;
+
+  @override
+  String toString() {
+    return 'MyEnumFreezed.b(field0: $field0)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$MyEnumFreezed_B &&
+            (identical(other.field0, field0) || other.field0 == field0));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, field0);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$MyEnumFreezed_BCopyWith<_$MyEnumFreezed_B> get copyWith =>
+      __$$MyEnumFreezed_BCopyWithImpl<_$MyEnumFreezed_B>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(int field0) a,
+    required TResult Function(String field0) b,
+  }) {
+    return b(field0);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(int field0)? a,
+    TResult? Function(String field0)? b,
+  }) {
+    return b?.call(field0);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(int field0)? a,
+    TResult Function(String field0)? b,
+    required TResult orElse(),
+  }) {
+    if (b != null) {
+      return b(field0);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(MyEnumFreezed_A value) a,
+    required TResult Function(MyEnumFreezed_B value) b,
+  }) {
+    return b(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(MyEnumFreezed_A value)? a,
+    TResult? Function(MyEnumFreezed_B value)? b,
+  }) {
+    return b?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(MyEnumFreezed_A value)? a,
+    TResult Function(MyEnumFreezed_B value)? b,
+    required TResult orElse(),
+  }) {
+    if (b != null) {
+      return b(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class MyEnumFreezed_B implements MyEnumFreezed {
+  const factory MyEnumFreezed_B(final String field0) = _$MyEnumFreezed_B;
+
+  @override
+  String get field0;
+  @JsonKey(ignore: true)
+  _$$MyEnumFreezed_BCopyWith<_$MyEnumFreezed_B> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
 mixin _$MySizeFreezed {
   int get width => throw _privateConstructorUsedError;
   int get height => throw _privateConstructorUsedError;

--- a/frb_example/pure_dart/dart/lib/bridge_generated.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.dart
@@ -718,6 +718,22 @@ class FlutterRustBridgeExampleSingleBlockTestImpl implements FlutterRustBridgeEx
         argNames: ["weekday"],
       );
 
+  MyEnumFreezed handleEnumSyncFreezed({required MyEnumFreezed value, dynamic hint}) {
+    var arg0 = _platform.api2wire_box_autoadd_my_enum_freezed(value);
+    return _platform.executeSync(FlutterRustBridgeSyncTask(
+      callFfi: () => _platform.inner.wire_handle_enum_sync_freezed(arg0),
+      parseSuccessData: _wire2api_my_enum_freezed,
+      constMeta: kHandleEnumSyncFreezedConstMeta,
+      argValues: [value],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kHandleEnumSyncFreezedConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "handle_enum_sync_freezed",
+        argNames: ["value"],
+      );
+
   Future<void> handleCustomizedStruct({required Customized val, dynamic hint}) {
     var arg0 = _platform.api2wire_box_autoadd_customized(val);
     return _platform.executeNormal(FlutterRustBridgeTask(
@@ -3564,6 +3580,21 @@ class FlutterRustBridgeExampleSingleBlockTestImpl implements FlutterRustBridgeEx
 
   MyEnum _wire2api_my_enum(dynamic raw) {
     return MyEnum.values[raw as int];
+  }
+
+  MyEnumFreezed _wire2api_my_enum_freezed(dynamic raw) {
+    switch (raw[0]) {
+      case 0:
+        return MyEnumFreezed_A(
+          _wire2api_i32(raw[1]),
+        );
+      case 1:
+        return MyEnumFreezed_B(
+          _wire2api_String(raw[1]),
+        );
+      default:
+        throw Exception("unreachable");
+    }
   }
 
   MyNestedStruct _wire2api_my_nested_struct(dynamic raw) {

--- a/frb_example/pure_dart/dart/lib/bridge_generated.io.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.io.dart
@@ -354,6 +354,13 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
   }
 
   @protected
+  ffi.Pointer<wire_MyEnumFreezed> api2wire_box_autoadd_my_enum_freezed(MyEnumFreezed raw) {
+    final ptr = inner.new_box_autoadd_my_enum_freezed_0();
+    _api_fill_to_wire_my_enum_freezed(raw, ptr.ref);
+    return ptr;
+  }
+
+  @protected
   ffi.Pointer<wire_MyNestedStruct> api2wire_box_autoadd_my_nested_struct(MyNestedStruct raw) {
     final ptr = inner.new_box_autoadd_my_nested_struct_0();
     _api_fill_to_wire_my_nested_struct(raw, ptr.ref);
@@ -1084,6 +1091,10 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
     _api_fill_to_wire_message_id(apiObj, wireObj.ref);
   }
 
+  void _api_fill_to_wire_box_autoadd_my_enum_freezed(MyEnumFreezed apiObj, ffi.Pointer<wire_MyEnumFreezed> wireObj) {
+    _api_fill_to_wire_my_enum_freezed(apiObj, wireObj.ref);
+  }
+
   void _api_fill_to_wire_box_autoadd_my_nested_struct(MyNestedStruct apiObj, ffi.Pointer<wire_MyNestedStruct> wireObj) {
     _api_fill_to_wire_my_nested_struct(apiObj, wireObj.ref);
   }
@@ -1368,6 +1379,23 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
 
   void _api_fill_to_wire_message_id(MessageId apiObj, wire_MessageId wireObj) {
     wireObj.field0 = api2wire_u8_array_32(apiObj.field0);
+  }
+
+  void _api_fill_to_wire_my_enum_freezed(MyEnumFreezed apiObj, wire_MyEnumFreezed wireObj) {
+    if (apiObj is MyEnumFreezed_A) {
+      var pre_field0 = api2wire_i32(apiObj.field0);
+      wireObj.tag = 0;
+      wireObj.kind = inner.inflate_MyEnumFreezed_A();
+      wireObj.kind.ref.A.ref.field0 = pre_field0;
+      return;
+    }
+    if (apiObj is MyEnumFreezed_B) {
+      var pre_field0 = api2wire_String(apiObj.field0);
+      wireObj.tag = 1;
+      wireObj.kind = inner.inflate_MyEnumFreezed_B();
+      wireObj.kind.ref.B.ref.field0 = pre_field0;
+      return;
+    }
   }
 
   void _api_fill_to_wire_my_nested_struct(MyNestedStruct apiObj, wire_MyNestedStruct wireObj) {
@@ -2209,6 +2237,20 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   late final _wire_handle_enum_parameterPtr =
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>('wire_handle_enum_parameter');
   late final _wire_handle_enum_parameter = _wire_handle_enum_parameterPtr.asFunction<void Function(int, int)>();
+
+  WireSyncReturn wire_handle_enum_sync_freezed(
+    ffi.Pointer<wire_MyEnumFreezed> value,
+  ) {
+    return _wire_handle_enum_sync_freezed(
+      value,
+    );
+  }
+
+  late final _wire_handle_enum_sync_freezedPtr =
+      _lookup<ffi.NativeFunction<WireSyncReturn Function(ffi.Pointer<wire_MyEnumFreezed>)>>(
+          'wire_handle_enum_sync_freezed');
+  late final _wire_handle_enum_sync_freezed =
+      _wire_handle_enum_sync_freezedPtr.asFunction<WireSyncReturn Function(ffi.Pointer<wire_MyEnumFreezed>)>();
 
   void wire_handle_customized_struct(
     int port_,
@@ -4336,6 +4378,15 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   late final _new_box_autoadd_message_id_0 =
       _new_box_autoadd_message_id_0Ptr.asFunction<ffi.Pointer<wire_MessageId> Function()>();
 
+  ffi.Pointer<wire_MyEnumFreezed> new_box_autoadd_my_enum_freezed_0() {
+    return _new_box_autoadd_my_enum_freezed_0();
+  }
+
+  late final _new_box_autoadd_my_enum_freezed_0Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_MyEnumFreezed> Function()>>('new_box_autoadd_my_enum_freezed_0');
+  late final _new_box_autoadd_my_enum_freezed_0 =
+      _new_box_autoadd_my_enum_freezed_0Ptr.asFunction<ffi.Pointer<wire_MyEnumFreezed> Function()>();
+
   ffi.Pointer<wire_MyNestedStruct> new_box_autoadd_my_nested_struct_0() {
     return _new_box_autoadd_my_nested_struct_0();
   }
@@ -5197,6 +5248,24 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
       _lookup<ffi.NativeFunction<ffi.Pointer<MeasureKind> Function()>>('inflate_Measure_Distance');
   late final _inflate_Measure_Distance = _inflate_Measure_DistancePtr.asFunction<ffi.Pointer<MeasureKind> Function()>();
 
+  ffi.Pointer<MyEnumFreezedKind> inflate_MyEnumFreezed_A() {
+    return _inflate_MyEnumFreezed_A();
+  }
+
+  late final _inflate_MyEnumFreezed_APtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<MyEnumFreezedKind> Function()>>('inflate_MyEnumFreezed_A');
+  late final _inflate_MyEnumFreezed_A =
+      _inflate_MyEnumFreezed_APtr.asFunction<ffi.Pointer<MyEnumFreezedKind> Function()>();
+
+  ffi.Pointer<MyEnumFreezedKind> inflate_MyEnumFreezed_B() {
+    return _inflate_MyEnumFreezed_B();
+  }
+
+  late final _inflate_MyEnumFreezed_BPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<MyEnumFreezedKind> Function()>>('inflate_MyEnumFreezed_B');
+  late final _inflate_MyEnumFreezed_B =
+      _inflate_MyEnumFreezed_BPtr.asFunction<ffi.Pointer<MyEnumFreezedKind> Function()>();
+
   ffi.Pointer<SpeedKind> inflate_Speed_GPS() {
     return _inflate_Speed_GPS();
   }
@@ -5370,6 +5439,28 @@ final class wire_Note extends ffi.Struct {
   external ffi.Pointer<ffi.Int32> day;
 
   external ffi.Pointer<wire_uint_8_list> body;
+}
+
+final class wire_MyEnumFreezed_A extends ffi.Struct {
+  @ffi.Int32()
+  external int field0;
+}
+
+final class wire_MyEnumFreezed_B extends ffi.Struct {
+  external ffi.Pointer<wire_uint_8_list> field0;
+}
+
+final class MyEnumFreezedKind extends ffi.Union {
+  external ffi.Pointer<wire_MyEnumFreezed_A> A;
+
+  external ffi.Pointer<wire_MyEnumFreezed_B> B;
+}
+
+final class wire_MyEnumFreezed extends ffi.Struct {
+  @ffi.Int32()
+  external int tag;
+
+  external ffi.Pointer<MyEnumFreezedKind> kind;
 }
 
 final class wire_Customized extends ffi.Struct {

--- a/frb_example/pure_dart/dart/lib/bridge_generated.web.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.web.dart
@@ -350,6 +350,11 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
   }
 
   @protected
+  List<dynamic> api2wire_box_autoadd_my_enum_freezed(MyEnumFreezed raw) {
+    return api2wire_my_enum_freezed(raw);
+  }
+
+  @protected
   List<dynamic> api2wire_box_autoadd_my_nested_struct(MyNestedStruct raw) {
     return api2wire_my_nested_struct(raw);
   }
@@ -741,6 +746,18 @@ class FlutterRustBridgeExampleSingleBlockTestPlatform
   }
 
   @protected
+  List<dynamic> api2wire_my_enum_freezed(MyEnumFreezed raw) {
+    if (raw is MyEnumFreezed_A) {
+      return [0, api2wire_i32(raw.field0)];
+    }
+    if (raw is MyEnumFreezed_B) {
+      return [1, api2wire_String(raw.field0)];
+    }
+
+    throw Exception('unreachable');
+  }
+
+  @protected
   List<dynamic> api2wire_my_nested_struct(MyNestedStruct raw) {
     return [api2wire_my_tree_node(raw.treeNode), api2wire_weekdays(raw.weekday)];
   }
@@ -1117,6 +1134,8 @@ class FlutterRustBridgeExampleSingleBlockTestWasmModule implements WasmModule {
   external dynamic /* void */ wire_handle_return_enum(NativePortType port_, String input);
 
   external dynamic /* void */ wire_handle_enum_parameter(NativePortType port_, int weekday);
+
+  external dynamic /* List<dynamic> */ wire_handle_enum_sync_freezed(List<dynamic> value);
 
   external dynamic /* void */ wire_handle_customized_struct(NativePortType port_, List<dynamic> val);
 
@@ -1531,6 +1550,9 @@ class FlutterRustBridgeExampleSingleBlockTestWire
 
   void wire_handle_enum_parameter(NativePortType port_, int weekday) =>
       wasmModule.wire_handle_enum_parameter(port_, weekday);
+
+  dynamic /* List<dynamic> */ wire_handle_enum_sync_freezed(List<dynamic> value) =>
+      wasmModule.wire_handle_enum_sync_freezed(value);
 
   void wire_handle_customized_struct(NativePortType port_, List<dynamic> val) =>
       wasmModule.wire_handle_customized_struct(port_, val);

--- a/frb_example/pure_dart/dart/lib/main.dart
+++ b/frb_example/pure_dart/dart/lib/main.dart
@@ -422,6 +422,10 @@ void main(List<String> args) async {
     expect(await api.handleEnumParameter(weekday: Weekdays.saturday), Weekdays.saturday);
   });
 
+  test('dart call handleEnumParameter', () async {
+    expect(api.handleEnumSyncFreezed(value: MyEnumFreezed.a(1)), MyEnumFreezed.b('hello'));
+  });
+
   test('dart call handleEnumStruct', () async {
     expect(await api.handleEnumStruct(val: KitchenSink_Empty()), KitchenSink_Empty());
     expect(

--- a/frb_example/pure_dart/rust/c_output_path/c_output.h
+++ b/frb_example/pure_dart/rust/c_output_path/c_output.h
@@ -114,6 +114,24 @@ typedef struct wire_Note {
   struct wire_uint_8_list *body;
 } wire_Note;
 
+typedef struct wire_MyEnumFreezed_A {
+  int32_t field0;
+} wire_MyEnumFreezed_A;
+
+typedef struct wire_MyEnumFreezed_B {
+  struct wire_uint_8_list *field0;
+} wire_MyEnumFreezed_B;
+
+typedef union MyEnumFreezedKind {
+  struct wire_MyEnumFreezed_A *A;
+  struct wire_MyEnumFreezed_B *B;
+} MyEnumFreezedKind;
+
+typedef struct wire_MyEnumFreezed {
+  int32_t tag;
+  union MyEnumFreezedKind *kind;
+} wire_MyEnumFreezed;
+
 typedef struct wire_Customized {
   struct wire_uint_8_list *final_field;
   struct wire_uint_8_list *non_final_field;
@@ -585,6 +603,8 @@ void wire_handle_return_enum(int64_t port_, struct wire_uint_8_list *input);
 
 void wire_handle_enum_parameter(int64_t port_, int32_t weekday);
 
+WireSyncReturn wire_handle_enum_sync_freezed(struct wire_MyEnumFreezed *value);
+
 void wire_handle_customized_struct(int64_t port_, struct wire_Customized *val);
 
 void wire_handle_enum_struct(int64_t port_, struct wire_KitchenSink *val);
@@ -931,6 +951,8 @@ struct wire_Measure *new_box_autoadd_measure_0(void);
 
 struct wire_MessageId *new_box_autoadd_message_id_0(void);
 
+struct wire_MyEnumFreezed *new_box_autoadd_my_enum_freezed_0(void);
+
 struct wire_MyNestedStruct *new_box_autoadd_my_nested_struct_0(void);
 
 struct wire_MySize *new_box_autoadd_my_size_0(void);
@@ -1093,6 +1115,10 @@ union MeasureKind *inflate_Measure_Speed(void);
 
 union MeasureKind *inflate_Measure_Distance(void);
 
+union MyEnumFreezedKind *inflate_MyEnumFreezed_A(void);
+
+union MyEnumFreezedKind *inflate_MyEnumFreezed_B(void);
+
 union SpeedKind *inflate_Speed_GPS(void);
 
 void free_WireSyncReturn(WireSyncReturn ptr);
@@ -1141,6 +1167,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_print_note);
     dummy_var ^= ((int64_t) (void*) wire_handle_return_enum);
     dummy_var ^= ((int64_t) (void*) wire_handle_enum_parameter);
+    dummy_var ^= ((int64_t) (void*) wire_handle_enum_sync_freezed);
     dummy_var ^= ((int64_t) (void*) wire_handle_customized_struct);
     dummy_var ^= ((int64_t) (void*) wire_handle_enum_struct);
     dummy_var ^= ((int64_t) (void*) wire_use_imported_struct);
@@ -1307,6 +1334,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_kitchen_sink_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_measure_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_message_id_0);
+    dummy_var ^= ((int64_t) (void*) new_box_autoadd_my_enum_freezed_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_my_nested_struct_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_my_size_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_my_size_freezed_0);
@@ -1388,6 +1416,8 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) inflate_KitchenSink_Enums);
     dummy_var ^= ((int64_t) (void*) inflate_Measure_Speed);
     dummy_var ^= ((int64_t) (void*) inflate_Measure_Distance);
+    dummy_var ^= ((int64_t) (void*) inflate_MyEnumFreezed_A);
+    dummy_var ^= ((int64_t) (void*) inflate_MyEnumFreezed_B);
     dummy_var ^= ((int64_t) (void*) inflate_Speed_GPS);
     dummy_var ^= ((int64_t) (void*) free_WireSyncReturn);
     dummy_var ^= ((int64_t) (void*) store_dart_post_cobject);

--- a/frb_example/pure_dart/rust/c_output_path_extra/c_output.h
+++ b/frb_example/pure_dart/rust/c_output_path_extra/c_output.h
@@ -114,6 +114,24 @@ typedef struct wire_Note {
   struct wire_uint_8_list *body;
 } wire_Note;
 
+typedef struct wire_MyEnumFreezed_A {
+  int32_t field0;
+} wire_MyEnumFreezed_A;
+
+typedef struct wire_MyEnumFreezed_B {
+  struct wire_uint_8_list *field0;
+} wire_MyEnumFreezed_B;
+
+typedef union MyEnumFreezedKind {
+  struct wire_MyEnumFreezed_A *A;
+  struct wire_MyEnumFreezed_B *B;
+} MyEnumFreezedKind;
+
+typedef struct wire_MyEnumFreezed {
+  int32_t tag;
+  union MyEnumFreezedKind *kind;
+} wire_MyEnumFreezed;
+
 typedef struct wire_Customized {
   struct wire_uint_8_list *final_field;
   struct wire_uint_8_list *non_final_field;
@@ -585,6 +603,8 @@ void wire_handle_return_enum(int64_t port_, struct wire_uint_8_list *input);
 
 void wire_handle_enum_parameter(int64_t port_, int32_t weekday);
 
+WireSyncReturn wire_handle_enum_sync_freezed(struct wire_MyEnumFreezed *value);
+
 void wire_handle_customized_struct(int64_t port_, struct wire_Customized *val);
 
 void wire_handle_enum_struct(int64_t port_, struct wire_KitchenSink *val);
@@ -931,6 +951,8 @@ struct wire_Measure *new_box_autoadd_measure_0(void);
 
 struct wire_MessageId *new_box_autoadd_message_id_0(void);
 
+struct wire_MyEnumFreezed *new_box_autoadd_my_enum_freezed_0(void);
+
 struct wire_MyNestedStruct *new_box_autoadd_my_nested_struct_0(void);
 
 struct wire_MySize *new_box_autoadd_my_size_0(void);
@@ -1093,6 +1115,10 @@ union MeasureKind *inflate_Measure_Speed(void);
 
 union MeasureKind *inflate_Measure_Distance(void);
 
+union MyEnumFreezedKind *inflate_MyEnumFreezed_A(void);
+
+union MyEnumFreezedKind *inflate_MyEnumFreezed_B(void);
+
 union SpeedKind *inflate_Speed_GPS(void);
 
 void free_WireSyncReturn(WireSyncReturn ptr);
@@ -1141,6 +1167,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_print_note);
     dummy_var ^= ((int64_t) (void*) wire_handle_return_enum);
     dummy_var ^= ((int64_t) (void*) wire_handle_enum_parameter);
+    dummy_var ^= ((int64_t) (void*) wire_handle_enum_sync_freezed);
     dummy_var ^= ((int64_t) (void*) wire_handle_customized_struct);
     dummy_var ^= ((int64_t) (void*) wire_handle_enum_struct);
     dummy_var ^= ((int64_t) (void*) wire_use_imported_struct);
@@ -1307,6 +1334,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_kitchen_sink_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_measure_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_message_id_0);
+    dummy_var ^= ((int64_t) (void*) new_box_autoadd_my_enum_freezed_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_my_nested_struct_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_my_size_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_my_size_freezed_0);
@@ -1388,6 +1416,8 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) inflate_KitchenSink_Enums);
     dummy_var ^= ((int64_t) (void*) inflate_Measure_Speed);
     dummy_var ^= ((int64_t) (void*) inflate_Measure_Distance);
+    dummy_var ^= ((int64_t) (void*) inflate_MyEnumFreezed_A);
+    dummy_var ^= ((int64_t) (void*) inflate_MyEnumFreezed_B);
     dummy_var ^= ((int64_t) (void*) inflate_Speed_GPS);
     dummy_var ^= ((int64_t) (void*) free_WireSyncReturn);
     dummy_var ^= ((int64_t) (void*) store_dart_post_cobject);

--- a/frb_example/pure_dart/rust/src/api.rs
+++ b/frb_example/pure_dart/rust/src/api.rs
@@ -569,6 +569,17 @@ pub fn handle_enum_parameter(weekday: Weekdays) -> Weekdays {
     weekday
 }
 
+#[derive(Debug)]
+pub enum MyEnumFreezed {
+    A(i32),
+    B(String),
+}
+
+pub fn handle_enum_sync_freezed(value: MyEnumFreezed) -> SyncReturn<MyEnumFreezed> {
+    info!("handle_struct_sync_enum_freezed({:?})", &value);
+    SyncReturn(MyEnumFreezed::B("hello".to_string()))
+}
+
 #[frb]
 #[derive(Debug, Clone)]
 pub struct Customized {

--- a/frb_example/pure_dart/rust/src/bridge_generated.io.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.io.rs
@@ -252,6 +252,13 @@ pub extern "C" fn wire_handle_enum_parameter(port_: i64, weekday: i32) {
 }
 
 #[no_mangle]
+pub extern "C" fn wire_handle_enum_sync_freezed(
+    value: *mut wire_MyEnumFreezed,
+) -> support::WireSyncReturn {
+    wire_handle_enum_sync_freezed_impl(value)
+}
+
+#[no_mangle]
 pub extern "C" fn wire_handle_customized_struct(port_: i64, val: *mut wire_Customized) {
     wire_handle_customized_struct_impl(port_, val)
 }
@@ -1126,6 +1133,11 @@ pub extern "C" fn new_box_autoadd_message_id_0() -> *mut wire_MessageId {
 }
 
 #[no_mangle]
+pub extern "C" fn new_box_autoadd_my_enum_freezed_0() -> *mut wire_MyEnumFreezed {
+    support::new_leak_box_ptr(wire_MyEnumFreezed::new_with_null_ptr())
+}
+
+#[no_mangle]
 pub extern "C" fn new_box_autoadd_my_nested_struct_0() -> *mut wire_MyNestedStruct {
     support::new_leak_box_ptr(wire_MyNestedStruct::new_with_null_ptr())
 }
@@ -1919,6 +1931,12 @@ impl Wire2Api<MessageId> for *mut wire_MessageId {
         Wire2Api::<MessageId>::wire2api(*wrap).into()
     }
 }
+impl Wire2Api<MyEnumFreezed> for *mut wire_MyEnumFreezed {
+    fn wire2api(self) -> MyEnumFreezed {
+        let wrap = unsafe { support::box_from_leak_ptr(self) };
+        Wire2Api::<MyEnumFreezed>::wire2api(*wrap).into()
+    }
+}
 impl Wire2Api<MyNestedStruct> for *mut wire_MyNestedStruct {
     fn wire2api(self) -> MyNestedStruct {
         let wrap = unsafe { support::box_from_leak_ptr(self) };
@@ -2439,6 +2457,23 @@ impl Wire2Api<MessageId> for wire_MessageId {
     }
 }
 
+impl Wire2Api<MyEnumFreezed> for wire_MyEnumFreezed {
+    fn wire2api(self) -> MyEnumFreezed {
+        match self.tag {
+            0 => unsafe {
+                let ans = support::box_from_leak_ptr(self.kind);
+                let ans = support::box_from_leak_ptr(ans.A);
+                MyEnumFreezed::A(ans.field0.wire2api())
+            },
+            1 => unsafe {
+                let ans = support::box_from_leak_ptr(self.kind);
+                let ans = support::box_from_leak_ptr(ans.B);
+                MyEnumFreezed::B(ans.field0.wire2api())
+            },
+            _ => unreachable!(),
+        }
+    }
+}
 impl Wire2Api<MyNestedStruct> for wire_MyNestedStruct {
     fn wire2api(self) -> MyNestedStruct {
         MyNestedStruct {
@@ -3196,6 +3231,31 @@ pub struct wire_Measure_Distance {
 
 #[repr(C)]
 #[derive(Clone)]
+pub struct wire_MyEnumFreezed {
+    tag: i32,
+    kind: *mut MyEnumFreezedKind,
+}
+
+#[repr(C)]
+pub union MyEnumFreezedKind {
+    A: *mut wire_MyEnumFreezed_A,
+    B: *mut wire_MyEnumFreezed_B,
+}
+
+#[repr(C)]
+#[derive(Clone)]
+pub struct wire_MyEnumFreezed_A {
+    field0: i32,
+}
+
+#[repr(C)]
+#[derive(Clone)]
+pub struct wire_MyEnumFreezed_B {
+    field0: *mut wire_uint_8_list,
+}
+
+#[repr(C)]
+#[derive(Clone)]
 pub struct wire_Speed {
     tag: i32,
     kind: *mut SpeedKind,
@@ -3841,6 +3901,39 @@ impl Default for wire_MessageId {
     fn default() -> Self {
         Self::new_with_null_ptr()
     }
+}
+
+impl Default for wire_MyEnumFreezed {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
+
+impl NewWithNullPtr for wire_MyEnumFreezed {
+    fn new_with_null_ptr() -> Self {
+        Self {
+            tag: -1,
+            kind: core::ptr::null_mut(),
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn inflate_MyEnumFreezed_A() -> *mut MyEnumFreezedKind {
+    support::new_leak_box_ptr(MyEnumFreezedKind {
+        A: support::new_leak_box_ptr(wire_MyEnumFreezed_A {
+            field0: Default::default(),
+        }),
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn inflate_MyEnumFreezed_B() -> *mut MyEnumFreezedKind {
+    support::new_leak_box_ptr(MyEnumFreezedKind {
+        B: support::new_leak_box_ptr(wire_MyEnumFreezed_B {
+            field0: core::ptr::null_mut(),
+        }),
+    })
 }
 
 impl NewWithNullPtr for wire_MyNestedStruct {

--- a/frb_example/pure_dart/rust/src/bridge_generated.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.rs
@@ -703,6 +703,21 @@ fn wire_handle_enum_parameter_impl(
         },
     )
 }
+fn wire_handle_enum_sync_freezed_impl(
+    value: impl Wire2Api<MyEnumFreezed> + UnwindSafe,
+) -> support::WireSyncReturn {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync(
+        WrapInfo {
+            debug_name: "handle_enum_sync_freezed",
+            port: None,
+            mode: FfiCallMode::Sync,
+        },
+        move || {
+            let api_value = value.wire2api();
+            Ok(handle_enum_sync_freezed(api_value))
+        },
+    )
+}
 fn wire_handle_customized_struct_impl(
     port_: MessagePort,
     val: impl Wire2Api<Customized> + UnwindSafe,
@@ -3255,6 +3270,22 @@ impl support::IntoDart for MyEnum {
 }
 impl support::IntoDartExceptPrimitive for MyEnum {}
 impl rust2dart::IntoIntoDart<MyEnum> for MyEnum {
+    fn into_into_dart(self) -> Self {
+        self
+    }
+}
+
+impl support::IntoDart for MyEnumFreezed {
+    fn into_dart(self) -> support::DartAbi {
+        match self {
+            Self::A(field0) => vec![0.into_dart(), field0.into_into_dart().into_dart()],
+            Self::B(field0) => vec![1.into_dart(), field0.into_into_dart().into_dart()],
+        }
+        .into_dart()
+    }
+}
+impl support::IntoDartExceptPrimitive for MyEnumFreezed {}
+impl rust2dart::IntoIntoDart<MyEnumFreezed> for MyEnumFreezed {
     fn into_into_dart(self) -> Self {
         self
     }

--- a/frb_example/pure_dart/rust/src/bridge_generated.web.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.web.rs
@@ -240,6 +240,11 @@ pub fn wire_handle_enum_parameter(port_: MessagePort, weekday: i32) {
 }
 
 #[wasm_bindgen]
+pub fn wire_handle_enum_sync_freezed(value: JsValue) -> support::WireSyncReturn {
+    wire_handle_enum_sync_freezed_impl(value)
+}
+
+#[wasm_bindgen]
 pub fn wire_handle_customized_struct(port_: MessagePort, val: JsValue) {
     wire_handle_customized_struct_impl(port_, val)
 }
@@ -1582,6 +1587,16 @@ impl Wire2Api<MessageId> for JsValue {
     }
 }
 
+impl Wire2Api<MyEnumFreezed> for JsValue {
+    fn wire2api(self) -> MyEnumFreezed {
+        let self_ = self.unchecked_into::<JsArray>();
+        match self_.get(0).unchecked_into_f64() as _ {
+            0 => MyEnumFreezed::A(self_.get(1).wire2api()),
+            1 => MyEnumFreezed::B(self_.get(1).wire2api()),
+            _ => unreachable!(),
+        }
+    }
+}
 impl Wire2Api<MyNestedStruct> for JsValue {
     fn wire2api(self) -> MyNestedStruct {
         let self_ = self.dyn_into::<JsArray>().unwrap();


### PR DESCRIPTION
## Changes
Allow all structs/enums that meet the conditions to be able to generate code correctly through `freezed` because the approach in #1304 may fail under certain circumstances.

## Checklist

- [x] An issue to be fixed by this PR is listed above.
- x] New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api.rs` and `dart/lib/main.dart`.
- [x] The code generator is run and the code is formatted (via `just precommit`).
- [x] If this PR adds/changes features, documentations (in the `./book` folder) are updated.
- [ ] CI is passing.

## Remark for PR creator

- Justfile is a task runner for the command line interface that allows you to run shell commands from a file named `justfile` in your project directory. You can use Justfile after [installing it](https://github.com/casey/just). Note that commands written in `justfile` of this repository are expected to be run in `bash`, not `cmd` or `powershell`. Running `just ...` commands in `cmd` or `powershell` will produce errors as the syntax is not compatible. On Windows, you can use `git bash` if you have Git installed.
- If fzyzcjy does not reply for a few days, maybe he just did not see it, so please ping him.
