### PR TITLE
fix invalid sdk spec syntax

### DIFF
--- a/frb_dart/pubspec.yaml
+++ b/frb_dart/pubspec.yaml
@@ -3,7 +3,7 @@ description: High-level memory-safe binding generator for Flutter/Dart <-> Rust
 version: 1.81.0
 repository: https://github.com/fzyzcjy/flutter_rust_bridge
 environment:
-  sdk: ">=3.0.0 < 4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 dependencies:
   args: ^2.3.1
   build_cli_annotations: ^2.1.0


### PR DESCRIPTION
## Changes

Fixes a typo in frb_dart/pubspec.yaml. Before: red squiggles in vscode due to pubspec.json validation. After: no squiggles.

## Checklist

- [ ] An issue to be fixed by this PR is listed above.
- [ ] New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api.rs` and `dart/lib/main.dart`.
- [ ] The code generator is run and the code is formatted (via `just precommit`).
- [ ] If this PR adds/changes features, documentations (in the `./book` folder) are updated.
- [ ] CI is passing.