### PR TITLE
Provide more info for "Creating a Library" chapter, "CI/CD" section

### DIFF
--- a/book/src/library/ci.md
+++ b/book/src/library/ci.md
@@ -313,13 +313,16 @@ jobs:
 In order for this workflow to execute correctly and publish packages to pub.dev,
 you need to have the contents of your pub credentials JSON file in a GitHub repo secret.
 
-After signing into pub locally, open the credentials file which can be found:
+First you need to sign-in into your pub account locally by
+running the following command ```dart pub login```
+
+After the authorization is completed, open the credentials file, which can be found:
 
 - On Linux, at `~/.config/dart/pub-credentials.json`
 - On macOS, at `~/Library/Application Support/dart/pub-credentials.json`
 - On Windows, at `C:\Users\YourUsername\AppData\Roaming\dart\pub-credentials.json`
   
-Now copy the contents of this `pub-credentials.json` file to a new GitHub repo secret named `PUB_CRED_JSON`.
+And copy the contents of this `pub-credentials.json` file to a new GitHub repo secret named `PUB_CRED_JSON`.
 
 This workflow is set to execute whenever new version tags are pushed up to GitHub.
 

--- a/book/src/library/ci.md
+++ b/book/src/library/ci.md
@@ -313,13 +313,13 @@ jobs:
 In order for this workflow to execute correctly and publish packages to pub.dev,
 you need to have the contents of your pub credentials JSON file in a GitHub repo secret.
 
-After signing into pub locally:
+After signing into pub locally, open the credentials file which can be found:
 
-- On Linux, open the file at `~/.config/dart/pub-credentials.json`,
-- On macOS, open the file at `~/Library/Application Support/dart/pub-credentials.json`
-- Not sure where the `dart` config folder is on Windows, but you should be able to find it
-  - Feel free to PR and fix this if you find it!
-    And copy the contents of this `pub-credentials.json` file to a new GitHub repo secret named `PUB_CRED_JSON`.
+- On Linux, at `~/.config/dart/pub-credentials.json`
+- On macOS, at `~/Library/Application Support/dart/pub-credentials.json`
+- On Windows, at `C:\Users\YourUsername\AppData\Roaming\dart\pub-credentials.json`
+  
+Now copy the contents of this `pub-credentials.json` file to a new GitHub repo secret named `PUB_CRED_JSON`.
 
 This workflow is set to execute whenever new version tags are pushed up to GitHub.
 

--- a/book/src/library/ci.md
+++ b/book/src/library/ci.md
@@ -314,7 +314,7 @@ In order for this workflow to execute correctly and publish packages to pub.dev,
 you need to have the contents of your pub credentials JSON file in a GitHub repo secret.
 
 First you need to sign-in into your pub account locally by
-running the following command ```dart pub login```
+running the following command: `dart pub login`.
 
 After the authorization is completed, open the credentials file, which can be found:
 


### PR DESCRIPTION
## Changes
Hey👋🏻
In the "Creating a Dart\Flutter Library" chapter of the book and regarding CI/CD:
- I've provided the location of  `pub-credentials.json` file on Windows and it'd be helpful if anyone can double-check.
- Add a lil bit of info on how to locally login to `Pub.dev`.

**And of course thanks to everyone for ur hard work.**

## Checklist

- [ ] An issue to be fixed by this PR is listed above.
- [ ] New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api.rs` and `dart/lib/main.dart`.
- [ ] The code generator is run and the code is formatted (via `just precommit`).
- [x] If this PR adds/changes features, documentations (in the `./book` folder) are updated.
- [ ] CI is passing.