### PR TITLE
Fix `rustfmt::skip`

### DIFF
--- a/frb_codegen/src/entrypoint/rust.rs
+++ b/frb_codegen/src/entrypoint/rust.rs
@@ -59,7 +59,7 @@ fn write_rust_modules(
 #[cfg(not(target_family = \"wasm\"))]
 {mod_io}
 #[cfg(not(target_family = \"wasm\"))]
-pub use io::*;
+pub use self::io::*;
 ",
         common,
         mod_web = if config.wasm_enabled {
@@ -69,7 +69,7 @@ pub use io::*;
 #[cfg(target_family = \"wasm\")]
 {}
 #[cfg(target_family = \"wasm\")]
-pub use web::*;",
+pub use self::web::*;",
                 emit_platform_module("web", wasm, config, Target::Wasm)
             )
         } else {

--- a/frb_example/pure_dart/rust/src/bridge_generated.rs
+++ b/frb_example/pure_dart/rust/src/bridge_generated.rs
@@ -4140,10 +4140,10 @@ support::lazy_static! {
 #[path = "bridge_generated.web.rs"]
 mod web;
 #[cfg(target_family = "wasm")]
-pub use web::*;
+pub use self::web::*;
 
 #[cfg(not(target_family = "wasm"))]
 #[path = "bridge_generated.io.rs"]
 mod io;
 #[cfg(not(target_family = "wasm"))]
-pub use io::*;
+pub use self::io::*;

--- a/frb_example/pure_dart/rust/src/lib.rs
+++ b/frb_example/pure_dart/rust/src/lib.rs
@@ -1,4 +1,5 @@
 mod api;
+#[rustfmt::skip]
 mod bridge_generated;
 mod data;
 mod new_module_system;

--- a/frb_example/pure_dart_multi/rust/src/generated_api_1.rs
+++ b/frb_example/pure_dart_multi/rust/src/generated_api_1.rs
@@ -80,10 +80,10 @@ support::lazy_static! {
 #[path = "generated_api_1.web.rs"]
 mod web;
 #[cfg(target_family = "wasm")]
-pub use web::*;
+pub use self::web::*;
 
 #[cfg(not(target_family = "wasm"))]
 #[path = "generated_api_1.io.rs"]
 mod io;
 #[cfg(not(target_family = "wasm"))]
-pub use io::*;
+pub use self::io::*;

--- a/frb_example/pure_dart_multi/rust/src/generated_api_2.rs
+++ b/frb_example/pure_dart_multi/rust/src/generated_api_2.rs
@@ -80,10 +80,10 @@ support::lazy_static! {
 #[path = "generated_api_2.web.rs"]
 mod web;
 #[cfg(target_family = "wasm")]
-pub use web::*;
+pub use self::web::*;
 
 #[cfg(not(target_family = "wasm"))]
 #[path = "generated_api_2.io.rs"]
 mod io;
 #[cfg(not(target_family = "wasm"))]
-pub use io::*;
+pub use self::io::*;

--- a/frb_example/with_flutter/rust/src/bridge_generated.rs
+++ b/frb_example/with_flutter/rust/src/bridge_generated.rs
@@ -409,10 +409,10 @@ support::lazy_static! {
 #[path = "bridge_generated.web.rs"]
 mod web;
 #[cfg(target_family = "wasm")]
-pub use web::*;
+pub use self::web::*;
 
 #[cfg(not(target_family = "wasm"))]
 #[path = "bridge_generated.io.rs"]
 mod io;
 #[cfg(not(target_family = "wasm"))]
-pub use io::*;
+pub use self::io::*;


### PR DESCRIPTION
Can't add `#[rustfmt::skip]` for `bridge_generated`
```
error[E0659]: `io` is ambiguous
    --> frb_example/pure_dart/rust/src/bridge_generated.rs:4149:9
     |
4149 | pub use io::*;
     |         ^^ ambiguous name
```