### PR TITLE
fix: Err returned in Rust not properly passed to Dart

### DIFF
--- a/frb_codegen/src/parser/error.rs
+++ b/frb_codegen/src/parser/error.rs
@@ -20,6 +20,9 @@ pub enum Error {
     #[error("Mutating methods are not yet supported.")]
     NoMutSelf,
 
+    #[error("When the function signature contains a StreamSink, the return value can only be None or a unit type. Function name that triggered this error: {0}.")]
+    NoStreamSinkAndOutput(Arc<str>),
+
     #[error(transparent)]
     SerdeYaml(#[from] serde_yaml::Error),
 

--- a/frb_codegen/src/parser/mod.rs
+++ b/frb_codegen/src/parser/mod.rs
@@ -245,7 +245,6 @@ impl<'a> Parser<'a> {
 
         let mut inputs = Vec::new();
         let mut output = None;
-        let mut error = None;
         let mut mode: Option<IrFuncMode> = None;
         let mut fallible = true;
 
@@ -294,35 +293,41 @@ impl<'a> Parser<'a> {
             }
         }
 
-        if output.is_none() {
-            let result = match &sig.output {
-                ReturnType::Type(_, ty) => {
-                    let output_type = self.try_parse_fn_output_type(ty).with_context(|| {
-                        format!(
-                            "Failed to parse function output type `{}`",
-                            type_to_string(ty)
-                        )
-                    })?;
-                    match output_type {
-                        IrFuncOutput::ResultType { ok: ty, error: err } => (ty, err),
-                        IrFuncOutput::Type(ty) => {
-                            fallible = false;
-                            (ty, None)
-                        }
+        let result = match &sig.output {
+            ReturnType::Type(_, ty) => {
+                let output_type = self.try_parse_fn_output_type(ty).with_context(|| {
+                    format!(
+                        "Failed to parse function output type `{}`",
+                        type_to_string(ty)
+                    )
+                })?;
+                match output_type {
+                    IrFuncOutput::ResultType { ok: ty, error: err } => (ty, err),
+                    IrFuncOutput::Type(ty) => {
+                        fallible = false;
+                        (ty, None)
                     }
                 }
-                ReturnType::Default => {
-                    fallible = false;
-                    (IrType::Primitive(IrTypePrimitive::Unit), None)
-                }
-            };
-            output = Some(result.0);
-            error = result.1;
-            mode = Some(if let Some(IrType::SyncReturn(_)) = output {
+            }
+            ReturnType::Default => {
+                fallible = false;
+                (IrType::Primitive(IrTypePrimitive::Unit), None)
+            }
+        };
+
+        if matches!(mode, Some(IrFuncMode::Stream { argument_index: _ }) if result.0 != IrType::Primitive(IrTypePrimitive::Unit))
+        {
+            return Err(Error::NoStreamSinkAndOutput(func_name.into()));
+        }
+
+        if output.is_none() {
+            let tmp_mode = if let IrType::SyncReturn(_) = result.0 {
                 IrFuncMode::Sync
             } else {
                 IrFuncMode::Normal
-            });
+            };
+            mode = Some(tmp_mode);
+            output = Some(result.0);
         }
 
         Ok(IrFunc {
@@ -332,7 +337,7 @@ impl<'a> Parser<'a> {
             fallible,
             mode: mode.context("Missing mode")?,
             comments: extract_comments(&func.attrs),
-            error_output: error,
+            error_output: result.1,
         })
     }
 }

--- a/frb_codegen/src/parser/mod.rs
+++ b/frb_codegen/src/parser/mod.rs
@@ -321,12 +321,11 @@ impl<'a> Parser<'a> {
         }
 
         if output.is_none() {
-            let tmp_mode = if let IrType::SyncReturn(_) = result.0 {
+            mode = Some(if let IrType::SyncReturn(_) = result.0 {
                 IrFuncMode::Sync
             } else {
                 IrFuncMode::Normal
-            };
-            mode = Some(tmp_mode);
+            });
             output = Some(result.0);
         }
 

--- a/frb_dart/lib/src/basic.dart
+++ b/frb_dart/lib/src/basic.dart
@@ -236,7 +236,7 @@ class FrbAnyhowException implements FrbException {
   FrbAnyhowException(this.anyhow);
 
   @override
-  String toString() => anyhow;
+  String toString() => 'FrbAnyhowException($anyhow)';
 }
 
 abstract class FrbBacktracedException extends FrbException {

--- a/frb_dart/lib/src/basic.dart
+++ b/frb_dart/lib/src/basic.dart
@@ -234,6 +234,9 @@ class FrbAnyhowException implements FrbException {
   final String anyhow;
 
   FrbAnyhowException(this.anyhow);
+
+  @override
+  String toString() => anyhow;
 }
 
 abstract class FrbBacktracedException extends FrbException {

--- a/frb_example/pure_dart/dart/lib/bridge_definitions.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_definitions.dart
@@ -736,6 +736,10 @@ abstract class FlutterRustBridgeExampleSingleBlockTest {
 
   FlutterRustBridgeTaskConstMeta get kPanicWithCustomResultConstMeta;
 
+  Stream<String> streamSinkThrowAnyhow({dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kStreamSinkThrowAnyhowConstMeta;
+
   Future<String> asStringMethodEvent({required Event that, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kAsStringMethodEventConstMeta;

--- a/frb_example/pure_dart/dart/lib/bridge_generated.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.dart
@@ -2965,6 +2965,22 @@ class FlutterRustBridgeExampleSingleBlockTestImpl implements FlutterRustBridgeEx
         argNames: [],
       );
 
+  Stream<String> streamSinkThrowAnyhow({dynamic hint}) {
+    return _platform.executeStream(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_stream_sink_throw_anyhow(port_),
+      parseSuccessData: _wire2api_String,
+      parseErrorData: _wire2api_FrbAnyhowException,
+      constMeta: kStreamSinkThrowAnyhowConstMeta,
+      argValues: [],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kStreamSinkThrowAnyhowConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "stream_sink_throw_anyhow",
+        argNames: [],
+      );
+
   Future<String> asStringMethodEvent({required Event that, dynamic hint}) {
     var arg0 = _platform.api2wire_box_autoadd_event(that);
     return _platform.executeNormal(FlutterRustBridgeTask(

--- a/frb_example/pure_dart/dart/lib/bridge_generated.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.dart
@@ -1131,7 +1131,7 @@ class FlutterRustBridgeExampleSingleBlockTestImpl implements FlutterRustBridgeEx
     return _platform.executeStream(FlutterRustBridgeTask(
       callFfi: (port_) => _platform.inner.wire_register_event_listener(port_),
       parseSuccessData: (d) => _wire2api_event(d),
-      parseErrorData: null,
+      parseErrorData: _wire2api_FrbAnyhowException,
       constMeta: kRegisterEventListenerConstMeta,
       argValues: [],
       hint: hint,

--- a/frb_example/pure_dart/dart/lib/bridge_generated.io.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.io.dart
@@ -1949,9 +1949,9 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   }
 
   late final _wire_handle_struct_sync_freezedPtr = _lookup<
-      ffi.NativeFunction<
-          WireSyncReturn Function(
-              ffi.Pointer<wire_MySizeFreezed>, ffi.Pointer<wire_MySizeFreezed>)>>('wire_handle_struct_sync_freezed');
+          ffi
+          .NativeFunction<WireSyncReturn Function(ffi.Pointer<wire_MySizeFreezed>, ffi.Pointer<wire_MySizeFreezed>)>>(
+      'wire_handle_struct_sync_freezed');
   late final _wire_handle_struct_sync_freezed = _wire_handle_struct_sync_freezedPtr
       .asFunction<WireSyncReturn Function(ffi.Pointer<wire_MySizeFreezed>, ffi.Pointer<wire_MySizeFreezed>)>();
 
@@ -2635,9 +2635,9 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   }
 
   late final _wire_create_eventPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-              ffi.Int64, ffi.Pointer<wire_uint_8_list>, ffi.Pointer<wire_uint_8_list>)>>('wire_create_event');
+          ffi
+          .NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>, ffi.Pointer<wire_uint_8_list>)>>(
+      'wire_create_event');
   late final _wire_create_event = _wire_create_eventPtr
       .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>, ffi.Pointer<wire_uint_8_list>)>();
 
@@ -4164,9 +4164,9 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   }
 
   late final _wire_concatenate_static__static_method__ConcatenateWithPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>,
-              ffi.Pointer<wire_uint_8_list>)>>('wire_concatenate_static__static_method__ConcatenateWith');
+          ffi
+          .NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>, ffi.Pointer<wire_uint_8_list>)>>(
+      'wire_concatenate_static__static_method__ConcatenateWith');
   late final _wire_concatenate_static__static_method__ConcatenateWith =
       _wire_concatenate_static__static_method__ConcatenateWithPtr
           .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>, ffi.Pointer<wire_uint_8_list>)>();

--- a/frb_example/pure_dart/dart/lib/bridge_generated.io.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.io.dart
@@ -4080,6 +4080,18 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_panic_with_custom_result');
   late final _wire_panic_with_custom_result = _wire_panic_with_custom_resultPtr.asFunction<void Function(int)>();
 
+  void wire_stream_sink_throw_anyhow(
+    int port_,
+  ) {
+    return _wire_stream_sink_throw_anyhow(
+      port_,
+    );
+  }
+
+  late final _wire_stream_sink_throw_anyhowPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_stream_sink_throw_anyhow');
+  late final _wire_stream_sink_throw_anyhow = _wire_stream_sink_throw_anyhowPtr.asFunction<void Function(int)>();
+
   void wire_as_string__method__Event(
     int port_,
     ffi.Pointer<wire_Event> that,

--- a/frb_example/pure_dart/dart/lib/bridge_generated.io.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.io.dart
@@ -1949,9 +1949,9 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   }
 
   late final _wire_handle_struct_sync_freezedPtr = _lookup<
-          ffi
-          .NativeFunction<WireSyncReturn Function(ffi.Pointer<wire_MySizeFreezed>, ffi.Pointer<wire_MySizeFreezed>)>>(
-      'wire_handle_struct_sync_freezed');
+      ffi.NativeFunction<
+          WireSyncReturn Function(
+              ffi.Pointer<wire_MySizeFreezed>, ffi.Pointer<wire_MySizeFreezed>)>>('wire_handle_struct_sync_freezed');
   late final _wire_handle_struct_sync_freezed = _wire_handle_struct_sync_freezedPtr
       .asFunction<WireSyncReturn Function(ffi.Pointer<wire_MySizeFreezed>, ffi.Pointer<wire_MySizeFreezed>)>();
 
@@ -2635,9 +2635,9 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   }
 
   late final _wire_create_eventPtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>, ffi.Pointer<wire_uint_8_list>)>>(
-      'wire_create_event');
+      ffi.NativeFunction<
+          ffi.Void Function(
+              ffi.Int64, ffi.Pointer<wire_uint_8_list>, ffi.Pointer<wire_uint_8_list>)>>('wire_create_event');
   late final _wire_create_event = _wire_create_eventPtr
       .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>, ffi.Pointer<wire_uint_8_list>)>();
 
@@ -4164,9 +4164,9 @@ class FlutterRustBridgeExampleSingleBlockTestWire implements FlutterRustBridgeWi
   }
 
   late final _wire_concatenate_static__static_method__ConcatenateWithPtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>, ffi.Pointer<wire_uint_8_list>)>>(
-      'wire_concatenate_static__static_method__ConcatenateWith');
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>,
+              ffi.Pointer<wire_uint_8_list>)>>('wire_concatenate_static__static_method__ConcatenateWith');
   late final _wire_concatenate_static__static_method__ConcatenateWith =
       _wire_concatenate_static__static_method__ConcatenateWithPtr
           .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>, ffi.Pointer<wire_uint_8_list>)>();

--- a/frb_example/pure_dart/dart/lib/bridge_generated.web.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.web.dart
@@ -1456,6 +1456,8 @@ class FlutterRustBridgeExampleSingleBlockTestWasmModule implements WasmModule {
 
   external dynamic /* void */ wire_panic_with_custom_result(NativePortType port_);
 
+  external dynamic /* void */ wire_stream_sink_throw_anyhow(NativePortType port_);
+
   external dynamic /* void */ wire_as_string__method__Event(NativePortType port_, List<dynamic> that);
 
   external dynamic /* void */ wire_sum__method__SumWith(NativePortType port_, List<dynamic> that, int y, int z);
@@ -1966,6 +1968,8 @@ class FlutterRustBridgeExampleSingleBlockTestWire
   void wire_throw_anyhow(NativePortType port_) => wasmModule.wire_throw_anyhow(port_);
 
   void wire_panic_with_custom_result(NativePortType port_) => wasmModule.wire_panic_with_custom_result(port_);
+
+  void wire_stream_sink_throw_anyhow(NativePortType port_) => wasmModule.wire_stream_sink_throw_anyhow(port_);
 
   void wire_as_string__method__Event(NativePortType port_, List<dynamic> that) =>
       wasmModule.wire_as_string__method__Event(port_, that);

--- a/frb_example/pure_dart/dart/lib/main.dart
+++ b/frb_example/pure_dart/dart/lib/main.dart
@@ -1504,16 +1504,12 @@ void main(List<String> args) async {
     });
 
     test('Stream sink throw anyhow error', () async {
-      try {
-        await for (final _ in api.streamSinkThrowAnyhow()) {
-          break;
-        }
-        assert(false);
-      } catch (e) {
-        final FrbAnyhowException p = e as FrbAnyhowException;
-        print("anyhow error: ${p.anyhow}");
-        assert(p.anyhow.contains("anyhow error"));
-      }
+      expect(
+        () async {
+          await for (final _ in api.streamSinkThrowAnyhow()) {}
+        },
+        throwsA(isA<FrbAnyhowException>().having((e) => e.toString(), 'toString', 'FrbAnyhowException(anyhow error)')),
+      );
     });
   });
 }

--- a/frb_example/pure_dart/dart/lib/main.dart
+++ b/frb_example/pure_dart/dart/lib/main.dart
@@ -1502,6 +1502,19 @@ void main(List<String> args) async {
         assert(p.error.contains("just a panic"));
       }
     });
+
+    test('Stream sink throw anyhow error', () async {
+      try {
+        await for (final _ in api.streamSinkThrowAnyhow()) {
+          break;
+        }
+        assert(false);
+      } catch (e) {
+        final FrbAnyhowException p = e as FrbAnyhowException;
+        print("anyhow error: ${p.anyhow}");
+        assert(p.anyhow.contains("anyhow error"));
+      }
+    });
   });
 }
 

--- a/frb_example/pure_dart/rust/c_output_path/c_output.h
+++ b/frb_example/pure_dart/rust/c_output_path/c_output.h
@@ -906,6 +906,8 @@ void wire_throw_anyhow(int64_t port_);
 
 void wire_panic_with_custom_result(int64_t port_);
 
+void wire_stream_sink_throw_anyhow(int64_t port_);
+
 void wire_as_string__method__Event(int64_t port_, struct wire_Event *that);
 
 void wire_sum__method__SumWith(int64_t port_, struct wire_SumWith *that, uint32_t y, uint32_t z);
@@ -1400,6 +1402,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_return_custom_struct_ok);
     dummy_var ^= ((int64_t) (void*) wire_throw_anyhow);
     dummy_var ^= ((int64_t) (void*) wire_panic_with_custom_result);
+    dummy_var ^= ((int64_t) (void*) wire_stream_sink_throw_anyhow);
     dummy_var ^= ((int64_t) (void*) wire_as_string__method__Event);
     dummy_var ^= ((int64_t) (void*) wire_sum__method__SumWith);
     dummy_var ^= ((int64_t) (void*) wire_new__static_method__ConcatenateWith);

--- a/frb_example/pure_dart/rust/c_output_path_extra/c_output.h
+++ b/frb_example/pure_dart/rust/c_output_path_extra/c_output.h
@@ -906,6 +906,8 @@ void wire_throw_anyhow(int64_t port_);
 
 void wire_panic_with_custom_result(int64_t port_);
 
+void wire_stream_sink_throw_anyhow(int64_t port_);
+
 void wire_as_string__method__Event(int64_t port_, struct wire_Event *that);
 
 void wire_sum__method__SumWith(int64_t port_, struct wire_SumWith *that, uint32_t y, uint32_t z);
@@ -1400,6 +1402,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_return_custom_struct_ok);
     dummy_var ^= ((int64_t) (void*) wire_throw_anyhow);
     dummy_var ^= ((int64_t) (void*) wire_panic_with_custom_result);
+    dummy_var ^= ((int64_t) (void*) wire_stream_sink_throw_anyhow);
     dummy_var ^= ((int64_t) (void*) wire_as_string__method__Event);
     dummy_var ^= ((int64_t) (void*) wire_sum__method__SumWith);
     dummy_var ^= ((int64_t) (void*) wire_new__static_method__ConcatenateWith);

--- a/frb_example/pure_dart/rust/src/api.rs
+++ b/frb_example/pure_dart/rust/src/api.rs
@@ -1886,3 +1886,7 @@ pub fn throw_anyhow() -> Result<(), anyhow::Error> {
 pub fn panic_with_custom_result() -> Result<(), CustomError> {
     panic!("just a panic");
 }
+
+pub fn stream_sink_throw_anyhow(_sink: StreamSink<String>) -> Result<()> {
+    Err(anyhow!("anyhow error"))
+}

--- a/frb_example/pure_dart/rust/src/bridge_generated.io.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.io.rs
@@ -930,6 +930,11 @@ pub extern "C" fn wire_panic_with_custom_result(port_: i64) {
 }
 
 #[no_mangle]
+pub extern "C" fn wire_stream_sink_throw_anyhow(port_: i64) {
+    wire_stream_sink_throw_anyhow_impl(port_)
+}
+
+#[no_mangle]
 pub extern "C" fn wire_as_string__method__Event(port_: i64, that: *mut wire_Event) {
     wire_as_string__method__Event_impl(port_, that)
 }

--- a/frb_example/pure_dart/rust/src/bridge_generated.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.rs
@@ -2456,6 +2456,18 @@ fn wire_panic_with_custom_result_impl(port_: MessagePort) {
         move || move |task_callback| panic_with_custom_result(),
     )
 }
+fn wire_stream_sink_throw_anyhow_impl(port_: MessagePort) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, (), _>(
+        WrapInfo {
+            debug_name: "stream_sink_throw_anyhow",
+            port: Some(port_),
+            mode: FfiCallMode::Stream,
+        },
+        move || {
+            move |task_callback| stream_sink_throw_anyhow(task_callback.stream_sink::<_, String>())
+        },
+    )
+}
 fn wire_as_string__method__Event_impl(port_: MessagePort, that: impl Wire2Api<Event> + UnwindSafe) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, String, _>(
         WrapInfo {

--- a/frb_example/pure_dart/rust/src/bridge_generated.web.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.web.rs
@@ -900,6 +900,11 @@ pub fn wire_panic_with_custom_result(port_: MessagePort) {
 }
 
 #[wasm_bindgen]
+pub fn wire_stream_sink_throw_anyhow(port_: MessagePort) {
+    wire_stream_sink_throw_anyhow_impl(port_)
+}
+
+#[wasm_bindgen]
 pub fn wire_as_string__method__Event(port_: MessagePort, that: JsValue) {
     wire_as_string__method__Event_impl(port_, that)
 }


### PR DESCRIPTION
## Changes

Fixes #1387
Fixes #1389 

## Checklist

- [x] An issue to be fixed by this PR is listed above.
- [x] New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api.rs` and `dart/lib/main.dart`.
- [x] The code generator is run and the code is formatted (via `just precommit`).
- [ ] If this PR adds/changes features, documentations (in the `./book` folder) are updated.
- [x] CI is passing.

## Remark for PR creator

- Justfile is a task runner for the command line interface that allows you to run shell commands from a file named `justfile` in your project directory. You can use Justfile after [installing it](https://github.com/casey/just). Note that commands written in `justfile` of this repository are expected to be run in `bash`, not `cmd` or `powershell`. Running `just ...` commands in `cmd` or `powershell` will produce errors as the syntax is not compatible. On Windows, you can use `git bash` if you have Git installed.
- If fzyzcjy does not reply for a few days, maybe he just did not see it, so please ping him.
