### PR TITLE
Use delegate-attr to simplify code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,14 +491,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "delegate"
-version = "0.8.0"
+name = "delegate-attr"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "082a24a9967533dc5d743c602157637116fc1b52806d694a5a45e6f32567fcdd"
+checksum = "51aac4c99b2e6775164b412ea33ae8441b2fde2dbf05a20bc0052a63d08c475b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -675,7 +675,7 @@ dependencies = [
  "chrono",
  "clap 4.3.21",
  "convert_case",
- "delegate",
+ "delegate-attr",
  "enum-iterator",
  "enum_dispatch",
  "fern",

--- a/frb_codegen/Cargo.toml
+++ b/frb_codegen/Cargo.toml
@@ -21,7 +21,7 @@ anyhow = {workspace = true}
 thiserror = {workspace = true}
 cargo_metadata = "0.14.1"
 convert_case = "0.5.0"
-delegate = "0.8.0"
+delegate-attr = "0.3.0"
 enum_dispatch = "0.3.8"
 itertools = "0.10.3"
 lazy_static = {workspace = true}

--- a/frb_codegen/src/generator/dart/ty_sync_return.rs
+++ b/frb_codegen/src/generator/dart/ty_sync_return.rs
@@ -1,4 +1,4 @@
-use delegate::delegate;
+use delegate_attr::delegate;
 
 use crate::generator::dart::*;
 use crate::target::Acc;
@@ -22,13 +22,10 @@ impl<'a> TypeSyncReturnGenerator<'a> {
     }
 }
 
+#[delegate(self.inner)]
 impl<'a> TypeDartGeneratorTrait for TypeSyncReturnGenerator<'a> {
-    delegate! {
-        to self.inner {
-            fn api2wire_body(&self) -> Acc<Option<String>>;
-            fn api_fill_to_wire_body(&self) -> Option<String>;
-            fn wire2api_body(&self) -> String;
-            fn structs(&self) -> String;
-        }
-    }
+    fn api2wire_body(&self) -> Acc<Option<String>> {}
+    fn api_fill_to_wire_body(&self) -> Option<String> {}
+    fn wire2api_body(&self) -> String {}
+    fn structs(&self) -> String {}
 }

--- a/frb_codegen/src/generator/rust/ty_sync_return.rs
+++ b/frb_codegen/src/generator/rust/ty_sync_return.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::fmt::Debug;
 
-use delegate::delegate;
+use delegate_attr::delegate;
 
 use crate::generator::rust::*;
 use crate::target::Acc;
@@ -25,30 +25,29 @@ impl<'a> TypeSyncReturnGenerator<'a> {
     }
 }
 
+#[delegate(self.inner)]
 impl<'a> TypeRustGeneratorTrait for TypeSyncReturnGenerator<'a> {
-    delegate! {
-        to self.inner {
-            fn wire2api_body(&self) -> Acc<Option<String>>;
-            fn wire2api_jsvalue(&self) -> Option<Cow<str>>;
-            fn wire_struct_fields(&self) -> Option<Vec<String>>;
-            fn static_checks(&self) -> Option<String>;
-            fn wrapper_struct(&self) -> Option<String>;
-            fn self_access(&self, obj: String) -> String;
-            fn convert_to_dart(&self, obj: String) -> String;
-            fn structs(&self) -> String;
-            fn allocate_funcs(
-                &self,
-                _collector: &mut ExternFuncCollector,
-                _block_index: BlockIndex,
-            ) -> Acc<Option<String>>;
-            fn related_funcs(
-                &self,
-                _collector: &mut ExternFuncCollector,
-                _block_index: BlockIndex,
-            ) -> Acc<Option<String>>;
-            fn impl_intodart(&self) -> String;
-            fn new_with_nullptr(&self, _collector: &mut ExternFuncCollector) -> String;
-            fn imports(&self) -> Option<String>;
-        }
+    fn wire2api_body(&self) -> Acc<Option<String>> {}
+    fn wire2api_jsvalue(&self) -> Option<Cow<str>> {}
+    fn wire_struct_fields(&self) -> Option<Vec<String>> {}
+    fn static_checks(&self) -> Option<String> {}
+    fn wrapper_struct(&self) -> Option<String> {}
+    fn self_access(&self, obj: String) -> String {}
+    fn convert_to_dart(&self, obj: String) -> String {}
+    fn structs(&self) -> String {}
+    fn allocate_funcs(
+        &self,
+        _collector: &mut ExternFuncCollector,
+        _block_index: BlockIndex,
+    ) -> Acc<Option<String>> {
     }
+    fn related_funcs(
+        &self,
+        _collector: &mut ExternFuncCollector,
+        _block_index: BlockIndex,
+    ) -> Acc<Option<String>> {
+    }
+    fn impl_intodart(&self) -> String {}
+    fn new_with_nullptr(&self, _collector: &mut ExternFuncCollector) -> String {}
+    fn imports(&self) -> Option<String> {}
 }

--- a/frb_codegen/src/ir/ty_sync_return.rs
+++ b/frb_codegen/src/ir/ty_sync_return.rs
@@ -1,4 +1,4 @@
-use delegate::delegate;
+use delegate_attr::delegate;
 
 use crate::{ir::*, target::Target};
 
@@ -16,15 +16,12 @@ impl IrTypeSyncReturn {
     }
 }
 
+#[delegate(self.0)]
 impl IrTypeTrait for IrTypeSyncReturn {
-    delegate! {
-        to self.0 {
-            fn visit_children_types<F: FnMut(&IrType) -> bool>(&self, f: &mut F, ir_file: &IrFile);
-            fn safe_ident(&self) -> String;
-            fn dart_api_type(&self) -> String;
-            fn dart_wire_type(&self, target: Target) -> String;
-            fn rust_api_type(&self) -> String;
-            fn rust_wire_type(&self, target: Target) -> String;
-        }
-    }
+    fn visit_children_types<F: FnMut(&IrType) -> bool>(&self, f: &mut F, ir_file: &IrFile) {}
+    fn safe_ident(&self) -> String {}
+    fn dart_api_type(&self) -> String {}
+    fn dart_wire_type(&self, target: Target) -> String {}
+    fn rust_api_type(&self) -> String {}
+    fn rust_wire_type(&self, target: Target) -> String {}
 }


### PR DESCRIPTION
## Changes

This PR replaces the use of `delegate` crate with `delegate-attr` crate to simplify the code while keeping the same functionality.
