### PR TITLE
Fix small typos in logging.md

### DIFF
--- a/book/src/feature/logging.md
+++ b/book/src/feature/logging.md
@@ -4,7 +4,7 @@ Since I have seen some questions asking how logging can be implemented with a Fl
 
 ## Logger in production
 
-In my own app in production, I use the following strategy for Rust logging: Use normal Rust logging methods, such as `info!` and `debug!` macros. The logs are consumed in two places: They are printed via platform-specific methods (like android Logcat and iOS NSLog), and also use a Stream to send them to the Dart side such that my Dart code and further process it using the same pipeline as normal Dart logs (e.g. save to a file, send to server, etc).
+In my own app in production, I use the following strategy for Rust logging: Use normal Rust logging methods, such as `info!` and `debug!` macros. The logs are consumed in two places: They are printed via platform-specific methods (like android Logcat and iOS NSLog), and also use a Stream to send them to the Dart side such that my Dart code and further process are using the same pipeline as normal Dart logs (e.g. save to a file, send to server, etc).
 
 The *full* code related to logging in my app can be seen here: [#486](https://github.com/fzyzcjy/flutter_rust_bridge/issues/486).
 
@@ -58,7 +58,7 @@ And now we can happily log anything in Rust:
 log_stream_sink.add(LogEntry { msg: "hello I am a log from Rust", ... })
 ```
 
-Of course, you can implement a logger following the Rust's `log` crate wrapping this raw stream sink, then you can use standard Rust logging mechanisms like `info!`. I exactly did that in my project.
+Of course, you can implement a logger following the Rust's `log` crate wrapping this raw stream sink, then you can use standard Rust logging mechanisms like `info!`. I did exactly that in my project.
 
 ### Example: Simple timer
 


### PR DESCRIPTION
## Changes

The "Logging" page of the book had some small typos, this pr fixes them

## Checklist

- [x] An issue to be fixed by this PR is listed above.
- [ ] New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api.rs` and `dart/lib/main.dart`.
- [ ] The code generator is run and the code is formatted (via `just precommit`).
- [ ] If this PR adds/changes features, documentations (in the `./book` folder) are updated.
- [ ] CI is passing.

## Remark for PR creator

- Justfile is a task runner for the command line interface that allows you to run shell commands from a file named `justfile` in your project directory. You can use Justfile after [installing it](https://github.com/casey/just). Note that commands written in `justfile` of this repository are expected to be run in `bash`, not `cmd` or `powershell`. Running `just ...` commands in `cmd` or `powershell` will produce errors as the syntax is not compatible. On Windows, you can use `git bash` if you have Git installed.
- If fzyzcjy does not reply for a few days, maybe he just did not see it, so please ping him.
