### PR TITLE
Allow ffigen 10.x

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -339,7 +339,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dart-lang/setup-dart@v1
         with:
-          sdk: 3.0.0
+          sdk: stable
           architecture: x64
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -397,7 +397,7 @@ jobs:
 
       - uses: dart-lang/setup-dart@v1
         with:
-          sdk: 3.0.0
+          sdk: stable
           architecture: x64
       - uses: extractions/setup-just@v1
         env:
@@ -428,7 +428,7 @@ jobs:
 
       - uses: dart-lang/setup-dart@v1
         with:
-          sdk: 3.0.0
+          sdk: stable
           architecture: x64
       - uses: extractions/setup-just@v1
         env:
@@ -458,7 +458,7 @@ jobs:
           components: rustfmt, clippy
       - uses: dart-lang/setup-dart@v1
         with:
-          sdk: 3.0.0
+          sdk: stable
           architecture: x64
       - uses: extractions/setup-just@v1
         env:
@@ -475,7 +475,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dart-lang/setup-dart@v1
         with:
-          sdk: 3.0.0
+          sdk: stable
           architecture: x64
       - uses: subosito/flutter-action@v2
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,7 +94,7 @@ jobs:
         with:
           cache: true
           channel: "stable"
-          flutter-version: 3.13.6
+          flutter-version: 3.16.2
           architecture: x64
       - id: cache-deps
         uses: ./.github/actions/setup
@@ -148,7 +148,7 @@ jobs:
         with:
           cache: true
           channel: "stable"
-          flutter-version: 3.13.6
+          flutter-version: 3.16.2
           architecture: x64
       - id: checkout
         uses: dtolnay/rust-toolchain@stable
@@ -230,7 +230,7 @@ jobs:
         with:
           cache: true
           channel: "stable"
-          flutter-version: 3.13.6
+          flutter-version: 3.16.2
           architecture: x64
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -277,7 +277,7 @@ jobs:
   #         cache: true
   #         # TODO should be 3.7.3 but has a weird bug currently
   #         # https://github.com/fzyzcjy/flutter_rust_bridge/pull/1023#issuecomment-1415852845
-  #         flutter-version: 3.13.6
+  #         flutter-version: 3.16.2
   #         architecture: x64
   #     - uses: dtolnay/rust-toolchain@stable
   #       with:
@@ -300,7 +300,7 @@ jobs:
         with:
           cache: true
           channel: "stable"
-          flutter-version: 3.13.6
+          flutter-version: 3.16.2
           architecture: x64
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -482,7 +482,7 @@ jobs:
           cache: true
           channel: "stable"
 
-          flutter-version: 3.13.6
+          flutter-version: 3.16.2
 
       - uses: extractions/setup-just@v1
         env:
@@ -515,7 +515,7 @@ jobs:
         with:
           cache: true
           channel: "stable"
-          flutter-version: 3.13.6
+          flutter-version: 3.16.2
           architecture: x64
       - uses: extractions/setup-just@v1
         env:
@@ -558,7 +558,7 @@ jobs:
         with:
           cache: true
           channel: "stable"
-          flutter-version: 3.13.6
+          flutter-version: 3.16.2
           architecture: x64
 
       - uses: extractions/setup-just@v1

--- a/.github/workflows/post_release.yaml
+++ b/.github/workflows/post_release.yaml
@@ -71,7 +71,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: "stable"
-          flutter-version: 3.13.6
+          flutter-version: 3.16.2
           architecture: x64
       - uses: actions/setup-java@v1
         with:
@@ -142,7 +142,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: "stable"
-          flutter-version: "3.13.6"
+          flutter-version: "3.16.2"
           architecture: x64
       - uses: extractions/setup-just@v1
         env:

--- a/.github/workflows/post_release.yaml
+++ b/.github/workflows/post_release.yaml
@@ -35,7 +35,7 @@ jobs:
           components: rustfmt
       - uses: dart-lang/setup-dart@v1
         with:
-          sdk: "3.0.0"
+          sdk: stable
           architecture: x64
       - uses: actions/setup-python@v2
         with:

--- a/frb_codegen/src/commands.rs
+++ b/frb_codegen/src/commands.rs
@@ -24,7 +24,7 @@ lazy_static! {
     pub(crate) static ref FFI_REQUIREMENT: VersionReq =
         VersionReq::parse(">= 2.0.1, < 3.0.0").unwrap();
     pub(crate) static ref FFIGEN_REQUIREMENT: VersionReq =
-        VersionReq::parse(">= 8.0.0, < 10.0.0").unwrap();
+        VersionReq::parse(">= 8.0.0, < 11.0.0").unwrap();
 }
 
 pub fn ensure_tools_available(dart_root: &str, skip_deps_check: bool) -> Result<(), Error> {

--- a/frb_example/pure_dart/dart/lib/bridge_generated.io.dart
+++ b/frb_example/pure_dart/dart/lib/bridge_generated.io.dart
@@ -6435,6 +6435,8 @@ final class wire_CustomStruct extends ffi.Struct {
   external ffi.Pointer<wire_uint_8_list> message;
 }
 
-typedef DartPostCObjectFnType
-    = ffi.Pointer<ffi.NativeFunction<ffi.Bool Function(DartPort port_id, ffi.Pointer<ffi.Void> message)>>;
+typedef DartPostCObjectFnType = ffi.Pointer<ffi.NativeFunction<DartPostCObjectFnTypeFunction>>;
+typedef DartPostCObjectFnTypeFunction = ffi.Bool Function(DartPort port_id, ffi.Pointer<ffi.Void> message);
+typedef DartDartPostCObjectFnTypeFunction = bool Function(DartDartPort port_id, ffi.Pointer<ffi.Void> message);
 typedef DartPort = ffi.Int64;
+typedef DartDartPort = int;

--- a/frb_example/pure_dart/dart/pubspec.lock
+++ b/frb_example/pure_dart/dart/pubspec.lock
@@ -197,10 +197,10 @@ packages:
     dependency: "direct dev"
     description:
       name: ffigen
-      sha256: "3a80687577e7e51ba915114742f389a128e8aa241c52ce69a0f70aecb8e14365"
+      sha256: "0a4e9c5437c5c4600fa583141508beaf90fe29b58b0fd7437a9b022cda228747"
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.1"
+    version: "10.0.0"
   file:
     dependency: transitive
     description:
@@ -649,4 +649,4 @@ packages:
     source: hosted
     version: "2.1.1"
 sdks:
-  dart: ">=3.1.0 <4.0.0"
+  dart: ">=3.2.0 <4.0.0"

--- a/frb_example/pure_dart/dart/pubspec.yaml
+++ b/frb_example/pure_dart/dart/pubspec.yaml
@@ -20,4 +20,4 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.4.7
   freezed: ^2.1.0+1
-  ffigen: ^9.0.0
+  ffigen: ^10.0.0

--- a/frb_example/pure_dart/dart/pubspec.yaml.release
+++ b/frb_example/pure_dart/dart/pubspec.yaml.release
@@ -18,4 +18,4 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.2.0
   freezed: ^2.1.0+1
-  ffigen: ^7.0.0
+  ffigen: ^10.0.0

--- a/frb_example/pure_dart_multi/dart/lib/bridge_generated_api_1.io.dart
+++ b/frb_example/pure_dart_multi/dart/lib/bridge_generated_api_1.io.dart
@@ -131,6 +131,8 @@ class ApiClass1Wire implements FlutterRustBridgeWireBase {
 
 final class _Dart_Handle extends ffi.Opaque {}
 
-typedef DartPostCObjectFnType
-    = ffi.Pointer<ffi.NativeFunction<ffi.Bool Function(DartPort port_id, ffi.Pointer<ffi.Void> message)>>;
+typedef DartPostCObjectFnType = ffi.Pointer<ffi.NativeFunction<DartPostCObjectFnTypeFunction>>;
+typedef DartPostCObjectFnTypeFunction = ffi.Bool Function(DartPort port_id, ffi.Pointer<ffi.Void> message);
+typedef DartDartPostCObjectFnTypeFunction = bool Function(DartDartPort port_id, ffi.Pointer<ffi.Void> message);
 typedef DartPort = ffi.Int64;
+typedef DartDartPort = int;

--- a/frb_example/pure_dart_multi/dart/lib/bridge_generated_api_2.io.dart
+++ b/frb_example/pure_dart_multi/dart/lib/bridge_generated_api_2.io.dart
@@ -131,6 +131,8 @@ class ApiClass2Wire implements FlutterRustBridgeWireBase {
 
 final class _Dart_Handle extends ffi.Opaque {}
 
-typedef DartPostCObjectFnType
-    = ffi.Pointer<ffi.NativeFunction<ffi.Bool Function(DartPort port_id, ffi.Pointer<ffi.Void> message)>>;
+typedef DartPostCObjectFnType = ffi.Pointer<ffi.NativeFunction<DartPostCObjectFnTypeFunction>>;
+typedef DartPostCObjectFnTypeFunction = ffi.Bool Function(DartPort port_id, ffi.Pointer<ffi.Void> message);
+typedef DartDartPostCObjectFnTypeFunction = bool Function(DartDartPort port_id, ffi.Pointer<ffi.Void> message);
 typedef DartPort = ffi.Int64;
+typedef DartDartPort = int;

--- a/frb_example/pure_dart_multi/dart/pubspec.lock
+++ b/frb_example/pure_dart_multi/dart/pubspec.lock
@@ -197,10 +197,10 @@ packages:
     dependency: "direct dev"
     description:
       name: ffigen
-      sha256: "3a80687577e7e51ba915114742f389a128e8aa241c52ce69a0f70aecb8e14365"
+      sha256: "0a4e9c5437c5c4600fa583141508beaf90fe29b58b0fd7437a9b022cda228747"
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.1"
+    version: "10.0.0"
   file:
     dependency: transitive
     description:
@@ -649,4 +649,4 @@ packages:
     source: hosted
     version: "2.1.1"
 sdks:
-  dart: ">=3.1.0 <4.0.0"
+  dart: ">=3.2.0 <4.0.0"

--- a/frb_example/pure_dart_multi/dart/pubspec.yaml
+++ b/frb_example/pure_dart_multi/dart/pubspec.yaml
@@ -17,4 +17,4 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.4.4
   freezed: ^2.0.2
-  ffigen: ^9.0.0
+  ffigen: ^10.0.0

--- a/frb_example/pure_dart_multi/dart/pubspec.yaml.release
+++ b/frb_example/pure_dart_multi/dart/pubspec.yaml.release
@@ -15,4 +15,4 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.1.11
   freezed: ^2.0.2
-  ffigen: ^7.0.0
+  ffigen: ^10.0.0

--- a/frb_example/with_flutter/pubspec.lock
+++ b/frb_example/with_flutter/pubspec.lock
@@ -165,10 +165,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.18.0"
   convert:
     dependency: transitive
     description:
@@ -221,18 +221,18 @@ packages:
     dependency: "direct dev"
     description:
       name: ffigen
-      sha256: d3e76c2ad48a4e7f93a29a162006f00eba46ce7c08194a77bb5c5e97d1b5ff0a
+      sha256: "0a4e9c5437c5c4600fa583141508beaf90fe29b58b0fd7437a9b022cda228747"
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.2"
+    version: "10.0.0"
   file:
     dependency: transitive
     description:
       name: file
-      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.4"
+    version: "7.0.0"
   fixnum:
     dependency: transitive
     description:
@@ -397,18 +397,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.11.0"
   mime:
     dependency: transitive
     description:
@@ -445,10 +445,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "4a451831508d7d6ca779f7ac6e212b4023dd5a7d08a27a63da33756410e32b76"
+      sha256: "0a279f0707af40c890e80b1e9df8bb761694c074ba7e1d4ab1bc4b728e200b59"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.3"
   pointycastle:
     dependency: transitive
     description:
@@ -469,10 +469,10 @@ packages:
     dependency: transitive
     description:
       name: process
-      sha256: "53fd8db9cec1d37b0574e12f07520d582019cb6c44abf5479a01505099a34a09"
+      sha256: "266ca5be5820feefc777793d0a583acfc8c40834893c87c00c6c09e2cf58ea42"
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.4"
+    version: "5.0.1"
   pub_semver:
     dependency: transitive
     description:
@@ -562,18 +562,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   stream_transform:
     dependency: transitive
     description:
@@ -610,10 +610,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.6.1"
   timing:
     dependency: transitive
     description:
@@ -658,10 +658,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: c620a6f783fa22436da68e42db7ebbf18b8c44b9a46ab911f666ff09ffd9153f
+      sha256: c538be99af830f478718b51630ec1b6bee5e74e52c8a802d328d9e71d35d2583
       url: "https://pub.dev"
     source: hosted
-    version: "11.7.1"
+    version: "11.10.0"
   watcher:
     dependency: transitive
     description:
@@ -674,10 +674,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.4-beta"
+    version: "0.3.0"
   web_socket_channel:
     dependency: transitive
     description:
@@ -690,10 +690,10 @@ packages:
     dependency: transitive
     description:
       name: webdriver
-      sha256: "3c923e918918feeb90c4c9fdf1fe39220fa4c0e8e2c0fffaded174498ef86c49"
+      sha256: "003d7da9519e1e5f329422b36c4dcdf18d7d2978d1ba099ea4e45ba490ed845e"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.3"
   yaml:
     dependency: transitive
     description:
@@ -711,4 +711,4 @@ packages:
     source: hosted
     version: "2.1.1"
 sdks:
-  dart: ">=3.1.0 <4.0.0"
+  dart: ">=3.2.0 <4.0.0"

--- a/frb_example/with_flutter/pubspec.yaml
+++ b/frb_example/with_flutter/pubspec.yaml
@@ -53,7 +53,7 @@ dev_dependencies:
   flutter_lints: ^1.0.0
   freezed: ^2.2.0
   build_runner: ^2.4.4
-  ffigen: ^8.0.0
+  ffigen: ^10.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/frb_example/with_flutter/pubspec.yaml.release
+++ b/frb_example/with_flutter/pubspec.yaml.release
@@ -52,7 +52,7 @@ dev_dependencies:
   flutter_lints: ^1.0.0
   freezed: ^2.1.0+1
   build_runner: ^2.2.0
-  ffigen: ^7.0.0
+  ffigen: ^10.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
Allow ffigen 10.x in commands.rs validation.
Update pubspec.yaml files and respective .lock files. Changes in frb_example/pure_dart_multi/dart/lib/ are due to `just rust_build_and_test`.

Fixes #1429

## Changes

Fixes #1429

## Checklist

- [X] An issue to be fixed by this PR is listed above.
- [N/A] New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api.rs` and `dart/lib/main.dart`.
- [N/A] The code generator is run and the code is formatted (via `just precommit`).
- [N/A] If this PR adds/changes features, documentations (in the `./book` folder) are updated.
- [ ] CI is passing.

## Remark for PR creator

- Justfile is a task runner for the command line interface that allows you to run shell commands from a file named `justfile` in your project directory. You can use Justfile after [installing it](https://github.com/casey/just). Note that commands written in `justfile` of this repository are expected to be run in `bash`, not `cmd` or `powershell`. Running `just ...` commands in `cmd` or `powershell` will produce errors as the syntax is not compatible. On Windows, you can use `git bash` if you have Git installed.
- If fzyzcjy does not reply for a few days, maybe he just did not see it, so please ping him.
