### PR TITLE
Fixes #1454 by setting the msrv

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,6 +104,21 @@ jobs:
       - run: ./frb_internal generate-website
 
   # ----------------------------------- codegen -----------------------------------
+  msrv:
+    name: 'Test :: FRB Codegen :: MSRV'    
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+
+    - name: Run cargo msrv
+      run: |
+        cargo install cargo-msrv
+        cargo msrv --path frb_codegen verify
 
   generate_run_frb_codegen_command_generate:
     name: 'Generate :: FRB Codegen :: Command Generate'
@@ -146,7 +161,7 @@ jobs:
           flutter-version: ${{ env.FRB_MAIN_FLUTTER_VERSION }}
           architecture: x64
       - uses: taiki-e/install-action@cargo-llvm-cov
-
+      
       # execute
       - run: ./frb_internal generate-run-frb-codegen-command-generate --set-exit-if-changed --package ${{ matrix.package }} --coverage
 
@@ -339,7 +354,6 @@ jobs:
             version: nightly
           - image: ubuntu-latest
             version: nightly-2023-12-16
-          # TODO(@fzyzcjy, @gutenfries): add MSRV here, as well as other locked versions as needed
 
     steps:
       # setup
@@ -367,8 +381,8 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ github.job }}--${{ matrix.info.image }}--${{ matrix.info.version }}--coverage
-          path: target/coverage
-
+          path: target/coverage  
+    
   test_dart_native:
     name: 'Test :: Dart :: Native'
     runs-on: ${{ matrix.image }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -347,8 +347,6 @@ jobs:
   test_rust:
     name: 'Test :: Rust'
     runs-on: ${{ matrix.info.image }}
-    outputs:
-        FRB_MSRV_RUST_VERSION: ${{ env.FRB_MSRV_RUST_VERSION }}
     strategy:
       fail-fast: false
       matrix:
@@ -366,9 +364,9 @@ jobs:
           - image: ubuntu-latest
             version: nightly-2023-12-16
           # tests the MSRV
-          # run on all rust packages, though only neede for frb_rust and frb_codegen
+          # run on all rust packages, though only needed for frb_rust and frb_codegen
           - image: ubuntu-latest
-          # update this, if a later MSVR is needed
+          # update this, if a later MSRV is needed
             version: 1.74.0
 
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -365,7 +365,7 @@ jobs:
           - image: ubuntu-latest
             version: nightly-2023-12-16
           - image: ubuntu-latest
-            version: ${{ env.FRB_MSRV_RUST_VERSION }}
+            version: $env.FRB_MSRV_RUST_VERSION
 
     steps:
       # setup

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -348,6 +348,8 @@ jobs:
   test_rust:
     name: 'Test :: Rust'
     runs-on: ${{ matrix.info.image }}
+    outputs:
+        FRB_MSRV_RUST_VERSION: ${{ env.FRB_MSRV_RUST_VERSION }}
     strategy:
       fail-fast: false
       matrix:
@@ -365,7 +367,7 @@ jobs:
           - image: ubuntu-latest
             version: nightly-2023-12-16
           - image: ubuntu-latest
-            version: $env.FRB_MSRV_RUST_VERSION
+            version: ${{ needs.test_rust.outputs.FRB_MSRV_RUST_VERSION }}
 
     steps:
       # setup

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -369,7 +369,7 @@ jobs:
           # run on all rust packages, though only neede for frb_rust and frb_codegen
           - image: ubuntu-latest
           # update this, if a later MSVR is needed
-            version: 1.70.0
+            version: 1.74.0
 
     steps:
       # setup

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   FRB_MAIN_RUST_VERSION: 1.74.0
-  FRB_MSRV_RUST_VERSION: 1.68.0
   FRB_MAIN_DART_VERSION: 3.2.0
   FRB_MAIN_FLUTTER_VERSION: 3.16.0
 
@@ -366,8 +365,11 @@ jobs:
             version: nightly
           - image: ubuntu-latest
             version: nightly-2023-12-16
+          # tests the MSRV
+          # run on all rust packages, though only neede for frb_rust and frb_codegen
           - image: ubuntu-latest
-            version: ${{ needs.test_rust.outputs.FRB_MSRV_RUST_VERSION }}
+          # update this, if a later MSVR is needed
+            version: 1.68.0
 
     steps:
       # setup

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -369,7 +369,7 @@ jobs:
           # run on all rust packages, though only neede for frb_rust and frb_codegen
           - image: ubuntu-latest
           # update this, if a later MSVR is needed
-            version: 1.68.0
+            version: 1.70.0
 
     steps:
       # setup

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   FRB_MAIN_RUST_VERSION: 1.74.0
+  FRB_MSRV_RUST_VERSION: 1.68.0
   FRB_MAIN_DART_VERSION: 3.2.0
   FRB_MAIN_FLUTTER_VERSION: 3.16.0
 
@@ -104,21 +105,30 @@ jobs:
       - run: ./frb_internal generate-website
 
   # ----------------------------------- codegen -----------------------------------
-  msrv:
-    name: 'Test :: FRB Codegen :: MSRV'    
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
+  # instead of running this explicit test for frb_codegen and frb_rust only, we run the test for
+  # all rust packages in the job "test_rust". While this would not be needed for these other packages,
+  # we avoid a ci dependency to cargo-msrv.
+  # However, the code is left commented here in case this decission changes.
+  # msrv:
+  #   name: 'Test :: FRB Codegen :: MSRV'    
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@v2
 
-    - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
+  #   - name: Install Rust
+  #     uses: actions-rs/toolchain@v1
+  #     with:
+  #       toolchain: stable
 
-    - name: Run cargo msrv
-      run: |
-        cargo install cargo-msrv
-        cargo msrv --path frb_codegen verify
+  #   - name: Verify MSRV for frb_codegen
+  #     run: |
+  #       cargo install cargo-msrv
+  #       cargo msrv --path frb_codegen verify
+
+  #   - name: Verify MSRV for frb_rust
+  #     run: |
+  #       cargo install cargo-msrv
+  #       cargo msrv --path frb_rust verify
 
   generate_run_frb_codegen_command_generate:
     name: 'Generate :: FRB Codegen :: Command Generate'
@@ -354,6 +364,8 @@ jobs:
             version: nightly
           - image: ubuntu-latest
             version: nightly-2023-12-16
+          - image: ubuntu-latest
+            version: ${{ env.FRB_MSRV_RUST_VERSION }}
 
     steps:
       # setup

--- a/frb_codegen/Cargo.toml
+++ b/frb_codegen/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 name = "flutter_rust_bridge_codegen"
 repository.workspace = true
 version.workspace = true
-rust-version = "1.72.0"
+rust-version = "1.74.0"
 
 [lib]
 name = "lib_flutter_rust_bridge_codegen"

--- a/frb_codegen/Cargo.toml
+++ b/frb_codegen/Cargo.toml
@@ -2,12 +2,12 @@
 categories.workspace = true
 description.workspace = true
 edition.workspace = true
+rust-version = "1.73.0"
 keywords.workspace = true
 license.workspace = true
 name = "flutter_rust_bridge_codegen"
 repository.workspace = true
 version.workspace = true
-rust-version = "1.74.0"
 
 [lib]
 name = "lib_flutter_rust_bridge_codegen"

--- a/frb_codegen/Cargo.toml
+++ b/frb_codegen/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 name = "flutter_rust_bridge_codegen"
 repository.workspace = true
 version.workspace = true
+rust-version = "1.72.0"
 
 [lib]
 name = "lib_flutter_rust_bridge_codegen"

--- a/frb_codegen/Cargo.toml
+++ b/frb_codegen/Cargo.toml
@@ -2,7 +2,7 @@
 categories.workspace = true
 description.workspace = true
 edition.workspace = true
-rust-version = "1.73.0"
+rust-version = "1.74.0"
 keywords.workspace = true
 license.workspace = true
 name = "flutter_rust_bridge_codegen"

--- a/frb_rust/Cargo.toml
+++ b/frb_rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flutter_rust_bridge"
 edition.workspace = true
-rust-version = "1.69.0"
+rust-version = "1.70.0"
 version.workspace = true
 description.workspace = true
 license.workspace = true

--- a/frb_rust/Cargo.toml
+++ b/frb_rust/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "flutter_rust_bridge"
 edition.workspace = true
+rust-version = "1.69.0"
 version.workspace = true
 description.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Changes
- fixes #1454 by adding the MSRV to fab_codegen

## Checklist

- [x] An issue to be fixed by this PR is listed above.
- [x] New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api/whatever.rs` and `test/api/whatever_test.dart`. => test is in ci
- [ ] `./frb_internal precommit --mode slow` (or `fast`) is run (it internal runs code generator, does auto formatting, etc).
- [x] If this PR adds/changes features, documentations (in the `./website` folder) are updated.
- [x] CI is passing. (Operations are reproducible using corresponding `./frb_internal something` commands shown in CI.)
=> all passes, except "Benchmark" jobs. They did not pass before this changes either.
## Remark for PR creator
- The ci test installs "crate msrv", which verifies that the version set is correct. It can be used to find the correct version number as well - but that should be done locally, not in ci - as the MSRV usually doesn't change ofter. The ci fails only when the MSRV is not working anymore, by installing that version and running cargo check.
- This PR adds a MSRV to frb_codegen only, no other rust crates.
- There are two ways to specify the MSRV in the cargo.toml:
  - [platform.rust-version] (which I choose) and 
  - [platform.metadata.MSRV]
