### PR TITLE
Fix expand missing code

### DIFF
--- a/frb_codegen/src/commands.rs
+++ b/frb_codegen/src/commands.rs
@@ -318,7 +318,6 @@ fn run_cargo_expand(dir: &str) -> String {
             // remove first and last line to get rid of wrapping module
             let mut output = stdout.lines();
             output.next();
-            output.next_back();
             output
                 .collect::<Vec<_>>()
                 .join("\n")


### PR DESCRIPTION
## Changes

Fixes #1354 

This PR removes this line of code:
https://github.com/fzyzcjy/flutter_rust_bridge/blob/d54eae758f94ca1a5e69787d20f16af39daa89c2/frb_codegen/src/commands.rs#L321

This code was removing the last line of the output from `cargo-expand`. This caused a `lex error` to be thrown because it removed an important piece of code (ex. `}`).

## Checklist

- [x] An issue to be fixed by this PR is listed above.
- [ ] New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api.rs` and `dart/lib/main.dart`.
- [ ] The code generator is run and the code is formatted (via `just precommit`).
- [ ] If this PR adds/changes features, documentations (in the `./book` folder) are updated.
- [ ] CI is passing.

## Remark for PR creator

- Justfile is a task runner for the command line interface that allows you to run shell commands from a file named `justfile` in your project directory. You can use Justfile after [installing it](https://github.com/casey/just). Note that commands written in `justfile` of this repository are expected to be run in `bash`, not `cmd` or `powershell`. Running `just ...` commands in `cmd` or `powershell` will produce errors as the syntax is not compatible. On Windows, you can use `git bash` if you have Git installed.
- If fzyzcjy does not reply for a few days, maybe he just did not see it, so please ping him.
