### PR TITLE
Ffigen version

### DIFF
--- a/frb_codegen/src/commands.rs
+++ b/frb_codegen/src/commands.rs
@@ -24,7 +24,7 @@ lazy_static! {
     pub(crate) static ref FFI_REQUIREMENT: VersionReq =
         VersionReq::parse(">= 2.0.1, < 3.0.0").unwrap();
     pub(crate) static ref FFIGEN_REQUIREMENT: VersionReq =
-        VersionReq::parse(">= 8.0.0, < 9.0.0").unwrap();
+        VersionReq::parse(">= 8.0.0, < 10.0.0").unwrap();
 }
 
 pub fn ensure_tools_available(dart_root: &str, skip_deps_check: bool) -> Result<(), Error> {

--- a/frb_example/pure_dart/dart/pubspec.lock
+++ b/frb_example/pure_dart/dart/pubspec.lock
@@ -197,18 +197,18 @@ packages:
     dependency: "direct dev"
     description:
       name: ffigen
-      sha256: d3e76c2ad48a4e7f93a29a162006f00eba46ce7c08194a77bb5c5e97d1b5ff0a
+      sha256: "3a80687577e7e51ba915114742f389a128e8aa241c52ce69a0f70aecb8e14365"
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.2"
+    version: "9.0.1"
   file:
     dependency: transitive
     description:
       name: file
-      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.4"
+    version: "7.0.0"
   fixnum:
     dependency: transitive
     description:

--- a/frb_example/pure_dart/dart/pubspec.yaml
+++ b/frb_example/pure_dart/dart/pubspec.yaml
@@ -20,4 +20,4 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.4.4
   freezed: ^2.1.0+1
-  ffigen: ^8.0.0
+  ffigen: ^9.0.0

--- a/frb_example/pure_dart_multi/dart/pubspec.lock
+++ b/frb_example/pure_dart_multi/dart/pubspec.lock
@@ -197,18 +197,18 @@ packages:
     dependency: "direct dev"
     description:
       name: ffigen
-      sha256: d3e76c2ad48a4e7f93a29a162006f00eba46ce7c08194a77bb5c5e97d1b5ff0a
+      sha256: "3a80687577e7e51ba915114742f389a128e8aa241c52ce69a0f70aecb8e14365"
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.2"
+    version: "9.0.1"
   file:
     dependency: transitive
     description:
       name: file
-      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.4"
+    version: "7.0.0"
   fixnum:
     dependency: transitive
     description:

--- a/frb_example/pure_dart_multi/dart/pubspec.yaml
+++ b/frb_example/pure_dart_multi/dart/pubspec.yaml
@@ -17,4 +17,4 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.4.4
   freezed: ^2.0.2
-  ffigen: ^8.0.0
+  ffigen: ^9.0.0


### PR DESCRIPTION
## Changes

Fixes #1329. Tested with `cargo test`. 

Note: In with_flutter, pubspec.yaml cannot be upgraded to ffigen 9 because of a conflicting major version of `file` via flutter sdk `integration_test`. `cargo test` run with 
```yaml
# (frb_example/with_flutter/pubspec.yaml)
+  ffigen: ^9.0.1
+dependency_overrides:
+  file: ^7.0.0
```

## Checklist

- [X] An issue to be fixed by this PR is listed above.
- [ ] New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api.rs` and `dart/lib/main.dart`.
- [ ] The code generator is run and the code is formatted (via `just precommit`).
- [ ] If this PR adds/changes features, documentations (in the `./book` folder) are updated.
- [ ] CI is passing.
