### PR TITLE
Avoid `RwLock` in generated rust-auto-opaque name

### DIFF
--- a/frb_codegen/src/library/codegen/generator/api_dart/spec_generator/info.rs
+++ b/frb_codegen/src/library/codegen/generator/api_dart/spec_generator/info.rs
@@ -234,7 +234,7 @@ impl<'a> ApiDartGeneratorInfoTrait for UnencodableApiDartGenerator<'a> {
 fn rust_type_to_dart_type(rust: &str) -> String {
     lazy_static! {
         static ref OPAQUE_FILTER: Regex =
-            Regex::new(r"(\bdyn|'static|\bDartSafe|\bAssertUnwindSafe|\+ (Send|Sync|UnwindSafe|RefUnwindSafe))\b")
+            Regex::new(r"(\bdyn|'static|\bDartSafe|\bAssertUnwindSafe|\bRwLock|\+ (Send|Sync|UnwindSafe|RefUnwindSafe))\b")
                 .unwrap();
     }
     let rust = rust.split("::").last().unwrap();

--- a/frb_codegen/src/library/codegen/generator/api_dart/spec_generator/info.rs
+++ b/frb_codegen/src/library/codegen/generator/api_dart/spec_generator/info.rs
@@ -203,7 +203,7 @@ impl<'a> ApiDartGeneratorInfoTrait for RustAutoOpaqueApiDartGenerator<'a> {
 
 impl<'a> ApiDartGeneratorInfoTrait for RustOpaqueApiDartGenerator<'a> {
     fn dart_api_type(&self) -> String {
-        rust_type_to_dart_type(&self.ir.inner.rust_api_type())
+        rust_type_to_dart_type(&self.ir.inner.rust_api_type(), self.ir.brief_name)
     }
 }
 
@@ -231,16 +231,18 @@ impl<'a> ApiDartGeneratorInfoTrait for UnencodableApiDartGenerator<'a> {
     }
 }
 
-fn rust_type_to_dart_type(rust: &str) -> String {
+fn rust_type_to_dart_type(rust: &str, brief_name: bool) -> String {
     lazy_static! {
-        static ref OPAQUE_FILTER: Regex =
-            Regex::new(r"(\bdyn|'static|\bDartSafe|\bAssertUnwindSafe|\bRwLock|\+ (Send|Sync|UnwindSafe|RefUnwindSafe))\b")
-                .unwrap();
+        static ref OPAQUE_FILTER: Regex =Regex::new(r"(\bdyn|'static|\bDartSafe|\bAssertUnwindSafe|\+ (Send|Sync|UnwindSafe|RefUnwindSafe))\b").unwrap();
+        static ref OPAQUE_BRIEF_NAME_FILTER: Regex =Regex::new(r"(\bRwLock)\b").unwrap();
     }
+
     let rust = rust.split("::").last().unwrap();
-    OPAQUE_FILTER
-        .replace_all(rust, "")
-        .replace(char_not_alphanumeric, "_")
+    let mut rust = OPAQUE_FILTER.replace_all(rust, "").to_string();
+    if brief_name {
+        rust = OPAQUE_BRIEF_NAME_FILTER.replace_all(&rust, "").to_string();
+    }
+    rust.replace(char_not_alphanumeric, "_")
         .to_case(Case::Pascal)
 }
 

--- a/frb_codegen/src/library/codegen/ir/ty/rust_opaque.rs
+++ b/frb_codegen/src/library/codegen/ir/ty/rust_opaque.rs
@@ -6,14 +6,16 @@ crate::ir! {
 pub struct IrTypeRustOpaque {
     pub namespace: Namespace,
     pub inner: Box<IrType>,
+    pub brief_name: bool,
 }
 }
 
 impl IrTypeRustOpaque {
-    pub fn new(namespace: Namespace, inner: IrType) -> Self {
+    pub fn new(namespace: Namespace, inner: IrType, brief_name: bool) -> Self {
         Self {
             namespace,
             inner: Box::new(inner),
+            brief_name,
         }
     }
 

--- a/frb_codegen/src/library/codegen/parser/type_parser/rust_auto_opaque.rs
+++ b/frb_codegen/src/library/codegen/parser/type_parser/rust_auto_opaque.rs
@@ -53,6 +53,7 @@ impl<'a, 'b, 'c> TypeParserWithContext<'a, 'b, 'c> {
                     string: format!("std::sync::RwLock<{}>", inner.rust_api_type()),
                     segments: vec![],
                 })),
+                brief_name: true,
             },
         };
 

--- a/frb_codegen/src/library/codegen/parser/type_parser/rust_opaque.rs
+++ b/frb_codegen/src/library/codegen/parser/type_parser/rust_opaque.rs
@@ -21,7 +21,8 @@ impl<'a, 'b, 'c> TypeParserWithContext<'a, 'b, 'c> {
     }
 
     fn parse_rust_opaque(&mut self, ty: &IrType) -> IrType {
-        let new_ir = IrTypeRustOpaque::new(self.context.initiated_namespace.clone(), ty.clone());
+        let new_ir =
+            IrTypeRustOpaque::new(self.context.initiated_namespace.clone(), ty.clone(), false);
         RustOpaque((self.inner.rust_opaque_parser_info).get_or_insert(ty, new_ir))
     }
 }

--- a/frb_codegen/test_fixtures/library/codegen/parser/mod/generics/expect_ir.json
+++ b/frb_codegen/test_fixtures/library/codegen/parser/mod/generics/expect_ir.json
@@ -107,6 +107,7 @@
           "ty": {
             "data": {
               "inner": {
+                "brief_name": true,
                 "inner": {
                   "data": {
                     "namespace": null,
@@ -154,6 +155,7 @@
           "ty": {
             "data": {
               "inner": {
+                "brief_name": true,
                 "inner": {
                   "data": {
                     "namespace": null,
@@ -201,6 +203,7 @@
           "ty": {
             "data": {
               "inner": {
+                "brief_name": true,
                 "inner": {
                   "data": {
                     "namespace": null,
@@ -248,6 +251,7 @@
           "ty": {
             "data": {
               "inner": {
+                "brief_name": true,
                 "inner": {
                   "data": {
                     "namespace": null,
@@ -295,6 +299,7 @@
           "ty": {
             "data": {
               "inner": {
+                "brief_name": true,
                 "inner": {
                   "data": {
                     "namespace": null,

--- a/frb_example/pure_dart/lib/src/rust/api/pseudo_manual/rust_auto_opaque_twin_sse.dart
+++ b/frb_example/pure_dart/lib/src/rust/api/pseudo_manual/rust_auto_opaque_twin_sse.dart
@@ -7,120 +7,113 @@ import '../../frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
 Future<void> rustAutoOpaqueArgOwnTwinSse(
-        {required RwLockNonCloneSimpleTwinSse arg,
+        {required NonCloneSimpleTwinSse arg,
         required int expect,
         dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaqueArgOwnTwinSse(arg: arg, expect: expect, hint: hint);
 
 Future<void> rustAutoOpaqueArgBorrowTwinSse(
-        {required RwLockNonCloneSimpleTwinSse arg,
+        {required NonCloneSimpleTwinSse arg,
         required int expect,
         dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaqueArgBorrowTwinSse(arg: arg, expect: expect, hint: hint);
 
 Future<void> rustAutoOpaqueArgMutBorrowTwinSse(
-        {required RwLockNonCloneSimpleTwinSse arg,
+        {required NonCloneSimpleTwinSse arg,
         required int expect,
         required int adder,
         dynamic hint}) =>
     RustLib.instance.api.rustAutoOpaqueArgMutBorrowTwinSse(
         arg: arg, expect: expect, adder: adder, hint: hint);
 
-Future<RwLockNonCloneSimpleTwinSse> rustAutoOpaqueReturnOwnTwinSse(
+Future<NonCloneSimpleTwinSse> rustAutoOpaqueReturnOwnTwinSse(
         {required int initial, dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaqueReturnOwnTwinSse(initial: initial, hint: hint);
 
-Future<RwLockNonCloneSimpleTwinSse> rustAutoOpaqueArgOwnAndReturnOwnTwinSse(
-        {required RwLockNonCloneSimpleTwinSse arg, dynamic hint}) =>
+Future<NonCloneSimpleTwinSse> rustAutoOpaqueArgOwnAndReturnOwnTwinSse(
+        {required NonCloneSimpleTwinSse arg, dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaqueArgOwnAndReturnOwnTwinSse(arg: arg, hint: hint);
 
 Future<void> rustAutoOpaqueTwoArgsTwinSse(
-        {required RwLockNonCloneSimpleTwinSse a,
-        required RwLockNonCloneSimpleTwinSse b,
+        {required NonCloneSimpleTwinSse a,
+        required NonCloneSimpleTwinSse b,
         dynamic hint}) =>
     RustLib.instance.api.rustAutoOpaqueTwoArgsTwinSse(a: a, b: b, hint: hint);
 
 Future<void> rustAutoOpaqueNormalAndOpaqueArgTwinSse(
-        {required RwLockNonCloneSimpleTwinSse a,
-        required String b,
-        dynamic hint}) =>
+        {required NonCloneSimpleTwinSse a, required String b, dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaqueNormalAndOpaqueArgTwinSse(a: a, b: b, hint: hint);
 
 /// "+" inside the type signature
 Future<void> rustAutoOpaquePlusSignArgTwinSse(
-        {required RwLockBoxMyTraitTwinSse arg, dynamic hint}) =>
+        {required BoxMyTraitTwinSse arg, dynamic hint}) =>
     RustLib.instance.api.rustAutoOpaquePlusSignArgTwinSse(arg: arg, hint: hint);
 
-Future<RwLockBoxMyTraitTwinSse> rustAutoOpaquePlusSignReturnTwinSse(
-        {dynamic hint}) =>
+Future<BoxMyTraitTwinSse> rustAutoOpaquePlusSignReturnTwinSse({dynamic hint}) =>
     RustLib.instance.api.rustAutoOpaquePlusSignReturnTwinSse(hint: hint);
 
 Future<void> rustAutoOpaqueCallableArgTwinSse(
-        {required RwLockBoxFnStringString arg, dynamic hint}) =>
+        {required BoxFnStringString arg, dynamic hint}) =>
     RustLib.instance.api.rustAutoOpaqueCallableArgTwinSse(arg: arg, hint: hint);
 
-Future<RwLockBoxFnStringString> rustAutoOpaqueCallableReturnTwinSse(
-        {dynamic hint}) =>
+Future<BoxFnStringString> rustAutoOpaqueCallableReturnTwinSse({dynamic hint}) =>
     RustLib.instance.api.rustAutoOpaqueCallableReturnTwinSse(hint: hint);
 
 Future<void> rustAutoOpaqueTraitObjectArgOwnTwinSse(
-        {required RwLockBoxHelloTraitTwinSse arg,
+        {required BoxHelloTraitTwinSse arg,
         required String expect,
         dynamic hint}) =>
     RustLib.instance.api.rustAutoOpaqueTraitObjectArgOwnTwinSse(
         arg: arg, expect: expect, hint: hint);
 
 Future<void> rustAutoOpaqueTraitObjectArgBorrowTwinSse(
-        {required RwLockBoxHelloTraitTwinSse arg,
+        {required BoxHelloTraitTwinSse arg,
         required String expect,
         dynamic hint}) =>
     RustLib.instance.api.rustAutoOpaqueTraitObjectArgBorrowTwinSse(
         arg: arg, expect: expect, hint: hint);
 
 Future<void> rustAutoOpaqueTraitObjectArgMutBorrowTwinSse(
-        {required RwLockBoxHelloTraitTwinSse arg,
+        {required BoxHelloTraitTwinSse arg,
         required String expect,
         dynamic hint}) =>
     RustLib.instance.api.rustAutoOpaqueTraitObjectArgMutBorrowTwinSse(
         arg: arg, expect: expect, hint: hint);
 
-Future<RwLockBoxHelloTraitTwinSse> rustAutoOpaqueTraitObjectReturnOwnOneTwinSse(
+Future<BoxHelloTraitTwinSse> rustAutoOpaqueTraitObjectReturnOwnOneTwinSse(
         {dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaqueTraitObjectReturnOwnOneTwinSse(hint: hint);
 
-Future<RwLockBoxHelloTraitTwinSse> rustAutoOpaqueTraitObjectReturnOwnTwoTwinSse(
+Future<BoxHelloTraitTwinSse> rustAutoOpaqueTraitObjectReturnOwnTwoTwinSse(
         {dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaqueTraitObjectReturnOwnTwoTwinSse(hint: hint);
 
 Future<void> rustAutoOpaqueStructWithGoodAndOpaqueFieldArgOwnTwinSse(
-        {required RwLockStructWithGoodAndOpaqueFieldTwinSse arg,
-        dynamic hint}) =>
+        {required StructWithGoodAndOpaqueFieldTwinSse arg, dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaqueStructWithGoodAndOpaqueFieldArgOwnTwinSse(
             arg: arg, hint: hint);
 
 Future<void> rustAutoOpaqueStructWithGoodAndOpaqueFieldArgBorrowTwinSse(
-        {required RwLockStructWithGoodAndOpaqueFieldTwinSse arg,
-        dynamic hint}) =>
+        {required StructWithGoodAndOpaqueFieldTwinSse arg, dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaqueStructWithGoodAndOpaqueFieldArgBorrowTwinSse(
             arg: arg, hint: hint);
 
 Future<void> rustAutoOpaqueStructWithGoodAndOpaqueFieldArgMutBorrowTwinSse(
-        {required RwLockStructWithGoodAndOpaqueFieldTwinSse arg,
-        dynamic hint}) =>
+        {required StructWithGoodAndOpaqueFieldTwinSse arg, dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaqueStructWithGoodAndOpaqueFieldArgMutBorrowTwinSse(
             arg: arg, hint: hint);
 
-Future<RwLockStructWithGoodAndOpaqueFieldTwinSse>
+Future<StructWithGoodAndOpaqueFieldTwinSse>
     rustAutoOpaqueStructWithGoodAndOpaqueFieldReturnOwnTwinSse(
             {dynamic hint}) =>
         RustLib.instance.api
@@ -129,77 +122,77 @@ Future<RwLockStructWithGoodAndOpaqueFieldTwinSse>
 
 // Rust type: flutter_rust_bridge::RustOpaque<std::sync::RwLock<Box<dyn Fn (String) -> String + Send + Sync + UnwindSafe + RefUnwindSafe>>>
 @sealed
-class RwLockBoxFnStringString extends RustOpaque {
-  RwLockBoxFnStringString.dcoDecode(dynamic wire)
+class BoxFnStringString extends RustOpaque {
+  BoxFnStringString.dcoDecode(dynamic wire)
       : super.dcoDecode(wire, _kStaticData);
 
-  RwLockBoxFnStringString.sseDecode(int ptr, int externalSizeOnNative)
+  BoxFnStringString.sseDecode(int ptr, int externalSizeOnNative)
       : super.sseDecode(ptr, externalSizeOnNative, _kStaticData);
 
   static final _kStaticData = RustArcStaticData(
-    rustArcIncrementStrongCount: RustLib
-        .instance.api.rust_arc_increment_strong_count_RwLockBoxFnStringString,
-    rustArcDecrementStrongCount: RustLib
-        .instance.api.rust_arc_decrement_strong_count_RwLockBoxFnStringString,
-    rustArcDecrementStrongCountPtr: RustLib.instance.api
-        .rust_arc_decrement_strong_count_RwLockBoxFnStringStringPtr,
+    rustArcIncrementStrongCount:
+        RustLib.instance.api.rust_arc_increment_strong_count_BoxFnStringString,
+    rustArcDecrementStrongCount:
+        RustLib.instance.api.rust_arc_decrement_strong_count_BoxFnStringString,
+    rustArcDecrementStrongCountPtr: RustLib
+        .instance.api.rust_arc_decrement_strong_count_BoxFnStringStringPtr,
   );
 }
 
 // Rust type: flutter_rust_bridge::RustOpaque<std::sync::RwLock<Box<dyn HelloTraitTwinSse>>>
 @sealed
-class RwLockBoxHelloTraitTwinSse extends RustOpaque {
-  RwLockBoxHelloTraitTwinSse.dcoDecode(dynamic wire)
+class BoxHelloTraitTwinSse extends RustOpaque {
+  BoxHelloTraitTwinSse.dcoDecode(dynamic wire)
       : super.dcoDecode(wire, _kStaticData);
 
-  RwLockBoxHelloTraitTwinSse.sseDecode(int ptr, int externalSizeOnNative)
+  BoxHelloTraitTwinSse.sseDecode(int ptr, int externalSizeOnNative)
       : super.sseDecode(ptr, externalSizeOnNative, _kStaticData);
 
   static final _kStaticData = RustArcStaticData(
-    rustArcIncrementStrongCount: RustLib.instance.api
-        .rust_arc_increment_strong_count_RwLockBoxHelloTraitTwinSse,
-    rustArcDecrementStrongCount: RustLib.instance.api
-        .rust_arc_decrement_strong_count_RwLockBoxHelloTraitTwinSse,
-    rustArcDecrementStrongCountPtr: RustLib.instance.api
-        .rust_arc_decrement_strong_count_RwLockBoxHelloTraitTwinSsePtr,
+    rustArcIncrementStrongCount: RustLib
+        .instance.api.rust_arc_increment_strong_count_BoxHelloTraitTwinSse,
+    rustArcDecrementStrongCount: RustLib
+        .instance.api.rust_arc_decrement_strong_count_BoxHelloTraitTwinSse,
+    rustArcDecrementStrongCountPtr: RustLib
+        .instance.api.rust_arc_decrement_strong_count_BoxHelloTraitTwinSsePtr,
   );
 }
 
 // Rust type: flutter_rust_bridge::RustOpaque<std::sync::RwLock<Box<dyn MyTraitTwinSse + Send + Sync>>>
 @sealed
-class RwLockBoxMyTraitTwinSse extends RustOpaque {
-  RwLockBoxMyTraitTwinSse.dcoDecode(dynamic wire)
+class BoxMyTraitTwinSse extends RustOpaque {
+  BoxMyTraitTwinSse.dcoDecode(dynamic wire)
       : super.dcoDecode(wire, _kStaticData);
 
-  RwLockBoxMyTraitTwinSse.sseDecode(int ptr, int externalSizeOnNative)
+  BoxMyTraitTwinSse.sseDecode(int ptr, int externalSizeOnNative)
       : super.sseDecode(ptr, externalSizeOnNative, _kStaticData);
 
   static final _kStaticData = RustArcStaticData(
-    rustArcIncrementStrongCount: RustLib
-        .instance.api.rust_arc_increment_strong_count_RwLockBoxMyTraitTwinSse,
-    rustArcDecrementStrongCount: RustLib
-        .instance.api.rust_arc_decrement_strong_count_RwLockBoxMyTraitTwinSse,
-    rustArcDecrementStrongCountPtr: RustLib.instance.api
-        .rust_arc_decrement_strong_count_RwLockBoxMyTraitTwinSsePtr,
+    rustArcIncrementStrongCount:
+        RustLib.instance.api.rust_arc_increment_strong_count_BoxMyTraitTwinSse,
+    rustArcDecrementStrongCount:
+        RustLib.instance.api.rust_arc_decrement_strong_count_BoxMyTraitTwinSse,
+    rustArcDecrementStrongCountPtr: RustLib
+        .instance.api.rust_arc_decrement_strong_count_BoxMyTraitTwinSsePtr,
   );
 }
 
 // Rust type: flutter_rust_bridge::RustOpaque<std::sync::RwLock<NonCloneSimpleTwinSse>>
 @sealed
-class RwLockNonCloneSimpleTwinSse extends RustOpaque {
-  RwLockNonCloneSimpleTwinSse.dcoDecode(dynamic wire)
+class NonCloneSimpleTwinSse extends RustOpaque {
+  NonCloneSimpleTwinSse.dcoDecode(dynamic wire)
       : super.dcoDecode(wire, _kStaticData);
 
-  RwLockNonCloneSimpleTwinSse.sseDecode(int ptr, int externalSizeOnNative)
+  NonCloneSimpleTwinSse.sseDecode(int ptr, int externalSizeOnNative)
       : super.sseDecode(ptr, externalSizeOnNative, _kStaticData);
 
   static final _kStaticData = RustArcStaticData(
-    rustArcIncrementStrongCount: RustLib.instance.api
-        .rust_arc_increment_strong_count_RwLockNonCloneSimpleTwinSse,
-    rustArcDecrementStrongCount: RustLib.instance.api
-        .rust_arc_decrement_strong_count_RwLockNonCloneSimpleTwinSse,
-    rustArcDecrementStrongCountPtr: RustLib.instance.api
-        .rust_arc_decrement_strong_count_RwLockNonCloneSimpleTwinSsePtr,
+    rustArcIncrementStrongCount: RustLib
+        .instance.api.rust_arc_increment_strong_count_NonCloneSimpleTwinSse,
+    rustArcDecrementStrongCount: RustLib
+        .instance.api.rust_arc_decrement_strong_count_NonCloneSimpleTwinSse,
+    rustArcDecrementStrongCountPtr: RustLib
+        .instance.api.rust_arc_decrement_strong_count_NonCloneSimpleTwinSsePtr,
   );
 
   Future<void> instanceMethodArgBorrowTwinSse({dynamic hint}) =>
@@ -218,38 +211,37 @@ class RwLockNonCloneSimpleTwinSse extends RustOpaque {
         that: this,
       );
 
-  Future<RwLockNonCloneSimpleTwinSse> instanceMethodReturnOwnTwinSse(
+  Future<NonCloneSimpleTwinSse> instanceMethodReturnOwnTwinSse(
           {dynamic hint}) =>
       RustLib.instance.api.nonCloneSimpleTwinSseInstanceMethodReturnOwnTwinSse(
         that: this,
       );
 
   /// named constructor
-  static Future<RwLockNonCloneSimpleTwinSse> newCustomNameTwinSse(
-          {dynamic hint}) =>
+  static Future<NonCloneSimpleTwinSse> newCustomNameTwinSse({dynamic hint}) =>
       RustLib.instance.api
           .nonCloneSimpleTwinSseNewCustomNameTwinSse(hint: hint);
 
   /// unnamed constructor
-  static Future<RwLockNonCloneSimpleTwinSse> newTwinSse({dynamic hint}) =>
+  static Future<NonCloneSimpleTwinSse> newTwinSse({dynamic hint}) =>
       RustLib.instance.api.nonCloneSimpleTwinSseNewTwinSse(hint: hint);
 
   static Future<void> staticMethodArgBorrowTwinSse(
-          {required RwLockNonCloneSimpleTwinSse arg, dynamic hint}) =>
+          {required NonCloneSimpleTwinSse arg, dynamic hint}) =>
       RustLib.instance.api.nonCloneSimpleTwinSseStaticMethodArgBorrowTwinSse(
           arg: arg, hint: hint);
 
   static Future<void> staticMethodArgMutBorrowTwinSse(
-          {required RwLockNonCloneSimpleTwinSse arg, dynamic hint}) =>
+          {required NonCloneSimpleTwinSse arg, dynamic hint}) =>
       RustLib.instance.api.nonCloneSimpleTwinSseStaticMethodArgMutBorrowTwinSse(
           arg: arg, hint: hint);
 
   static Future<void> staticMethodArgOwnTwinSse(
-          {required RwLockNonCloneSimpleTwinSse arg, dynamic hint}) =>
+          {required NonCloneSimpleTwinSse arg, dynamic hint}) =>
       RustLib.instance.api
           .nonCloneSimpleTwinSseStaticMethodArgOwnTwinSse(arg: arg, hint: hint);
 
-  static Future<RwLockNonCloneSimpleTwinSse> staticMethodReturnOwnTwinSse(
+  static Future<NonCloneSimpleTwinSse> staticMethodReturnOwnTwinSse(
           {dynamic hint}) =>
       RustLib.instance.api
           .nonCloneSimpleTwinSseStaticMethodReturnOwnTwinSse(hint: hint);
@@ -257,20 +249,20 @@ class RwLockNonCloneSimpleTwinSse extends RustOpaque {
 
 // Rust type: flutter_rust_bridge::RustOpaque<std::sync::RwLock<StructWithGoodAndOpaqueFieldTwinSse>>
 @sealed
-class RwLockStructWithGoodAndOpaqueFieldTwinSse extends RustOpaque {
-  RwLockStructWithGoodAndOpaqueFieldTwinSse.dcoDecode(dynamic wire)
+class StructWithGoodAndOpaqueFieldTwinSse extends RustOpaque {
+  StructWithGoodAndOpaqueFieldTwinSse.dcoDecode(dynamic wire)
       : super.dcoDecode(wire, _kStaticData);
 
-  RwLockStructWithGoodAndOpaqueFieldTwinSse.sseDecode(
+  StructWithGoodAndOpaqueFieldTwinSse.sseDecode(
       int ptr, int externalSizeOnNative)
       : super.sseDecode(ptr, externalSizeOnNative, _kStaticData);
 
   static final _kStaticData = RustArcStaticData(
     rustArcIncrementStrongCount: RustLib.instance.api
-        .rust_arc_increment_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinSse,
+        .rust_arc_increment_strong_count_StructWithGoodAndOpaqueFieldTwinSse,
     rustArcDecrementStrongCount: RustLib.instance.api
-        .rust_arc_decrement_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinSse,
+        .rust_arc_decrement_strong_count_StructWithGoodAndOpaqueFieldTwinSse,
     rustArcDecrementStrongCountPtr: RustLib.instance.api
-        .rust_arc_decrement_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinSsePtr,
+        .rust_arc_decrement_strong_count_StructWithGoodAndOpaqueFieldTwinSsePtr,
   );
 }

--- a/frb_example/pure_dart/lib/src/rust/api/pseudo_manual/rust_auto_opaque_twin_sync.dart
+++ b/frb_example/pure_dart/lib/src/rust/api/pseudo_manual/rust_auto_opaque_twin_sync.dart
@@ -8,120 +8,115 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'rust_auto_opaque_twin_sse.dart';
 
 void rustAutoOpaqueArgOwnTwinSync(
-        {required RwLockNonCloneSimpleTwinSync arg,
+        {required NonCloneSimpleTwinSync arg,
         required int expect,
         dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaqueArgOwnTwinSync(arg: arg, expect: expect, hint: hint);
 
 void rustAutoOpaqueArgBorrowTwinSync(
-        {required RwLockNonCloneSimpleTwinSync arg,
+        {required NonCloneSimpleTwinSync arg,
         required int expect,
         dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaqueArgBorrowTwinSync(arg: arg, expect: expect, hint: hint);
 
 void rustAutoOpaqueArgMutBorrowTwinSync(
-        {required RwLockNonCloneSimpleTwinSync arg,
+        {required NonCloneSimpleTwinSync arg,
         required int expect,
         required int adder,
         dynamic hint}) =>
     RustLib.instance.api.rustAutoOpaqueArgMutBorrowTwinSync(
         arg: arg, expect: expect, adder: adder, hint: hint);
 
-RwLockNonCloneSimpleTwinSync rustAutoOpaqueReturnOwnTwinSync(
+NonCloneSimpleTwinSync rustAutoOpaqueReturnOwnTwinSync(
         {required int initial, dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaqueReturnOwnTwinSync(initial: initial, hint: hint);
 
-RwLockNonCloneSimpleTwinSync rustAutoOpaqueArgOwnAndReturnOwnTwinSync(
-        {required RwLockNonCloneSimpleTwinSync arg, dynamic hint}) =>
+NonCloneSimpleTwinSync rustAutoOpaqueArgOwnAndReturnOwnTwinSync(
+        {required NonCloneSimpleTwinSync arg, dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaqueArgOwnAndReturnOwnTwinSync(arg: arg, hint: hint);
 
 void rustAutoOpaqueTwoArgsTwinSync(
-        {required RwLockNonCloneSimpleTwinSync a,
-        required RwLockNonCloneSimpleTwinSync b,
+        {required NonCloneSimpleTwinSync a,
+        required NonCloneSimpleTwinSync b,
         dynamic hint}) =>
     RustLib.instance.api.rustAutoOpaqueTwoArgsTwinSync(a: a, b: b, hint: hint);
 
 void rustAutoOpaqueNormalAndOpaqueArgTwinSync(
-        {required RwLockNonCloneSimpleTwinSync a,
-        required String b,
-        dynamic hint}) =>
+        {required NonCloneSimpleTwinSync a, required String b, dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaqueNormalAndOpaqueArgTwinSync(a: a, b: b, hint: hint);
 
 /// "+" inside the type signature
 void rustAutoOpaquePlusSignArgTwinSync(
-        {required RwLockBoxMyTraitTwinSync arg, dynamic hint}) =>
+        {required BoxMyTraitTwinSync arg, dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaquePlusSignArgTwinSync(arg: arg, hint: hint);
 
-RwLockBoxMyTraitTwinSync rustAutoOpaquePlusSignReturnTwinSync({dynamic hint}) =>
+BoxMyTraitTwinSync rustAutoOpaquePlusSignReturnTwinSync({dynamic hint}) =>
     RustLib.instance.api.rustAutoOpaquePlusSignReturnTwinSync(hint: hint);
 
 void rustAutoOpaqueCallableArgTwinSync(
-        {required RwLockBoxFnStringString arg, dynamic hint}) =>
+        {required BoxFnStringString arg, dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaqueCallableArgTwinSync(arg: arg, hint: hint);
 
-RwLockBoxFnStringString rustAutoOpaqueCallableReturnTwinSync({dynamic hint}) =>
+BoxFnStringString rustAutoOpaqueCallableReturnTwinSync({dynamic hint}) =>
     RustLib.instance.api.rustAutoOpaqueCallableReturnTwinSync(hint: hint);
 
 void rustAutoOpaqueTraitObjectArgOwnTwinSync(
-        {required RwLockBoxHelloTraitTwinSync arg,
+        {required BoxHelloTraitTwinSync arg,
         required String expect,
         dynamic hint}) =>
     RustLib.instance.api.rustAutoOpaqueTraitObjectArgOwnTwinSync(
         arg: arg, expect: expect, hint: hint);
 
 void rustAutoOpaqueTraitObjectArgBorrowTwinSync(
-        {required RwLockBoxHelloTraitTwinSync arg,
+        {required BoxHelloTraitTwinSync arg,
         required String expect,
         dynamic hint}) =>
     RustLib.instance.api.rustAutoOpaqueTraitObjectArgBorrowTwinSync(
         arg: arg, expect: expect, hint: hint);
 
 void rustAutoOpaqueTraitObjectArgMutBorrowTwinSync(
-        {required RwLockBoxHelloTraitTwinSync arg,
+        {required BoxHelloTraitTwinSync arg,
         required String expect,
         dynamic hint}) =>
     RustLib.instance.api.rustAutoOpaqueTraitObjectArgMutBorrowTwinSync(
         arg: arg, expect: expect, hint: hint);
 
-RwLockBoxHelloTraitTwinSync rustAutoOpaqueTraitObjectReturnOwnOneTwinSync(
+BoxHelloTraitTwinSync rustAutoOpaqueTraitObjectReturnOwnOneTwinSync(
         {dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaqueTraitObjectReturnOwnOneTwinSync(hint: hint);
 
-RwLockBoxHelloTraitTwinSync rustAutoOpaqueTraitObjectReturnOwnTwoTwinSync(
+BoxHelloTraitTwinSync rustAutoOpaqueTraitObjectReturnOwnTwoTwinSync(
         {dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaqueTraitObjectReturnOwnTwoTwinSync(hint: hint);
 
 void rustAutoOpaqueStructWithGoodAndOpaqueFieldArgOwnTwinSync(
-        {required RwLockStructWithGoodAndOpaqueFieldTwinSync arg,
-        dynamic hint}) =>
+        {required StructWithGoodAndOpaqueFieldTwinSync arg, dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaqueStructWithGoodAndOpaqueFieldArgOwnTwinSync(
             arg: arg, hint: hint);
 
 void rustAutoOpaqueStructWithGoodAndOpaqueFieldArgBorrowTwinSync(
-        {required RwLockStructWithGoodAndOpaqueFieldTwinSync arg,
-        dynamic hint}) =>
+        {required StructWithGoodAndOpaqueFieldTwinSync arg, dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaqueStructWithGoodAndOpaqueFieldArgBorrowTwinSync(
             arg: arg, hint: hint);
 
 void rustAutoOpaqueStructWithGoodAndOpaqueFieldArgMutBorrowTwinSync(
-        {required RwLockStructWithGoodAndOpaqueFieldTwinSync arg,
-        dynamic hint}) =>
+        {required StructWithGoodAndOpaqueFieldTwinSync arg, dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaqueStructWithGoodAndOpaqueFieldArgMutBorrowTwinSync(
             arg: arg, hint: hint);
 
-RwLockStructWithGoodAndOpaqueFieldTwinSync
+StructWithGoodAndOpaqueFieldTwinSync
     rustAutoOpaqueStructWithGoodAndOpaqueFieldReturnOwnTwinSync(
             {dynamic hint}) =>
         RustLib.instance.api
@@ -130,58 +125,58 @@ RwLockStructWithGoodAndOpaqueFieldTwinSync
 
 // Rust type: flutter_rust_bridge::RustOpaque<std::sync::RwLock<Box<dyn HelloTraitTwinSync>>>
 @sealed
-class RwLockBoxHelloTraitTwinSync extends RustOpaque {
-  RwLockBoxHelloTraitTwinSync.dcoDecode(dynamic wire)
+class BoxHelloTraitTwinSync extends RustOpaque {
+  BoxHelloTraitTwinSync.dcoDecode(dynamic wire)
       : super.dcoDecode(wire, _kStaticData);
 
-  RwLockBoxHelloTraitTwinSync.sseDecode(int ptr, int externalSizeOnNative)
+  BoxHelloTraitTwinSync.sseDecode(int ptr, int externalSizeOnNative)
       : super.sseDecode(ptr, externalSizeOnNative, _kStaticData);
 
   static final _kStaticData = RustArcStaticData(
-    rustArcIncrementStrongCount: RustLib.instance.api
-        .rust_arc_increment_strong_count_RwLockBoxHelloTraitTwinSync,
-    rustArcDecrementStrongCount: RustLib.instance.api
-        .rust_arc_decrement_strong_count_RwLockBoxHelloTraitTwinSync,
-    rustArcDecrementStrongCountPtr: RustLib.instance.api
-        .rust_arc_decrement_strong_count_RwLockBoxHelloTraitTwinSyncPtr,
+    rustArcIncrementStrongCount: RustLib
+        .instance.api.rust_arc_increment_strong_count_BoxHelloTraitTwinSync,
+    rustArcDecrementStrongCount: RustLib
+        .instance.api.rust_arc_decrement_strong_count_BoxHelloTraitTwinSync,
+    rustArcDecrementStrongCountPtr: RustLib
+        .instance.api.rust_arc_decrement_strong_count_BoxHelloTraitTwinSyncPtr,
   );
 }
 
 // Rust type: flutter_rust_bridge::RustOpaque<std::sync::RwLock<Box<dyn MyTraitTwinSync + Send + Sync>>>
 @sealed
-class RwLockBoxMyTraitTwinSync extends RustOpaque {
-  RwLockBoxMyTraitTwinSync.dcoDecode(dynamic wire)
+class BoxMyTraitTwinSync extends RustOpaque {
+  BoxMyTraitTwinSync.dcoDecode(dynamic wire)
       : super.dcoDecode(wire, _kStaticData);
 
-  RwLockBoxMyTraitTwinSync.sseDecode(int ptr, int externalSizeOnNative)
+  BoxMyTraitTwinSync.sseDecode(int ptr, int externalSizeOnNative)
       : super.sseDecode(ptr, externalSizeOnNative, _kStaticData);
 
   static final _kStaticData = RustArcStaticData(
-    rustArcIncrementStrongCount: RustLib
-        .instance.api.rust_arc_increment_strong_count_RwLockBoxMyTraitTwinSync,
-    rustArcDecrementStrongCount: RustLib
-        .instance.api.rust_arc_decrement_strong_count_RwLockBoxMyTraitTwinSync,
-    rustArcDecrementStrongCountPtr: RustLib.instance.api
-        .rust_arc_decrement_strong_count_RwLockBoxMyTraitTwinSyncPtr,
+    rustArcIncrementStrongCount:
+        RustLib.instance.api.rust_arc_increment_strong_count_BoxMyTraitTwinSync,
+    rustArcDecrementStrongCount:
+        RustLib.instance.api.rust_arc_decrement_strong_count_BoxMyTraitTwinSync,
+    rustArcDecrementStrongCountPtr: RustLib
+        .instance.api.rust_arc_decrement_strong_count_BoxMyTraitTwinSyncPtr,
   );
 }
 
 // Rust type: flutter_rust_bridge::RustOpaque<std::sync::RwLock<NonCloneSimpleTwinSync>>
 @sealed
-class RwLockNonCloneSimpleTwinSync extends RustOpaque {
-  RwLockNonCloneSimpleTwinSync.dcoDecode(dynamic wire)
+class NonCloneSimpleTwinSync extends RustOpaque {
+  NonCloneSimpleTwinSync.dcoDecode(dynamic wire)
       : super.dcoDecode(wire, _kStaticData);
 
-  RwLockNonCloneSimpleTwinSync.sseDecode(int ptr, int externalSizeOnNative)
+  NonCloneSimpleTwinSync.sseDecode(int ptr, int externalSizeOnNative)
       : super.sseDecode(ptr, externalSizeOnNative, _kStaticData);
 
   static final _kStaticData = RustArcStaticData(
-    rustArcIncrementStrongCount: RustLib.instance.api
-        .rust_arc_increment_strong_count_RwLockNonCloneSimpleTwinSync,
-    rustArcDecrementStrongCount: RustLib.instance.api
-        .rust_arc_decrement_strong_count_RwLockNonCloneSimpleTwinSync,
-    rustArcDecrementStrongCountPtr: RustLib.instance.api
-        .rust_arc_decrement_strong_count_RwLockNonCloneSimpleTwinSyncPtr,
+    rustArcIncrementStrongCount: RustLib
+        .instance.api.rust_arc_increment_strong_count_NonCloneSimpleTwinSync,
+    rustArcDecrementStrongCount: RustLib
+        .instance.api.rust_arc_decrement_strong_count_NonCloneSimpleTwinSync,
+    rustArcDecrementStrongCountPtr: RustLib
+        .instance.api.rust_arc_decrement_strong_count_NonCloneSimpleTwinSyncPtr,
   );
 
   void instanceMethodArgBorrowTwinSync({dynamic hint}) => RustLib.instance.api
@@ -200,60 +195,58 @@ class RwLockNonCloneSimpleTwinSync extends RustOpaque {
         that: this,
       );
 
-  RwLockNonCloneSimpleTwinSync instanceMethodReturnOwnTwinSync(
-          {dynamic hint}) =>
+  NonCloneSimpleTwinSync instanceMethodReturnOwnTwinSync({dynamic hint}) =>
       RustLib.instance.api
           .nonCloneSimpleTwinSyncInstanceMethodReturnOwnTwinSync(
         that: this,
       );
 
   /// named constructor
-  static RwLockNonCloneSimpleTwinSync newCustomNameTwinSync({dynamic hint}) =>
+  static NonCloneSimpleTwinSync newCustomNameTwinSync({dynamic hint}) =>
       RustLib.instance.api
           .nonCloneSimpleTwinSyncNewCustomNameTwinSync(hint: hint);
 
   /// unnamed constructor
-  static RwLockNonCloneSimpleTwinSync newTwinSync({dynamic hint}) =>
+  static NonCloneSimpleTwinSync newTwinSync({dynamic hint}) =>
       RustLib.instance.api.nonCloneSimpleTwinSyncNewTwinSync(hint: hint);
 
   static void staticMethodArgBorrowTwinSync(
-          {required RwLockNonCloneSimpleTwinSync arg, dynamic hint}) =>
+          {required NonCloneSimpleTwinSync arg, dynamic hint}) =>
       RustLib.instance.api.nonCloneSimpleTwinSyncStaticMethodArgBorrowTwinSync(
           arg: arg, hint: hint);
 
   static void staticMethodArgMutBorrowTwinSync(
-          {required RwLockNonCloneSimpleTwinSync arg, dynamic hint}) =>
+          {required NonCloneSimpleTwinSync arg, dynamic hint}) =>
       RustLib.instance.api
           .nonCloneSimpleTwinSyncStaticMethodArgMutBorrowTwinSync(
               arg: arg, hint: hint);
 
   static void staticMethodArgOwnTwinSync(
-          {required RwLockNonCloneSimpleTwinSync arg, dynamic hint}) =>
+          {required NonCloneSimpleTwinSync arg, dynamic hint}) =>
       RustLib.instance.api.nonCloneSimpleTwinSyncStaticMethodArgOwnTwinSync(
           arg: arg, hint: hint);
 
-  static RwLockNonCloneSimpleTwinSync staticMethodReturnOwnTwinSync(
-          {dynamic hint}) =>
+  static NonCloneSimpleTwinSync staticMethodReturnOwnTwinSync({dynamic hint}) =>
       RustLib.instance.api
           .nonCloneSimpleTwinSyncStaticMethodReturnOwnTwinSync(hint: hint);
 }
 
 // Rust type: flutter_rust_bridge::RustOpaque<std::sync::RwLock<StructWithGoodAndOpaqueFieldTwinSync>>
 @sealed
-class RwLockStructWithGoodAndOpaqueFieldTwinSync extends RustOpaque {
-  RwLockStructWithGoodAndOpaqueFieldTwinSync.dcoDecode(dynamic wire)
+class StructWithGoodAndOpaqueFieldTwinSync extends RustOpaque {
+  StructWithGoodAndOpaqueFieldTwinSync.dcoDecode(dynamic wire)
       : super.dcoDecode(wire, _kStaticData);
 
-  RwLockStructWithGoodAndOpaqueFieldTwinSync.sseDecode(
+  StructWithGoodAndOpaqueFieldTwinSync.sseDecode(
       int ptr, int externalSizeOnNative)
       : super.sseDecode(ptr, externalSizeOnNative, _kStaticData);
 
   static final _kStaticData = RustArcStaticData(
     rustArcIncrementStrongCount: RustLib.instance.api
-        .rust_arc_increment_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinSync,
+        .rust_arc_increment_strong_count_StructWithGoodAndOpaqueFieldTwinSync,
     rustArcDecrementStrongCount: RustLib.instance.api
-        .rust_arc_decrement_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinSync,
+        .rust_arc_decrement_strong_count_StructWithGoodAndOpaqueFieldTwinSync,
     rustArcDecrementStrongCountPtr: RustLib.instance.api
-        .rust_arc_decrement_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinSyncPtr,
+        .rust_arc_decrement_strong_count_StructWithGoodAndOpaqueFieldTwinSyncPtr,
   );
 }

--- a/frb_example/pure_dart/lib/src/rust/api/pseudo_manual/rust_auto_opaque_twin_sync_sse.dart
+++ b/frb_example/pure_dart/lib/src/rust/api/pseudo_manual/rust_auto_opaque_twin_sync_sse.dart
@@ -8,46 +8,46 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'rust_auto_opaque_twin_sse.dart';
 
 void rustAutoOpaqueArgOwnTwinSyncSse(
-        {required RwLockNonCloneSimpleTwinSyncSse arg,
+        {required NonCloneSimpleTwinSyncSse arg,
         required int expect,
         dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaqueArgOwnTwinSyncSse(arg: arg, expect: expect, hint: hint);
 
 void rustAutoOpaqueArgBorrowTwinSyncSse(
-        {required RwLockNonCloneSimpleTwinSyncSse arg,
+        {required NonCloneSimpleTwinSyncSse arg,
         required int expect,
         dynamic hint}) =>
     RustLib.instance.api.rustAutoOpaqueArgBorrowTwinSyncSse(
         arg: arg, expect: expect, hint: hint);
 
 void rustAutoOpaqueArgMutBorrowTwinSyncSse(
-        {required RwLockNonCloneSimpleTwinSyncSse arg,
+        {required NonCloneSimpleTwinSyncSse arg,
         required int expect,
         required int adder,
         dynamic hint}) =>
     RustLib.instance.api.rustAutoOpaqueArgMutBorrowTwinSyncSse(
         arg: arg, expect: expect, adder: adder, hint: hint);
 
-RwLockNonCloneSimpleTwinSyncSse rustAutoOpaqueReturnOwnTwinSyncSse(
+NonCloneSimpleTwinSyncSse rustAutoOpaqueReturnOwnTwinSyncSse(
         {required int initial, dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaqueReturnOwnTwinSyncSse(initial: initial, hint: hint);
 
-RwLockNonCloneSimpleTwinSyncSse rustAutoOpaqueArgOwnAndReturnOwnTwinSyncSse(
-        {required RwLockNonCloneSimpleTwinSyncSse arg, dynamic hint}) =>
+NonCloneSimpleTwinSyncSse rustAutoOpaqueArgOwnAndReturnOwnTwinSyncSse(
+        {required NonCloneSimpleTwinSyncSse arg, dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaqueArgOwnAndReturnOwnTwinSyncSse(arg: arg, hint: hint);
 
 void rustAutoOpaqueTwoArgsTwinSyncSse(
-        {required RwLockNonCloneSimpleTwinSyncSse a,
-        required RwLockNonCloneSimpleTwinSyncSse b,
+        {required NonCloneSimpleTwinSyncSse a,
+        required NonCloneSimpleTwinSyncSse b,
         dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaqueTwoArgsTwinSyncSse(a: a, b: b, hint: hint);
 
 void rustAutoOpaqueNormalAndOpaqueArgTwinSyncSse(
-        {required RwLockNonCloneSimpleTwinSyncSse a,
+        {required NonCloneSimpleTwinSyncSse a,
         required String b,
         dynamic hint}) =>
     RustLib.instance.api
@@ -55,76 +55,71 @@ void rustAutoOpaqueNormalAndOpaqueArgTwinSyncSse(
 
 /// "+" inside the type signature
 void rustAutoOpaquePlusSignArgTwinSyncSse(
-        {required RwLockBoxMyTraitTwinSyncSse arg, dynamic hint}) =>
+        {required BoxMyTraitTwinSyncSse arg, dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaquePlusSignArgTwinSyncSse(arg: arg, hint: hint);
 
-RwLockBoxMyTraitTwinSyncSse rustAutoOpaquePlusSignReturnTwinSyncSse(
-        {dynamic hint}) =>
+BoxMyTraitTwinSyncSse rustAutoOpaquePlusSignReturnTwinSyncSse({dynamic hint}) =>
     RustLib.instance.api.rustAutoOpaquePlusSignReturnTwinSyncSse(hint: hint);
 
 void rustAutoOpaqueCallableArgTwinSyncSse(
-        {required RwLockBoxFnStringString arg, dynamic hint}) =>
+        {required BoxFnStringString arg, dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaqueCallableArgTwinSyncSse(arg: arg, hint: hint);
 
-RwLockBoxFnStringString rustAutoOpaqueCallableReturnTwinSyncSse(
-        {dynamic hint}) =>
+BoxFnStringString rustAutoOpaqueCallableReturnTwinSyncSse({dynamic hint}) =>
     RustLib.instance.api.rustAutoOpaqueCallableReturnTwinSyncSse(hint: hint);
 
 void rustAutoOpaqueTraitObjectArgOwnTwinSyncSse(
-        {required RwLockBoxHelloTraitTwinSyncSse arg,
+        {required BoxHelloTraitTwinSyncSse arg,
         required String expect,
         dynamic hint}) =>
     RustLib.instance.api.rustAutoOpaqueTraitObjectArgOwnTwinSyncSse(
         arg: arg, expect: expect, hint: hint);
 
 void rustAutoOpaqueTraitObjectArgBorrowTwinSyncSse(
-        {required RwLockBoxHelloTraitTwinSyncSse arg,
+        {required BoxHelloTraitTwinSyncSse arg,
         required String expect,
         dynamic hint}) =>
     RustLib.instance.api.rustAutoOpaqueTraitObjectArgBorrowTwinSyncSse(
         arg: arg, expect: expect, hint: hint);
 
 void rustAutoOpaqueTraitObjectArgMutBorrowTwinSyncSse(
-        {required RwLockBoxHelloTraitTwinSyncSse arg,
+        {required BoxHelloTraitTwinSyncSse arg,
         required String expect,
         dynamic hint}) =>
     RustLib.instance.api.rustAutoOpaqueTraitObjectArgMutBorrowTwinSyncSse(
         arg: arg, expect: expect, hint: hint);
 
-RwLockBoxHelloTraitTwinSyncSse rustAutoOpaqueTraitObjectReturnOwnOneTwinSyncSse(
+BoxHelloTraitTwinSyncSse rustAutoOpaqueTraitObjectReturnOwnOneTwinSyncSse(
         {dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaqueTraitObjectReturnOwnOneTwinSyncSse(hint: hint);
 
-RwLockBoxHelloTraitTwinSyncSse rustAutoOpaqueTraitObjectReturnOwnTwoTwinSyncSse(
+BoxHelloTraitTwinSyncSse rustAutoOpaqueTraitObjectReturnOwnTwoTwinSyncSse(
         {dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaqueTraitObjectReturnOwnTwoTwinSyncSse(hint: hint);
 
 void rustAutoOpaqueStructWithGoodAndOpaqueFieldArgOwnTwinSyncSse(
-        {required RwLockStructWithGoodAndOpaqueFieldTwinSyncSse arg,
-        dynamic hint}) =>
+        {required StructWithGoodAndOpaqueFieldTwinSyncSse arg, dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaqueStructWithGoodAndOpaqueFieldArgOwnTwinSyncSse(
             arg: arg, hint: hint);
 
 void rustAutoOpaqueStructWithGoodAndOpaqueFieldArgBorrowTwinSyncSse(
-        {required RwLockStructWithGoodAndOpaqueFieldTwinSyncSse arg,
-        dynamic hint}) =>
+        {required StructWithGoodAndOpaqueFieldTwinSyncSse arg, dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaqueStructWithGoodAndOpaqueFieldArgBorrowTwinSyncSse(
             arg: arg, hint: hint);
 
 void rustAutoOpaqueStructWithGoodAndOpaqueFieldArgMutBorrowTwinSyncSse(
-        {required RwLockStructWithGoodAndOpaqueFieldTwinSyncSse arg,
-        dynamic hint}) =>
+        {required StructWithGoodAndOpaqueFieldTwinSyncSse arg, dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaqueStructWithGoodAndOpaqueFieldArgMutBorrowTwinSyncSse(
             arg: arg, hint: hint);
 
-RwLockStructWithGoodAndOpaqueFieldTwinSyncSse
+StructWithGoodAndOpaqueFieldTwinSyncSse
     rustAutoOpaqueStructWithGoodAndOpaqueFieldReturnOwnTwinSyncSse(
             {dynamic hint}) =>
         RustLib.instance.api
@@ -133,58 +128,58 @@ RwLockStructWithGoodAndOpaqueFieldTwinSyncSse
 
 // Rust type: flutter_rust_bridge::RustOpaque<std::sync::RwLock<Box<dyn HelloTraitTwinSyncSse>>>
 @sealed
-class RwLockBoxHelloTraitTwinSyncSse extends RustOpaque {
-  RwLockBoxHelloTraitTwinSyncSse.dcoDecode(dynamic wire)
+class BoxHelloTraitTwinSyncSse extends RustOpaque {
+  BoxHelloTraitTwinSyncSse.dcoDecode(dynamic wire)
       : super.dcoDecode(wire, _kStaticData);
 
-  RwLockBoxHelloTraitTwinSyncSse.sseDecode(int ptr, int externalSizeOnNative)
+  BoxHelloTraitTwinSyncSse.sseDecode(int ptr, int externalSizeOnNative)
       : super.sseDecode(ptr, externalSizeOnNative, _kStaticData);
 
   static final _kStaticData = RustArcStaticData(
-    rustArcIncrementStrongCount: RustLib.instance.api
-        .rust_arc_increment_strong_count_RwLockBoxHelloTraitTwinSyncSse,
-    rustArcDecrementStrongCount: RustLib.instance.api
-        .rust_arc_decrement_strong_count_RwLockBoxHelloTraitTwinSyncSse,
+    rustArcIncrementStrongCount: RustLib
+        .instance.api.rust_arc_increment_strong_count_BoxHelloTraitTwinSyncSse,
+    rustArcDecrementStrongCount: RustLib
+        .instance.api.rust_arc_decrement_strong_count_BoxHelloTraitTwinSyncSse,
     rustArcDecrementStrongCountPtr: RustLib.instance.api
-        .rust_arc_decrement_strong_count_RwLockBoxHelloTraitTwinSyncSsePtr,
+        .rust_arc_decrement_strong_count_BoxHelloTraitTwinSyncSsePtr,
   );
 }
 
 // Rust type: flutter_rust_bridge::RustOpaque<std::sync::RwLock<Box<dyn MyTraitTwinSyncSse + Send + Sync>>>
 @sealed
-class RwLockBoxMyTraitTwinSyncSse extends RustOpaque {
-  RwLockBoxMyTraitTwinSyncSse.dcoDecode(dynamic wire)
+class BoxMyTraitTwinSyncSse extends RustOpaque {
+  BoxMyTraitTwinSyncSse.dcoDecode(dynamic wire)
       : super.dcoDecode(wire, _kStaticData);
 
-  RwLockBoxMyTraitTwinSyncSse.sseDecode(int ptr, int externalSizeOnNative)
+  BoxMyTraitTwinSyncSse.sseDecode(int ptr, int externalSizeOnNative)
       : super.sseDecode(ptr, externalSizeOnNative, _kStaticData);
 
   static final _kStaticData = RustArcStaticData(
-    rustArcIncrementStrongCount: RustLib.instance.api
-        .rust_arc_increment_strong_count_RwLockBoxMyTraitTwinSyncSse,
-    rustArcDecrementStrongCount: RustLib.instance.api
-        .rust_arc_decrement_strong_count_RwLockBoxMyTraitTwinSyncSse,
-    rustArcDecrementStrongCountPtr: RustLib.instance.api
-        .rust_arc_decrement_strong_count_RwLockBoxMyTraitTwinSyncSsePtr,
+    rustArcIncrementStrongCount: RustLib
+        .instance.api.rust_arc_increment_strong_count_BoxMyTraitTwinSyncSse,
+    rustArcDecrementStrongCount: RustLib
+        .instance.api.rust_arc_decrement_strong_count_BoxMyTraitTwinSyncSse,
+    rustArcDecrementStrongCountPtr: RustLib
+        .instance.api.rust_arc_decrement_strong_count_BoxMyTraitTwinSyncSsePtr,
   );
 }
 
 // Rust type: flutter_rust_bridge::RustOpaque<std::sync::RwLock<NonCloneSimpleTwinSyncSse>>
 @sealed
-class RwLockNonCloneSimpleTwinSyncSse extends RustOpaque {
-  RwLockNonCloneSimpleTwinSyncSse.dcoDecode(dynamic wire)
+class NonCloneSimpleTwinSyncSse extends RustOpaque {
+  NonCloneSimpleTwinSyncSse.dcoDecode(dynamic wire)
       : super.dcoDecode(wire, _kStaticData);
 
-  RwLockNonCloneSimpleTwinSyncSse.sseDecode(int ptr, int externalSizeOnNative)
+  NonCloneSimpleTwinSyncSse.sseDecode(int ptr, int externalSizeOnNative)
       : super.sseDecode(ptr, externalSizeOnNative, _kStaticData);
 
   static final _kStaticData = RustArcStaticData(
-    rustArcIncrementStrongCount: RustLib.instance.api
-        .rust_arc_increment_strong_count_RwLockNonCloneSimpleTwinSyncSse,
-    rustArcDecrementStrongCount: RustLib.instance.api
-        .rust_arc_decrement_strong_count_RwLockNonCloneSimpleTwinSyncSse,
+    rustArcIncrementStrongCount: RustLib
+        .instance.api.rust_arc_increment_strong_count_NonCloneSimpleTwinSyncSse,
+    rustArcDecrementStrongCount: RustLib
+        .instance.api.rust_arc_decrement_strong_count_NonCloneSimpleTwinSyncSse,
     rustArcDecrementStrongCountPtr: RustLib.instance.api
-        .rust_arc_decrement_strong_count_RwLockNonCloneSimpleTwinSyncSsePtr,
+        .rust_arc_decrement_strong_count_NonCloneSimpleTwinSyncSsePtr,
   );
 
   void instanceMethodArgBorrowTwinSyncSse({dynamic hint}) =>
@@ -204,7 +199,7 @@ class RwLockNonCloneSimpleTwinSyncSse extends RustOpaque {
         that: this,
       );
 
-  RwLockNonCloneSimpleTwinSyncSse instanceMethodReturnOwnTwinSyncSse(
+  NonCloneSimpleTwinSyncSse instanceMethodReturnOwnTwinSyncSse(
           {dynamic hint}) =>
       RustLib.instance.api
           .nonCloneSimpleTwinSyncSseInstanceMethodReturnOwnTwinSyncSse(
@@ -212,34 +207,33 @@ class RwLockNonCloneSimpleTwinSyncSse extends RustOpaque {
       );
 
   /// named constructor
-  static RwLockNonCloneSimpleTwinSyncSse newCustomNameTwinSyncSse(
-          {dynamic hint}) =>
+  static NonCloneSimpleTwinSyncSse newCustomNameTwinSyncSse({dynamic hint}) =>
       RustLib.instance.api
           .nonCloneSimpleTwinSyncSseNewCustomNameTwinSyncSse(hint: hint);
 
   /// unnamed constructor
-  static RwLockNonCloneSimpleTwinSyncSse newTwinSyncSse({dynamic hint}) =>
+  static NonCloneSimpleTwinSyncSse newTwinSyncSse({dynamic hint}) =>
       RustLib.instance.api.nonCloneSimpleTwinSyncSseNewTwinSyncSse(hint: hint);
 
   static void staticMethodArgBorrowTwinSyncSse(
-          {required RwLockNonCloneSimpleTwinSyncSse arg, dynamic hint}) =>
+          {required NonCloneSimpleTwinSyncSse arg, dynamic hint}) =>
       RustLib.instance.api
           .nonCloneSimpleTwinSyncSseStaticMethodArgBorrowTwinSyncSse(
               arg: arg, hint: hint);
 
   static void staticMethodArgMutBorrowTwinSyncSse(
-          {required RwLockNonCloneSimpleTwinSyncSse arg, dynamic hint}) =>
+          {required NonCloneSimpleTwinSyncSse arg, dynamic hint}) =>
       RustLib.instance.api
           .nonCloneSimpleTwinSyncSseStaticMethodArgMutBorrowTwinSyncSse(
               arg: arg, hint: hint);
 
   static void staticMethodArgOwnTwinSyncSse(
-          {required RwLockNonCloneSimpleTwinSyncSse arg, dynamic hint}) =>
+          {required NonCloneSimpleTwinSyncSse arg, dynamic hint}) =>
       RustLib.instance.api
           .nonCloneSimpleTwinSyncSseStaticMethodArgOwnTwinSyncSse(
               arg: arg, hint: hint);
 
-  static RwLockNonCloneSimpleTwinSyncSse staticMethodReturnOwnTwinSyncSse(
+  static NonCloneSimpleTwinSyncSse staticMethodReturnOwnTwinSyncSse(
           {dynamic hint}) =>
       RustLib.instance.api
           .nonCloneSimpleTwinSyncSseStaticMethodReturnOwnTwinSyncSse(
@@ -248,20 +242,20 @@ class RwLockNonCloneSimpleTwinSyncSse extends RustOpaque {
 
 // Rust type: flutter_rust_bridge::RustOpaque<std::sync::RwLock<StructWithGoodAndOpaqueFieldTwinSyncSse>>
 @sealed
-class RwLockStructWithGoodAndOpaqueFieldTwinSyncSse extends RustOpaque {
-  RwLockStructWithGoodAndOpaqueFieldTwinSyncSse.dcoDecode(dynamic wire)
+class StructWithGoodAndOpaqueFieldTwinSyncSse extends RustOpaque {
+  StructWithGoodAndOpaqueFieldTwinSyncSse.dcoDecode(dynamic wire)
       : super.dcoDecode(wire, _kStaticData);
 
-  RwLockStructWithGoodAndOpaqueFieldTwinSyncSse.sseDecode(
+  StructWithGoodAndOpaqueFieldTwinSyncSse.sseDecode(
       int ptr, int externalSizeOnNative)
       : super.sseDecode(ptr, externalSizeOnNative, _kStaticData);
 
   static final _kStaticData = RustArcStaticData(
     rustArcIncrementStrongCount: RustLib.instance.api
-        .rust_arc_increment_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinSyncSse,
+        .rust_arc_increment_strong_count_StructWithGoodAndOpaqueFieldTwinSyncSse,
     rustArcDecrementStrongCount: RustLib.instance.api
-        .rust_arc_decrement_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinSyncSse,
+        .rust_arc_decrement_strong_count_StructWithGoodAndOpaqueFieldTwinSyncSse,
     rustArcDecrementStrongCountPtr: RustLib.instance.api
-        .rust_arc_decrement_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinSyncSsePtr,
+        .rust_arc_decrement_strong_count_StructWithGoodAndOpaqueFieldTwinSyncSsePtr,
   );
 }

--- a/frb_example/pure_dart/lib/src/rust/api/rust_auto_opaque.dart
+++ b/frb_example/pure_dart/lib/src/rust/api/rust_auto_opaque.dart
@@ -8,47 +8,46 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'pseudo_manual/rust_auto_opaque_twin_sse.dart';
 
 Future<void> rustAutoOpaqueArgOwnTwinNormal(
-        {required RwLockNonCloneSimpleTwinNormal arg,
+        {required NonCloneSimpleTwinNormal arg,
         required int expect,
         dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaqueArgOwnTwinNormal(arg: arg, expect: expect, hint: hint);
 
 Future<void> rustAutoOpaqueArgBorrowTwinNormal(
-        {required RwLockNonCloneSimpleTwinNormal arg,
+        {required NonCloneSimpleTwinNormal arg,
         required int expect,
         dynamic hint}) =>
     RustLib.instance.api.rustAutoOpaqueArgBorrowTwinNormal(
         arg: arg, expect: expect, hint: hint);
 
 Future<void> rustAutoOpaqueArgMutBorrowTwinNormal(
-        {required RwLockNonCloneSimpleTwinNormal arg,
+        {required NonCloneSimpleTwinNormal arg,
         required int expect,
         required int adder,
         dynamic hint}) =>
     RustLib.instance.api.rustAutoOpaqueArgMutBorrowTwinNormal(
         arg: arg, expect: expect, adder: adder, hint: hint);
 
-Future<RwLockNonCloneSimpleTwinNormal> rustAutoOpaqueReturnOwnTwinNormal(
+Future<NonCloneSimpleTwinNormal> rustAutoOpaqueReturnOwnTwinNormal(
         {required int initial, dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaqueReturnOwnTwinNormal(initial: initial, hint: hint);
 
-Future<RwLockNonCloneSimpleTwinNormal>
-    rustAutoOpaqueArgOwnAndReturnOwnTwinNormal(
-            {required RwLockNonCloneSimpleTwinNormal arg, dynamic hint}) =>
-        RustLib.instance.api
-            .rustAutoOpaqueArgOwnAndReturnOwnTwinNormal(arg: arg, hint: hint);
+Future<NonCloneSimpleTwinNormal> rustAutoOpaqueArgOwnAndReturnOwnTwinNormal(
+        {required NonCloneSimpleTwinNormal arg, dynamic hint}) =>
+    RustLib.instance.api
+        .rustAutoOpaqueArgOwnAndReturnOwnTwinNormal(arg: arg, hint: hint);
 
 Future<void> rustAutoOpaqueTwoArgsTwinNormal(
-        {required RwLockNonCloneSimpleTwinNormal a,
-        required RwLockNonCloneSimpleTwinNormal b,
+        {required NonCloneSimpleTwinNormal a,
+        required NonCloneSimpleTwinNormal b,
         dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaqueTwoArgsTwinNormal(a: a, b: b, hint: hint);
 
 Future<void> rustAutoOpaqueNormalAndOpaqueArgTwinNormal(
-        {required RwLockNonCloneSimpleTwinNormal a,
+        {required NonCloneSimpleTwinNormal a,
         required String b,
         dynamic hint}) =>
     RustLib.instance.api
@@ -56,76 +55,73 @@ Future<void> rustAutoOpaqueNormalAndOpaqueArgTwinNormal(
 
 /// "+" inside the type signature
 Future<void> rustAutoOpaquePlusSignArgTwinNormal(
-        {required RwLockBoxMyTraitTwinNormal arg, dynamic hint}) =>
+        {required BoxMyTraitTwinNormal arg, dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaquePlusSignArgTwinNormal(arg: arg, hint: hint);
 
-Future<RwLockBoxMyTraitTwinNormal> rustAutoOpaquePlusSignReturnTwinNormal(
+Future<BoxMyTraitTwinNormal> rustAutoOpaquePlusSignReturnTwinNormal(
         {dynamic hint}) =>
     RustLib.instance.api.rustAutoOpaquePlusSignReturnTwinNormal(hint: hint);
 
 Future<void> rustAutoOpaqueCallableArgTwinNormal(
-        {required RwLockBoxFnStringString arg, dynamic hint}) =>
+        {required BoxFnStringString arg, dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaqueCallableArgTwinNormal(arg: arg, hint: hint);
 
-Future<RwLockBoxFnStringString> rustAutoOpaqueCallableReturnTwinNormal(
+Future<BoxFnStringString> rustAutoOpaqueCallableReturnTwinNormal(
         {dynamic hint}) =>
     RustLib.instance.api.rustAutoOpaqueCallableReturnTwinNormal(hint: hint);
 
 Future<void> rustAutoOpaqueTraitObjectArgOwnTwinNormal(
-        {required RwLockBoxHelloTraitTwinNormal arg,
+        {required BoxHelloTraitTwinNormal arg,
         required String expect,
         dynamic hint}) =>
     RustLib.instance.api.rustAutoOpaqueTraitObjectArgOwnTwinNormal(
         arg: arg, expect: expect, hint: hint);
 
 Future<void> rustAutoOpaqueTraitObjectArgBorrowTwinNormal(
-        {required RwLockBoxHelloTraitTwinNormal arg,
+        {required BoxHelloTraitTwinNormal arg,
         required String expect,
         dynamic hint}) =>
     RustLib.instance.api.rustAutoOpaqueTraitObjectArgBorrowTwinNormal(
         arg: arg, expect: expect, hint: hint);
 
 Future<void> rustAutoOpaqueTraitObjectArgMutBorrowTwinNormal(
-        {required RwLockBoxHelloTraitTwinNormal arg,
+        {required BoxHelloTraitTwinNormal arg,
         required String expect,
         dynamic hint}) =>
     RustLib.instance.api.rustAutoOpaqueTraitObjectArgMutBorrowTwinNormal(
         arg: arg, expect: expect, hint: hint);
 
-Future<RwLockBoxHelloTraitTwinNormal>
-    rustAutoOpaqueTraitObjectReturnOwnOneTwinNormal({dynamic hint}) =>
-        RustLib.instance.api
-            .rustAutoOpaqueTraitObjectReturnOwnOneTwinNormal(hint: hint);
+Future<BoxHelloTraitTwinNormal> rustAutoOpaqueTraitObjectReturnOwnOneTwinNormal(
+        {dynamic hint}) =>
+    RustLib.instance.api
+        .rustAutoOpaqueTraitObjectReturnOwnOneTwinNormal(hint: hint);
 
-Future<RwLockBoxHelloTraitTwinNormal>
-    rustAutoOpaqueTraitObjectReturnOwnTwoTwinNormal({dynamic hint}) =>
-        RustLib.instance.api
-            .rustAutoOpaqueTraitObjectReturnOwnTwoTwinNormal(hint: hint);
+Future<BoxHelloTraitTwinNormal> rustAutoOpaqueTraitObjectReturnOwnTwoTwinNormal(
+        {dynamic hint}) =>
+    RustLib.instance.api
+        .rustAutoOpaqueTraitObjectReturnOwnTwoTwinNormal(hint: hint);
 
 Future<void> rustAutoOpaqueStructWithGoodAndOpaqueFieldArgOwnTwinNormal(
-        {required RwLockStructWithGoodAndOpaqueFieldTwinNormal arg,
-        dynamic hint}) =>
+        {required StructWithGoodAndOpaqueFieldTwinNormal arg, dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaqueStructWithGoodAndOpaqueFieldArgOwnTwinNormal(
             arg: arg, hint: hint);
 
 Future<void> rustAutoOpaqueStructWithGoodAndOpaqueFieldArgBorrowTwinNormal(
-        {required RwLockStructWithGoodAndOpaqueFieldTwinNormal arg,
-        dynamic hint}) =>
+        {required StructWithGoodAndOpaqueFieldTwinNormal arg, dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaqueStructWithGoodAndOpaqueFieldArgBorrowTwinNormal(
             arg: arg, hint: hint);
 
 Future<void> rustAutoOpaqueStructWithGoodAndOpaqueFieldArgMutBorrowTwinNormal(
-        {required RwLockStructWithGoodAndOpaqueFieldTwinNormal arg,
-        dynamic hint}) =>
+        {required StructWithGoodAndOpaqueFieldTwinNormal arg, dynamic hint}) =>
     RustLib.instance.api
         .rustAutoOpaqueStructWithGoodAndOpaqueFieldArgMutBorrowTwinNormal(
             arg: arg, hint: hint);
 
-Future<RwLockStructWithGoodAndOpaqueFieldTwinNormal>
+Future<StructWithGoodAndOpaqueFieldTwinNormal>
     rustAutoOpaqueStructWithGoodAndOpaqueFieldReturnOwnTwinNormal(
             {dynamic hint}) =>
         RustLib.instance.api
@@ -134,58 +130,58 @@ Future<RwLockStructWithGoodAndOpaqueFieldTwinNormal>
 
 // Rust type: flutter_rust_bridge::RustOpaque<std::sync::RwLock<Box<dyn HelloTraitTwinNormal>>>
 @sealed
-class RwLockBoxHelloTraitTwinNormal extends RustOpaque {
-  RwLockBoxHelloTraitTwinNormal.dcoDecode(dynamic wire)
+class BoxHelloTraitTwinNormal extends RustOpaque {
+  BoxHelloTraitTwinNormal.dcoDecode(dynamic wire)
       : super.dcoDecode(wire, _kStaticData);
 
-  RwLockBoxHelloTraitTwinNormal.sseDecode(int ptr, int externalSizeOnNative)
+  BoxHelloTraitTwinNormal.sseDecode(int ptr, int externalSizeOnNative)
       : super.sseDecode(ptr, externalSizeOnNative, _kStaticData);
 
   static final _kStaticData = RustArcStaticData(
-    rustArcIncrementStrongCount: RustLib.instance.api
-        .rust_arc_increment_strong_count_RwLockBoxHelloTraitTwinNormal,
-    rustArcDecrementStrongCount: RustLib.instance.api
-        .rust_arc_decrement_strong_count_RwLockBoxHelloTraitTwinNormal,
+    rustArcIncrementStrongCount: RustLib
+        .instance.api.rust_arc_increment_strong_count_BoxHelloTraitTwinNormal,
+    rustArcDecrementStrongCount: RustLib
+        .instance.api.rust_arc_decrement_strong_count_BoxHelloTraitTwinNormal,
     rustArcDecrementStrongCountPtr: RustLib.instance.api
-        .rust_arc_decrement_strong_count_RwLockBoxHelloTraitTwinNormalPtr,
+        .rust_arc_decrement_strong_count_BoxHelloTraitTwinNormalPtr,
   );
 }
 
 // Rust type: flutter_rust_bridge::RustOpaque<std::sync::RwLock<Box<dyn MyTraitTwinNormal + Send + Sync>>>
 @sealed
-class RwLockBoxMyTraitTwinNormal extends RustOpaque {
-  RwLockBoxMyTraitTwinNormal.dcoDecode(dynamic wire)
+class BoxMyTraitTwinNormal extends RustOpaque {
+  BoxMyTraitTwinNormal.dcoDecode(dynamic wire)
       : super.dcoDecode(wire, _kStaticData);
 
-  RwLockBoxMyTraitTwinNormal.sseDecode(int ptr, int externalSizeOnNative)
+  BoxMyTraitTwinNormal.sseDecode(int ptr, int externalSizeOnNative)
       : super.sseDecode(ptr, externalSizeOnNative, _kStaticData);
 
   static final _kStaticData = RustArcStaticData(
-    rustArcIncrementStrongCount: RustLib.instance.api
-        .rust_arc_increment_strong_count_RwLockBoxMyTraitTwinNormal,
-    rustArcDecrementStrongCount: RustLib.instance.api
-        .rust_arc_decrement_strong_count_RwLockBoxMyTraitTwinNormal,
-    rustArcDecrementStrongCountPtr: RustLib.instance.api
-        .rust_arc_decrement_strong_count_RwLockBoxMyTraitTwinNormalPtr,
+    rustArcIncrementStrongCount: RustLib
+        .instance.api.rust_arc_increment_strong_count_BoxMyTraitTwinNormal,
+    rustArcDecrementStrongCount: RustLib
+        .instance.api.rust_arc_decrement_strong_count_BoxMyTraitTwinNormal,
+    rustArcDecrementStrongCountPtr: RustLib
+        .instance.api.rust_arc_decrement_strong_count_BoxMyTraitTwinNormalPtr,
   );
 }
 
 // Rust type: flutter_rust_bridge::RustOpaque<std::sync::RwLock<NonCloneSimpleTwinNormal>>
 @sealed
-class RwLockNonCloneSimpleTwinNormal extends RustOpaque {
-  RwLockNonCloneSimpleTwinNormal.dcoDecode(dynamic wire)
+class NonCloneSimpleTwinNormal extends RustOpaque {
+  NonCloneSimpleTwinNormal.dcoDecode(dynamic wire)
       : super.dcoDecode(wire, _kStaticData);
 
-  RwLockNonCloneSimpleTwinNormal.sseDecode(int ptr, int externalSizeOnNative)
+  NonCloneSimpleTwinNormal.sseDecode(int ptr, int externalSizeOnNative)
       : super.sseDecode(ptr, externalSizeOnNative, _kStaticData);
 
   static final _kStaticData = RustArcStaticData(
-    rustArcIncrementStrongCount: RustLib.instance.api
-        .rust_arc_increment_strong_count_RwLockNonCloneSimpleTwinNormal,
-    rustArcDecrementStrongCount: RustLib.instance.api
-        .rust_arc_decrement_strong_count_RwLockNonCloneSimpleTwinNormal,
+    rustArcIncrementStrongCount: RustLib
+        .instance.api.rust_arc_increment_strong_count_NonCloneSimpleTwinNormal,
+    rustArcDecrementStrongCount: RustLib
+        .instance.api.rust_arc_decrement_strong_count_NonCloneSimpleTwinNormal,
     rustArcDecrementStrongCountPtr: RustLib.instance.api
-        .rust_arc_decrement_strong_count_RwLockNonCloneSimpleTwinNormalPtr,
+        .rust_arc_decrement_strong_count_NonCloneSimpleTwinNormalPtr,
   );
 
   Future<void> instanceMethodArgBorrowTwinNormal({dynamic hint}) =>
@@ -206,7 +202,7 @@ class RwLockNonCloneSimpleTwinNormal extends RustOpaque {
         that: this,
       );
 
-  Future<RwLockNonCloneSimpleTwinNormal> instanceMethodReturnOwnTwinNormal(
+  Future<NonCloneSimpleTwinNormal> instanceMethodReturnOwnTwinNormal(
           {dynamic hint}) =>
       RustLib.instance.api
           .nonCloneSimpleTwinNormalInstanceMethodReturnOwnTwinNormal(
@@ -214,33 +210,33 @@ class RwLockNonCloneSimpleTwinNormal extends RustOpaque {
       );
 
   /// named constructor
-  static Future<RwLockNonCloneSimpleTwinNormal> newCustomNameTwinNormal(
+  static Future<NonCloneSimpleTwinNormal> newCustomNameTwinNormal(
           {dynamic hint}) =>
       RustLib.instance.api
           .nonCloneSimpleTwinNormalNewCustomNameTwinNormal(hint: hint);
 
   /// unnamed constructor
-  static Future<RwLockNonCloneSimpleTwinNormal> newTwinNormal({dynamic hint}) =>
+  static Future<NonCloneSimpleTwinNormal> newTwinNormal({dynamic hint}) =>
       RustLib.instance.api.nonCloneSimpleTwinNormalNewTwinNormal(hint: hint);
 
   static Future<void> staticMethodArgBorrowTwinNormal(
-          {required RwLockNonCloneSimpleTwinNormal arg, dynamic hint}) =>
+          {required NonCloneSimpleTwinNormal arg, dynamic hint}) =>
       RustLib.instance.api
           .nonCloneSimpleTwinNormalStaticMethodArgBorrowTwinNormal(
               arg: arg, hint: hint);
 
   static Future<void> staticMethodArgMutBorrowTwinNormal(
-          {required RwLockNonCloneSimpleTwinNormal arg, dynamic hint}) =>
+          {required NonCloneSimpleTwinNormal arg, dynamic hint}) =>
       RustLib.instance.api
           .nonCloneSimpleTwinNormalStaticMethodArgMutBorrowTwinNormal(
               arg: arg, hint: hint);
 
   static Future<void> staticMethodArgOwnTwinNormal(
-          {required RwLockNonCloneSimpleTwinNormal arg, dynamic hint}) =>
+          {required NonCloneSimpleTwinNormal arg, dynamic hint}) =>
       RustLib.instance.api.nonCloneSimpleTwinNormalStaticMethodArgOwnTwinNormal(
           arg: arg, hint: hint);
 
-  static Future<RwLockNonCloneSimpleTwinNormal> staticMethodReturnOwnTwinNormal(
+  static Future<NonCloneSimpleTwinNormal> staticMethodReturnOwnTwinNormal(
           {dynamic hint}) =>
       RustLib.instance.api
           .nonCloneSimpleTwinNormalStaticMethodReturnOwnTwinNormal(hint: hint);
@@ -248,20 +244,20 @@ class RwLockNonCloneSimpleTwinNormal extends RustOpaque {
 
 // Rust type: flutter_rust_bridge::RustOpaque<std::sync::RwLock<StructWithGoodAndOpaqueFieldTwinNormal>>
 @sealed
-class RwLockStructWithGoodAndOpaqueFieldTwinNormal extends RustOpaque {
-  RwLockStructWithGoodAndOpaqueFieldTwinNormal.dcoDecode(dynamic wire)
+class StructWithGoodAndOpaqueFieldTwinNormal extends RustOpaque {
+  StructWithGoodAndOpaqueFieldTwinNormal.dcoDecode(dynamic wire)
       : super.dcoDecode(wire, _kStaticData);
 
-  RwLockStructWithGoodAndOpaqueFieldTwinNormal.sseDecode(
+  StructWithGoodAndOpaqueFieldTwinNormal.sseDecode(
       int ptr, int externalSizeOnNative)
       : super.sseDecode(ptr, externalSizeOnNative, _kStaticData);
 
   static final _kStaticData = RustArcStaticData(
     rustArcIncrementStrongCount: RustLib.instance.api
-        .rust_arc_increment_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinNormal,
+        .rust_arc_increment_strong_count_StructWithGoodAndOpaqueFieldTwinNormal,
     rustArcDecrementStrongCount: RustLib.instance.api
-        .rust_arc_decrement_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinNormal,
+        .rust_arc_decrement_strong_count_StructWithGoodAndOpaqueFieldTwinNormal,
     rustArcDecrementStrongCountPtr: RustLib.instance.api
-        .rust_arc_decrement_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinNormalPtr,
+        .rust_arc_decrement_strong_count_StructWithGoodAndOpaqueFieldTwinNormalPtr,
   );
 }

--- a/frb_example/pure_dart/lib/src/rust/frb_generated.dart
+++ b/frb_example/pure_dart/lib/src/rust/frb_generated.dart
@@ -3611,331 +3611,307 @@ abstract class RustLibApi extends BaseApi {
       {dynamic hint});
 
   Future<void> nonCloneSimpleTwinSseInstanceMethodArgBorrowTwinSse(
-      {required RwLockNonCloneSimpleTwinSse that, dynamic hint});
+      {required NonCloneSimpleTwinSse that, dynamic hint});
 
   Future<void> nonCloneSimpleTwinSseInstanceMethodArgMutBorrowTwinSse(
-      {required RwLockNonCloneSimpleTwinSse that, dynamic hint});
+      {required NonCloneSimpleTwinSse that, dynamic hint});
 
   Future<void> nonCloneSimpleTwinSseInstanceMethodArgOwnTwinSse(
-      {required RwLockNonCloneSimpleTwinSse that, dynamic hint});
+      {required NonCloneSimpleTwinSse that, dynamic hint});
 
-  Future<RwLockNonCloneSimpleTwinSse>
+  Future<NonCloneSimpleTwinSse>
       nonCloneSimpleTwinSseInstanceMethodReturnOwnTwinSse(
-          {required RwLockNonCloneSimpleTwinSse that, dynamic hint});
+          {required NonCloneSimpleTwinSse that, dynamic hint});
 
-  Future<RwLockNonCloneSimpleTwinSse> nonCloneSimpleTwinSseNewCustomNameTwinSse(
+  Future<NonCloneSimpleTwinSse> nonCloneSimpleTwinSseNewCustomNameTwinSse(
       {dynamic hint});
 
-  Future<RwLockNonCloneSimpleTwinSse> nonCloneSimpleTwinSseNewTwinSse(
-      {dynamic hint});
+  Future<NonCloneSimpleTwinSse> nonCloneSimpleTwinSseNewTwinSse({dynamic hint});
 
   Future<void> nonCloneSimpleTwinSseStaticMethodArgBorrowTwinSse(
-      {required RwLockNonCloneSimpleTwinSse arg, dynamic hint});
+      {required NonCloneSimpleTwinSse arg, dynamic hint});
 
   Future<void> nonCloneSimpleTwinSseStaticMethodArgMutBorrowTwinSse(
-      {required RwLockNonCloneSimpleTwinSse arg, dynamic hint});
+      {required NonCloneSimpleTwinSse arg, dynamic hint});
 
   Future<void> nonCloneSimpleTwinSseStaticMethodArgOwnTwinSse(
-      {required RwLockNonCloneSimpleTwinSse arg, dynamic hint});
+      {required NonCloneSimpleTwinSse arg, dynamic hint});
 
-  Future<RwLockNonCloneSimpleTwinSse>
+  Future<NonCloneSimpleTwinSse>
       nonCloneSimpleTwinSseStaticMethodReturnOwnTwinSse({dynamic hint});
 
   Future<void> rustAutoOpaqueArgBorrowTwinSse(
-      {required RwLockNonCloneSimpleTwinSse arg,
-      required int expect,
-      dynamic hint});
+      {required NonCloneSimpleTwinSse arg, required int expect, dynamic hint});
 
   Future<void> rustAutoOpaqueArgMutBorrowTwinSse(
-      {required RwLockNonCloneSimpleTwinSse arg,
+      {required NonCloneSimpleTwinSse arg,
       required int expect,
       required int adder,
       dynamic hint});
 
-  Future<RwLockNonCloneSimpleTwinSse> rustAutoOpaqueArgOwnAndReturnOwnTwinSse(
-      {required RwLockNonCloneSimpleTwinSse arg, dynamic hint});
+  Future<NonCloneSimpleTwinSse> rustAutoOpaqueArgOwnAndReturnOwnTwinSse(
+      {required NonCloneSimpleTwinSse arg, dynamic hint});
 
   Future<void> rustAutoOpaqueArgOwnTwinSse(
-      {required RwLockNonCloneSimpleTwinSse arg,
-      required int expect,
-      dynamic hint});
+      {required NonCloneSimpleTwinSse arg, required int expect, dynamic hint});
 
   Future<void> rustAutoOpaqueCallableArgTwinSse(
-      {required RwLockBoxFnStringString arg, dynamic hint});
+      {required BoxFnStringString arg, dynamic hint});
 
-  Future<RwLockBoxFnStringString> rustAutoOpaqueCallableReturnTwinSse(
-      {dynamic hint});
+  Future<BoxFnStringString> rustAutoOpaqueCallableReturnTwinSse({dynamic hint});
 
   Future<void> rustAutoOpaqueNormalAndOpaqueArgTwinSse(
-      {required RwLockNonCloneSimpleTwinSse a,
-      required String b,
-      dynamic hint});
+      {required NonCloneSimpleTwinSse a, required String b, dynamic hint});
 
   Future<void> rustAutoOpaquePlusSignArgTwinSse(
-      {required RwLockBoxMyTraitTwinSse arg, dynamic hint});
+      {required BoxMyTraitTwinSse arg, dynamic hint});
 
-  Future<RwLockBoxMyTraitTwinSse> rustAutoOpaquePlusSignReturnTwinSse(
-      {dynamic hint});
+  Future<BoxMyTraitTwinSse> rustAutoOpaquePlusSignReturnTwinSse({dynamic hint});
 
-  Future<RwLockNonCloneSimpleTwinSse> rustAutoOpaqueReturnOwnTwinSse(
+  Future<NonCloneSimpleTwinSse> rustAutoOpaqueReturnOwnTwinSse(
       {required int initial, dynamic hint});
 
   Future<void> rustAutoOpaqueStructWithGoodAndOpaqueFieldArgBorrowTwinSse(
-      {required RwLockStructWithGoodAndOpaqueFieldTwinSse arg, dynamic hint});
+      {required StructWithGoodAndOpaqueFieldTwinSse arg, dynamic hint});
 
   Future<void> rustAutoOpaqueStructWithGoodAndOpaqueFieldArgMutBorrowTwinSse(
-      {required RwLockStructWithGoodAndOpaqueFieldTwinSse arg, dynamic hint});
+      {required StructWithGoodAndOpaqueFieldTwinSse arg, dynamic hint});
 
   Future<void> rustAutoOpaqueStructWithGoodAndOpaqueFieldArgOwnTwinSse(
-      {required RwLockStructWithGoodAndOpaqueFieldTwinSse arg, dynamic hint});
+      {required StructWithGoodAndOpaqueFieldTwinSse arg, dynamic hint});
 
-  Future<RwLockStructWithGoodAndOpaqueFieldTwinSse>
+  Future<StructWithGoodAndOpaqueFieldTwinSse>
       rustAutoOpaqueStructWithGoodAndOpaqueFieldReturnOwnTwinSse(
           {dynamic hint});
 
   Future<void> rustAutoOpaqueTraitObjectArgBorrowTwinSse(
-      {required RwLockBoxHelloTraitTwinSse arg,
+      {required BoxHelloTraitTwinSse arg,
       required String expect,
       dynamic hint});
 
   Future<void> rustAutoOpaqueTraitObjectArgMutBorrowTwinSse(
-      {required RwLockBoxHelloTraitTwinSse arg,
+      {required BoxHelloTraitTwinSse arg,
       required String expect,
       dynamic hint});
 
   Future<void> rustAutoOpaqueTraitObjectArgOwnTwinSse(
-      {required RwLockBoxHelloTraitTwinSse arg,
+      {required BoxHelloTraitTwinSse arg,
       required String expect,
       dynamic hint});
 
-  Future<RwLockBoxHelloTraitTwinSse>
-      rustAutoOpaqueTraitObjectReturnOwnOneTwinSse({dynamic hint});
+  Future<BoxHelloTraitTwinSse> rustAutoOpaqueTraitObjectReturnOwnOneTwinSse(
+      {dynamic hint});
 
-  Future<RwLockBoxHelloTraitTwinSse>
-      rustAutoOpaqueTraitObjectReturnOwnTwoTwinSse({dynamic hint});
+  Future<BoxHelloTraitTwinSse> rustAutoOpaqueTraitObjectReturnOwnTwoTwinSse(
+      {dynamic hint});
 
   Future<void> rustAutoOpaqueTwoArgsTwinSse(
-      {required RwLockNonCloneSimpleTwinSse a,
-      required RwLockNonCloneSimpleTwinSse b,
+      {required NonCloneSimpleTwinSse a,
+      required NonCloneSimpleTwinSse b,
       dynamic hint});
 
   void nonCloneSimpleTwinSyncInstanceMethodArgBorrowTwinSync(
-      {required RwLockNonCloneSimpleTwinSync that, dynamic hint});
+      {required NonCloneSimpleTwinSync that, dynamic hint});
 
   void nonCloneSimpleTwinSyncInstanceMethodArgMutBorrowTwinSync(
-      {required RwLockNonCloneSimpleTwinSync that, dynamic hint});
+      {required NonCloneSimpleTwinSync that, dynamic hint});
 
   void nonCloneSimpleTwinSyncInstanceMethodArgOwnTwinSync(
-      {required RwLockNonCloneSimpleTwinSync that, dynamic hint});
+      {required NonCloneSimpleTwinSync that, dynamic hint});
 
-  RwLockNonCloneSimpleTwinSync
-      nonCloneSimpleTwinSyncInstanceMethodReturnOwnTwinSync(
-          {required RwLockNonCloneSimpleTwinSync that, dynamic hint});
+  NonCloneSimpleTwinSync nonCloneSimpleTwinSyncInstanceMethodReturnOwnTwinSync(
+      {required NonCloneSimpleTwinSync that, dynamic hint});
 
-  RwLockNonCloneSimpleTwinSync nonCloneSimpleTwinSyncNewCustomNameTwinSync(
+  NonCloneSimpleTwinSync nonCloneSimpleTwinSyncNewCustomNameTwinSync(
       {dynamic hint});
 
-  RwLockNonCloneSimpleTwinSync nonCloneSimpleTwinSyncNewTwinSync(
-      {dynamic hint});
+  NonCloneSimpleTwinSync nonCloneSimpleTwinSyncNewTwinSync({dynamic hint});
 
   void nonCloneSimpleTwinSyncStaticMethodArgBorrowTwinSync(
-      {required RwLockNonCloneSimpleTwinSync arg, dynamic hint});
+      {required NonCloneSimpleTwinSync arg, dynamic hint});
 
   void nonCloneSimpleTwinSyncStaticMethodArgMutBorrowTwinSync(
-      {required RwLockNonCloneSimpleTwinSync arg, dynamic hint});
+      {required NonCloneSimpleTwinSync arg, dynamic hint});
 
   void nonCloneSimpleTwinSyncStaticMethodArgOwnTwinSync(
-      {required RwLockNonCloneSimpleTwinSync arg, dynamic hint});
+      {required NonCloneSimpleTwinSync arg, dynamic hint});
 
-  RwLockNonCloneSimpleTwinSync
-      nonCloneSimpleTwinSyncStaticMethodReturnOwnTwinSync({dynamic hint});
+  NonCloneSimpleTwinSync nonCloneSimpleTwinSyncStaticMethodReturnOwnTwinSync(
+      {dynamic hint});
 
   void rustAutoOpaqueArgBorrowTwinSync(
-      {required RwLockNonCloneSimpleTwinSync arg,
-      required int expect,
-      dynamic hint});
+      {required NonCloneSimpleTwinSync arg, required int expect, dynamic hint});
 
   void rustAutoOpaqueArgMutBorrowTwinSync(
-      {required RwLockNonCloneSimpleTwinSync arg,
+      {required NonCloneSimpleTwinSync arg,
       required int expect,
       required int adder,
       dynamic hint});
 
-  RwLockNonCloneSimpleTwinSync rustAutoOpaqueArgOwnAndReturnOwnTwinSync(
-      {required RwLockNonCloneSimpleTwinSync arg, dynamic hint});
+  NonCloneSimpleTwinSync rustAutoOpaqueArgOwnAndReturnOwnTwinSync(
+      {required NonCloneSimpleTwinSync arg, dynamic hint});
 
   void rustAutoOpaqueArgOwnTwinSync(
-      {required RwLockNonCloneSimpleTwinSync arg,
-      required int expect,
-      dynamic hint});
+      {required NonCloneSimpleTwinSync arg, required int expect, dynamic hint});
 
   void rustAutoOpaqueCallableArgTwinSync(
-      {required RwLockBoxFnStringString arg, dynamic hint});
+      {required BoxFnStringString arg, dynamic hint});
 
-  RwLockBoxFnStringString rustAutoOpaqueCallableReturnTwinSync({dynamic hint});
+  BoxFnStringString rustAutoOpaqueCallableReturnTwinSync({dynamic hint});
 
   void rustAutoOpaqueNormalAndOpaqueArgTwinSync(
-      {required RwLockNonCloneSimpleTwinSync a,
-      required String b,
-      dynamic hint});
+      {required NonCloneSimpleTwinSync a, required String b, dynamic hint});
 
   void rustAutoOpaquePlusSignArgTwinSync(
-      {required RwLockBoxMyTraitTwinSync arg, dynamic hint});
+      {required BoxMyTraitTwinSync arg, dynamic hint});
 
-  RwLockBoxMyTraitTwinSync rustAutoOpaquePlusSignReturnTwinSync({dynamic hint});
+  BoxMyTraitTwinSync rustAutoOpaquePlusSignReturnTwinSync({dynamic hint});
 
-  RwLockNonCloneSimpleTwinSync rustAutoOpaqueReturnOwnTwinSync(
+  NonCloneSimpleTwinSync rustAutoOpaqueReturnOwnTwinSync(
       {required int initial, dynamic hint});
 
   void rustAutoOpaqueStructWithGoodAndOpaqueFieldArgBorrowTwinSync(
-      {required RwLockStructWithGoodAndOpaqueFieldTwinSync arg, dynamic hint});
+      {required StructWithGoodAndOpaqueFieldTwinSync arg, dynamic hint});
 
   void rustAutoOpaqueStructWithGoodAndOpaqueFieldArgMutBorrowTwinSync(
-      {required RwLockStructWithGoodAndOpaqueFieldTwinSync arg, dynamic hint});
+      {required StructWithGoodAndOpaqueFieldTwinSync arg, dynamic hint});
 
   void rustAutoOpaqueStructWithGoodAndOpaqueFieldArgOwnTwinSync(
-      {required RwLockStructWithGoodAndOpaqueFieldTwinSync arg, dynamic hint});
+      {required StructWithGoodAndOpaqueFieldTwinSync arg, dynamic hint});
 
-  RwLockStructWithGoodAndOpaqueFieldTwinSync
+  StructWithGoodAndOpaqueFieldTwinSync
       rustAutoOpaqueStructWithGoodAndOpaqueFieldReturnOwnTwinSync(
           {dynamic hint});
 
   void rustAutoOpaqueTraitObjectArgBorrowTwinSync(
-      {required RwLockBoxHelloTraitTwinSync arg,
+      {required BoxHelloTraitTwinSync arg,
       required String expect,
       dynamic hint});
 
   void rustAutoOpaqueTraitObjectArgMutBorrowTwinSync(
-      {required RwLockBoxHelloTraitTwinSync arg,
+      {required BoxHelloTraitTwinSync arg,
       required String expect,
       dynamic hint});
 
   void rustAutoOpaqueTraitObjectArgOwnTwinSync(
-      {required RwLockBoxHelloTraitTwinSync arg,
+      {required BoxHelloTraitTwinSync arg,
       required String expect,
       dynamic hint});
 
-  RwLockBoxHelloTraitTwinSync rustAutoOpaqueTraitObjectReturnOwnOneTwinSync(
+  BoxHelloTraitTwinSync rustAutoOpaqueTraitObjectReturnOwnOneTwinSync(
       {dynamic hint});
 
-  RwLockBoxHelloTraitTwinSync rustAutoOpaqueTraitObjectReturnOwnTwoTwinSync(
+  BoxHelloTraitTwinSync rustAutoOpaqueTraitObjectReturnOwnTwoTwinSync(
       {dynamic hint});
 
   void rustAutoOpaqueTwoArgsTwinSync(
-      {required RwLockNonCloneSimpleTwinSync a,
-      required RwLockNonCloneSimpleTwinSync b,
+      {required NonCloneSimpleTwinSync a,
+      required NonCloneSimpleTwinSync b,
       dynamic hint});
 
   void nonCloneSimpleTwinSyncSseInstanceMethodArgBorrowTwinSyncSse(
-      {required RwLockNonCloneSimpleTwinSyncSse that, dynamic hint});
+      {required NonCloneSimpleTwinSyncSse that, dynamic hint});
 
   void nonCloneSimpleTwinSyncSseInstanceMethodArgMutBorrowTwinSyncSse(
-      {required RwLockNonCloneSimpleTwinSyncSse that, dynamic hint});
+      {required NonCloneSimpleTwinSyncSse that, dynamic hint});
 
   void nonCloneSimpleTwinSyncSseInstanceMethodArgOwnTwinSyncSse(
-      {required RwLockNonCloneSimpleTwinSyncSse that, dynamic hint});
+      {required NonCloneSimpleTwinSyncSse that, dynamic hint});
 
-  RwLockNonCloneSimpleTwinSyncSse
+  NonCloneSimpleTwinSyncSse
       nonCloneSimpleTwinSyncSseInstanceMethodReturnOwnTwinSyncSse(
-          {required RwLockNonCloneSimpleTwinSyncSse that, dynamic hint});
+          {required NonCloneSimpleTwinSyncSse that, dynamic hint});
 
-  RwLockNonCloneSimpleTwinSyncSse
-      nonCloneSimpleTwinSyncSseNewCustomNameTwinSyncSse({dynamic hint});
+  NonCloneSimpleTwinSyncSse nonCloneSimpleTwinSyncSseNewCustomNameTwinSyncSse(
+      {dynamic hint});
 
-  RwLockNonCloneSimpleTwinSyncSse nonCloneSimpleTwinSyncSseNewTwinSyncSse(
+  NonCloneSimpleTwinSyncSse nonCloneSimpleTwinSyncSseNewTwinSyncSse(
       {dynamic hint});
 
   void nonCloneSimpleTwinSyncSseStaticMethodArgBorrowTwinSyncSse(
-      {required RwLockNonCloneSimpleTwinSyncSse arg, dynamic hint});
+      {required NonCloneSimpleTwinSyncSse arg, dynamic hint});
 
   void nonCloneSimpleTwinSyncSseStaticMethodArgMutBorrowTwinSyncSse(
-      {required RwLockNonCloneSimpleTwinSyncSse arg, dynamic hint});
+      {required NonCloneSimpleTwinSyncSse arg, dynamic hint});
 
   void nonCloneSimpleTwinSyncSseStaticMethodArgOwnTwinSyncSse(
-      {required RwLockNonCloneSimpleTwinSyncSse arg, dynamic hint});
+      {required NonCloneSimpleTwinSyncSse arg, dynamic hint});
 
-  RwLockNonCloneSimpleTwinSyncSse
+  NonCloneSimpleTwinSyncSse
       nonCloneSimpleTwinSyncSseStaticMethodReturnOwnTwinSyncSse({dynamic hint});
 
   void rustAutoOpaqueArgBorrowTwinSyncSse(
-      {required RwLockNonCloneSimpleTwinSyncSse arg,
+      {required NonCloneSimpleTwinSyncSse arg,
       required int expect,
       dynamic hint});
 
   void rustAutoOpaqueArgMutBorrowTwinSyncSse(
-      {required RwLockNonCloneSimpleTwinSyncSse arg,
+      {required NonCloneSimpleTwinSyncSse arg,
       required int expect,
       required int adder,
       dynamic hint});
 
-  RwLockNonCloneSimpleTwinSyncSse rustAutoOpaqueArgOwnAndReturnOwnTwinSyncSse(
-      {required RwLockNonCloneSimpleTwinSyncSse arg, dynamic hint});
+  NonCloneSimpleTwinSyncSse rustAutoOpaqueArgOwnAndReturnOwnTwinSyncSse(
+      {required NonCloneSimpleTwinSyncSse arg, dynamic hint});
 
   void rustAutoOpaqueArgOwnTwinSyncSse(
-      {required RwLockNonCloneSimpleTwinSyncSse arg,
+      {required NonCloneSimpleTwinSyncSse arg,
       required int expect,
       dynamic hint});
 
   void rustAutoOpaqueCallableArgTwinSyncSse(
-      {required RwLockBoxFnStringString arg, dynamic hint});
+      {required BoxFnStringString arg, dynamic hint});
 
-  RwLockBoxFnStringString rustAutoOpaqueCallableReturnTwinSyncSse(
-      {dynamic hint});
+  BoxFnStringString rustAutoOpaqueCallableReturnTwinSyncSse({dynamic hint});
 
   void rustAutoOpaqueNormalAndOpaqueArgTwinSyncSse(
-      {required RwLockNonCloneSimpleTwinSyncSse a,
-      required String b,
-      dynamic hint});
+      {required NonCloneSimpleTwinSyncSse a, required String b, dynamic hint});
 
   void rustAutoOpaquePlusSignArgTwinSyncSse(
-      {required RwLockBoxMyTraitTwinSyncSse arg, dynamic hint});
+      {required BoxMyTraitTwinSyncSse arg, dynamic hint});
 
-  RwLockBoxMyTraitTwinSyncSse rustAutoOpaquePlusSignReturnTwinSyncSse(
-      {dynamic hint});
+  BoxMyTraitTwinSyncSse rustAutoOpaquePlusSignReturnTwinSyncSse({dynamic hint});
 
-  RwLockNonCloneSimpleTwinSyncSse rustAutoOpaqueReturnOwnTwinSyncSse(
+  NonCloneSimpleTwinSyncSse rustAutoOpaqueReturnOwnTwinSyncSse(
       {required int initial, dynamic hint});
 
   void rustAutoOpaqueStructWithGoodAndOpaqueFieldArgBorrowTwinSyncSse(
-      {required RwLockStructWithGoodAndOpaqueFieldTwinSyncSse arg,
-      dynamic hint});
+      {required StructWithGoodAndOpaqueFieldTwinSyncSse arg, dynamic hint});
 
   void rustAutoOpaqueStructWithGoodAndOpaqueFieldArgMutBorrowTwinSyncSse(
-      {required RwLockStructWithGoodAndOpaqueFieldTwinSyncSse arg,
-      dynamic hint});
+      {required StructWithGoodAndOpaqueFieldTwinSyncSse arg, dynamic hint});
 
   void rustAutoOpaqueStructWithGoodAndOpaqueFieldArgOwnTwinSyncSse(
-      {required RwLockStructWithGoodAndOpaqueFieldTwinSyncSse arg,
-      dynamic hint});
+      {required StructWithGoodAndOpaqueFieldTwinSyncSse arg, dynamic hint});
 
-  RwLockStructWithGoodAndOpaqueFieldTwinSyncSse
+  StructWithGoodAndOpaqueFieldTwinSyncSse
       rustAutoOpaqueStructWithGoodAndOpaqueFieldReturnOwnTwinSyncSse(
           {dynamic hint});
 
   void rustAutoOpaqueTraitObjectArgBorrowTwinSyncSse(
-      {required RwLockBoxHelloTraitTwinSyncSse arg,
+      {required BoxHelloTraitTwinSyncSse arg,
       required String expect,
       dynamic hint});
 
   void rustAutoOpaqueTraitObjectArgMutBorrowTwinSyncSse(
-      {required RwLockBoxHelloTraitTwinSyncSse arg,
+      {required BoxHelloTraitTwinSyncSse arg,
       required String expect,
       dynamic hint});
 
   void rustAutoOpaqueTraitObjectArgOwnTwinSyncSse(
-      {required RwLockBoxHelloTraitTwinSyncSse arg,
+      {required BoxHelloTraitTwinSyncSse arg,
       required String expect,
       dynamic hint});
 
-  RwLockBoxHelloTraitTwinSyncSse
-      rustAutoOpaqueTraitObjectReturnOwnOneTwinSyncSse({dynamic hint});
+  BoxHelloTraitTwinSyncSse rustAutoOpaqueTraitObjectReturnOwnOneTwinSyncSse(
+      {dynamic hint});
 
-  RwLockBoxHelloTraitTwinSyncSse
-      rustAutoOpaqueTraitObjectReturnOwnTwoTwinSyncSse({dynamic hint});
+  BoxHelloTraitTwinSyncSse rustAutoOpaqueTraitObjectReturnOwnTwoTwinSyncSse(
+      {dynamic hint});
 
   void rustAutoOpaqueTwoArgsTwinSyncSse(
-      {required RwLockNonCloneSimpleTwinSyncSse a,
-      required RwLockNonCloneSimpleTwinSyncSse b,
+      {required NonCloneSimpleTwinSyncSse a,
+      required NonCloneSimpleTwinSyncSse b,
       dynamic hint});
 
   FrbOpaqueSyncReturn frbSyncGeneratorTestTwinSse({dynamic hint});
@@ -4381,116 +4357,110 @@ abstract class RustLibApi extends BaseApi {
       {dynamic hint});
 
   Future<void> nonCloneSimpleTwinNormalInstanceMethodArgBorrowTwinNormal(
-      {required RwLockNonCloneSimpleTwinNormal that, dynamic hint});
+      {required NonCloneSimpleTwinNormal that, dynamic hint});
 
   Future<void> nonCloneSimpleTwinNormalInstanceMethodArgMutBorrowTwinNormal(
-      {required RwLockNonCloneSimpleTwinNormal that, dynamic hint});
+      {required NonCloneSimpleTwinNormal that, dynamic hint});
 
   Future<void> nonCloneSimpleTwinNormalInstanceMethodArgOwnTwinNormal(
-      {required RwLockNonCloneSimpleTwinNormal that, dynamic hint});
+      {required NonCloneSimpleTwinNormal that, dynamic hint});
 
-  Future<RwLockNonCloneSimpleTwinNormal>
+  Future<NonCloneSimpleTwinNormal>
       nonCloneSimpleTwinNormalInstanceMethodReturnOwnTwinNormal(
-          {required RwLockNonCloneSimpleTwinNormal that, dynamic hint});
+          {required NonCloneSimpleTwinNormal that, dynamic hint});
 
-  Future<RwLockNonCloneSimpleTwinNormal>
+  Future<NonCloneSimpleTwinNormal>
       nonCloneSimpleTwinNormalNewCustomNameTwinNormal({dynamic hint});
 
-  Future<RwLockNonCloneSimpleTwinNormal> nonCloneSimpleTwinNormalNewTwinNormal(
+  Future<NonCloneSimpleTwinNormal> nonCloneSimpleTwinNormalNewTwinNormal(
       {dynamic hint});
 
   Future<void> nonCloneSimpleTwinNormalStaticMethodArgBorrowTwinNormal(
-      {required RwLockNonCloneSimpleTwinNormal arg, dynamic hint});
+      {required NonCloneSimpleTwinNormal arg, dynamic hint});
 
   Future<void> nonCloneSimpleTwinNormalStaticMethodArgMutBorrowTwinNormal(
-      {required RwLockNonCloneSimpleTwinNormal arg, dynamic hint});
+      {required NonCloneSimpleTwinNormal arg, dynamic hint});
 
   Future<void> nonCloneSimpleTwinNormalStaticMethodArgOwnTwinNormal(
-      {required RwLockNonCloneSimpleTwinNormal arg, dynamic hint});
+      {required NonCloneSimpleTwinNormal arg, dynamic hint});
 
-  Future<RwLockNonCloneSimpleTwinNormal>
+  Future<NonCloneSimpleTwinNormal>
       nonCloneSimpleTwinNormalStaticMethodReturnOwnTwinNormal({dynamic hint});
 
   Future<void> rustAutoOpaqueArgBorrowTwinNormal(
-      {required RwLockNonCloneSimpleTwinNormal arg,
+      {required NonCloneSimpleTwinNormal arg,
       required int expect,
       dynamic hint});
 
   Future<void> rustAutoOpaqueArgMutBorrowTwinNormal(
-      {required RwLockNonCloneSimpleTwinNormal arg,
+      {required NonCloneSimpleTwinNormal arg,
       required int expect,
       required int adder,
       dynamic hint});
 
-  Future<RwLockNonCloneSimpleTwinNormal>
-      rustAutoOpaqueArgOwnAndReturnOwnTwinNormal(
-          {required RwLockNonCloneSimpleTwinNormal arg, dynamic hint});
+  Future<NonCloneSimpleTwinNormal> rustAutoOpaqueArgOwnAndReturnOwnTwinNormal(
+      {required NonCloneSimpleTwinNormal arg, dynamic hint});
 
   Future<void> rustAutoOpaqueArgOwnTwinNormal(
-      {required RwLockNonCloneSimpleTwinNormal arg,
+      {required NonCloneSimpleTwinNormal arg,
       required int expect,
       dynamic hint});
 
   Future<void> rustAutoOpaqueCallableArgTwinNormal(
-      {required RwLockBoxFnStringString arg, dynamic hint});
+      {required BoxFnStringString arg, dynamic hint});
 
-  Future<RwLockBoxFnStringString> rustAutoOpaqueCallableReturnTwinNormal(
+  Future<BoxFnStringString> rustAutoOpaqueCallableReturnTwinNormal(
       {dynamic hint});
 
   Future<void> rustAutoOpaqueNormalAndOpaqueArgTwinNormal(
-      {required RwLockNonCloneSimpleTwinNormal a,
-      required String b,
-      dynamic hint});
+      {required NonCloneSimpleTwinNormal a, required String b, dynamic hint});
 
   Future<void> rustAutoOpaquePlusSignArgTwinNormal(
-      {required RwLockBoxMyTraitTwinNormal arg, dynamic hint});
+      {required BoxMyTraitTwinNormal arg, dynamic hint});
 
-  Future<RwLockBoxMyTraitTwinNormal> rustAutoOpaquePlusSignReturnTwinNormal(
+  Future<BoxMyTraitTwinNormal> rustAutoOpaquePlusSignReturnTwinNormal(
       {dynamic hint});
 
-  Future<RwLockNonCloneSimpleTwinNormal> rustAutoOpaqueReturnOwnTwinNormal(
+  Future<NonCloneSimpleTwinNormal> rustAutoOpaqueReturnOwnTwinNormal(
       {required int initial, dynamic hint});
 
   Future<void> rustAutoOpaqueStructWithGoodAndOpaqueFieldArgBorrowTwinNormal(
-      {required RwLockStructWithGoodAndOpaqueFieldTwinNormal arg,
-      dynamic hint});
+      {required StructWithGoodAndOpaqueFieldTwinNormal arg, dynamic hint});
 
   Future<void> rustAutoOpaqueStructWithGoodAndOpaqueFieldArgMutBorrowTwinNormal(
-      {required RwLockStructWithGoodAndOpaqueFieldTwinNormal arg,
-      dynamic hint});
+      {required StructWithGoodAndOpaqueFieldTwinNormal arg, dynamic hint});
 
   Future<void> rustAutoOpaqueStructWithGoodAndOpaqueFieldArgOwnTwinNormal(
-      {required RwLockStructWithGoodAndOpaqueFieldTwinNormal arg,
-      dynamic hint});
+      {required StructWithGoodAndOpaqueFieldTwinNormal arg, dynamic hint});
 
-  Future<RwLockStructWithGoodAndOpaqueFieldTwinNormal>
+  Future<StructWithGoodAndOpaqueFieldTwinNormal>
       rustAutoOpaqueStructWithGoodAndOpaqueFieldReturnOwnTwinNormal(
           {dynamic hint});
 
   Future<void> rustAutoOpaqueTraitObjectArgBorrowTwinNormal(
-      {required RwLockBoxHelloTraitTwinNormal arg,
+      {required BoxHelloTraitTwinNormal arg,
       required String expect,
       dynamic hint});
 
   Future<void> rustAutoOpaqueTraitObjectArgMutBorrowTwinNormal(
-      {required RwLockBoxHelloTraitTwinNormal arg,
+      {required BoxHelloTraitTwinNormal arg,
       required String expect,
       dynamic hint});
 
   Future<void> rustAutoOpaqueTraitObjectArgOwnTwinNormal(
-      {required RwLockBoxHelloTraitTwinNormal arg,
+      {required BoxHelloTraitTwinNormal arg,
       required String expect,
       dynamic hint});
 
-  Future<RwLockBoxHelloTraitTwinNormal>
+  Future<BoxHelloTraitTwinNormal>
       rustAutoOpaqueTraitObjectReturnOwnOneTwinNormal({dynamic hint});
 
-  Future<RwLockBoxHelloTraitTwinNormal>
+  Future<BoxHelloTraitTwinNormal>
       rustAutoOpaqueTraitObjectReturnOwnTwoTwinNormal({dynamic hint});
 
   Future<void> rustAutoOpaqueTwoArgsTwinNormal(
-      {required RwLockNonCloneSimpleTwinNormal a,
-      required RwLockNonCloneSimpleTwinNormal b,
+      {required NonCloneSimpleTwinNormal a,
+      required NonCloneSimpleTwinNormal b,
       dynamic hint});
 
   Future<EnumOpaqueTwinNormalArray5> createArrayOpaqueEnumTwinNormal(
@@ -4730,157 +4700,157 @@ abstract class RustLibApi extends BaseApi {
       get rust_arc_decrement_strong_count_NonSendHideDataPtr;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockBoxFnStringString;
+      get rust_arc_increment_strong_count_BoxFnStringString;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockBoxFnStringString;
+      get rust_arc_decrement_strong_count_BoxFnStringString;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockBoxFnStringStringPtr;
+      get rust_arc_decrement_strong_count_BoxFnStringStringPtr;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockBoxHelloTraitTwinNormal;
+      get rust_arc_increment_strong_count_BoxHelloTraitTwinNormal;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockBoxHelloTraitTwinNormal;
+      get rust_arc_decrement_strong_count_BoxHelloTraitTwinNormal;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockBoxHelloTraitTwinNormalPtr;
+      get rust_arc_decrement_strong_count_BoxHelloTraitTwinNormalPtr;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockBoxHelloTraitTwinSse;
+      get rust_arc_increment_strong_count_BoxHelloTraitTwinSse;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockBoxHelloTraitTwinSse;
+      get rust_arc_decrement_strong_count_BoxHelloTraitTwinSse;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockBoxHelloTraitTwinSsePtr;
+      get rust_arc_decrement_strong_count_BoxHelloTraitTwinSsePtr;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockBoxHelloTraitTwinSync;
+      get rust_arc_increment_strong_count_BoxHelloTraitTwinSync;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockBoxHelloTraitTwinSync;
+      get rust_arc_decrement_strong_count_BoxHelloTraitTwinSync;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockBoxHelloTraitTwinSyncPtr;
+      get rust_arc_decrement_strong_count_BoxHelloTraitTwinSyncPtr;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockBoxHelloTraitTwinSyncSse;
+      get rust_arc_increment_strong_count_BoxHelloTraitTwinSyncSse;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockBoxHelloTraitTwinSyncSse;
+      get rust_arc_decrement_strong_count_BoxHelloTraitTwinSyncSse;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockBoxHelloTraitTwinSyncSsePtr;
+      get rust_arc_decrement_strong_count_BoxHelloTraitTwinSyncSsePtr;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockBoxMyTraitTwinNormal;
+      get rust_arc_increment_strong_count_BoxMyTraitTwinNormal;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockBoxMyTraitTwinNormal;
+      get rust_arc_decrement_strong_count_BoxMyTraitTwinNormal;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockBoxMyTraitTwinNormalPtr;
+      get rust_arc_decrement_strong_count_BoxMyTraitTwinNormalPtr;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockBoxMyTraitTwinSse;
+      get rust_arc_increment_strong_count_BoxMyTraitTwinSse;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockBoxMyTraitTwinSse;
+      get rust_arc_decrement_strong_count_BoxMyTraitTwinSse;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockBoxMyTraitTwinSsePtr;
+      get rust_arc_decrement_strong_count_BoxMyTraitTwinSsePtr;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockBoxMyTraitTwinSync;
+      get rust_arc_increment_strong_count_BoxMyTraitTwinSync;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockBoxMyTraitTwinSync;
+      get rust_arc_decrement_strong_count_BoxMyTraitTwinSync;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockBoxMyTraitTwinSyncPtr;
+      get rust_arc_decrement_strong_count_BoxMyTraitTwinSyncPtr;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockBoxMyTraitTwinSyncSse;
+      get rust_arc_increment_strong_count_BoxMyTraitTwinSyncSse;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockBoxMyTraitTwinSyncSse;
+      get rust_arc_decrement_strong_count_BoxMyTraitTwinSyncSse;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockBoxMyTraitTwinSyncSsePtr;
+      get rust_arc_decrement_strong_count_BoxMyTraitTwinSyncSsePtr;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockNonCloneSimpleTwinNormal;
+      get rust_arc_increment_strong_count_NonCloneSimpleTwinNormal;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockNonCloneSimpleTwinNormal;
+      get rust_arc_decrement_strong_count_NonCloneSimpleTwinNormal;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockNonCloneSimpleTwinNormalPtr;
+      get rust_arc_decrement_strong_count_NonCloneSimpleTwinNormalPtr;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockNonCloneSimpleTwinSse;
+      get rust_arc_increment_strong_count_NonCloneSimpleTwinSse;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockNonCloneSimpleTwinSse;
+      get rust_arc_decrement_strong_count_NonCloneSimpleTwinSse;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockNonCloneSimpleTwinSsePtr;
+      get rust_arc_decrement_strong_count_NonCloneSimpleTwinSsePtr;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockNonCloneSimpleTwinSync;
+      get rust_arc_increment_strong_count_NonCloneSimpleTwinSync;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockNonCloneSimpleTwinSync;
+      get rust_arc_decrement_strong_count_NonCloneSimpleTwinSync;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockNonCloneSimpleTwinSyncPtr;
+      get rust_arc_decrement_strong_count_NonCloneSimpleTwinSyncPtr;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockNonCloneSimpleTwinSyncSse;
+      get rust_arc_increment_strong_count_NonCloneSimpleTwinSyncSse;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockNonCloneSimpleTwinSyncSse;
+      get rust_arc_decrement_strong_count_NonCloneSimpleTwinSyncSse;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockNonCloneSimpleTwinSyncSsePtr;
+      get rust_arc_decrement_strong_count_NonCloneSimpleTwinSyncSsePtr;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinNormal;
+      get rust_arc_increment_strong_count_StructWithGoodAndOpaqueFieldTwinNormal;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinNormal;
+      get rust_arc_decrement_strong_count_StructWithGoodAndOpaqueFieldTwinNormal;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinNormalPtr;
+      get rust_arc_decrement_strong_count_StructWithGoodAndOpaqueFieldTwinNormalPtr;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinSse;
+      get rust_arc_increment_strong_count_StructWithGoodAndOpaqueFieldTwinSse;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinSse;
+      get rust_arc_decrement_strong_count_StructWithGoodAndOpaqueFieldTwinSse;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinSsePtr;
+      get rust_arc_decrement_strong_count_StructWithGoodAndOpaqueFieldTwinSsePtr;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinSync;
+      get rust_arc_increment_strong_count_StructWithGoodAndOpaqueFieldTwinSync;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinSync;
+      get rust_arc_decrement_strong_count_StructWithGoodAndOpaqueFieldTwinSync;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinSyncPtr;
+      get rust_arc_decrement_strong_count_StructWithGoodAndOpaqueFieldTwinSyncPtr;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinSyncSse;
+      get rust_arc_increment_strong_count_StructWithGoodAndOpaqueFieldTwinSyncSse;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinSyncSse;
+      get rust_arc_decrement_strong_count_StructWithGoodAndOpaqueFieldTwinSyncSse;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinSyncSsePtr;
+      get rust_arc_decrement_strong_count_StructWithGoodAndOpaqueFieldTwinSyncSsePtr;
 }
 
 class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
@@ -36326,7 +36296,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void> nonCloneSimpleTwinSseInstanceMethodArgBorrowTwinSse(
-      {required RwLockNonCloneSimpleTwinSse that, dynamic hint}) {
+      {required NonCloneSimpleTwinSse that, dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
@@ -36358,7 +36328,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void> nonCloneSimpleTwinSseInstanceMethodArgMutBorrowTwinSse(
-      {required RwLockNonCloneSimpleTwinSse that, dynamic hint}) {
+      {required NonCloneSimpleTwinSse that, dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
@@ -36391,7 +36361,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void> nonCloneSimpleTwinSseInstanceMethodArgOwnTwinSse(
-      {required RwLockNonCloneSimpleTwinSse that, dynamic hint}) {
+      {required NonCloneSimpleTwinSse that, dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
@@ -36420,9 +36390,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           );
 
   @override
-  Future<RwLockNonCloneSimpleTwinSse>
+  Future<NonCloneSimpleTwinSse>
       nonCloneSimpleTwinSseInstanceMethodReturnOwnTwinSse(
-          {required RwLockNonCloneSimpleTwinSse that, dynamic hint}) {
+          {required NonCloneSimpleTwinSse that, dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
@@ -36454,7 +36424,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           );
 
   @override
-  Future<RwLockNonCloneSimpleTwinSse> nonCloneSimpleTwinSseNewCustomNameTwinSse(
+  Future<NonCloneSimpleTwinSse> nonCloneSimpleTwinSseNewCustomNameTwinSse(
       {dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
@@ -36483,7 +36453,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<RwLockNonCloneSimpleTwinSse> nonCloneSimpleTwinSseNewTwinSse(
+  Future<NonCloneSimpleTwinSse> nonCloneSimpleTwinSseNewTwinSse(
       {dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
@@ -36513,7 +36483,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void> nonCloneSimpleTwinSseStaticMethodArgBorrowTwinSse(
-      {required RwLockNonCloneSimpleTwinSse arg, dynamic hint}) {
+      {required NonCloneSimpleTwinSse arg, dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
@@ -36545,7 +36515,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void> nonCloneSimpleTwinSseStaticMethodArgMutBorrowTwinSse(
-      {required RwLockNonCloneSimpleTwinSse arg, dynamic hint}) {
+      {required NonCloneSimpleTwinSse arg, dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
@@ -36577,7 +36547,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void> nonCloneSimpleTwinSseStaticMethodArgOwnTwinSse(
-      {required RwLockNonCloneSimpleTwinSse arg, dynamic hint}) {
+      {required NonCloneSimpleTwinSse arg, dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
@@ -36605,7 +36575,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<RwLockNonCloneSimpleTwinSse>
+  Future<NonCloneSimpleTwinSse>
       nonCloneSimpleTwinSseStaticMethodReturnOwnTwinSse({dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
@@ -36638,9 +36608,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void> rustAutoOpaqueArgBorrowTwinSse(
-      {required RwLockNonCloneSimpleTwinSse arg,
-      required int expect,
-      dynamic hint}) {
+      {required NonCloneSimpleTwinSse arg, required int expect, dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
@@ -36670,7 +36638,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void> rustAutoOpaqueArgMutBorrowTwinSse(
-      {required RwLockNonCloneSimpleTwinSse arg,
+      {required NonCloneSimpleTwinSse arg,
       required int expect,
       required int adder,
       dynamic hint}) {
@@ -36703,8 +36671,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<RwLockNonCloneSimpleTwinSse> rustAutoOpaqueArgOwnAndReturnOwnTwinSse(
-      {required RwLockNonCloneSimpleTwinSse arg, dynamic hint}) {
+  Future<NonCloneSimpleTwinSse> rustAutoOpaqueArgOwnAndReturnOwnTwinSse(
+      {required NonCloneSimpleTwinSse arg, dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
@@ -36734,9 +36702,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void> rustAutoOpaqueArgOwnTwinSse(
-      {required RwLockNonCloneSimpleTwinSse arg,
-      required int expect,
-      dynamic hint}) {
+      {required NonCloneSimpleTwinSse arg, required int expect, dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
@@ -36766,7 +36732,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void> rustAutoOpaqueCallableArgTwinSse(
-      {required RwLockBoxFnStringString arg, dynamic hint}) {
+      {required BoxFnStringString arg, dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
@@ -36794,7 +36760,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<RwLockBoxFnStringString> rustAutoOpaqueCallableReturnTwinSse(
+  Future<BoxFnStringString> rustAutoOpaqueCallableReturnTwinSse(
       {dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
@@ -36824,9 +36790,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void> rustAutoOpaqueNormalAndOpaqueArgTwinSse(
-      {required RwLockNonCloneSimpleTwinSse a,
-      required String b,
-      dynamic hint}) {
+      {required NonCloneSimpleTwinSse a, required String b, dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
@@ -36856,7 +36820,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void> rustAutoOpaquePlusSignArgTwinSse(
-      {required RwLockBoxMyTraitTwinSse arg, dynamic hint}) {
+      {required BoxMyTraitTwinSse arg, dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
@@ -36884,7 +36848,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<RwLockBoxMyTraitTwinSse> rustAutoOpaquePlusSignReturnTwinSse(
+  Future<BoxMyTraitTwinSse> rustAutoOpaquePlusSignReturnTwinSse(
       {dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
@@ -36913,7 +36877,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<RwLockNonCloneSimpleTwinSse> rustAutoOpaqueReturnOwnTwinSse(
+  Future<NonCloneSimpleTwinSse> rustAutoOpaqueReturnOwnTwinSse(
       {required int initial, dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
@@ -36943,7 +36907,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void> rustAutoOpaqueStructWithGoodAndOpaqueFieldArgBorrowTwinSse(
-      {required RwLockStructWithGoodAndOpaqueFieldTwinSse arg, dynamic hint}) {
+      {required StructWithGoodAndOpaqueFieldTwinSse arg, dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
@@ -36976,7 +36940,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void> rustAutoOpaqueStructWithGoodAndOpaqueFieldArgMutBorrowTwinSse(
-      {required RwLockStructWithGoodAndOpaqueFieldTwinSse arg, dynamic hint}) {
+      {required StructWithGoodAndOpaqueFieldTwinSse arg, dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
@@ -37009,7 +36973,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void> rustAutoOpaqueStructWithGoodAndOpaqueFieldArgOwnTwinSse(
-      {required RwLockStructWithGoodAndOpaqueFieldTwinSse arg, dynamic hint}) {
+      {required StructWithGoodAndOpaqueFieldTwinSse arg, dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
@@ -37041,7 +37005,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           );
 
   @override
-  Future<RwLockStructWithGoodAndOpaqueFieldTwinSse>
+  Future<StructWithGoodAndOpaqueFieldTwinSse>
       rustAutoOpaqueStructWithGoodAndOpaqueFieldReturnOwnTwinSse(
           {dynamic hint}) {
     return handler.executeNormal(NormalTask(
@@ -37076,7 +37040,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void> rustAutoOpaqueTraitObjectArgBorrowTwinSse(
-      {required RwLockBoxHelloTraitTwinSse arg,
+      {required BoxHelloTraitTwinSse arg,
       required String expect,
       dynamic hint}) {
     return handler.executeNormal(NormalTask(
@@ -37108,7 +37072,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void> rustAutoOpaqueTraitObjectArgMutBorrowTwinSse(
-      {required RwLockBoxHelloTraitTwinSse arg,
+      {required BoxHelloTraitTwinSse arg,
       required String expect,
       dynamic hint}) {
     return handler.executeNormal(NormalTask(
@@ -37140,7 +37104,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void> rustAutoOpaqueTraitObjectArgOwnTwinSse(
-      {required RwLockBoxHelloTraitTwinSse arg,
+      {required BoxHelloTraitTwinSse arg,
       required String expect,
       dynamic hint}) {
     return handler.executeNormal(NormalTask(
@@ -37171,8 +37135,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<RwLockBoxHelloTraitTwinSse>
-      rustAutoOpaqueTraitObjectReturnOwnOneTwinSse({dynamic hint}) {
+  Future<BoxHelloTraitTwinSse> rustAutoOpaqueTraitObjectReturnOwnOneTwinSse(
+      {dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
@@ -37200,8 +37164,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<RwLockBoxHelloTraitTwinSse>
-      rustAutoOpaqueTraitObjectReturnOwnTwoTwinSse({dynamic hint}) {
+  Future<BoxHelloTraitTwinSse> rustAutoOpaqueTraitObjectReturnOwnTwoTwinSse(
+      {dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
@@ -37230,8 +37194,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void> rustAutoOpaqueTwoArgsTwinSse(
-      {required RwLockNonCloneSimpleTwinSse a,
-      required RwLockNonCloneSimpleTwinSse b,
+      {required NonCloneSimpleTwinSse a,
+      required NonCloneSimpleTwinSse b,
       dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
@@ -37263,7 +37227,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   void nonCloneSimpleTwinSyncInstanceMethodArgBorrowTwinSync(
-      {required RwLockNonCloneSimpleTwinSync that, dynamic hint}) {
+      {required NonCloneSimpleTwinSync that, dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         var arg0 =
@@ -37295,7 +37259,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   void nonCloneSimpleTwinSyncInstanceMethodArgMutBorrowTwinSync(
-      {required RwLockNonCloneSimpleTwinSync that, dynamic hint}) {
+      {required NonCloneSimpleTwinSync that, dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         var arg0 =
@@ -37327,7 +37291,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   void nonCloneSimpleTwinSyncInstanceMethodArgOwnTwinSync(
-      {required RwLockNonCloneSimpleTwinSync that, dynamic hint}) {
+      {required NonCloneSimpleTwinSync that, dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         var arg0 =
@@ -37357,9 +37321,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           );
 
   @override
-  RwLockNonCloneSimpleTwinSync
-      nonCloneSimpleTwinSyncInstanceMethodReturnOwnTwinSync(
-          {required RwLockNonCloneSimpleTwinSync that, dynamic hint}) {
+  NonCloneSimpleTwinSync nonCloneSimpleTwinSyncInstanceMethodReturnOwnTwinSync(
+      {required NonCloneSimpleTwinSync that, dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         var arg0 =
@@ -37391,7 +37354,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           );
 
   @override
-  RwLockNonCloneSimpleTwinSync nonCloneSimpleTwinSyncNewCustomNameTwinSync(
+  NonCloneSimpleTwinSync nonCloneSimpleTwinSyncNewCustomNameTwinSync(
       {dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
@@ -37416,8 +37379,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  RwLockNonCloneSimpleTwinSync nonCloneSimpleTwinSyncNewTwinSync(
-      {dynamic hint}) {
+  NonCloneSimpleTwinSync nonCloneSimpleTwinSyncNewTwinSync({dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         return wire.wire_NonCloneSimpleTwinSync_new_twin_sync();
@@ -37442,7 +37404,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   void nonCloneSimpleTwinSyncStaticMethodArgBorrowTwinSync(
-      {required RwLockNonCloneSimpleTwinSync arg, dynamic hint}) {
+      {required NonCloneSimpleTwinSync arg, dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         var arg0 =
@@ -37473,7 +37435,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   void nonCloneSimpleTwinSyncStaticMethodArgMutBorrowTwinSync(
-      {required RwLockNonCloneSimpleTwinSync arg, dynamic hint}) {
+      {required NonCloneSimpleTwinSync arg, dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         var arg0 =
@@ -37505,7 +37467,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   void nonCloneSimpleTwinSyncStaticMethodArgOwnTwinSync(
-      {required RwLockNonCloneSimpleTwinSync arg, dynamic hint}) {
+      {required NonCloneSimpleTwinSync arg, dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         var arg0 =
@@ -37533,8 +37495,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           );
 
   @override
-  RwLockNonCloneSimpleTwinSync
-      nonCloneSimpleTwinSyncStaticMethodReturnOwnTwinSync({dynamic hint}) {
+  NonCloneSimpleTwinSync nonCloneSimpleTwinSyncStaticMethodReturnOwnTwinSync(
+      {dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         return wire
@@ -37562,7 +37524,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   void rustAutoOpaqueArgBorrowTwinSync(
-      {required RwLockNonCloneSimpleTwinSync arg,
+      {required NonCloneSimpleTwinSync arg,
       required int expect,
       dynamic hint}) {
     return handler.executeSync(SyncTask(
@@ -37592,7 +37554,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   void rustAutoOpaqueArgMutBorrowTwinSync(
-      {required RwLockNonCloneSimpleTwinSync arg,
+      {required NonCloneSimpleTwinSync arg,
       required int expect,
       required int adder,
       dynamic hint}) {
@@ -37624,8 +37586,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  RwLockNonCloneSimpleTwinSync rustAutoOpaqueArgOwnAndReturnOwnTwinSync(
-      {required RwLockNonCloneSimpleTwinSync arg, dynamic hint}) {
+  NonCloneSimpleTwinSync rustAutoOpaqueArgOwnAndReturnOwnTwinSync(
+      {required NonCloneSimpleTwinSync arg, dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         var arg0 =
@@ -37654,7 +37616,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   void rustAutoOpaqueArgOwnTwinSync(
-      {required RwLockNonCloneSimpleTwinSync arg,
+      {required NonCloneSimpleTwinSync arg,
       required int expect,
       dynamic hint}) {
     return handler.executeSync(SyncTask(
@@ -37684,7 +37646,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   void rustAutoOpaqueCallableArgTwinSync(
-      {required RwLockBoxFnStringString arg, dynamic hint}) {
+      {required BoxFnStringString arg, dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         var arg0 =
@@ -37710,7 +37672,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  RwLockBoxFnStringString rustAutoOpaqueCallableReturnTwinSync({dynamic hint}) {
+  BoxFnStringString rustAutoOpaqueCallableReturnTwinSync({dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         return wire.wire_rust_auto_opaque_callable_return_twin_sync();
@@ -37735,9 +37697,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   void rustAutoOpaqueNormalAndOpaqueArgTwinSync(
-      {required RwLockNonCloneSimpleTwinSync a,
-      required String b,
-      dynamic hint}) {
+      {required NonCloneSimpleTwinSync a, required String b, dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         var arg0 =
@@ -37766,7 +37726,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   void rustAutoOpaquePlusSignArgTwinSync(
-      {required RwLockBoxMyTraitTwinSync arg, dynamic hint}) {
+      {required BoxMyTraitTwinSync arg, dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         var arg0 =
@@ -37792,8 +37752,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  RwLockBoxMyTraitTwinSync rustAutoOpaquePlusSignReturnTwinSync(
-      {dynamic hint}) {
+  BoxMyTraitTwinSync rustAutoOpaquePlusSignReturnTwinSync({dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         return wire.wire_rust_auto_opaque_plus_sign_return_twin_sync();
@@ -37817,7 +37776,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  RwLockNonCloneSimpleTwinSync rustAutoOpaqueReturnOwnTwinSync(
+  NonCloneSimpleTwinSync rustAutoOpaqueReturnOwnTwinSync(
       {required int initial, dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
@@ -37844,7 +37803,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   void rustAutoOpaqueStructWithGoodAndOpaqueFieldArgBorrowTwinSync(
-      {required RwLockStructWithGoodAndOpaqueFieldTwinSync arg, dynamic hint}) {
+      {required StructWithGoodAndOpaqueFieldTwinSync arg, dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         var arg0 =
@@ -37876,7 +37835,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   void rustAutoOpaqueStructWithGoodAndOpaqueFieldArgMutBorrowTwinSync(
-      {required RwLockStructWithGoodAndOpaqueFieldTwinSync arg, dynamic hint}) {
+      {required StructWithGoodAndOpaqueFieldTwinSync arg, dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         var arg0 =
@@ -37908,7 +37867,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   void rustAutoOpaqueStructWithGoodAndOpaqueFieldArgOwnTwinSync(
-      {required RwLockStructWithGoodAndOpaqueFieldTwinSync arg, dynamic hint}) {
+      {required StructWithGoodAndOpaqueFieldTwinSync arg, dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         var arg0 =
@@ -37939,7 +37898,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           );
 
   @override
-  RwLockStructWithGoodAndOpaqueFieldTwinSync
+  StructWithGoodAndOpaqueFieldTwinSync
       rustAutoOpaqueStructWithGoodAndOpaqueFieldReturnOwnTwinSync(
           {dynamic hint}) {
     return handler.executeSync(SyncTask(
@@ -37970,7 +37929,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   void rustAutoOpaqueTraitObjectArgBorrowTwinSync(
-      {required RwLockBoxHelloTraitTwinSync arg,
+      {required BoxHelloTraitTwinSync arg,
       required String expect,
       dynamic hint}) {
     return handler.executeSync(SyncTask(
@@ -38001,7 +37960,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   void rustAutoOpaqueTraitObjectArgMutBorrowTwinSync(
-      {required RwLockBoxHelloTraitTwinSync arg,
+      {required BoxHelloTraitTwinSync arg,
       required String expect,
       dynamic hint}) {
     return handler.executeSync(SyncTask(
@@ -38032,7 +37991,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   void rustAutoOpaqueTraitObjectArgOwnTwinSync(
-      {required RwLockBoxHelloTraitTwinSync arg,
+      {required BoxHelloTraitTwinSync arg,
       required String expect,
       dynamic hint}) {
     return handler.executeSync(SyncTask(
@@ -38062,7 +38021,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  RwLockBoxHelloTraitTwinSync rustAutoOpaqueTraitObjectReturnOwnOneTwinSync(
+  BoxHelloTraitTwinSync rustAutoOpaqueTraitObjectReturnOwnOneTwinSync(
       {dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
@@ -38088,7 +38047,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  RwLockBoxHelloTraitTwinSync rustAutoOpaqueTraitObjectReturnOwnTwoTwinSync(
+  BoxHelloTraitTwinSync rustAutoOpaqueTraitObjectReturnOwnTwoTwinSync(
       {dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
@@ -38115,8 +38074,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   void rustAutoOpaqueTwoArgsTwinSync(
-      {required RwLockNonCloneSimpleTwinSync a,
-      required RwLockNonCloneSimpleTwinSync b,
+      {required NonCloneSimpleTwinSync a,
+      required NonCloneSimpleTwinSync b,
       dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
@@ -38147,7 +38106,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   void nonCloneSimpleTwinSyncSseInstanceMethodArgBorrowTwinSyncSse(
-      {required RwLockNonCloneSimpleTwinSyncSse that, dynamic hint}) {
+      {required NonCloneSimpleTwinSyncSse that, dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
@@ -38180,7 +38139,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   void nonCloneSimpleTwinSyncSseInstanceMethodArgMutBorrowTwinSyncSse(
-      {required RwLockNonCloneSimpleTwinSyncSse that, dynamic hint}) {
+      {required NonCloneSimpleTwinSyncSse that, dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
@@ -38213,7 +38172,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   void nonCloneSimpleTwinSyncSseInstanceMethodArgOwnTwinSyncSse(
-      {required RwLockNonCloneSimpleTwinSyncSse that, dynamic hint}) {
+      {required NonCloneSimpleTwinSyncSse that, dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
@@ -38245,9 +38204,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           );
 
   @override
-  RwLockNonCloneSimpleTwinSyncSse
+  NonCloneSimpleTwinSyncSse
       nonCloneSimpleTwinSyncSseInstanceMethodReturnOwnTwinSyncSse(
-          {required RwLockNonCloneSimpleTwinSyncSse that, dynamic hint}) {
+          {required NonCloneSimpleTwinSyncSse that, dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
@@ -38280,8 +38239,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           );
 
   @override
-  RwLockNonCloneSimpleTwinSyncSse
-      nonCloneSimpleTwinSyncSseNewCustomNameTwinSyncSse({dynamic hint}) {
+  NonCloneSimpleTwinSyncSse nonCloneSimpleTwinSyncSseNewCustomNameTwinSyncSse(
+      {dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
@@ -38312,7 +38271,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           );
 
   @override
-  RwLockNonCloneSimpleTwinSyncSse nonCloneSimpleTwinSyncSseNewTwinSyncSse(
+  NonCloneSimpleTwinSyncSse nonCloneSimpleTwinSyncSseNewTwinSyncSse(
       {dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
@@ -38342,7 +38301,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   void nonCloneSimpleTwinSyncSseStaticMethodArgBorrowTwinSyncSse(
-      {required RwLockNonCloneSimpleTwinSyncSse arg, dynamic hint}) {
+      {required NonCloneSimpleTwinSyncSse arg, dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
@@ -38375,7 +38334,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   void nonCloneSimpleTwinSyncSseStaticMethodArgMutBorrowTwinSyncSse(
-      {required RwLockNonCloneSimpleTwinSyncSse arg, dynamic hint}) {
+      {required NonCloneSimpleTwinSyncSse arg, dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
@@ -38408,7 +38367,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   void nonCloneSimpleTwinSyncSseStaticMethodArgOwnTwinSyncSse(
-      {required RwLockNonCloneSimpleTwinSyncSse arg, dynamic hint}) {
+      {required NonCloneSimpleTwinSyncSse arg, dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
@@ -38440,7 +38399,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           );
 
   @override
-  RwLockNonCloneSimpleTwinSyncSse
+  NonCloneSimpleTwinSyncSse
       nonCloneSimpleTwinSyncSseStaticMethodReturnOwnTwinSyncSse(
           {dynamic hint}) {
     return handler.executeSync(SyncTask(
@@ -38475,7 +38434,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   void rustAutoOpaqueArgBorrowTwinSyncSse(
-      {required RwLockNonCloneSimpleTwinSyncSse arg,
+      {required NonCloneSimpleTwinSyncSse arg,
       required int expect,
       dynamic hint}) {
     return handler.executeSync(SyncTask(
@@ -38507,7 +38466,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   void rustAutoOpaqueArgMutBorrowTwinSyncSse(
-      {required RwLockNonCloneSimpleTwinSyncSse arg,
+      {required NonCloneSimpleTwinSyncSse arg,
       required int expect,
       required int adder,
       dynamic hint}) {
@@ -38540,8 +38499,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  RwLockNonCloneSimpleTwinSyncSse rustAutoOpaqueArgOwnAndReturnOwnTwinSyncSse(
-      {required RwLockNonCloneSimpleTwinSyncSse arg, dynamic hint}) {
+  NonCloneSimpleTwinSyncSse rustAutoOpaqueArgOwnAndReturnOwnTwinSyncSse(
+      {required NonCloneSimpleTwinSyncSse arg, dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
@@ -38571,7 +38530,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   void rustAutoOpaqueArgOwnTwinSyncSse(
-      {required RwLockNonCloneSimpleTwinSyncSse arg,
+      {required NonCloneSimpleTwinSyncSse arg,
       required int expect,
       dynamic hint}) {
     return handler.executeSync(SyncTask(
@@ -38603,7 +38562,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   void rustAutoOpaqueCallableArgTwinSyncSse(
-      {required RwLockBoxFnStringString arg, dynamic hint}) {
+      {required BoxFnStringString arg, dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
@@ -38631,8 +38590,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  RwLockBoxFnStringString rustAutoOpaqueCallableReturnTwinSyncSse(
-      {dynamic hint}) {
+  BoxFnStringString rustAutoOpaqueCallableReturnTwinSyncSse({dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
@@ -38661,9 +38619,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   void rustAutoOpaqueNormalAndOpaqueArgTwinSyncSse(
-      {required RwLockNonCloneSimpleTwinSyncSse a,
-      required String b,
-      dynamic hint}) {
+      {required NonCloneSimpleTwinSyncSse a, required String b, dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
@@ -38693,7 +38649,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   void rustAutoOpaquePlusSignArgTwinSyncSse(
-      {required RwLockBoxMyTraitTwinSyncSse arg, dynamic hint}) {
+      {required BoxMyTraitTwinSyncSse arg, dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
@@ -38721,7 +38677,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  RwLockBoxMyTraitTwinSyncSse rustAutoOpaquePlusSignReturnTwinSyncSse(
+  BoxMyTraitTwinSyncSse rustAutoOpaquePlusSignReturnTwinSyncSse(
       {dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
@@ -38750,7 +38706,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  RwLockNonCloneSimpleTwinSyncSse rustAutoOpaqueReturnOwnTwinSyncSse(
+  NonCloneSimpleTwinSyncSse rustAutoOpaqueReturnOwnTwinSyncSse(
       {required int initial, dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
@@ -38780,8 +38736,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   void rustAutoOpaqueStructWithGoodAndOpaqueFieldArgBorrowTwinSyncSse(
-      {required RwLockStructWithGoodAndOpaqueFieldTwinSyncSse arg,
-      dynamic hint}) {
+      {required StructWithGoodAndOpaqueFieldTwinSyncSse arg, dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
@@ -38814,8 +38769,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   void rustAutoOpaqueStructWithGoodAndOpaqueFieldArgMutBorrowTwinSyncSse(
-      {required RwLockStructWithGoodAndOpaqueFieldTwinSyncSse arg,
-      dynamic hint}) {
+      {required StructWithGoodAndOpaqueFieldTwinSyncSse arg, dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
@@ -38848,8 +38802,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   void rustAutoOpaqueStructWithGoodAndOpaqueFieldArgOwnTwinSyncSse(
-      {required RwLockStructWithGoodAndOpaqueFieldTwinSyncSse arg,
-      dynamic hint}) {
+      {required StructWithGoodAndOpaqueFieldTwinSyncSse arg, dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
@@ -38881,7 +38834,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           );
 
   @override
-  RwLockStructWithGoodAndOpaqueFieldTwinSyncSse
+  StructWithGoodAndOpaqueFieldTwinSyncSse
       rustAutoOpaqueStructWithGoodAndOpaqueFieldReturnOwnTwinSyncSse(
           {dynamic hint}) {
     return handler.executeSync(SyncTask(
@@ -38916,7 +38869,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   void rustAutoOpaqueTraitObjectArgBorrowTwinSyncSse(
-      {required RwLockBoxHelloTraitTwinSyncSse arg,
+      {required BoxHelloTraitTwinSyncSse arg,
       required String expect,
       dynamic hint}) {
     return handler.executeSync(SyncTask(
@@ -38948,7 +38901,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   void rustAutoOpaqueTraitObjectArgMutBorrowTwinSyncSse(
-      {required RwLockBoxHelloTraitTwinSyncSse arg,
+      {required BoxHelloTraitTwinSyncSse arg,
       required String expect,
       dynamic hint}) {
     return handler.executeSync(SyncTask(
@@ -38983,7 +38936,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   void rustAutoOpaqueTraitObjectArgOwnTwinSyncSse(
-      {required RwLockBoxHelloTraitTwinSyncSse arg,
+      {required BoxHelloTraitTwinSyncSse arg,
       required String expect,
       dynamic hint}) {
     return handler.executeSync(SyncTask(
@@ -39014,8 +38967,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  RwLockBoxHelloTraitTwinSyncSse
-      rustAutoOpaqueTraitObjectReturnOwnOneTwinSyncSse({dynamic hint}) {
+  BoxHelloTraitTwinSyncSse rustAutoOpaqueTraitObjectReturnOwnOneTwinSyncSse(
+      {dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
@@ -39046,8 +38999,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           );
 
   @override
-  RwLockBoxHelloTraitTwinSyncSse
-      rustAutoOpaqueTraitObjectReturnOwnTwoTwinSyncSse({dynamic hint}) {
+  BoxHelloTraitTwinSyncSse rustAutoOpaqueTraitObjectReturnOwnTwoTwinSyncSse(
+      {dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
@@ -39079,8 +39032,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   void rustAutoOpaqueTwoArgsTwinSyncSse(
-      {required RwLockNonCloneSimpleTwinSyncSse a,
-      required RwLockNonCloneSimpleTwinSyncSse b,
+      {required NonCloneSimpleTwinSyncSse a,
+      required NonCloneSimpleTwinSyncSse b,
       dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
@@ -43544,7 +43497,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void> nonCloneSimpleTwinNormalInstanceMethodArgBorrowTwinNormal(
-      {required RwLockNonCloneSimpleTwinNormal that, dynamic hint}) {
+      {required NonCloneSimpleTwinNormal that, dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         var arg0 =
@@ -43576,7 +43529,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void> nonCloneSimpleTwinNormalInstanceMethodArgMutBorrowTwinNormal(
-      {required RwLockNonCloneSimpleTwinNormal that, dynamic hint}) {
+      {required NonCloneSimpleTwinNormal that, dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         var arg0 =
@@ -43608,7 +43561,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void> nonCloneSimpleTwinNormalInstanceMethodArgOwnTwinNormal(
-      {required RwLockNonCloneSimpleTwinNormal that, dynamic hint}) {
+      {required NonCloneSimpleTwinNormal that, dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         var arg0 =
@@ -43639,9 +43592,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           );
 
   @override
-  Future<RwLockNonCloneSimpleTwinNormal>
+  Future<NonCloneSimpleTwinNormal>
       nonCloneSimpleTwinNormalInstanceMethodReturnOwnTwinNormal(
-          {required RwLockNonCloneSimpleTwinNormal that, dynamic hint}) {
+          {required NonCloneSimpleTwinNormal that, dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         var arg0 =
@@ -43673,7 +43626,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           );
 
   @override
-  Future<RwLockNonCloneSimpleTwinNormal>
+  Future<NonCloneSimpleTwinNormal>
       nonCloneSimpleTwinNormalNewCustomNameTwinNormal({dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
@@ -43699,7 +43652,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<RwLockNonCloneSimpleTwinNormal> nonCloneSimpleTwinNormalNewTwinNormal(
+  Future<NonCloneSimpleTwinNormal> nonCloneSimpleTwinNormalNewTwinNormal(
       {dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
@@ -43725,7 +43678,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void> nonCloneSimpleTwinNormalStaticMethodArgBorrowTwinNormal(
-      {required RwLockNonCloneSimpleTwinNormal arg, dynamic hint}) {
+      {required NonCloneSimpleTwinNormal arg, dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         var arg0 =
@@ -43757,7 +43710,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void> nonCloneSimpleTwinNormalStaticMethodArgMutBorrowTwinNormal(
-      {required RwLockNonCloneSimpleTwinNormal arg, dynamic hint}) {
+      {required NonCloneSimpleTwinNormal arg, dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         var arg0 =
@@ -43789,7 +43742,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void> nonCloneSimpleTwinNormalStaticMethodArgOwnTwinNormal(
-      {required RwLockNonCloneSimpleTwinNormal arg, dynamic hint}) {
+      {required NonCloneSimpleTwinNormal arg, dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         var arg0 =
@@ -43819,7 +43772,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           );
 
   @override
-  Future<RwLockNonCloneSimpleTwinNormal>
+  Future<NonCloneSimpleTwinNormal>
       nonCloneSimpleTwinNormalStaticMethodReturnOwnTwinNormal({dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
@@ -43850,7 +43803,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void> rustAutoOpaqueArgBorrowTwinNormal(
-      {required RwLockNonCloneSimpleTwinNormal arg,
+      {required NonCloneSimpleTwinNormal arg,
       required int expect,
       dynamic hint}) {
     return handler.executeNormal(NormalTask(
@@ -43881,7 +43834,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void> rustAutoOpaqueArgMutBorrowTwinNormal(
-      {required RwLockNonCloneSimpleTwinNormal arg,
+      {required NonCloneSimpleTwinNormal arg,
       required int expect,
       required int adder,
       dynamic hint}) {
@@ -43913,9 +43866,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<RwLockNonCloneSimpleTwinNormal>
-      rustAutoOpaqueArgOwnAndReturnOwnTwinNormal(
-          {required RwLockNonCloneSimpleTwinNormal arg, dynamic hint}) {
+  Future<NonCloneSimpleTwinNormal> rustAutoOpaqueArgOwnAndReturnOwnTwinNormal(
+      {required NonCloneSimpleTwinNormal arg, dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         var arg0 =
@@ -43944,7 +43896,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void> rustAutoOpaqueArgOwnTwinNormal(
-      {required RwLockNonCloneSimpleTwinNormal arg,
+      {required NonCloneSimpleTwinNormal arg,
       required int expect,
       dynamic hint}) {
     return handler.executeNormal(NormalTask(
@@ -43975,7 +43927,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void> rustAutoOpaqueCallableArgTwinNormal(
-      {required RwLockBoxFnStringString arg, dynamic hint}) {
+      {required BoxFnStringString arg, dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         var arg0 =
@@ -44001,7 +43953,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<RwLockBoxFnStringString> rustAutoOpaqueCallableReturnTwinNormal(
+  Future<BoxFnStringString> rustAutoOpaqueCallableReturnTwinNormal(
       {dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
@@ -44027,9 +43979,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void> rustAutoOpaqueNormalAndOpaqueArgTwinNormal(
-      {required RwLockNonCloneSimpleTwinNormal a,
-      required String b,
-      dynamic hint}) {
+      {required NonCloneSimpleTwinNormal a, required String b, dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         var arg0 =
@@ -44058,7 +44008,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void> rustAutoOpaquePlusSignArgTwinNormal(
-      {required RwLockBoxMyTraitTwinNormal arg, dynamic hint}) {
+      {required BoxMyTraitTwinNormal arg, dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         var arg0 =
@@ -44085,7 +44035,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<RwLockBoxMyTraitTwinNormal> rustAutoOpaquePlusSignReturnTwinNormal(
+  Future<BoxMyTraitTwinNormal> rustAutoOpaquePlusSignReturnTwinNormal(
       {dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
@@ -44110,7 +44060,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<RwLockNonCloneSimpleTwinNormal> rustAutoOpaqueReturnOwnTwinNormal(
+  Future<NonCloneSimpleTwinNormal> rustAutoOpaqueReturnOwnTwinNormal(
       {required int initial, dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
@@ -44137,8 +44087,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void> rustAutoOpaqueStructWithGoodAndOpaqueFieldArgBorrowTwinNormal(
-      {required RwLockStructWithGoodAndOpaqueFieldTwinNormal arg,
-      dynamic hint}) {
+      {required StructWithGoodAndOpaqueFieldTwinNormal arg, dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         var arg0 =
@@ -44170,8 +44119,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void> rustAutoOpaqueStructWithGoodAndOpaqueFieldArgMutBorrowTwinNormal(
-      {required RwLockStructWithGoodAndOpaqueFieldTwinNormal arg,
-      dynamic hint}) {
+      {required StructWithGoodAndOpaqueFieldTwinNormal arg, dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         var arg0 =
@@ -44203,8 +44151,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void> rustAutoOpaqueStructWithGoodAndOpaqueFieldArgOwnTwinNormal(
-      {required RwLockStructWithGoodAndOpaqueFieldTwinNormal arg,
-      dynamic hint}) {
+      {required StructWithGoodAndOpaqueFieldTwinNormal arg, dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         var arg0 =
@@ -44235,7 +44182,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           );
 
   @override
-  Future<RwLockStructWithGoodAndOpaqueFieldTwinNormal>
+  Future<StructWithGoodAndOpaqueFieldTwinNormal>
       rustAutoOpaqueStructWithGoodAndOpaqueFieldReturnOwnTwinNormal(
           {dynamic hint}) {
     return handler.executeNormal(NormalTask(
@@ -44267,7 +44214,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void> rustAutoOpaqueTraitObjectArgBorrowTwinNormal(
-      {required RwLockBoxHelloTraitTwinNormal arg,
+      {required BoxHelloTraitTwinNormal arg,
       required String expect,
       dynamic hint}) {
     return handler.executeNormal(NormalTask(
@@ -44298,7 +44245,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void> rustAutoOpaqueTraitObjectArgMutBorrowTwinNormal(
-      {required RwLockBoxHelloTraitTwinNormal arg,
+      {required BoxHelloTraitTwinNormal arg,
       required String expect,
       dynamic hint}) {
     return handler.executeNormal(NormalTask(
@@ -44330,7 +44277,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void> rustAutoOpaqueTraitObjectArgOwnTwinNormal(
-      {required RwLockBoxHelloTraitTwinNormal arg,
+      {required BoxHelloTraitTwinNormal arg,
       required String expect,
       dynamic hint}) {
     return handler.executeNormal(NormalTask(
@@ -44360,7 +44307,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<RwLockBoxHelloTraitTwinNormal>
+  Future<BoxHelloTraitTwinNormal>
       rustAutoOpaqueTraitObjectReturnOwnOneTwinNormal({dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
@@ -44387,7 +44334,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<RwLockBoxHelloTraitTwinNormal>
+  Future<BoxHelloTraitTwinNormal>
       rustAutoOpaqueTraitObjectReturnOwnTwoTwinNormal({dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
@@ -44415,8 +44362,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void> rustAutoOpaqueTwoArgsTwinNormal(
-      {required RwLockNonCloneSimpleTwinNormal a,
-      required RwLockNonCloneSimpleTwinNormal b,
+      {required NonCloneSimpleTwinNormal a,
+      required NonCloneSimpleTwinNormal b,
       dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
@@ -45848,139 +45795,139 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           wire.rust_arc_decrement_strong_count_RustOpaque_non_send_hide_data;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockBoxFnStringString => wire
+      get rust_arc_increment_strong_count_BoxFnStringString => wire
           .rust_arc_increment_strong_count_RustOpaque_stdsyncRwLockBoxdynFnStringStringSendSyncUnwindSafeRefUnwindSafe;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockBoxFnStringString => wire
+      get rust_arc_decrement_strong_count_BoxFnStringString => wire
           .rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockBoxdynFnStringStringSendSyncUnwindSafeRefUnwindSafe;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockBoxHelloTraitTwinNormal => wire
+      get rust_arc_increment_strong_count_BoxHelloTraitTwinNormal => wire
           .rust_arc_increment_strong_count_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockBoxHelloTraitTwinNormal => wire
+      get rust_arc_decrement_strong_count_BoxHelloTraitTwinNormal => wire
           .rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockBoxHelloTraitTwinSse => wire
+      get rust_arc_increment_strong_count_BoxHelloTraitTwinSse => wire
           .rust_arc_increment_strong_count_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockBoxHelloTraitTwinSse => wire
+      get rust_arc_decrement_strong_count_BoxHelloTraitTwinSse => wire
           .rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockBoxHelloTraitTwinSync => wire
+      get rust_arc_increment_strong_count_BoxHelloTraitTwinSync => wire
           .rust_arc_increment_strong_count_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockBoxHelloTraitTwinSync => wire
+      get rust_arc_decrement_strong_count_BoxHelloTraitTwinSync => wire
           .rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockBoxHelloTraitTwinSyncSse => wire
+      get rust_arc_increment_strong_count_BoxHelloTraitTwinSyncSse => wire
           .rust_arc_increment_strong_count_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockBoxHelloTraitTwinSyncSse => wire
+      get rust_arc_decrement_strong_count_BoxHelloTraitTwinSyncSse => wire
           .rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockBoxMyTraitTwinNormal => wire
+      get rust_arc_increment_strong_count_BoxMyTraitTwinNormal => wire
           .rust_arc_increment_strong_count_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinNormalSendSync;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockBoxMyTraitTwinNormal => wire
+      get rust_arc_decrement_strong_count_BoxMyTraitTwinNormal => wire
           .rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinNormalSendSync;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockBoxMyTraitTwinSse => wire
+      get rust_arc_increment_strong_count_BoxMyTraitTwinSse => wire
           .rust_arc_increment_strong_count_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSseSendSync;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockBoxMyTraitTwinSse => wire
+      get rust_arc_decrement_strong_count_BoxMyTraitTwinSse => wire
           .rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSseSendSync;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockBoxMyTraitTwinSync => wire
+      get rust_arc_increment_strong_count_BoxMyTraitTwinSync => wire
           .rust_arc_increment_strong_count_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSendSync;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockBoxMyTraitTwinSync => wire
+      get rust_arc_decrement_strong_count_BoxMyTraitTwinSync => wire
           .rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSendSync;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockBoxMyTraitTwinSyncSse => wire
+      get rust_arc_increment_strong_count_BoxMyTraitTwinSyncSse => wire
           .rust_arc_increment_strong_count_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSseSendSync;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockBoxMyTraitTwinSyncSse => wire
+      get rust_arc_decrement_strong_count_BoxMyTraitTwinSyncSse => wire
           .rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSseSendSync;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockNonCloneSimpleTwinNormal => wire
+      get rust_arc_increment_strong_count_NonCloneSimpleTwinNormal => wire
           .rust_arc_increment_strong_count_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockNonCloneSimpleTwinNormal => wire
+      get rust_arc_decrement_strong_count_NonCloneSimpleTwinNormal => wire
           .rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockNonCloneSimpleTwinSse => wire
+      get rust_arc_increment_strong_count_NonCloneSimpleTwinSse => wire
           .rust_arc_increment_strong_count_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockNonCloneSimpleTwinSse => wire
+      get rust_arc_decrement_strong_count_NonCloneSimpleTwinSse => wire
           .rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockNonCloneSimpleTwinSync => wire
+      get rust_arc_increment_strong_count_NonCloneSimpleTwinSync => wire
           .rust_arc_increment_strong_count_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockNonCloneSimpleTwinSync => wire
+      get rust_arc_decrement_strong_count_NonCloneSimpleTwinSync => wire
           .rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockNonCloneSimpleTwinSyncSse => wire
+      get rust_arc_increment_strong_count_NonCloneSimpleTwinSyncSse => wire
           .rust_arc_increment_strong_count_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockNonCloneSimpleTwinSyncSse => wire
+      get rust_arc_decrement_strong_count_NonCloneSimpleTwinSyncSse => wire
           .rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinNormal =>
+      get rust_arc_increment_strong_count_StructWithGoodAndOpaqueFieldTwinNormal =>
           wire.rust_arc_increment_strong_count_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinNormal =>
+      get rust_arc_decrement_strong_count_StructWithGoodAndOpaqueFieldTwinNormal =>
           wire.rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinSse =>
+      get rust_arc_increment_strong_count_StructWithGoodAndOpaqueFieldTwinSse =>
           wire.rust_arc_increment_strong_count_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinSse =>
+      get rust_arc_decrement_strong_count_StructWithGoodAndOpaqueFieldTwinSse =>
           wire.rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinSync =>
+      get rust_arc_increment_strong_count_StructWithGoodAndOpaqueFieldTwinSync =>
           wire.rust_arc_increment_strong_count_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinSync =>
+      get rust_arc_decrement_strong_count_StructWithGoodAndOpaqueFieldTwinSync =>
           wire.rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinSyncSse =>
+      get rust_arc_increment_strong_count_StructWithGoodAndOpaqueFieldTwinSyncSse =>
           wire.rust_arc_increment_strong_count_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinSyncSse =>
+      get rust_arc_decrement_strong_count_StructWithGoodAndOpaqueFieldTwinSyncSse =>
           wire.rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse;
 
   @protected
@@ -45989,290 +45936,290 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  RwLockBoxFnStringString
+  BoxFnStringString
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynFnStringStringSendSyncUnwindSafeRefUnwindSafe(
           dynamic raw) {
-    return RwLockBoxFnStringString.dcoDecode(raw);
+    return BoxFnStringString.dcoDecode(raw);
   }
 
   @protected
-  RwLockBoxHelloTraitTwinNormal
+  BoxHelloTraitTwinNormal
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
           dynamic raw) {
-    return RwLockBoxHelloTraitTwinNormal.dcoDecode(raw);
+    return BoxHelloTraitTwinNormal.dcoDecode(raw);
   }
 
   @protected
-  RwLockBoxHelloTraitTwinSse
+  BoxHelloTraitTwinSse
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
           dynamic raw) {
-    return RwLockBoxHelloTraitTwinSse.dcoDecode(raw);
+    return BoxHelloTraitTwinSse.dcoDecode(raw);
   }
 
   @protected
-  RwLockBoxHelloTraitTwinSync
+  BoxHelloTraitTwinSync
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
           dynamic raw) {
-    return RwLockBoxHelloTraitTwinSync.dcoDecode(raw);
+    return BoxHelloTraitTwinSync.dcoDecode(raw);
   }
 
   @protected
-  RwLockBoxHelloTraitTwinSyncSse
+  BoxHelloTraitTwinSyncSse
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
           dynamic raw) {
-    return RwLockBoxHelloTraitTwinSyncSse.dcoDecode(raw);
+    return BoxHelloTraitTwinSyncSse.dcoDecode(raw);
   }
 
   @protected
-  RwLockBoxMyTraitTwinNormal
+  BoxMyTraitTwinNormal
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinNormalSendSync(
           dynamic raw) {
-    return RwLockBoxMyTraitTwinNormal.dcoDecode(raw);
+    return BoxMyTraitTwinNormal.dcoDecode(raw);
   }
 
   @protected
-  RwLockBoxMyTraitTwinSse
+  BoxMyTraitTwinSse
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSseSendSync(
           dynamic raw) {
-    return RwLockBoxMyTraitTwinSse.dcoDecode(raw);
+    return BoxMyTraitTwinSse.dcoDecode(raw);
   }
 
   @protected
-  RwLockBoxMyTraitTwinSync
+  BoxMyTraitTwinSync
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSendSync(
           dynamic raw) {
-    return RwLockBoxMyTraitTwinSync.dcoDecode(raw);
+    return BoxMyTraitTwinSync.dcoDecode(raw);
   }
 
   @protected
-  RwLockBoxMyTraitTwinSyncSse
+  BoxMyTraitTwinSyncSse
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSseSendSync(
           dynamic raw) {
-    return RwLockBoxMyTraitTwinSyncSse.dcoDecode(raw);
+    return BoxMyTraitTwinSyncSse.dcoDecode(raw);
   }
 
   @protected
-  RwLockNonCloneSimpleTwinNormal
+  NonCloneSimpleTwinNormal
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
           dynamic raw) {
-    return RwLockNonCloneSimpleTwinNormal.dcoDecode(raw);
+    return NonCloneSimpleTwinNormal.dcoDecode(raw);
   }
 
   @protected
-  RwLockNonCloneSimpleTwinSse
+  NonCloneSimpleTwinSse
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
           dynamic raw) {
-    return RwLockNonCloneSimpleTwinSse.dcoDecode(raw);
+    return NonCloneSimpleTwinSse.dcoDecode(raw);
   }
 
   @protected
-  RwLockNonCloneSimpleTwinSync
+  NonCloneSimpleTwinSync
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
           dynamic raw) {
-    return RwLockNonCloneSimpleTwinSync.dcoDecode(raw);
+    return NonCloneSimpleTwinSync.dcoDecode(raw);
   }
 
   @protected
-  RwLockNonCloneSimpleTwinSyncSse
+  NonCloneSimpleTwinSyncSse
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
           dynamic raw) {
-    return RwLockNonCloneSimpleTwinSyncSse.dcoDecode(raw);
+    return NonCloneSimpleTwinSyncSse.dcoDecode(raw);
   }
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinNormal
+  StructWithGoodAndOpaqueFieldTwinNormal
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
           dynamic raw) {
-    return RwLockStructWithGoodAndOpaqueFieldTwinNormal.dcoDecode(raw);
+    return StructWithGoodAndOpaqueFieldTwinNormal.dcoDecode(raw);
   }
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSse
+  StructWithGoodAndOpaqueFieldTwinSse
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
           dynamic raw) {
-    return RwLockStructWithGoodAndOpaqueFieldTwinSse.dcoDecode(raw);
+    return StructWithGoodAndOpaqueFieldTwinSse.dcoDecode(raw);
   }
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSync
+  StructWithGoodAndOpaqueFieldTwinSync
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
           dynamic raw) {
-    return RwLockStructWithGoodAndOpaqueFieldTwinSync.dcoDecode(raw);
+    return StructWithGoodAndOpaqueFieldTwinSync.dcoDecode(raw);
   }
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSyncSse
+  StructWithGoodAndOpaqueFieldTwinSyncSse
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
           dynamic raw) {
-    return RwLockStructWithGoodAndOpaqueFieldTwinSyncSse.dcoDecode(raw);
+    return StructWithGoodAndOpaqueFieldTwinSyncSse.dcoDecode(raw);
   }
 
   @protected
-  RwLockBoxHelloTraitTwinNormal
+  BoxHelloTraitTwinNormal
       dco_decode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
           dynamic raw) {
-    return RwLockBoxHelloTraitTwinNormal.dcoDecode(raw);
+    return BoxHelloTraitTwinNormal.dcoDecode(raw);
   }
 
   @protected
-  RwLockBoxHelloTraitTwinSse
+  BoxHelloTraitTwinSse
       dco_decode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
           dynamic raw) {
-    return RwLockBoxHelloTraitTwinSse.dcoDecode(raw);
+    return BoxHelloTraitTwinSse.dcoDecode(raw);
   }
 
   @protected
-  RwLockBoxHelloTraitTwinSync
+  BoxHelloTraitTwinSync
       dco_decode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
           dynamic raw) {
-    return RwLockBoxHelloTraitTwinSync.dcoDecode(raw);
+    return BoxHelloTraitTwinSync.dcoDecode(raw);
   }
 
   @protected
-  RwLockBoxHelloTraitTwinSyncSse
+  BoxHelloTraitTwinSyncSse
       dco_decode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
           dynamic raw) {
-    return RwLockBoxHelloTraitTwinSyncSse.dcoDecode(raw);
+    return BoxHelloTraitTwinSyncSse.dcoDecode(raw);
   }
 
   @protected
-  RwLockNonCloneSimpleTwinNormal
+  NonCloneSimpleTwinNormal
       dco_decode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
           dynamic raw) {
-    return RwLockNonCloneSimpleTwinNormal.dcoDecode(raw);
+    return NonCloneSimpleTwinNormal.dcoDecode(raw);
   }
 
   @protected
-  RwLockNonCloneSimpleTwinSse
+  NonCloneSimpleTwinSse
       dco_decode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
           dynamic raw) {
-    return RwLockNonCloneSimpleTwinSse.dcoDecode(raw);
+    return NonCloneSimpleTwinSse.dcoDecode(raw);
   }
 
   @protected
-  RwLockNonCloneSimpleTwinSync
+  NonCloneSimpleTwinSync
       dco_decode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
           dynamic raw) {
-    return RwLockNonCloneSimpleTwinSync.dcoDecode(raw);
+    return NonCloneSimpleTwinSync.dcoDecode(raw);
   }
 
   @protected
-  RwLockNonCloneSimpleTwinSyncSse
+  NonCloneSimpleTwinSyncSse
       dco_decode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
           dynamic raw) {
-    return RwLockNonCloneSimpleTwinSyncSse.dcoDecode(raw);
+    return NonCloneSimpleTwinSyncSse.dcoDecode(raw);
   }
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinNormal
+  StructWithGoodAndOpaqueFieldTwinNormal
       dco_decode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
           dynamic raw) {
-    return RwLockStructWithGoodAndOpaqueFieldTwinNormal.dcoDecode(raw);
+    return StructWithGoodAndOpaqueFieldTwinNormal.dcoDecode(raw);
   }
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSse
+  StructWithGoodAndOpaqueFieldTwinSse
       dco_decode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
           dynamic raw) {
-    return RwLockStructWithGoodAndOpaqueFieldTwinSse.dcoDecode(raw);
+    return StructWithGoodAndOpaqueFieldTwinSse.dcoDecode(raw);
   }
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSync
+  StructWithGoodAndOpaqueFieldTwinSync
       dco_decode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
           dynamic raw) {
-    return RwLockStructWithGoodAndOpaqueFieldTwinSync.dcoDecode(raw);
+    return StructWithGoodAndOpaqueFieldTwinSync.dcoDecode(raw);
   }
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSyncSse
+  StructWithGoodAndOpaqueFieldTwinSyncSse
       dco_decode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
           dynamic raw) {
-    return RwLockStructWithGoodAndOpaqueFieldTwinSyncSse.dcoDecode(raw);
+    return StructWithGoodAndOpaqueFieldTwinSyncSse.dcoDecode(raw);
   }
 
   @protected
-  RwLockBoxHelloTraitTwinNormal
+  BoxHelloTraitTwinNormal
       dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
           dynamic raw) {
-    return RwLockBoxHelloTraitTwinNormal.dcoDecode(raw);
+    return BoxHelloTraitTwinNormal.dcoDecode(raw);
   }
 
   @protected
-  RwLockBoxHelloTraitTwinSse
+  BoxHelloTraitTwinSse
       dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
           dynamic raw) {
-    return RwLockBoxHelloTraitTwinSse.dcoDecode(raw);
+    return BoxHelloTraitTwinSse.dcoDecode(raw);
   }
 
   @protected
-  RwLockBoxHelloTraitTwinSync
+  BoxHelloTraitTwinSync
       dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
           dynamic raw) {
-    return RwLockBoxHelloTraitTwinSync.dcoDecode(raw);
+    return BoxHelloTraitTwinSync.dcoDecode(raw);
   }
 
   @protected
-  RwLockBoxHelloTraitTwinSyncSse
+  BoxHelloTraitTwinSyncSse
       dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
           dynamic raw) {
-    return RwLockBoxHelloTraitTwinSyncSse.dcoDecode(raw);
+    return BoxHelloTraitTwinSyncSse.dcoDecode(raw);
   }
 
   @protected
-  RwLockNonCloneSimpleTwinNormal
+  NonCloneSimpleTwinNormal
       dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
           dynamic raw) {
-    return RwLockNonCloneSimpleTwinNormal.dcoDecode(raw);
+    return NonCloneSimpleTwinNormal.dcoDecode(raw);
   }
 
   @protected
-  RwLockNonCloneSimpleTwinSse
+  NonCloneSimpleTwinSse
       dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
           dynamic raw) {
-    return RwLockNonCloneSimpleTwinSse.dcoDecode(raw);
+    return NonCloneSimpleTwinSse.dcoDecode(raw);
   }
 
   @protected
-  RwLockNonCloneSimpleTwinSync
+  NonCloneSimpleTwinSync
       dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
           dynamic raw) {
-    return RwLockNonCloneSimpleTwinSync.dcoDecode(raw);
+    return NonCloneSimpleTwinSync.dcoDecode(raw);
   }
 
   @protected
-  RwLockNonCloneSimpleTwinSyncSse
+  NonCloneSimpleTwinSyncSse
       dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
           dynamic raw) {
-    return RwLockNonCloneSimpleTwinSyncSse.dcoDecode(raw);
+    return NonCloneSimpleTwinSyncSse.dcoDecode(raw);
   }
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinNormal
+  StructWithGoodAndOpaqueFieldTwinNormal
       dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
           dynamic raw) {
-    return RwLockStructWithGoodAndOpaqueFieldTwinNormal.dcoDecode(raw);
+    return StructWithGoodAndOpaqueFieldTwinNormal.dcoDecode(raw);
   }
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSse
+  StructWithGoodAndOpaqueFieldTwinSse
       dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
           dynamic raw) {
-    return RwLockStructWithGoodAndOpaqueFieldTwinSse.dcoDecode(raw);
+    return StructWithGoodAndOpaqueFieldTwinSse.dcoDecode(raw);
   }
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSync
+  StructWithGoodAndOpaqueFieldTwinSync
       dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
           dynamic raw) {
-    return RwLockStructWithGoodAndOpaqueFieldTwinSync.dcoDecode(raw);
+    return StructWithGoodAndOpaqueFieldTwinSync.dcoDecode(raw);
   }
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSyncSse
+  StructWithGoodAndOpaqueFieldTwinSyncSse
       dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
           dynamic raw) {
-    return RwLockStructWithGoodAndOpaqueFieldTwinSyncSse.dcoDecode(raw);
+    return StructWithGoodAndOpaqueFieldTwinSyncSse.dcoDecode(raw);
   }
 
   @protected
@@ -46484,117 +46431,117 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  RwLockBoxFnStringString
+  BoxFnStringString
       dco_decode_RustOpaque_stdsyncRwLockBoxdynFnStringStringSendSyncUnwindSafeRefUnwindSafe(
           dynamic raw) {
-    return RwLockBoxFnStringString.dcoDecode(raw);
+    return BoxFnStringString.dcoDecode(raw);
   }
 
   @protected
-  RwLockBoxHelloTraitTwinNormal
+  BoxHelloTraitTwinNormal
       dco_decode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
           dynamic raw) {
-    return RwLockBoxHelloTraitTwinNormal.dcoDecode(raw);
+    return BoxHelloTraitTwinNormal.dcoDecode(raw);
   }
 
   @protected
-  RwLockBoxHelloTraitTwinSse
+  BoxHelloTraitTwinSse
       dco_decode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(dynamic raw) {
-    return RwLockBoxHelloTraitTwinSse.dcoDecode(raw);
+    return BoxHelloTraitTwinSse.dcoDecode(raw);
   }
 
   @protected
-  RwLockBoxHelloTraitTwinSync
+  BoxHelloTraitTwinSync
       dco_decode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(dynamic raw) {
-    return RwLockBoxHelloTraitTwinSync.dcoDecode(raw);
+    return BoxHelloTraitTwinSync.dcoDecode(raw);
   }
 
   @protected
-  RwLockBoxHelloTraitTwinSyncSse
+  BoxHelloTraitTwinSyncSse
       dco_decode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
           dynamic raw) {
-    return RwLockBoxHelloTraitTwinSyncSse.dcoDecode(raw);
+    return BoxHelloTraitTwinSyncSse.dcoDecode(raw);
   }
 
   @protected
-  RwLockBoxMyTraitTwinNormal
+  BoxMyTraitTwinNormal
       dco_decode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinNormalSendSync(
           dynamic raw) {
-    return RwLockBoxMyTraitTwinNormal.dcoDecode(raw);
+    return BoxMyTraitTwinNormal.dcoDecode(raw);
   }
 
   @protected
-  RwLockBoxMyTraitTwinSse
+  BoxMyTraitTwinSse
       dco_decode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSseSendSync(
           dynamic raw) {
-    return RwLockBoxMyTraitTwinSse.dcoDecode(raw);
+    return BoxMyTraitTwinSse.dcoDecode(raw);
   }
 
   @protected
-  RwLockBoxMyTraitTwinSync
+  BoxMyTraitTwinSync
       dco_decode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSendSync(
           dynamic raw) {
-    return RwLockBoxMyTraitTwinSync.dcoDecode(raw);
+    return BoxMyTraitTwinSync.dcoDecode(raw);
   }
 
   @protected
-  RwLockBoxMyTraitTwinSyncSse
+  BoxMyTraitTwinSyncSse
       dco_decode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSseSendSync(
           dynamic raw) {
-    return RwLockBoxMyTraitTwinSyncSse.dcoDecode(raw);
+    return BoxMyTraitTwinSyncSse.dcoDecode(raw);
   }
 
   @protected
-  RwLockNonCloneSimpleTwinNormal
+  NonCloneSimpleTwinNormal
       dco_decode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(dynamic raw) {
-    return RwLockNonCloneSimpleTwinNormal.dcoDecode(raw);
+    return NonCloneSimpleTwinNormal.dcoDecode(raw);
   }
 
   @protected
-  RwLockNonCloneSimpleTwinSse
+  NonCloneSimpleTwinSse
       dco_decode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(dynamic raw) {
-    return RwLockNonCloneSimpleTwinSse.dcoDecode(raw);
+    return NonCloneSimpleTwinSse.dcoDecode(raw);
   }
 
   @protected
-  RwLockNonCloneSimpleTwinSync
+  NonCloneSimpleTwinSync
       dco_decode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(dynamic raw) {
-    return RwLockNonCloneSimpleTwinSync.dcoDecode(raw);
+    return NonCloneSimpleTwinSync.dcoDecode(raw);
   }
 
   @protected
-  RwLockNonCloneSimpleTwinSyncSse
+  NonCloneSimpleTwinSyncSse
       dco_decode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
           dynamic raw) {
-    return RwLockNonCloneSimpleTwinSyncSse.dcoDecode(raw);
+    return NonCloneSimpleTwinSyncSse.dcoDecode(raw);
   }
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinNormal
+  StructWithGoodAndOpaqueFieldTwinNormal
       dco_decode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
           dynamic raw) {
-    return RwLockStructWithGoodAndOpaqueFieldTwinNormal.dcoDecode(raw);
+    return StructWithGoodAndOpaqueFieldTwinNormal.dcoDecode(raw);
   }
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSse
+  StructWithGoodAndOpaqueFieldTwinSse
       dco_decode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
           dynamic raw) {
-    return RwLockStructWithGoodAndOpaqueFieldTwinSse.dcoDecode(raw);
+    return StructWithGoodAndOpaqueFieldTwinSse.dcoDecode(raw);
   }
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSync
+  StructWithGoodAndOpaqueFieldTwinSync
       dco_decode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
           dynamic raw) {
-    return RwLockStructWithGoodAndOpaqueFieldTwinSync.dcoDecode(raw);
+    return StructWithGoodAndOpaqueFieldTwinSync.dcoDecode(raw);
   }
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSyncSse
+  StructWithGoodAndOpaqueFieldTwinSyncSse
       dco_decode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
           dynamic raw) {
-    return RwLockStructWithGoodAndOpaqueFieldTwinSyncSse.dcoDecode(raw);
+    return StructWithGoodAndOpaqueFieldTwinSyncSse.dcoDecode(raw);
   }
 
   @protected
@@ -55763,330 +55710,330 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  RwLockBoxFnStringString
+  BoxFnStringString
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynFnStringStringSendSyncUnwindSafeRefUnwindSafe(
           SseDeserializer deserializer) {
-    return RwLockBoxFnStringString.sseDecode(
+    return BoxFnStringString.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockBoxHelloTraitTwinNormal
+  BoxHelloTraitTwinNormal
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
           SseDeserializer deserializer) {
-    return RwLockBoxHelloTraitTwinNormal.sseDecode(
+    return BoxHelloTraitTwinNormal.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockBoxHelloTraitTwinSse
+  BoxHelloTraitTwinSse
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
           SseDeserializer deserializer) {
-    return RwLockBoxHelloTraitTwinSse.sseDecode(
+    return BoxHelloTraitTwinSse.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockBoxHelloTraitTwinSync
+  BoxHelloTraitTwinSync
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
           SseDeserializer deserializer) {
-    return RwLockBoxHelloTraitTwinSync.sseDecode(
+    return BoxHelloTraitTwinSync.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockBoxHelloTraitTwinSyncSse
+  BoxHelloTraitTwinSyncSse
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
           SseDeserializer deserializer) {
-    return RwLockBoxHelloTraitTwinSyncSse.sseDecode(
+    return BoxHelloTraitTwinSyncSse.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockBoxMyTraitTwinNormal
+  BoxMyTraitTwinNormal
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinNormalSendSync(
           SseDeserializer deserializer) {
-    return RwLockBoxMyTraitTwinNormal.sseDecode(
+    return BoxMyTraitTwinNormal.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockBoxMyTraitTwinSse
+  BoxMyTraitTwinSse
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSseSendSync(
           SseDeserializer deserializer) {
-    return RwLockBoxMyTraitTwinSse.sseDecode(
+    return BoxMyTraitTwinSse.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockBoxMyTraitTwinSync
+  BoxMyTraitTwinSync
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSendSync(
           SseDeserializer deserializer) {
-    return RwLockBoxMyTraitTwinSync.sseDecode(
+    return BoxMyTraitTwinSync.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockBoxMyTraitTwinSyncSse
+  BoxMyTraitTwinSyncSse
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSseSendSync(
           SseDeserializer deserializer) {
-    return RwLockBoxMyTraitTwinSyncSse.sseDecode(
+    return BoxMyTraitTwinSyncSse.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockNonCloneSimpleTwinNormal
+  NonCloneSimpleTwinNormal
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
           SseDeserializer deserializer) {
-    return RwLockNonCloneSimpleTwinNormal.sseDecode(
+    return NonCloneSimpleTwinNormal.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockNonCloneSimpleTwinSse
+  NonCloneSimpleTwinSse
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
           SseDeserializer deserializer) {
-    return RwLockNonCloneSimpleTwinSse.sseDecode(
+    return NonCloneSimpleTwinSse.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockNonCloneSimpleTwinSync
+  NonCloneSimpleTwinSync
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
           SseDeserializer deserializer) {
-    return RwLockNonCloneSimpleTwinSync.sseDecode(
+    return NonCloneSimpleTwinSync.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockNonCloneSimpleTwinSyncSse
+  NonCloneSimpleTwinSyncSse
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
           SseDeserializer deserializer) {
-    return RwLockNonCloneSimpleTwinSyncSse.sseDecode(
+    return NonCloneSimpleTwinSyncSse.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinNormal
+  StructWithGoodAndOpaqueFieldTwinNormal
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
           SseDeserializer deserializer) {
-    return RwLockStructWithGoodAndOpaqueFieldTwinNormal.sseDecode(
+    return StructWithGoodAndOpaqueFieldTwinNormal.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSse
+  StructWithGoodAndOpaqueFieldTwinSse
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
           SseDeserializer deserializer) {
-    return RwLockStructWithGoodAndOpaqueFieldTwinSse.sseDecode(
+    return StructWithGoodAndOpaqueFieldTwinSse.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSync
+  StructWithGoodAndOpaqueFieldTwinSync
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
           SseDeserializer deserializer) {
-    return RwLockStructWithGoodAndOpaqueFieldTwinSync.sseDecode(
+    return StructWithGoodAndOpaqueFieldTwinSync.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSyncSse
+  StructWithGoodAndOpaqueFieldTwinSyncSse
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
           SseDeserializer deserializer) {
-    return RwLockStructWithGoodAndOpaqueFieldTwinSyncSse.sseDecode(
+    return StructWithGoodAndOpaqueFieldTwinSyncSse.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockBoxHelloTraitTwinNormal
+  BoxHelloTraitTwinNormal
       sse_decode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
           SseDeserializer deserializer) {
-    return RwLockBoxHelloTraitTwinNormal.sseDecode(
+    return BoxHelloTraitTwinNormal.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockBoxHelloTraitTwinSse
+  BoxHelloTraitTwinSse
       sse_decode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
           SseDeserializer deserializer) {
-    return RwLockBoxHelloTraitTwinSse.sseDecode(
+    return BoxHelloTraitTwinSse.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockBoxHelloTraitTwinSync
+  BoxHelloTraitTwinSync
       sse_decode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
           SseDeserializer deserializer) {
-    return RwLockBoxHelloTraitTwinSync.sseDecode(
+    return BoxHelloTraitTwinSync.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockBoxHelloTraitTwinSyncSse
+  BoxHelloTraitTwinSyncSse
       sse_decode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
           SseDeserializer deserializer) {
-    return RwLockBoxHelloTraitTwinSyncSse.sseDecode(
+    return BoxHelloTraitTwinSyncSse.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockNonCloneSimpleTwinNormal
+  NonCloneSimpleTwinNormal
       sse_decode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
           SseDeserializer deserializer) {
-    return RwLockNonCloneSimpleTwinNormal.sseDecode(
+    return NonCloneSimpleTwinNormal.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockNonCloneSimpleTwinSse
+  NonCloneSimpleTwinSse
       sse_decode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
           SseDeserializer deserializer) {
-    return RwLockNonCloneSimpleTwinSse.sseDecode(
+    return NonCloneSimpleTwinSse.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockNonCloneSimpleTwinSync
+  NonCloneSimpleTwinSync
       sse_decode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
           SseDeserializer deserializer) {
-    return RwLockNonCloneSimpleTwinSync.sseDecode(
+    return NonCloneSimpleTwinSync.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockNonCloneSimpleTwinSyncSse
+  NonCloneSimpleTwinSyncSse
       sse_decode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
           SseDeserializer deserializer) {
-    return RwLockNonCloneSimpleTwinSyncSse.sseDecode(
+    return NonCloneSimpleTwinSyncSse.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinNormal
+  StructWithGoodAndOpaqueFieldTwinNormal
       sse_decode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
           SseDeserializer deserializer) {
-    return RwLockStructWithGoodAndOpaqueFieldTwinNormal.sseDecode(
+    return StructWithGoodAndOpaqueFieldTwinNormal.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSse
+  StructWithGoodAndOpaqueFieldTwinSse
       sse_decode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
           SseDeserializer deserializer) {
-    return RwLockStructWithGoodAndOpaqueFieldTwinSse.sseDecode(
+    return StructWithGoodAndOpaqueFieldTwinSse.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSync
+  StructWithGoodAndOpaqueFieldTwinSync
       sse_decode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
           SseDeserializer deserializer) {
-    return RwLockStructWithGoodAndOpaqueFieldTwinSync.sseDecode(
+    return StructWithGoodAndOpaqueFieldTwinSync.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSyncSse
+  StructWithGoodAndOpaqueFieldTwinSyncSse
       sse_decode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
           SseDeserializer deserializer) {
-    return RwLockStructWithGoodAndOpaqueFieldTwinSyncSse.sseDecode(
+    return StructWithGoodAndOpaqueFieldTwinSyncSse.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockBoxHelloTraitTwinNormal
+  BoxHelloTraitTwinNormal
       sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
           SseDeserializer deserializer) {
-    return RwLockBoxHelloTraitTwinNormal.sseDecode(
+    return BoxHelloTraitTwinNormal.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockBoxHelloTraitTwinSse
+  BoxHelloTraitTwinSse
       sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
           SseDeserializer deserializer) {
-    return RwLockBoxHelloTraitTwinSse.sseDecode(
+    return BoxHelloTraitTwinSse.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockBoxHelloTraitTwinSync
+  BoxHelloTraitTwinSync
       sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
           SseDeserializer deserializer) {
-    return RwLockBoxHelloTraitTwinSync.sseDecode(
+    return BoxHelloTraitTwinSync.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockBoxHelloTraitTwinSyncSse
+  BoxHelloTraitTwinSyncSse
       sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
           SseDeserializer deserializer) {
-    return RwLockBoxHelloTraitTwinSyncSse.sseDecode(
+    return BoxHelloTraitTwinSyncSse.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockNonCloneSimpleTwinNormal
+  NonCloneSimpleTwinNormal
       sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
           SseDeserializer deserializer) {
-    return RwLockNonCloneSimpleTwinNormal.sseDecode(
+    return NonCloneSimpleTwinNormal.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockNonCloneSimpleTwinSse
+  NonCloneSimpleTwinSse
       sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
           SseDeserializer deserializer) {
-    return RwLockNonCloneSimpleTwinSse.sseDecode(
+    return NonCloneSimpleTwinSse.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockNonCloneSimpleTwinSync
+  NonCloneSimpleTwinSync
       sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
           SseDeserializer deserializer) {
-    return RwLockNonCloneSimpleTwinSync.sseDecode(
+    return NonCloneSimpleTwinSync.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockNonCloneSimpleTwinSyncSse
+  NonCloneSimpleTwinSyncSse
       sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
           SseDeserializer deserializer) {
-    return RwLockNonCloneSimpleTwinSyncSse.sseDecode(
+    return NonCloneSimpleTwinSyncSse.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinNormal
+  StructWithGoodAndOpaqueFieldTwinNormal
       sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
           SseDeserializer deserializer) {
-    return RwLockStructWithGoodAndOpaqueFieldTwinNormal.sseDecode(
+    return StructWithGoodAndOpaqueFieldTwinNormal.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSse
+  StructWithGoodAndOpaqueFieldTwinSse
       sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
           SseDeserializer deserializer) {
-    return RwLockStructWithGoodAndOpaqueFieldTwinSse.sseDecode(
+    return StructWithGoodAndOpaqueFieldTwinSse.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSync
+  StructWithGoodAndOpaqueFieldTwinSync
       sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
           SseDeserializer deserializer) {
-    return RwLockStructWithGoodAndOpaqueFieldTwinSync.sseDecode(
+    return StructWithGoodAndOpaqueFieldTwinSync.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSyncSse
+  StructWithGoodAndOpaqueFieldTwinSyncSse
       sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
           SseDeserializer deserializer) {
-    return RwLockStructWithGoodAndOpaqueFieldTwinSyncSse.sseDecode(
+    return StructWithGoodAndOpaqueFieldTwinSyncSse.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
@@ -56237,138 +56184,138 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  RwLockBoxFnStringString
+  BoxFnStringString
       sse_decode_RustOpaque_stdsyncRwLockBoxdynFnStringStringSendSyncUnwindSafeRefUnwindSafe(
           SseDeserializer deserializer) {
-    return RwLockBoxFnStringString.sseDecode(
+    return BoxFnStringString.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockBoxHelloTraitTwinNormal
+  BoxHelloTraitTwinNormal
       sse_decode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
           SseDeserializer deserializer) {
-    return RwLockBoxHelloTraitTwinNormal.sseDecode(
+    return BoxHelloTraitTwinNormal.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockBoxHelloTraitTwinSse
+  BoxHelloTraitTwinSse
       sse_decode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
           SseDeserializer deserializer) {
-    return RwLockBoxHelloTraitTwinSse.sseDecode(
+    return BoxHelloTraitTwinSse.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockBoxHelloTraitTwinSync
+  BoxHelloTraitTwinSync
       sse_decode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
           SseDeserializer deserializer) {
-    return RwLockBoxHelloTraitTwinSync.sseDecode(
+    return BoxHelloTraitTwinSync.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockBoxHelloTraitTwinSyncSse
+  BoxHelloTraitTwinSyncSse
       sse_decode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
           SseDeserializer deserializer) {
-    return RwLockBoxHelloTraitTwinSyncSse.sseDecode(
+    return BoxHelloTraitTwinSyncSse.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockBoxMyTraitTwinNormal
+  BoxMyTraitTwinNormal
       sse_decode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinNormalSendSync(
           SseDeserializer deserializer) {
-    return RwLockBoxMyTraitTwinNormal.sseDecode(
+    return BoxMyTraitTwinNormal.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockBoxMyTraitTwinSse
+  BoxMyTraitTwinSse
       sse_decode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSseSendSync(
           SseDeserializer deserializer) {
-    return RwLockBoxMyTraitTwinSse.sseDecode(
+    return BoxMyTraitTwinSse.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockBoxMyTraitTwinSync
+  BoxMyTraitTwinSync
       sse_decode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSendSync(
           SseDeserializer deserializer) {
-    return RwLockBoxMyTraitTwinSync.sseDecode(
+    return BoxMyTraitTwinSync.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockBoxMyTraitTwinSyncSse
+  BoxMyTraitTwinSyncSse
       sse_decode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSseSendSync(
           SseDeserializer deserializer) {
-    return RwLockBoxMyTraitTwinSyncSse.sseDecode(
+    return BoxMyTraitTwinSyncSse.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockNonCloneSimpleTwinNormal
+  NonCloneSimpleTwinNormal
       sse_decode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
           SseDeserializer deserializer) {
-    return RwLockNonCloneSimpleTwinNormal.sseDecode(
+    return NonCloneSimpleTwinNormal.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockNonCloneSimpleTwinSse
+  NonCloneSimpleTwinSse
       sse_decode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
           SseDeserializer deserializer) {
-    return RwLockNonCloneSimpleTwinSse.sseDecode(
+    return NonCloneSimpleTwinSse.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockNonCloneSimpleTwinSync
+  NonCloneSimpleTwinSync
       sse_decode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
           SseDeserializer deserializer) {
-    return RwLockNonCloneSimpleTwinSync.sseDecode(
+    return NonCloneSimpleTwinSync.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockNonCloneSimpleTwinSyncSse
+  NonCloneSimpleTwinSyncSse
       sse_decode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
           SseDeserializer deserializer) {
-    return RwLockNonCloneSimpleTwinSyncSse.sseDecode(
+    return NonCloneSimpleTwinSyncSse.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinNormal
+  StructWithGoodAndOpaqueFieldTwinNormal
       sse_decode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
           SseDeserializer deserializer) {
-    return RwLockStructWithGoodAndOpaqueFieldTwinNormal.sseDecode(
+    return StructWithGoodAndOpaqueFieldTwinNormal.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSse
+  StructWithGoodAndOpaqueFieldTwinSse
       sse_decode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
           SseDeserializer deserializer) {
-    return RwLockStructWithGoodAndOpaqueFieldTwinSse.sseDecode(
+    return StructWithGoodAndOpaqueFieldTwinSse.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSync
+  StructWithGoodAndOpaqueFieldTwinSync
       sse_decode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
           SseDeserializer deserializer) {
-    return RwLockStructWithGoodAndOpaqueFieldTwinSync.sseDecode(
+    return StructWithGoodAndOpaqueFieldTwinSync.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSyncSse
+  StructWithGoodAndOpaqueFieldTwinSyncSse
       sse_decode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
           SseDeserializer deserializer) {
-    return RwLockStructWithGoodAndOpaqueFieldTwinSyncSse.sseDecode(
+    return StructWithGoodAndOpaqueFieldTwinSyncSse.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
@@ -65749,7 +65696,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynFnStringStringSendSyncUnwindSafeRefUnwindSafe(
-          RwLockBoxFnStringString raw) {
+          BoxFnStringString raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: true);
   }
@@ -65757,7 +65704,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
-          RwLockBoxHelloTraitTwinNormal raw) {
+          BoxHelloTraitTwinNormal raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: true);
   }
@@ -65765,7 +65712,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
-          RwLockBoxHelloTraitTwinSse raw) {
+          BoxHelloTraitTwinSse raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: true);
   }
@@ -65773,7 +65720,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
-          RwLockBoxHelloTraitTwinSync raw) {
+          BoxHelloTraitTwinSync raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: true);
   }
@@ -65781,7 +65728,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
-          RwLockBoxHelloTraitTwinSyncSse raw) {
+          BoxHelloTraitTwinSyncSse raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: true);
   }
@@ -65789,7 +65736,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinNormalSendSync(
-          RwLockBoxMyTraitTwinNormal raw) {
+          BoxMyTraitTwinNormal raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: true);
   }
@@ -65797,7 +65744,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSseSendSync(
-          RwLockBoxMyTraitTwinSse raw) {
+          BoxMyTraitTwinSse raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: true);
   }
@@ -65805,7 +65752,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSendSync(
-          RwLockBoxMyTraitTwinSync raw) {
+          BoxMyTraitTwinSync raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: true);
   }
@@ -65813,7 +65760,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSseSendSync(
-          RwLockBoxMyTraitTwinSyncSse raw) {
+          BoxMyTraitTwinSyncSse raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: true);
   }
@@ -65821,7 +65768,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
-          RwLockNonCloneSimpleTwinNormal raw) {
+          NonCloneSimpleTwinNormal raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: true);
   }
@@ -65829,7 +65776,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
-          RwLockNonCloneSimpleTwinSse raw) {
+          NonCloneSimpleTwinSse raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: true);
   }
@@ -65837,7 +65784,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
-          RwLockNonCloneSimpleTwinSync raw) {
+          NonCloneSimpleTwinSync raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: true);
   }
@@ -65845,7 +65792,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
-          RwLockNonCloneSimpleTwinSyncSse raw) {
+          NonCloneSimpleTwinSyncSse raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: true);
   }
@@ -65853,7 +65800,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
-          RwLockStructWithGoodAndOpaqueFieldTwinNormal raw) {
+          StructWithGoodAndOpaqueFieldTwinNormal raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: true);
   }
@@ -65861,7 +65808,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSse raw) {
+          StructWithGoodAndOpaqueFieldTwinSse raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: true);
   }
@@ -65869,7 +65816,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
-          RwLockStructWithGoodAndOpaqueFieldTwinSync raw) {
+          StructWithGoodAndOpaqueFieldTwinSync raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: true);
   }
@@ -65877,7 +65824,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSyncSse raw) {
+          StructWithGoodAndOpaqueFieldTwinSyncSse raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: true);
   }
@@ -65885,7 +65832,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
-          RwLockBoxHelloTraitTwinNormal raw) {
+          BoxHelloTraitTwinNormal raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: false);
   }
@@ -65893,7 +65840,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
-          RwLockBoxHelloTraitTwinSse raw) {
+          BoxHelloTraitTwinSse raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: false);
   }
@@ -65901,7 +65848,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
-          RwLockBoxHelloTraitTwinSync raw) {
+          BoxHelloTraitTwinSync raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: false);
   }
@@ -65909,7 +65856,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
-          RwLockBoxHelloTraitTwinSyncSse raw) {
+          BoxHelloTraitTwinSyncSse raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: false);
   }
@@ -65917,7 +65864,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
-          RwLockNonCloneSimpleTwinNormal raw) {
+          NonCloneSimpleTwinNormal raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: false);
   }
@@ -65925,7 +65872,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
-          RwLockNonCloneSimpleTwinSse raw) {
+          NonCloneSimpleTwinSse raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: false);
   }
@@ -65933,7 +65880,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
-          RwLockNonCloneSimpleTwinSync raw) {
+          NonCloneSimpleTwinSync raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: false);
   }
@@ -65941,7 +65888,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
-          RwLockNonCloneSimpleTwinSyncSse raw) {
+          NonCloneSimpleTwinSyncSse raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: false);
   }
@@ -65949,7 +65896,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
-          RwLockStructWithGoodAndOpaqueFieldTwinNormal raw) {
+          StructWithGoodAndOpaqueFieldTwinNormal raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: false);
   }
@@ -65957,7 +65904,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSse raw) {
+          StructWithGoodAndOpaqueFieldTwinSse raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: false);
   }
@@ -65965,7 +65912,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
-          RwLockStructWithGoodAndOpaqueFieldTwinSync raw) {
+          StructWithGoodAndOpaqueFieldTwinSync raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: false);
   }
@@ -65973,7 +65920,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSyncSse raw) {
+          StructWithGoodAndOpaqueFieldTwinSyncSse raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: false);
   }
@@ -65981,7 +65928,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
-          RwLockBoxHelloTraitTwinNormal raw) {
+          BoxHelloTraitTwinNormal raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: false);
   }
@@ -65989,7 +65936,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
-          RwLockBoxHelloTraitTwinSse raw) {
+          BoxHelloTraitTwinSse raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: false);
   }
@@ -65997,7 +65944,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
-          RwLockBoxHelloTraitTwinSync raw) {
+          BoxHelloTraitTwinSync raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: false);
   }
@@ -66005,7 +65952,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
-          RwLockBoxHelloTraitTwinSyncSse raw) {
+          BoxHelloTraitTwinSyncSse raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: false);
   }
@@ -66013,7 +65960,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
-          RwLockNonCloneSimpleTwinNormal raw) {
+          NonCloneSimpleTwinNormal raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: false);
   }
@@ -66021,7 +65968,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
-          RwLockNonCloneSimpleTwinSse raw) {
+          NonCloneSimpleTwinSse raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: false);
   }
@@ -66029,7 +65976,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
-          RwLockNonCloneSimpleTwinSync raw) {
+          NonCloneSimpleTwinSync raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: false);
   }
@@ -66037,7 +65984,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
-          RwLockNonCloneSimpleTwinSyncSse raw) {
+          NonCloneSimpleTwinSyncSse raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: false);
   }
@@ -66045,7 +65992,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
-          RwLockStructWithGoodAndOpaqueFieldTwinNormal raw) {
+          StructWithGoodAndOpaqueFieldTwinNormal raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: false);
   }
@@ -66053,7 +66000,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSse raw) {
+          StructWithGoodAndOpaqueFieldTwinSse raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: false);
   }
@@ -66061,7 +66008,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
-          RwLockStructWithGoodAndOpaqueFieldTwinSync raw) {
+          StructWithGoodAndOpaqueFieldTwinSync raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: false);
   }
@@ -66069,7 +66016,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSyncSse raw) {
+          StructWithGoodAndOpaqueFieldTwinSyncSse raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: false);
   }
@@ -66292,28 +66239,28 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_RustOpaque_stdsyncRwLockBoxdynFnStringStringSendSyncUnwindSafeRefUnwindSafe(
-          RwLockBoxFnStringString raw) {
+          BoxFnStringString raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode();
   }
 
   @protected
   PlatformPointer cst_encode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
-      RwLockBoxHelloTraitTwinNormal raw) {
+      BoxHelloTraitTwinNormal raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode();
   }
 
   @protected
   PlatformPointer cst_encode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
-      RwLockBoxHelloTraitTwinSse raw) {
+      BoxHelloTraitTwinSse raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode();
   }
 
   @protected
   PlatformPointer cst_encode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
-      RwLockBoxHelloTraitTwinSync raw) {
+      BoxHelloTraitTwinSync raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode();
   }
@@ -66321,7 +66268,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
-          RwLockBoxHelloTraitTwinSyncSse raw) {
+          BoxHelloTraitTwinSyncSse raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode();
   }
@@ -66329,7 +66276,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinNormalSendSync(
-          RwLockBoxMyTraitTwinNormal raw) {
+          BoxMyTraitTwinNormal raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode();
   }
@@ -66337,7 +66284,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSseSendSync(
-          RwLockBoxMyTraitTwinSse raw) {
+          BoxMyTraitTwinSse raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode();
   }
@@ -66345,7 +66292,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSendSync(
-          RwLockBoxMyTraitTwinSync raw) {
+          BoxMyTraitTwinSync raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode();
   }
@@ -66353,35 +66300,35 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSseSendSync(
-          RwLockBoxMyTraitTwinSyncSse raw) {
+          BoxMyTraitTwinSyncSse raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode();
   }
 
   @protected
   PlatformPointer cst_encode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
-      RwLockNonCloneSimpleTwinNormal raw) {
+      NonCloneSimpleTwinNormal raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode();
   }
 
   @protected
   PlatformPointer cst_encode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
-      RwLockNonCloneSimpleTwinSse raw) {
+      NonCloneSimpleTwinSse raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode();
   }
 
   @protected
   PlatformPointer cst_encode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
-      RwLockNonCloneSimpleTwinSync raw) {
+      NonCloneSimpleTwinSync raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode();
   }
 
   @protected
   PlatformPointer cst_encode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
-      RwLockNonCloneSimpleTwinSyncSse raw) {
+      NonCloneSimpleTwinSyncSse raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode();
   }
@@ -66389,7 +66336,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
-          RwLockStructWithGoodAndOpaqueFieldTwinNormal raw) {
+          StructWithGoodAndOpaqueFieldTwinNormal raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode();
   }
@@ -66397,7 +66344,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSse raw) {
+          StructWithGoodAndOpaqueFieldTwinSse raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode();
   }
@@ -66405,7 +66352,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
-          RwLockStructWithGoodAndOpaqueFieldTwinSync raw) {
+          StructWithGoodAndOpaqueFieldTwinSync raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode();
   }
@@ -66413,7 +66360,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PlatformPointer
       cst_encode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSyncSse raw) {
+          StructWithGoodAndOpaqueFieldTwinSyncSse raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode();
   }
@@ -66554,91 +66501,91 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   void
       sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynFnStringStringSendSyncUnwindSafeRefUnwindSafe(
-          RwLockBoxFnStringString self, SseSerializer serializer) {
+          BoxFnStringString self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: true), serializer);
   }
 
   @protected
   void sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
-      RwLockBoxHelloTraitTwinNormal self, SseSerializer serializer) {
+      BoxHelloTraitTwinNormal self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: true), serializer);
   }
 
   @protected
   void sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
-      RwLockBoxHelloTraitTwinSse self, SseSerializer serializer) {
+      BoxHelloTraitTwinSse self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: true), serializer);
   }
 
   @protected
   void sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
-      RwLockBoxHelloTraitTwinSync self, SseSerializer serializer) {
+      BoxHelloTraitTwinSync self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: true), serializer);
   }
 
   @protected
   void
       sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
-          RwLockBoxHelloTraitTwinSyncSse self, SseSerializer serializer) {
+          BoxHelloTraitTwinSyncSse self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: true), serializer);
   }
 
   @protected
   void
       sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinNormalSendSync(
-          RwLockBoxMyTraitTwinNormal self, SseSerializer serializer) {
+          BoxMyTraitTwinNormal self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: true), serializer);
   }
 
   @protected
   void
       sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSseSendSync(
-          RwLockBoxMyTraitTwinSse self, SseSerializer serializer) {
+          BoxMyTraitTwinSse self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: true), serializer);
   }
 
   @protected
   void
       sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSendSync(
-          RwLockBoxMyTraitTwinSync self, SseSerializer serializer) {
+          BoxMyTraitTwinSync self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: true), serializer);
   }
 
   @protected
   void
       sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSseSendSync(
-          RwLockBoxMyTraitTwinSyncSse self, SseSerializer serializer) {
+          BoxMyTraitTwinSyncSse self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: true), serializer);
   }
 
   @protected
   void sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
-      RwLockNonCloneSimpleTwinNormal self, SseSerializer serializer) {
+      NonCloneSimpleTwinNormal self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: true), serializer);
   }
 
   @protected
   void sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
-      RwLockNonCloneSimpleTwinSse self, SseSerializer serializer) {
+      NonCloneSimpleTwinSse self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: true), serializer);
   }
 
   @protected
   void sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
-      RwLockNonCloneSimpleTwinSync self, SseSerializer serializer) {
+      NonCloneSimpleTwinSync self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: true), serializer);
   }
 
   @protected
   void sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
-      RwLockNonCloneSimpleTwinSyncSse self, SseSerializer serializer) {
+      NonCloneSimpleTwinSyncSse self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: true), serializer);
   }
 
   @protected
   void
       sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
-          RwLockStructWithGoodAndOpaqueFieldTwinNormal self,
+          StructWithGoodAndOpaqueFieldTwinNormal self,
           SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: true), serializer);
   }
@@ -66646,23 +66593,21 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   void
       sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSse self,
-          SseSerializer serializer) {
+          StructWithGoodAndOpaqueFieldTwinSse self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: true), serializer);
   }
 
   @protected
   void
       sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
-          RwLockStructWithGoodAndOpaqueFieldTwinSync self,
-          SseSerializer serializer) {
+          StructWithGoodAndOpaqueFieldTwinSync self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: true), serializer);
   }
 
   @protected
   void
       sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSyncSse self,
+          StructWithGoodAndOpaqueFieldTwinSyncSse self,
           SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: true), serializer);
   }
@@ -66670,57 +66615,57 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   void
       sse_encode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
-          RwLockBoxHelloTraitTwinNormal self, SseSerializer serializer) {
+          BoxHelloTraitTwinNormal self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: false), serializer);
   }
 
   @protected
   void sse_encode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
-      RwLockBoxHelloTraitTwinSse self, SseSerializer serializer) {
+      BoxHelloTraitTwinSse self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: false), serializer);
   }
 
   @protected
   void sse_encode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
-      RwLockBoxHelloTraitTwinSync self, SseSerializer serializer) {
+      BoxHelloTraitTwinSync self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: false), serializer);
   }
 
   @protected
   void
       sse_encode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
-          RwLockBoxHelloTraitTwinSyncSse self, SseSerializer serializer) {
+          BoxHelloTraitTwinSyncSse self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: false), serializer);
   }
 
   @protected
   void sse_encode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
-      RwLockNonCloneSimpleTwinNormal self, SseSerializer serializer) {
+      NonCloneSimpleTwinNormal self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: false), serializer);
   }
 
   @protected
   void sse_encode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
-      RwLockNonCloneSimpleTwinSse self, SseSerializer serializer) {
+      NonCloneSimpleTwinSse self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: false), serializer);
   }
 
   @protected
   void sse_encode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
-      RwLockNonCloneSimpleTwinSync self, SseSerializer serializer) {
+      NonCloneSimpleTwinSync self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: false), serializer);
   }
 
   @protected
   void sse_encode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
-      RwLockNonCloneSimpleTwinSyncSse self, SseSerializer serializer) {
+      NonCloneSimpleTwinSyncSse self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: false), serializer);
   }
 
   @protected
   void
       sse_encode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
-          RwLockStructWithGoodAndOpaqueFieldTwinNormal self,
+          StructWithGoodAndOpaqueFieldTwinNormal self,
           SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: false), serializer);
   }
@@ -66728,79 +66673,77 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   void
       sse_encode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSse self,
-          SseSerializer serializer) {
+          StructWithGoodAndOpaqueFieldTwinSse self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: false), serializer);
   }
 
   @protected
   void
       sse_encode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
-          RwLockStructWithGoodAndOpaqueFieldTwinSync self,
-          SseSerializer serializer) {
+          StructWithGoodAndOpaqueFieldTwinSync self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: false), serializer);
   }
 
   @protected
   void
       sse_encode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSyncSse self,
+          StructWithGoodAndOpaqueFieldTwinSyncSse self,
           SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: false), serializer);
   }
 
   @protected
   void sse_encode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
-      RwLockBoxHelloTraitTwinNormal self, SseSerializer serializer) {
+      BoxHelloTraitTwinNormal self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: false), serializer);
   }
 
   @protected
   void sse_encode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
-      RwLockBoxHelloTraitTwinSse self, SseSerializer serializer) {
+      BoxHelloTraitTwinSse self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: false), serializer);
   }
 
   @protected
   void sse_encode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
-      RwLockBoxHelloTraitTwinSync self, SseSerializer serializer) {
+      BoxHelloTraitTwinSync self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: false), serializer);
   }
 
   @protected
   void sse_encode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
-      RwLockBoxHelloTraitTwinSyncSse self, SseSerializer serializer) {
+      BoxHelloTraitTwinSyncSse self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: false), serializer);
   }
 
   @protected
   void sse_encode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
-      RwLockNonCloneSimpleTwinNormal self, SseSerializer serializer) {
+      NonCloneSimpleTwinNormal self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: false), serializer);
   }
 
   @protected
   void sse_encode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
-      RwLockNonCloneSimpleTwinSse self, SseSerializer serializer) {
+      NonCloneSimpleTwinSse self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: false), serializer);
   }
 
   @protected
   void sse_encode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
-      RwLockNonCloneSimpleTwinSync self, SseSerializer serializer) {
+      NonCloneSimpleTwinSync self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: false), serializer);
   }
 
   @protected
   void sse_encode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
-      RwLockNonCloneSimpleTwinSyncSse self, SseSerializer serializer) {
+      NonCloneSimpleTwinSyncSse self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: false), serializer);
   }
 
   @protected
   void
       sse_encode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
-          RwLockStructWithGoodAndOpaqueFieldTwinNormal self,
+          StructWithGoodAndOpaqueFieldTwinNormal self,
           SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: false), serializer);
   }
@@ -66808,23 +66751,21 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   void
       sse_encode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSse self,
-          SseSerializer serializer) {
+          StructWithGoodAndOpaqueFieldTwinSse self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: false), serializer);
   }
 
   @protected
   void
       sse_encode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
-          RwLockStructWithGoodAndOpaqueFieldTwinSync self,
-          SseSerializer serializer) {
+          StructWithGoodAndOpaqueFieldTwinSync self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: false), serializer);
   }
 
   @protected
   void
       sse_encode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSyncSse self,
+          StructWithGoodAndOpaqueFieldTwinSyncSse self,
           SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: false), serializer);
   }
@@ -67101,108 +67042,106 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   void
       sse_encode_RustOpaque_stdsyncRwLockBoxdynFnStringStringSendSyncUnwindSafeRefUnwindSafe(
-          RwLockBoxFnStringString self, SseSerializer serializer) {
+          BoxFnStringString self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: null), serializer);
   }
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
-      RwLockBoxHelloTraitTwinNormal self, SseSerializer serializer) {
+      BoxHelloTraitTwinNormal self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: null), serializer);
   }
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
-      RwLockBoxHelloTraitTwinSse self, SseSerializer serializer) {
+      BoxHelloTraitTwinSse self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: null), serializer);
   }
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
-      RwLockBoxHelloTraitTwinSync self, SseSerializer serializer) {
+      BoxHelloTraitTwinSync self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: null), serializer);
   }
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
-      RwLockBoxHelloTraitTwinSyncSse self, SseSerializer serializer) {
+      BoxHelloTraitTwinSyncSse self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: null), serializer);
   }
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinNormalSendSync(
-      RwLockBoxMyTraitTwinNormal self, SseSerializer serializer) {
+      BoxMyTraitTwinNormal self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: null), serializer);
   }
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSseSendSync(
-      RwLockBoxMyTraitTwinSse self, SseSerializer serializer) {
+      BoxMyTraitTwinSse self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: null), serializer);
   }
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSendSync(
-      RwLockBoxMyTraitTwinSync self, SseSerializer serializer) {
+      BoxMyTraitTwinSync self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: null), serializer);
   }
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSseSendSync(
-      RwLockBoxMyTraitTwinSyncSse self, SseSerializer serializer) {
+      BoxMyTraitTwinSyncSse self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: null), serializer);
   }
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
-      RwLockNonCloneSimpleTwinNormal self, SseSerializer serializer) {
+      NonCloneSimpleTwinNormal self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: null), serializer);
   }
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
-      RwLockNonCloneSimpleTwinSse self, SseSerializer serializer) {
+      NonCloneSimpleTwinSse self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: null), serializer);
   }
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
-      RwLockNonCloneSimpleTwinSync self, SseSerializer serializer) {
+      NonCloneSimpleTwinSync self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: null), serializer);
   }
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
-      RwLockNonCloneSimpleTwinSyncSse self, SseSerializer serializer) {
+      NonCloneSimpleTwinSyncSse self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: null), serializer);
   }
 
   @protected
   void
       sse_encode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
-          RwLockStructWithGoodAndOpaqueFieldTwinNormal self,
+          StructWithGoodAndOpaqueFieldTwinNormal self,
           SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: null), serializer);
   }
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
-      RwLockStructWithGoodAndOpaqueFieldTwinSse self,
-      SseSerializer serializer) {
+      StructWithGoodAndOpaqueFieldTwinSse self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: null), serializer);
   }
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
-      RwLockStructWithGoodAndOpaqueFieldTwinSync self,
-      SseSerializer serializer) {
+      StructWithGoodAndOpaqueFieldTwinSync self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: null), serializer);
   }
 
   @protected
   void
       sse_encode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSyncSse self,
+          StructWithGoodAndOpaqueFieldTwinSyncSse self,
           SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: null), serializer);
   }

--- a/frb_example/pure_dart/lib/src/rust/frb_generated.io.dart
+++ b/frb_example/pure_dart/lib/src/rust/frb_generated.io.dart
@@ -268,278 +268,278 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
           ._rust_arc_decrement_strong_count_RustOpaque_non_send_hide_dataPtr;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockBoxFnStringStringPtr => wire
+      get rust_arc_decrement_strong_count_BoxFnStringStringPtr => wire
           ._rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockBoxdynFnStringStringSendSyncUnwindSafeRefUnwindSafePtr;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockBoxHelloTraitTwinNormalPtr => wire
+      get rust_arc_decrement_strong_count_BoxHelloTraitTwinNormalPtr => wire
           ._rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormalPtr;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockBoxHelloTraitTwinSsePtr => wire
+      get rust_arc_decrement_strong_count_BoxHelloTraitTwinSsePtr => wire
           ._rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSsePtr;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockBoxHelloTraitTwinSyncPtr => wire
+      get rust_arc_decrement_strong_count_BoxHelloTraitTwinSyncPtr => wire
           ._rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncPtr;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockBoxHelloTraitTwinSyncSsePtr => wire
+      get rust_arc_decrement_strong_count_BoxHelloTraitTwinSyncSsePtr => wire
           ._rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSsePtr;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockBoxMyTraitTwinNormalPtr => wire
+      get rust_arc_decrement_strong_count_BoxMyTraitTwinNormalPtr => wire
           ._rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinNormalSendSyncPtr;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockBoxMyTraitTwinSsePtr => wire
+      get rust_arc_decrement_strong_count_BoxMyTraitTwinSsePtr => wire
           ._rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSseSendSyncPtr;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockBoxMyTraitTwinSyncPtr => wire
+      get rust_arc_decrement_strong_count_BoxMyTraitTwinSyncPtr => wire
           ._rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSendSyncPtr;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockBoxMyTraitTwinSyncSsePtr => wire
+      get rust_arc_decrement_strong_count_BoxMyTraitTwinSyncSsePtr => wire
           ._rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSseSendSyncPtr;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockNonCloneSimpleTwinNormalPtr => wire
+      get rust_arc_decrement_strong_count_NonCloneSimpleTwinNormalPtr => wire
           ._rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormalPtr;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockNonCloneSimpleTwinSsePtr => wire
+      get rust_arc_decrement_strong_count_NonCloneSimpleTwinSsePtr => wire
           ._rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSsePtr;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockNonCloneSimpleTwinSyncPtr => wire
+      get rust_arc_decrement_strong_count_NonCloneSimpleTwinSyncPtr => wire
           ._rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncPtr;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockNonCloneSimpleTwinSyncSsePtr =>
-          wire._rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSsePtr;
+      get rust_arc_decrement_strong_count_NonCloneSimpleTwinSyncSsePtr => wire
+          ._rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSsePtr;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinNormalPtr =>
+      get rust_arc_decrement_strong_count_StructWithGoodAndOpaqueFieldTwinNormalPtr =>
           wire._rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormalPtr;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinSsePtr =>
+      get rust_arc_decrement_strong_count_StructWithGoodAndOpaqueFieldTwinSsePtr =>
           wire._rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSsePtr;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinSyncPtr =>
+      get rust_arc_decrement_strong_count_StructWithGoodAndOpaqueFieldTwinSyncPtr =>
           wire._rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncPtr;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinSyncSsePtr =>
+      get rust_arc_decrement_strong_count_StructWithGoodAndOpaqueFieldTwinSyncSsePtr =>
           wire._rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSsePtr;
 
   @protected
   AnyhowException dco_decode_AnyhowException(dynamic raw);
 
   @protected
-  RwLockBoxFnStringString
+  BoxFnStringString
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynFnStringStringSendSyncUnwindSafeRefUnwindSafe(
           dynamic raw);
 
   @protected
-  RwLockBoxHelloTraitTwinNormal
+  BoxHelloTraitTwinNormal
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
           dynamic raw);
 
   @protected
-  RwLockBoxHelloTraitTwinSse
+  BoxHelloTraitTwinSse
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
           dynamic raw);
 
   @protected
-  RwLockBoxHelloTraitTwinSync
+  BoxHelloTraitTwinSync
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
           dynamic raw);
 
   @protected
-  RwLockBoxHelloTraitTwinSyncSse
+  BoxHelloTraitTwinSyncSse
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
           dynamic raw);
 
   @protected
-  RwLockBoxMyTraitTwinNormal
+  BoxMyTraitTwinNormal
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinNormalSendSync(
           dynamic raw);
 
   @protected
-  RwLockBoxMyTraitTwinSse
+  BoxMyTraitTwinSse
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSseSendSync(
           dynamic raw);
 
   @protected
-  RwLockBoxMyTraitTwinSync
+  BoxMyTraitTwinSync
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSendSync(
           dynamic raw);
 
   @protected
-  RwLockBoxMyTraitTwinSyncSse
+  BoxMyTraitTwinSyncSse
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSseSendSync(
           dynamic raw);
 
   @protected
-  RwLockNonCloneSimpleTwinNormal
+  NonCloneSimpleTwinNormal
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
           dynamic raw);
 
   @protected
-  RwLockNonCloneSimpleTwinSse
+  NonCloneSimpleTwinSse
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
           dynamic raw);
 
   @protected
-  RwLockNonCloneSimpleTwinSync
+  NonCloneSimpleTwinSync
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
           dynamic raw);
 
   @protected
-  RwLockNonCloneSimpleTwinSyncSse
+  NonCloneSimpleTwinSyncSse
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
           dynamic raw);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinNormal
+  StructWithGoodAndOpaqueFieldTwinNormal
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
           dynamic raw);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSse
+  StructWithGoodAndOpaqueFieldTwinSse
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
           dynamic raw);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSync
+  StructWithGoodAndOpaqueFieldTwinSync
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
           dynamic raw);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSyncSse
+  StructWithGoodAndOpaqueFieldTwinSyncSse
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
           dynamic raw);
 
   @protected
-  RwLockBoxHelloTraitTwinNormal
+  BoxHelloTraitTwinNormal
       dco_decode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
           dynamic raw);
 
   @protected
-  RwLockBoxHelloTraitTwinSse
+  BoxHelloTraitTwinSse
       dco_decode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
           dynamic raw);
 
   @protected
-  RwLockBoxHelloTraitTwinSync
+  BoxHelloTraitTwinSync
       dco_decode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
           dynamic raw);
 
   @protected
-  RwLockBoxHelloTraitTwinSyncSse
+  BoxHelloTraitTwinSyncSse
       dco_decode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
           dynamic raw);
 
   @protected
-  RwLockNonCloneSimpleTwinNormal
+  NonCloneSimpleTwinNormal
       dco_decode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
           dynamic raw);
 
   @protected
-  RwLockNonCloneSimpleTwinSse
+  NonCloneSimpleTwinSse
       dco_decode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
           dynamic raw);
 
   @protected
-  RwLockNonCloneSimpleTwinSync
+  NonCloneSimpleTwinSync
       dco_decode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
           dynamic raw);
 
   @protected
-  RwLockNonCloneSimpleTwinSyncSse
+  NonCloneSimpleTwinSyncSse
       dco_decode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
           dynamic raw);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinNormal
+  StructWithGoodAndOpaqueFieldTwinNormal
       dco_decode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
           dynamic raw);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSse
+  StructWithGoodAndOpaqueFieldTwinSse
       dco_decode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
           dynamic raw);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSync
+  StructWithGoodAndOpaqueFieldTwinSync
       dco_decode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
           dynamic raw);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSyncSse
+  StructWithGoodAndOpaqueFieldTwinSyncSse
       dco_decode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
           dynamic raw);
 
   @protected
-  RwLockBoxHelloTraitTwinNormal
+  BoxHelloTraitTwinNormal
       dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
           dynamic raw);
 
   @protected
-  RwLockBoxHelloTraitTwinSse
+  BoxHelloTraitTwinSse
       dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
           dynamic raw);
 
   @protected
-  RwLockBoxHelloTraitTwinSync
+  BoxHelloTraitTwinSync
       dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
           dynamic raw);
 
   @protected
-  RwLockBoxHelloTraitTwinSyncSse
+  BoxHelloTraitTwinSyncSse
       dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
           dynamic raw);
 
   @protected
-  RwLockNonCloneSimpleTwinNormal
+  NonCloneSimpleTwinNormal
       dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
           dynamic raw);
 
   @protected
-  RwLockNonCloneSimpleTwinSse
+  NonCloneSimpleTwinSse
       dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
           dynamic raw);
 
   @protected
-  RwLockNonCloneSimpleTwinSync
+  NonCloneSimpleTwinSync
       dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
           dynamic raw);
 
   @protected
-  RwLockNonCloneSimpleTwinSyncSse
+  NonCloneSimpleTwinSyncSse
       dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
           dynamic raw);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinNormal
+  StructWithGoodAndOpaqueFieldTwinNormal
       dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
           dynamic raw);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSse
+  StructWithGoodAndOpaqueFieldTwinSse
       dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
           dynamic raw);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSync
+  StructWithGoodAndOpaqueFieldTwinSync
       dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
           dynamic raw);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSyncSse
+  StructWithGoodAndOpaqueFieldTwinSyncSse
       dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
           dynamic raw);
 
@@ -679,81 +679,81 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   NonSendHideData dco_decode_RustOpaque_non_send_hide_data(dynamic raw);
 
   @protected
-  RwLockBoxFnStringString
+  BoxFnStringString
       dco_decode_RustOpaque_stdsyncRwLockBoxdynFnStringStringSendSyncUnwindSafeRefUnwindSafe(
           dynamic raw);
 
   @protected
-  RwLockBoxHelloTraitTwinNormal
+  BoxHelloTraitTwinNormal
       dco_decode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
           dynamic raw);
 
   @protected
-  RwLockBoxHelloTraitTwinSse
+  BoxHelloTraitTwinSse
       dco_decode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(dynamic raw);
 
   @protected
-  RwLockBoxHelloTraitTwinSync
+  BoxHelloTraitTwinSync
       dco_decode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(dynamic raw);
 
   @protected
-  RwLockBoxHelloTraitTwinSyncSse
+  BoxHelloTraitTwinSyncSse
       dco_decode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
           dynamic raw);
 
   @protected
-  RwLockBoxMyTraitTwinNormal
+  BoxMyTraitTwinNormal
       dco_decode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinNormalSendSync(
           dynamic raw);
 
   @protected
-  RwLockBoxMyTraitTwinSse
+  BoxMyTraitTwinSse
       dco_decode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSseSendSync(
           dynamic raw);
 
   @protected
-  RwLockBoxMyTraitTwinSync
+  BoxMyTraitTwinSync
       dco_decode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSendSync(
           dynamic raw);
 
   @protected
-  RwLockBoxMyTraitTwinSyncSse
+  BoxMyTraitTwinSyncSse
       dco_decode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSseSendSync(
           dynamic raw);
 
   @protected
-  RwLockNonCloneSimpleTwinNormal
+  NonCloneSimpleTwinNormal
       dco_decode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(dynamic raw);
 
   @protected
-  RwLockNonCloneSimpleTwinSse
+  NonCloneSimpleTwinSse
       dco_decode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(dynamic raw);
 
   @protected
-  RwLockNonCloneSimpleTwinSync
+  NonCloneSimpleTwinSync
       dco_decode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(dynamic raw);
 
   @protected
-  RwLockNonCloneSimpleTwinSyncSse
+  NonCloneSimpleTwinSyncSse
       dco_decode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(dynamic raw);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinNormal
+  StructWithGoodAndOpaqueFieldTwinNormal
       dco_decode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
           dynamic raw);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSse
+  StructWithGoodAndOpaqueFieldTwinSse
       dco_decode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
           dynamic raw);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSync
+  StructWithGoodAndOpaqueFieldTwinSync
       dco_decode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
           dynamic raw);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSyncSse
+  StructWithGoodAndOpaqueFieldTwinSyncSse
       dco_decode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
           dynamic raw);
 
@@ -4359,207 +4359,207 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   AnyhowException sse_decode_AnyhowException(SseDeserializer deserializer);
 
   @protected
-  RwLockBoxFnStringString
+  BoxFnStringString
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynFnStringStringSendSyncUnwindSafeRefUnwindSafe(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxHelloTraitTwinNormal
+  BoxHelloTraitTwinNormal
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxHelloTraitTwinSse
+  BoxHelloTraitTwinSse
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxHelloTraitTwinSync
+  BoxHelloTraitTwinSync
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxHelloTraitTwinSyncSse
+  BoxHelloTraitTwinSyncSse
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxMyTraitTwinNormal
+  BoxMyTraitTwinNormal
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinNormalSendSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxMyTraitTwinSse
+  BoxMyTraitTwinSse
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSseSendSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxMyTraitTwinSync
+  BoxMyTraitTwinSync
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSendSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxMyTraitTwinSyncSse
+  BoxMyTraitTwinSyncSse
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSseSendSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockNonCloneSimpleTwinNormal
+  NonCloneSimpleTwinNormal
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
           SseDeserializer deserializer);
 
   @protected
-  RwLockNonCloneSimpleTwinSse
+  NonCloneSimpleTwinSse
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockNonCloneSimpleTwinSync
+  NonCloneSimpleTwinSync
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockNonCloneSimpleTwinSyncSse
+  NonCloneSimpleTwinSyncSse
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinNormal
+  StructWithGoodAndOpaqueFieldTwinNormal
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
           SseDeserializer deserializer);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSse
+  StructWithGoodAndOpaqueFieldTwinSse
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSync
+  StructWithGoodAndOpaqueFieldTwinSync
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSyncSse
+  StructWithGoodAndOpaqueFieldTwinSyncSse
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxHelloTraitTwinNormal
+  BoxHelloTraitTwinNormal
       sse_decode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxHelloTraitTwinSse
+  BoxHelloTraitTwinSse
       sse_decode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxHelloTraitTwinSync
+  BoxHelloTraitTwinSync
       sse_decode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxHelloTraitTwinSyncSse
+  BoxHelloTraitTwinSyncSse
       sse_decode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockNonCloneSimpleTwinNormal
+  NonCloneSimpleTwinNormal
       sse_decode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
           SseDeserializer deserializer);
 
   @protected
-  RwLockNonCloneSimpleTwinSse
+  NonCloneSimpleTwinSse
       sse_decode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockNonCloneSimpleTwinSync
+  NonCloneSimpleTwinSync
       sse_decode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockNonCloneSimpleTwinSyncSse
+  NonCloneSimpleTwinSyncSse
       sse_decode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinNormal
+  StructWithGoodAndOpaqueFieldTwinNormal
       sse_decode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
           SseDeserializer deserializer);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSse
+  StructWithGoodAndOpaqueFieldTwinSse
       sse_decode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSync
+  StructWithGoodAndOpaqueFieldTwinSync
       sse_decode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSyncSse
+  StructWithGoodAndOpaqueFieldTwinSyncSse
       sse_decode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxHelloTraitTwinNormal
+  BoxHelloTraitTwinNormal
       sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxHelloTraitTwinSse
+  BoxHelloTraitTwinSse
       sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxHelloTraitTwinSync
+  BoxHelloTraitTwinSync
       sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxHelloTraitTwinSyncSse
+  BoxHelloTraitTwinSyncSse
       sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockNonCloneSimpleTwinNormal
+  NonCloneSimpleTwinNormal
       sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
           SseDeserializer deserializer);
 
   @protected
-  RwLockNonCloneSimpleTwinSse
+  NonCloneSimpleTwinSse
       sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockNonCloneSimpleTwinSync
+  NonCloneSimpleTwinSync
       sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockNonCloneSimpleTwinSyncSse
+  NonCloneSimpleTwinSyncSse
       sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinNormal
+  StructWithGoodAndOpaqueFieldTwinNormal
       sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
           SseDeserializer deserializer);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSse
+  StructWithGoodAndOpaqueFieldTwinSse
       sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSync
+  StructWithGoodAndOpaqueFieldTwinSync
       sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSyncSse
+  StructWithGoodAndOpaqueFieldTwinSyncSse
       sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
           SseDeserializer deserializer);
 
@@ -4644,87 +4644,87 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       SseDeserializer deserializer);
 
   @protected
-  RwLockBoxFnStringString
+  BoxFnStringString
       sse_decode_RustOpaque_stdsyncRwLockBoxdynFnStringStringSendSyncUnwindSafeRefUnwindSafe(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxHelloTraitTwinNormal
+  BoxHelloTraitTwinNormal
       sse_decode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxHelloTraitTwinSse
+  BoxHelloTraitTwinSse
       sse_decode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxHelloTraitTwinSync
+  BoxHelloTraitTwinSync
       sse_decode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxHelloTraitTwinSyncSse
+  BoxHelloTraitTwinSyncSse
       sse_decode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxMyTraitTwinNormal
+  BoxMyTraitTwinNormal
       sse_decode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinNormalSendSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxMyTraitTwinSse
+  BoxMyTraitTwinSse
       sse_decode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSseSendSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxMyTraitTwinSync
+  BoxMyTraitTwinSync
       sse_decode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSendSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxMyTraitTwinSyncSse
+  BoxMyTraitTwinSyncSse
       sse_decode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSseSendSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockNonCloneSimpleTwinNormal
+  NonCloneSimpleTwinNormal
       sse_decode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
           SseDeserializer deserializer);
 
   @protected
-  RwLockNonCloneSimpleTwinSse
+  NonCloneSimpleTwinSse
       sse_decode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockNonCloneSimpleTwinSync
+  NonCloneSimpleTwinSync
       sse_decode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockNonCloneSimpleTwinSyncSse
+  NonCloneSimpleTwinSyncSse
       sse_decode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinNormal
+  StructWithGoodAndOpaqueFieldTwinNormal
       sse_decode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
           SseDeserializer deserializer);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSse
+  StructWithGoodAndOpaqueFieldTwinSse
       sse_decode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSync
+  StructWithGoodAndOpaqueFieldTwinSync
       sse_decode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSyncSse
+  StructWithGoodAndOpaqueFieldTwinSyncSse
       sse_decode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
           SseDeserializer deserializer);
 
@@ -21066,207 +21066,207 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynFnStringStringSendSyncUnwindSafeRefUnwindSafe(
-          RwLockBoxFnStringString raw);
+          BoxFnStringString raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
-          RwLockBoxHelloTraitTwinNormal raw);
+          BoxHelloTraitTwinNormal raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
-          RwLockBoxHelloTraitTwinSse raw);
+          BoxHelloTraitTwinSse raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
-          RwLockBoxHelloTraitTwinSync raw);
+          BoxHelloTraitTwinSync raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
-          RwLockBoxHelloTraitTwinSyncSse raw);
+          BoxHelloTraitTwinSyncSse raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinNormalSendSync(
-          RwLockBoxMyTraitTwinNormal raw);
+          BoxMyTraitTwinNormal raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSseSendSync(
-          RwLockBoxMyTraitTwinSse raw);
+          BoxMyTraitTwinSse raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSendSync(
-          RwLockBoxMyTraitTwinSync raw);
+          BoxMyTraitTwinSync raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSseSendSync(
-          RwLockBoxMyTraitTwinSyncSse raw);
+          BoxMyTraitTwinSyncSse raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
-          RwLockNonCloneSimpleTwinNormal raw);
+          NonCloneSimpleTwinNormal raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
-          RwLockNonCloneSimpleTwinSse raw);
+          NonCloneSimpleTwinSse raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
-          RwLockNonCloneSimpleTwinSync raw);
+          NonCloneSimpleTwinSync raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
-          RwLockNonCloneSimpleTwinSyncSse raw);
+          NonCloneSimpleTwinSyncSse raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
-          RwLockStructWithGoodAndOpaqueFieldTwinNormal raw);
+          StructWithGoodAndOpaqueFieldTwinNormal raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSse raw);
+          StructWithGoodAndOpaqueFieldTwinSse raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
-          RwLockStructWithGoodAndOpaqueFieldTwinSync raw);
+          StructWithGoodAndOpaqueFieldTwinSync raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSyncSse raw);
+          StructWithGoodAndOpaqueFieldTwinSyncSse raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
-          RwLockBoxHelloTraitTwinNormal raw);
+          BoxHelloTraitTwinNormal raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
-          RwLockBoxHelloTraitTwinSse raw);
+          BoxHelloTraitTwinSse raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
-          RwLockBoxHelloTraitTwinSync raw);
+          BoxHelloTraitTwinSync raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
-          RwLockBoxHelloTraitTwinSyncSse raw);
+          BoxHelloTraitTwinSyncSse raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
-          RwLockNonCloneSimpleTwinNormal raw);
+          NonCloneSimpleTwinNormal raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
-          RwLockNonCloneSimpleTwinSse raw);
+          NonCloneSimpleTwinSse raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
-          RwLockNonCloneSimpleTwinSync raw);
+          NonCloneSimpleTwinSync raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
-          RwLockNonCloneSimpleTwinSyncSse raw);
+          NonCloneSimpleTwinSyncSse raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
-          RwLockStructWithGoodAndOpaqueFieldTwinNormal raw);
+          StructWithGoodAndOpaqueFieldTwinNormal raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSse raw);
+          StructWithGoodAndOpaqueFieldTwinSse raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
-          RwLockStructWithGoodAndOpaqueFieldTwinSync raw);
+          StructWithGoodAndOpaqueFieldTwinSync raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSyncSse raw);
+          StructWithGoodAndOpaqueFieldTwinSyncSse raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
-          RwLockBoxHelloTraitTwinNormal raw);
+          BoxHelloTraitTwinNormal raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
-          RwLockBoxHelloTraitTwinSse raw);
+          BoxHelloTraitTwinSse raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
-          RwLockBoxHelloTraitTwinSync raw);
+          BoxHelloTraitTwinSync raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
-          RwLockBoxHelloTraitTwinSyncSse raw);
+          BoxHelloTraitTwinSyncSse raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
-          RwLockNonCloneSimpleTwinNormal raw);
+          NonCloneSimpleTwinNormal raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
-          RwLockNonCloneSimpleTwinSse raw);
+          NonCloneSimpleTwinSse raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
-          RwLockNonCloneSimpleTwinSync raw);
+          NonCloneSimpleTwinSync raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
-          RwLockNonCloneSimpleTwinSyncSse raw);
+          NonCloneSimpleTwinSyncSse raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
-          RwLockStructWithGoodAndOpaqueFieldTwinNormal raw);
+          StructWithGoodAndOpaqueFieldTwinNormal raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSse raw);
+          StructWithGoodAndOpaqueFieldTwinSse raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
-          RwLockStructWithGoodAndOpaqueFieldTwinSync raw);
+          StructWithGoodAndOpaqueFieldTwinSync raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSyncSse raw);
+          StructWithGoodAndOpaqueFieldTwinSyncSse raw);
 
   @protected
   PlatformPointer cst_encode_DartFn_Inputs_DartOpaque_Output_unit(
@@ -21397,80 +21397,80 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   PlatformPointer
       cst_encode_RustOpaque_stdsyncRwLockBoxdynFnStringStringSendSyncUnwindSafeRefUnwindSafe(
-          RwLockBoxFnStringString raw);
+          BoxFnStringString raw);
 
   @protected
   PlatformPointer cst_encode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
-      RwLockBoxHelloTraitTwinNormal raw);
+      BoxHelloTraitTwinNormal raw);
 
   @protected
   PlatformPointer cst_encode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
-      RwLockBoxHelloTraitTwinSse raw);
+      BoxHelloTraitTwinSse raw);
 
   @protected
   PlatformPointer cst_encode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
-      RwLockBoxHelloTraitTwinSync raw);
+      BoxHelloTraitTwinSync raw);
 
   @protected
   PlatformPointer
       cst_encode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
-          RwLockBoxHelloTraitTwinSyncSse raw);
+          BoxHelloTraitTwinSyncSse raw);
 
   @protected
   PlatformPointer
       cst_encode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinNormalSendSync(
-          RwLockBoxMyTraitTwinNormal raw);
+          BoxMyTraitTwinNormal raw);
 
   @protected
   PlatformPointer
       cst_encode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSseSendSync(
-          RwLockBoxMyTraitTwinSse raw);
+          BoxMyTraitTwinSse raw);
 
   @protected
   PlatformPointer
       cst_encode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSendSync(
-          RwLockBoxMyTraitTwinSync raw);
+          BoxMyTraitTwinSync raw);
 
   @protected
   PlatformPointer
       cst_encode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSseSendSync(
-          RwLockBoxMyTraitTwinSyncSse raw);
+          BoxMyTraitTwinSyncSse raw);
 
   @protected
   PlatformPointer cst_encode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
-      RwLockNonCloneSimpleTwinNormal raw);
+      NonCloneSimpleTwinNormal raw);
 
   @protected
   PlatformPointer cst_encode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
-      RwLockNonCloneSimpleTwinSse raw);
+      NonCloneSimpleTwinSse raw);
 
   @protected
   PlatformPointer cst_encode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
-      RwLockNonCloneSimpleTwinSync raw);
+      NonCloneSimpleTwinSync raw);
 
   @protected
   PlatformPointer cst_encode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
-      RwLockNonCloneSimpleTwinSyncSse raw);
+      NonCloneSimpleTwinSyncSse raw);
 
   @protected
   PlatformPointer
       cst_encode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
-          RwLockStructWithGoodAndOpaqueFieldTwinNormal raw);
+          StructWithGoodAndOpaqueFieldTwinNormal raw);
 
   @protected
   PlatformPointer
       cst_encode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSse raw);
+          StructWithGoodAndOpaqueFieldTwinSse raw);
 
   @protected
   PlatformPointer
       cst_encode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
-          RwLockStructWithGoodAndOpaqueFieldTwinSync raw);
+          StructWithGoodAndOpaqueFieldTwinSync raw);
 
   @protected
   PlatformPointer
       cst_encode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSyncSse raw);
+          StructWithGoodAndOpaqueFieldTwinSyncSse raw);
 
   @protected
   int cst_encode_application_mode(ApplicationMode raw);
@@ -21555,197 +21555,191 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void
       sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynFnStringStringSendSyncUnwindSafeRefUnwindSafe(
-          RwLockBoxFnStringString self, SseSerializer serializer);
+          BoxFnStringString self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
-      RwLockBoxHelloTraitTwinNormal self, SseSerializer serializer);
+      BoxHelloTraitTwinNormal self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
-      RwLockBoxHelloTraitTwinSse self, SseSerializer serializer);
+      BoxHelloTraitTwinSse self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
-      RwLockBoxHelloTraitTwinSync self, SseSerializer serializer);
+      BoxHelloTraitTwinSync self, SseSerializer serializer);
 
   @protected
   void
       sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
-          RwLockBoxHelloTraitTwinSyncSse self, SseSerializer serializer);
+          BoxHelloTraitTwinSyncSse self, SseSerializer serializer);
 
   @protected
   void
       sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinNormalSendSync(
-          RwLockBoxMyTraitTwinNormal self, SseSerializer serializer);
+          BoxMyTraitTwinNormal self, SseSerializer serializer);
 
   @protected
   void
       sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSseSendSync(
-          RwLockBoxMyTraitTwinSse self, SseSerializer serializer);
+          BoxMyTraitTwinSse self, SseSerializer serializer);
 
   @protected
   void
       sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSendSync(
-          RwLockBoxMyTraitTwinSync self, SseSerializer serializer);
+          BoxMyTraitTwinSync self, SseSerializer serializer);
 
   @protected
   void
       sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSseSendSync(
-          RwLockBoxMyTraitTwinSyncSse self, SseSerializer serializer);
+          BoxMyTraitTwinSyncSse self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
-      RwLockNonCloneSimpleTwinNormal self, SseSerializer serializer);
+      NonCloneSimpleTwinNormal self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
-      RwLockNonCloneSimpleTwinSse self, SseSerializer serializer);
+      NonCloneSimpleTwinSse self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
-      RwLockNonCloneSimpleTwinSync self, SseSerializer serializer);
+      NonCloneSimpleTwinSync self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
-      RwLockNonCloneSimpleTwinSyncSse self, SseSerializer serializer);
+      NonCloneSimpleTwinSyncSse self, SseSerializer serializer);
 
   @protected
   void
       sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
-          RwLockStructWithGoodAndOpaqueFieldTwinNormal self,
+          StructWithGoodAndOpaqueFieldTwinNormal self,
           SseSerializer serializer);
 
   @protected
   void
       sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSse self,
-          SseSerializer serializer);
+          StructWithGoodAndOpaqueFieldTwinSse self, SseSerializer serializer);
 
   @protected
   void
       sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
-          RwLockStructWithGoodAndOpaqueFieldTwinSync self,
-          SseSerializer serializer);
+          StructWithGoodAndOpaqueFieldTwinSync self, SseSerializer serializer);
 
   @protected
   void
       sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSyncSse self,
+          StructWithGoodAndOpaqueFieldTwinSyncSse self,
           SseSerializer serializer);
 
   @protected
   void
       sse_encode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
-          RwLockBoxHelloTraitTwinNormal self, SseSerializer serializer);
+          BoxHelloTraitTwinNormal self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
-      RwLockBoxHelloTraitTwinSse self, SseSerializer serializer);
+      BoxHelloTraitTwinSse self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
-      RwLockBoxHelloTraitTwinSync self, SseSerializer serializer);
+      BoxHelloTraitTwinSync self, SseSerializer serializer);
 
   @protected
   void
       sse_encode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
-          RwLockBoxHelloTraitTwinSyncSse self, SseSerializer serializer);
+          BoxHelloTraitTwinSyncSse self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
-      RwLockNonCloneSimpleTwinNormal self, SseSerializer serializer);
+      NonCloneSimpleTwinNormal self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
-      RwLockNonCloneSimpleTwinSse self, SseSerializer serializer);
+      NonCloneSimpleTwinSse self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
-      RwLockNonCloneSimpleTwinSync self, SseSerializer serializer);
+      NonCloneSimpleTwinSync self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
-      RwLockNonCloneSimpleTwinSyncSse self, SseSerializer serializer);
+      NonCloneSimpleTwinSyncSse self, SseSerializer serializer);
 
   @protected
   void
       sse_encode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
-          RwLockStructWithGoodAndOpaqueFieldTwinNormal self,
+          StructWithGoodAndOpaqueFieldTwinNormal self,
           SseSerializer serializer);
 
   @protected
   void
       sse_encode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSse self,
-          SseSerializer serializer);
+          StructWithGoodAndOpaqueFieldTwinSse self, SseSerializer serializer);
 
   @protected
   void
       sse_encode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
-          RwLockStructWithGoodAndOpaqueFieldTwinSync self,
-          SseSerializer serializer);
+          StructWithGoodAndOpaqueFieldTwinSync self, SseSerializer serializer);
 
   @protected
   void
       sse_encode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSyncSse self,
+          StructWithGoodAndOpaqueFieldTwinSyncSse self,
           SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
-      RwLockBoxHelloTraitTwinNormal self, SseSerializer serializer);
+      BoxHelloTraitTwinNormal self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
-      RwLockBoxHelloTraitTwinSse self, SseSerializer serializer);
+      BoxHelloTraitTwinSse self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
-      RwLockBoxHelloTraitTwinSync self, SseSerializer serializer);
+      BoxHelloTraitTwinSync self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
-      RwLockBoxHelloTraitTwinSyncSse self, SseSerializer serializer);
+      BoxHelloTraitTwinSyncSse self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
-      RwLockNonCloneSimpleTwinNormal self, SseSerializer serializer);
+      NonCloneSimpleTwinNormal self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
-      RwLockNonCloneSimpleTwinSse self, SseSerializer serializer);
+      NonCloneSimpleTwinSse self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
-      RwLockNonCloneSimpleTwinSync self, SseSerializer serializer);
+      NonCloneSimpleTwinSync self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
-      RwLockNonCloneSimpleTwinSyncSse self, SseSerializer serializer);
+      NonCloneSimpleTwinSyncSse self, SseSerializer serializer);
 
   @protected
   void
       sse_encode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
-          RwLockStructWithGoodAndOpaqueFieldTwinNormal self,
+          StructWithGoodAndOpaqueFieldTwinNormal self,
           SseSerializer serializer);
 
   @protected
   void
       sse_encode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSse self,
-          SseSerializer serializer);
+          StructWithGoodAndOpaqueFieldTwinSse self, SseSerializer serializer);
 
   @protected
   void
       sse_encode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
-          RwLockStructWithGoodAndOpaqueFieldTwinSync self,
-          SseSerializer serializer);
+          StructWithGoodAndOpaqueFieldTwinSync self, SseSerializer serializer);
 
   @protected
   void
       sse_encode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSyncSse self,
+          StructWithGoodAndOpaqueFieldTwinSyncSse self,
           SseSerializer serializer);
 
   @protected
@@ -21913,75 +21907,74 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void
       sse_encode_RustOpaque_stdsyncRwLockBoxdynFnStringStringSendSyncUnwindSafeRefUnwindSafe(
-          RwLockBoxFnStringString self, SseSerializer serializer);
+          BoxFnStringString self, SseSerializer serializer);
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
-      RwLockBoxHelloTraitTwinNormal self, SseSerializer serializer);
+      BoxHelloTraitTwinNormal self, SseSerializer serializer);
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
-      RwLockBoxHelloTraitTwinSse self, SseSerializer serializer);
+      BoxHelloTraitTwinSse self, SseSerializer serializer);
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
-      RwLockBoxHelloTraitTwinSync self, SseSerializer serializer);
+      BoxHelloTraitTwinSync self, SseSerializer serializer);
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
-      RwLockBoxHelloTraitTwinSyncSse self, SseSerializer serializer);
+      BoxHelloTraitTwinSyncSse self, SseSerializer serializer);
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinNormalSendSync(
-      RwLockBoxMyTraitTwinNormal self, SseSerializer serializer);
+      BoxMyTraitTwinNormal self, SseSerializer serializer);
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSseSendSync(
-      RwLockBoxMyTraitTwinSse self, SseSerializer serializer);
+      BoxMyTraitTwinSse self, SseSerializer serializer);
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSendSync(
-      RwLockBoxMyTraitTwinSync self, SseSerializer serializer);
+      BoxMyTraitTwinSync self, SseSerializer serializer);
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSseSendSync(
-      RwLockBoxMyTraitTwinSyncSse self, SseSerializer serializer);
+      BoxMyTraitTwinSyncSse self, SseSerializer serializer);
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
-      RwLockNonCloneSimpleTwinNormal self, SseSerializer serializer);
+      NonCloneSimpleTwinNormal self, SseSerializer serializer);
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
-      RwLockNonCloneSimpleTwinSse self, SseSerializer serializer);
+      NonCloneSimpleTwinSse self, SseSerializer serializer);
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
-      RwLockNonCloneSimpleTwinSync self, SseSerializer serializer);
+      NonCloneSimpleTwinSync self, SseSerializer serializer);
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
-      RwLockNonCloneSimpleTwinSyncSse self, SseSerializer serializer);
+      NonCloneSimpleTwinSyncSse self, SseSerializer serializer);
 
   @protected
   void
       sse_encode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
-          RwLockStructWithGoodAndOpaqueFieldTwinNormal self,
+          StructWithGoodAndOpaqueFieldTwinNormal self,
           SseSerializer serializer);
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
-      RwLockStructWithGoodAndOpaqueFieldTwinSse self, SseSerializer serializer);
+      StructWithGoodAndOpaqueFieldTwinSse self, SseSerializer serializer);
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
-      RwLockStructWithGoodAndOpaqueFieldTwinSync self,
-      SseSerializer serializer);
+      StructWithGoodAndOpaqueFieldTwinSync self, SseSerializer serializer);
 
   @protected
   void
       sse_encode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSyncSse self,
+          StructWithGoodAndOpaqueFieldTwinSyncSse self,
           SseSerializer serializer);
 
   @protected

--- a/frb_example/pure_dart/lib/src/rust/frb_generated.web.dart
+++ b/frb_example/pure_dart/lib/src/rust/frb_generated.web.dart
@@ -267,278 +267,278 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
           wire.rust_arc_decrement_strong_count_RustOpaque_non_send_hide_data;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockBoxFnStringStringPtr => wire
+      get rust_arc_decrement_strong_count_BoxFnStringStringPtr => wire
           .rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockBoxdynFnStringStringSendSyncUnwindSafeRefUnwindSafe;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockBoxHelloTraitTwinNormalPtr => wire
+      get rust_arc_decrement_strong_count_BoxHelloTraitTwinNormalPtr => wire
           .rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockBoxHelloTraitTwinSsePtr => wire
+      get rust_arc_decrement_strong_count_BoxHelloTraitTwinSsePtr => wire
           .rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockBoxHelloTraitTwinSyncPtr => wire
+      get rust_arc_decrement_strong_count_BoxHelloTraitTwinSyncPtr => wire
           .rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockBoxHelloTraitTwinSyncSsePtr => wire
+      get rust_arc_decrement_strong_count_BoxHelloTraitTwinSyncSsePtr => wire
           .rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockBoxMyTraitTwinNormalPtr => wire
+      get rust_arc_decrement_strong_count_BoxMyTraitTwinNormalPtr => wire
           .rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinNormalSendSync;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockBoxMyTraitTwinSsePtr => wire
+      get rust_arc_decrement_strong_count_BoxMyTraitTwinSsePtr => wire
           .rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSseSendSync;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockBoxMyTraitTwinSyncPtr => wire
+      get rust_arc_decrement_strong_count_BoxMyTraitTwinSyncPtr => wire
           .rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSendSync;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockBoxMyTraitTwinSyncSsePtr => wire
+      get rust_arc_decrement_strong_count_BoxMyTraitTwinSyncSsePtr => wire
           .rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSseSendSync;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockNonCloneSimpleTwinNormalPtr => wire
+      get rust_arc_decrement_strong_count_NonCloneSimpleTwinNormalPtr => wire
           .rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockNonCloneSimpleTwinSsePtr => wire
+      get rust_arc_decrement_strong_count_NonCloneSimpleTwinSsePtr => wire
           .rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockNonCloneSimpleTwinSyncPtr => wire
+      get rust_arc_decrement_strong_count_NonCloneSimpleTwinSyncPtr => wire
           .rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockNonCloneSimpleTwinSyncSsePtr =>
-          wire.rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse;
+      get rust_arc_decrement_strong_count_NonCloneSimpleTwinSyncSsePtr => wire
+          .rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinNormalPtr =>
+      get rust_arc_decrement_strong_count_StructWithGoodAndOpaqueFieldTwinNormalPtr =>
           wire.rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinSsePtr =>
+      get rust_arc_decrement_strong_count_StructWithGoodAndOpaqueFieldTwinSsePtr =>
           wire.rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinSyncPtr =>
+      get rust_arc_decrement_strong_count_StructWithGoodAndOpaqueFieldTwinSyncPtr =>
           wire.rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockStructWithGoodAndOpaqueFieldTwinSyncSsePtr =>
+      get rust_arc_decrement_strong_count_StructWithGoodAndOpaqueFieldTwinSyncSsePtr =>
           wire.rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse;
 
   @protected
   AnyhowException dco_decode_AnyhowException(dynamic raw);
 
   @protected
-  RwLockBoxFnStringString
+  BoxFnStringString
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynFnStringStringSendSyncUnwindSafeRefUnwindSafe(
           dynamic raw);
 
   @protected
-  RwLockBoxHelloTraitTwinNormal
+  BoxHelloTraitTwinNormal
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
           dynamic raw);
 
   @protected
-  RwLockBoxHelloTraitTwinSse
+  BoxHelloTraitTwinSse
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
           dynamic raw);
 
   @protected
-  RwLockBoxHelloTraitTwinSync
+  BoxHelloTraitTwinSync
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
           dynamic raw);
 
   @protected
-  RwLockBoxHelloTraitTwinSyncSse
+  BoxHelloTraitTwinSyncSse
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
           dynamic raw);
 
   @protected
-  RwLockBoxMyTraitTwinNormal
+  BoxMyTraitTwinNormal
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinNormalSendSync(
           dynamic raw);
 
   @protected
-  RwLockBoxMyTraitTwinSse
+  BoxMyTraitTwinSse
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSseSendSync(
           dynamic raw);
 
   @protected
-  RwLockBoxMyTraitTwinSync
+  BoxMyTraitTwinSync
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSendSync(
           dynamic raw);
 
   @protected
-  RwLockBoxMyTraitTwinSyncSse
+  BoxMyTraitTwinSyncSse
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSseSendSync(
           dynamic raw);
 
   @protected
-  RwLockNonCloneSimpleTwinNormal
+  NonCloneSimpleTwinNormal
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
           dynamic raw);
 
   @protected
-  RwLockNonCloneSimpleTwinSse
+  NonCloneSimpleTwinSse
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
           dynamic raw);
 
   @protected
-  RwLockNonCloneSimpleTwinSync
+  NonCloneSimpleTwinSync
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
           dynamic raw);
 
   @protected
-  RwLockNonCloneSimpleTwinSyncSse
+  NonCloneSimpleTwinSyncSse
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
           dynamic raw);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinNormal
+  StructWithGoodAndOpaqueFieldTwinNormal
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
           dynamic raw);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSse
+  StructWithGoodAndOpaqueFieldTwinSse
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
           dynamic raw);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSync
+  StructWithGoodAndOpaqueFieldTwinSync
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
           dynamic raw);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSyncSse
+  StructWithGoodAndOpaqueFieldTwinSyncSse
       dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
           dynamic raw);
 
   @protected
-  RwLockBoxHelloTraitTwinNormal
+  BoxHelloTraitTwinNormal
       dco_decode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
           dynamic raw);
 
   @protected
-  RwLockBoxHelloTraitTwinSse
+  BoxHelloTraitTwinSse
       dco_decode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
           dynamic raw);
 
   @protected
-  RwLockBoxHelloTraitTwinSync
+  BoxHelloTraitTwinSync
       dco_decode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
           dynamic raw);
 
   @protected
-  RwLockBoxHelloTraitTwinSyncSse
+  BoxHelloTraitTwinSyncSse
       dco_decode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
           dynamic raw);
 
   @protected
-  RwLockNonCloneSimpleTwinNormal
+  NonCloneSimpleTwinNormal
       dco_decode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
           dynamic raw);
 
   @protected
-  RwLockNonCloneSimpleTwinSse
+  NonCloneSimpleTwinSse
       dco_decode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
           dynamic raw);
 
   @protected
-  RwLockNonCloneSimpleTwinSync
+  NonCloneSimpleTwinSync
       dco_decode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
           dynamic raw);
 
   @protected
-  RwLockNonCloneSimpleTwinSyncSse
+  NonCloneSimpleTwinSyncSse
       dco_decode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
           dynamic raw);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinNormal
+  StructWithGoodAndOpaqueFieldTwinNormal
       dco_decode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
           dynamic raw);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSse
+  StructWithGoodAndOpaqueFieldTwinSse
       dco_decode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
           dynamic raw);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSync
+  StructWithGoodAndOpaqueFieldTwinSync
       dco_decode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
           dynamic raw);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSyncSse
+  StructWithGoodAndOpaqueFieldTwinSyncSse
       dco_decode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
           dynamic raw);
 
   @protected
-  RwLockBoxHelloTraitTwinNormal
+  BoxHelloTraitTwinNormal
       dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
           dynamic raw);
 
   @protected
-  RwLockBoxHelloTraitTwinSse
+  BoxHelloTraitTwinSse
       dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
           dynamic raw);
 
   @protected
-  RwLockBoxHelloTraitTwinSync
+  BoxHelloTraitTwinSync
       dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
           dynamic raw);
 
   @protected
-  RwLockBoxHelloTraitTwinSyncSse
+  BoxHelloTraitTwinSyncSse
       dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
           dynamic raw);
 
   @protected
-  RwLockNonCloneSimpleTwinNormal
+  NonCloneSimpleTwinNormal
       dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
           dynamic raw);
 
   @protected
-  RwLockNonCloneSimpleTwinSse
+  NonCloneSimpleTwinSse
       dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
           dynamic raw);
 
   @protected
-  RwLockNonCloneSimpleTwinSync
+  NonCloneSimpleTwinSync
       dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
           dynamic raw);
 
   @protected
-  RwLockNonCloneSimpleTwinSyncSse
+  NonCloneSimpleTwinSyncSse
       dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
           dynamic raw);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinNormal
+  StructWithGoodAndOpaqueFieldTwinNormal
       dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
           dynamic raw);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSse
+  StructWithGoodAndOpaqueFieldTwinSse
       dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
           dynamic raw);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSync
+  StructWithGoodAndOpaqueFieldTwinSync
       dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
           dynamic raw);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSyncSse
+  StructWithGoodAndOpaqueFieldTwinSyncSse
       dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
           dynamic raw);
 
@@ -678,81 +678,81 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   NonSendHideData dco_decode_RustOpaque_non_send_hide_data(dynamic raw);
 
   @protected
-  RwLockBoxFnStringString
+  BoxFnStringString
       dco_decode_RustOpaque_stdsyncRwLockBoxdynFnStringStringSendSyncUnwindSafeRefUnwindSafe(
           dynamic raw);
 
   @protected
-  RwLockBoxHelloTraitTwinNormal
+  BoxHelloTraitTwinNormal
       dco_decode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
           dynamic raw);
 
   @protected
-  RwLockBoxHelloTraitTwinSse
+  BoxHelloTraitTwinSse
       dco_decode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(dynamic raw);
 
   @protected
-  RwLockBoxHelloTraitTwinSync
+  BoxHelloTraitTwinSync
       dco_decode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(dynamic raw);
 
   @protected
-  RwLockBoxHelloTraitTwinSyncSse
+  BoxHelloTraitTwinSyncSse
       dco_decode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
           dynamic raw);
 
   @protected
-  RwLockBoxMyTraitTwinNormal
+  BoxMyTraitTwinNormal
       dco_decode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinNormalSendSync(
           dynamic raw);
 
   @protected
-  RwLockBoxMyTraitTwinSse
+  BoxMyTraitTwinSse
       dco_decode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSseSendSync(
           dynamic raw);
 
   @protected
-  RwLockBoxMyTraitTwinSync
+  BoxMyTraitTwinSync
       dco_decode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSendSync(
           dynamic raw);
 
   @protected
-  RwLockBoxMyTraitTwinSyncSse
+  BoxMyTraitTwinSyncSse
       dco_decode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSseSendSync(
           dynamic raw);
 
   @protected
-  RwLockNonCloneSimpleTwinNormal
+  NonCloneSimpleTwinNormal
       dco_decode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(dynamic raw);
 
   @protected
-  RwLockNonCloneSimpleTwinSse
+  NonCloneSimpleTwinSse
       dco_decode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(dynamic raw);
 
   @protected
-  RwLockNonCloneSimpleTwinSync
+  NonCloneSimpleTwinSync
       dco_decode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(dynamic raw);
 
   @protected
-  RwLockNonCloneSimpleTwinSyncSse
+  NonCloneSimpleTwinSyncSse
       dco_decode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(dynamic raw);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinNormal
+  StructWithGoodAndOpaqueFieldTwinNormal
       dco_decode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
           dynamic raw);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSse
+  StructWithGoodAndOpaqueFieldTwinSse
       dco_decode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
           dynamic raw);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSync
+  StructWithGoodAndOpaqueFieldTwinSync
       dco_decode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
           dynamic raw);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSyncSse
+  StructWithGoodAndOpaqueFieldTwinSyncSse
       dco_decode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
           dynamic raw);
 
@@ -4358,207 +4358,207 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   AnyhowException sse_decode_AnyhowException(SseDeserializer deserializer);
 
   @protected
-  RwLockBoxFnStringString
+  BoxFnStringString
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynFnStringStringSendSyncUnwindSafeRefUnwindSafe(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxHelloTraitTwinNormal
+  BoxHelloTraitTwinNormal
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxHelloTraitTwinSse
+  BoxHelloTraitTwinSse
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxHelloTraitTwinSync
+  BoxHelloTraitTwinSync
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxHelloTraitTwinSyncSse
+  BoxHelloTraitTwinSyncSse
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxMyTraitTwinNormal
+  BoxMyTraitTwinNormal
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinNormalSendSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxMyTraitTwinSse
+  BoxMyTraitTwinSse
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSseSendSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxMyTraitTwinSync
+  BoxMyTraitTwinSync
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSendSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxMyTraitTwinSyncSse
+  BoxMyTraitTwinSyncSse
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSseSendSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockNonCloneSimpleTwinNormal
+  NonCloneSimpleTwinNormal
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
           SseDeserializer deserializer);
 
   @protected
-  RwLockNonCloneSimpleTwinSse
+  NonCloneSimpleTwinSse
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockNonCloneSimpleTwinSync
+  NonCloneSimpleTwinSync
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockNonCloneSimpleTwinSyncSse
+  NonCloneSimpleTwinSyncSse
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinNormal
+  StructWithGoodAndOpaqueFieldTwinNormal
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
           SseDeserializer deserializer);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSse
+  StructWithGoodAndOpaqueFieldTwinSse
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSync
+  StructWithGoodAndOpaqueFieldTwinSync
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSyncSse
+  StructWithGoodAndOpaqueFieldTwinSyncSse
       sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxHelloTraitTwinNormal
+  BoxHelloTraitTwinNormal
       sse_decode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxHelloTraitTwinSse
+  BoxHelloTraitTwinSse
       sse_decode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxHelloTraitTwinSync
+  BoxHelloTraitTwinSync
       sse_decode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxHelloTraitTwinSyncSse
+  BoxHelloTraitTwinSyncSse
       sse_decode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockNonCloneSimpleTwinNormal
+  NonCloneSimpleTwinNormal
       sse_decode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
           SseDeserializer deserializer);
 
   @protected
-  RwLockNonCloneSimpleTwinSse
+  NonCloneSimpleTwinSse
       sse_decode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockNonCloneSimpleTwinSync
+  NonCloneSimpleTwinSync
       sse_decode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockNonCloneSimpleTwinSyncSse
+  NonCloneSimpleTwinSyncSse
       sse_decode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinNormal
+  StructWithGoodAndOpaqueFieldTwinNormal
       sse_decode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
           SseDeserializer deserializer);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSse
+  StructWithGoodAndOpaqueFieldTwinSse
       sse_decode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSync
+  StructWithGoodAndOpaqueFieldTwinSync
       sse_decode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSyncSse
+  StructWithGoodAndOpaqueFieldTwinSyncSse
       sse_decode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxHelloTraitTwinNormal
+  BoxHelloTraitTwinNormal
       sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxHelloTraitTwinSse
+  BoxHelloTraitTwinSse
       sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxHelloTraitTwinSync
+  BoxHelloTraitTwinSync
       sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxHelloTraitTwinSyncSse
+  BoxHelloTraitTwinSyncSse
       sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockNonCloneSimpleTwinNormal
+  NonCloneSimpleTwinNormal
       sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
           SseDeserializer deserializer);
 
   @protected
-  RwLockNonCloneSimpleTwinSse
+  NonCloneSimpleTwinSse
       sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockNonCloneSimpleTwinSync
+  NonCloneSimpleTwinSync
       sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockNonCloneSimpleTwinSyncSse
+  NonCloneSimpleTwinSyncSse
       sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinNormal
+  StructWithGoodAndOpaqueFieldTwinNormal
       sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
           SseDeserializer deserializer);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSse
+  StructWithGoodAndOpaqueFieldTwinSse
       sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSync
+  StructWithGoodAndOpaqueFieldTwinSync
       sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSyncSse
+  StructWithGoodAndOpaqueFieldTwinSyncSse
       sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
           SseDeserializer deserializer);
 
@@ -4643,87 +4643,87 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       SseDeserializer deserializer);
 
   @protected
-  RwLockBoxFnStringString
+  BoxFnStringString
       sse_decode_RustOpaque_stdsyncRwLockBoxdynFnStringStringSendSyncUnwindSafeRefUnwindSafe(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxHelloTraitTwinNormal
+  BoxHelloTraitTwinNormal
       sse_decode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxHelloTraitTwinSse
+  BoxHelloTraitTwinSse
       sse_decode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxHelloTraitTwinSync
+  BoxHelloTraitTwinSync
       sse_decode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxHelloTraitTwinSyncSse
+  BoxHelloTraitTwinSyncSse
       sse_decode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxMyTraitTwinNormal
+  BoxMyTraitTwinNormal
       sse_decode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinNormalSendSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxMyTraitTwinSse
+  BoxMyTraitTwinSse
       sse_decode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSseSendSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxMyTraitTwinSync
+  BoxMyTraitTwinSync
       sse_decode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSendSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockBoxMyTraitTwinSyncSse
+  BoxMyTraitTwinSyncSse
       sse_decode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSseSendSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockNonCloneSimpleTwinNormal
+  NonCloneSimpleTwinNormal
       sse_decode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
           SseDeserializer deserializer);
 
   @protected
-  RwLockNonCloneSimpleTwinSse
+  NonCloneSimpleTwinSse
       sse_decode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockNonCloneSimpleTwinSync
+  NonCloneSimpleTwinSync
       sse_decode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockNonCloneSimpleTwinSyncSse
+  NonCloneSimpleTwinSyncSse
       sse_decode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinNormal
+  StructWithGoodAndOpaqueFieldTwinNormal
       sse_decode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
           SseDeserializer deserializer);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSse
+  StructWithGoodAndOpaqueFieldTwinSse
       sse_decode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
           SseDeserializer deserializer);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSync
+  StructWithGoodAndOpaqueFieldTwinSync
       sse_decode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
           SseDeserializer deserializer);
 
   @protected
-  RwLockStructWithGoodAndOpaqueFieldTwinSyncSse
+  StructWithGoodAndOpaqueFieldTwinSyncSse
       sse_decode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
           SseDeserializer deserializer);
 
@@ -16279,207 +16279,207 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynFnStringStringSendSyncUnwindSafeRefUnwindSafe(
-          RwLockBoxFnStringString raw);
+          BoxFnStringString raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
-          RwLockBoxHelloTraitTwinNormal raw);
+          BoxHelloTraitTwinNormal raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
-          RwLockBoxHelloTraitTwinSse raw);
+          BoxHelloTraitTwinSse raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
-          RwLockBoxHelloTraitTwinSync raw);
+          BoxHelloTraitTwinSync raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
-          RwLockBoxHelloTraitTwinSyncSse raw);
+          BoxHelloTraitTwinSyncSse raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinNormalSendSync(
-          RwLockBoxMyTraitTwinNormal raw);
+          BoxMyTraitTwinNormal raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSseSendSync(
-          RwLockBoxMyTraitTwinSse raw);
+          BoxMyTraitTwinSse raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSendSync(
-          RwLockBoxMyTraitTwinSync raw);
+          BoxMyTraitTwinSync raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSseSendSync(
-          RwLockBoxMyTraitTwinSyncSse raw);
+          BoxMyTraitTwinSyncSse raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
-          RwLockNonCloneSimpleTwinNormal raw);
+          NonCloneSimpleTwinNormal raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
-          RwLockNonCloneSimpleTwinSse raw);
+          NonCloneSimpleTwinSse raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
-          RwLockNonCloneSimpleTwinSync raw);
+          NonCloneSimpleTwinSync raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
-          RwLockNonCloneSimpleTwinSyncSse raw);
+          NonCloneSimpleTwinSyncSse raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
-          RwLockStructWithGoodAndOpaqueFieldTwinNormal raw);
+          StructWithGoodAndOpaqueFieldTwinNormal raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSse raw);
+          StructWithGoodAndOpaqueFieldTwinSse raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
-          RwLockStructWithGoodAndOpaqueFieldTwinSync raw);
+          StructWithGoodAndOpaqueFieldTwinSync raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSyncSse raw);
+          StructWithGoodAndOpaqueFieldTwinSyncSse raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
-          RwLockBoxHelloTraitTwinNormal raw);
+          BoxHelloTraitTwinNormal raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
-          RwLockBoxHelloTraitTwinSse raw);
+          BoxHelloTraitTwinSse raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
-          RwLockBoxHelloTraitTwinSync raw);
+          BoxHelloTraitTwinSync raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
-          RwLockBoxHelloTraitTwinSyncSse raw);
+          BoxHelloTraitTwinSyncSse raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
-          RwLockNonCloneSimpleTwinNormal raw);
+          NonCloneSimpleTwinNormal raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
-          RwLockNonCloneSimpleTwinSse raw);
+          NonCloneSimpleTwinSse raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
-          RwLockNonCloneSimpleTwinSync raw);
+          NonCloneSimpleTwinSync raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
-          RwLockNonCloneSimpleTwinSyncSse raw);
+          NonCloneSimpleTwinSyncSse raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
-          RwLockStructWithGoodAndOpaqueFieldTwinNormal raw);
+          StructWithGoodAndOpaqueFieldTwinNormal raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSse raw);
+          StructWithGoodAndOpaqueFieldTwinSse raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
-          RwLockStructWithGoodAndOpaqueFieldTwinSync raw);
+          StructWithGoodAndOpaqueFieldTwinSync raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSyncSse raw);
+          StructWithGoodAndOpaqueFieldTwinSyncSse raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
-          RwLockBoxHelloTraitTwinNormal raw);
+          BoxHelloTraitTwinNormal raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
-          RwLockBoxHelloTraitTwinSse raw);
+          BoxHelloTraitTwinSse raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
-          RwLockBoxHelloTraitTwinSync raw);
+          BoxHelloTraitTwinSync raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
-          RwLockBoxHelloTraitTwinSyncSse raw);
+          BoxHelloTraitTwinSyncSse raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
-          RwLockNonCloneSimpleTwinNormal raw);
+          NonCloneSimpleTwinNormal raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
-          RwLockNonCloneSimpleTwinSse raw);
+          NonCloneSimpleTwinSse raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
-          RwLockNonCloneSimpleTwinSync raw);
+          NonCloneSimpleTwinSync raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
-          RwLockNonCloneSimpleTwinSyncSse raw);
+          NonCloneSimpleTwinSyncSse raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
-          RwLockStructWithGoodAndOpaqueFieldTwinNormal raw);
+          StructWithGoodAndOpaqueFieldTwinNormal raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSse raw);
+          StructWithGoodAndOpaqueFieldTwinSse raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
-          RwLockStructWithGoodAndOpaqueFieldTwinSync raw);
+          StructWithGoodAndOpaqueFieldTwinSync raw);
 
   @protected
   PlatformPointer
       cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSyncSse raw);
+          StructWithGoodAndOpaqueFieldTwinSyncSse raw);
 
   @protected
   PlatformPointer cst_encode_DartFn_Inputs_DartOpaque_Output_unit(
@@ -16610,80 +16610,80 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   PlatformPointer
       cst_encode_RustOpaque_stdsyncRwLockBoxdynFnStringStringSendSyncUnwindSafeRefUnwindSafe(
-          RwLockBoxFnStringString raw);
+          BoxFnStringString raw);
 
   @protected
   PlatformPointer cst_encode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
-      RwLockBoxHelloTraitTwinNormal raw);
+      BoxHelloTraitTwinNormal raw);
 
   @protected
   PlatformPointer cst_encode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
-      RwLockBoxHelloTraitTwinSse raw);
+      BoxHelloTraitTwinSse raw);
 
   @protected
   PlatformPointer cst_encode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
-      RwLockBoxHelloTraitTwinSync raw);
+      BoxHelloTraitTwinSync raw);
 
   @protected
   PlatformPointer
       cst_encode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
-          RwLockBoxHelloTraitTwinSyncSse raw);
+          BoxHelloTraitTwinSyncSse raw);
 
   @protected
   PlatformPointer
       cst_encode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinNormalSendSync(
-          RwLockBoxMyTraitTwinNormal raw);
+          BoxMyTraitTwinNormal raw);
 
   @protected
   PlatformPointer
       cst_encode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSseSendSync(
-          RwLockBoxMyTraitTwinSse raw);
+          BoxMyTraitTwinSse raw);
 
   @protected
   PlatformPointer
       cst_encode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSendSync(
-          RwLockBoxMyTraitTwinSync raw);
+          BoxMyTraitTwinSync raw);
 
   @protected
   PlatformPointer
       cst_encode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSseSendSync(
-          RwLockBoxMyTraitTwinSyncSse raw);
+          BoxMyTraitTwinSyncSse raw);
 
   @protected
   PlatformPointer cst_encode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
-      RwLockNonCloneSimpleTwinNormal raw);
+      NonCloneSimpleTwinNormal raw);
 
   @protected
   PlatformPointer cst_encode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
-      RwLockNonCloneSimpleTwinSse raw);
+      NonCloneSimpleTwinSse raw);
 
   @protected
   PlatformPointer cst_encode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
-      RwLockNonCloneSimpleTwinSync raw);
+      NonCloneSimpleTwinSync raw);
 
   @protected
   PlatformPointer cst_encode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
-      RwLockNonCloneSimpleTwinSyncSse raw);
+      NonCloneSimpleTwinSyncSse raw);
 
   @protected
   PlatformPointer
       cst_encode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
-          RwLockStructWithGoodAndOpaqueFieldTwinNormal raw);
+          StructWithGoodAndOpaqueFieldTwinNormal raw);
 
   @protected
   PlatformPointer
       cst_encode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSse raw);
+          StructWithGoodAndOpaqueFieldTwinSse raw);
 
   @protected
   PlatformPointer
       cst_encode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
-          RwLockStructWithGoodAndOpaqueFieldTwinSync raw);
+          StructWithGoodAndOpaqueFieldTwinSync raw);
 
   @protected
   PlatformPointer
       cst_encode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSyncSse raw);
+          StructWithGoodAndOpaqueFieldTwinSyncSse raw);
 
   @protected
   int cst_encode_application_mode(ApplicationMode raw);
@@ -16768,197 +16768,191 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void
       sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynFnStringStringSendSyncUnwindSafeRefUnwindSafe(
-          RwLockBoxFnStringString self, SseSerializer serializer);
+          BoxFnStringString self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
-      RwLockBoxHelloTraitTwinNormal self, SseSerializer serializer);
+      BoxHelloTraitTwinNormal self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
-      RwLockBoxHelloTraitTwinSse self, SseSerializer serializer);
+      BoxHelloTraitTwinSse self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
-      RwLockBoxHelloTraitTwinSync self, SseSerializer serializer);
+      BoxHelloTraitTwinSync self, SseSerializer serializer);
 
   @protected
   void
       sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
-          RwLockBoxHelloTraitTwinSyncSse self, SseSerializer serializer);
+          BoxHelloTraitTwinSyncSse self, SseSerializer serializer);
 
   @protected
   void
       sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinNormalSendSync(
-          RwLockBoxMyTraitTwinNormal self, SseSerializer serializer);
+          BoxMyTraitTwinNormal self, SseSerializer serializer);
 
   @protected
   void
       sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSseSendSync(
-          RwLockBoxMyTraitTwinSse self, SseSerializer serializer);
+          BoxMyTraitTwinSse self, SseSerializer serializer);
 
   @protected
   void
       sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSendSync(
-          RwLockBoxMyTraitTwinSync self, SseSerializer serializer);
+          BoxMyTraitTwinSync self, SseSerializer serializer);
 
   @protected
   void
       sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSseSendSync(
-          RwLockBoxMyTraitTwinSyncSse self, SseSerializer serializer);
+          BoxMyTraitTwinSyncSse self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
-      RwLockNonCloneSimpleTwinNormal self, SseSerializer serializer);
+      NonCloneSimpleTwinNormal self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
-      RwLockNonCloneSimpleTwinSse self, SseSerializer serializer);
+      NonCloneSimpleTwinSse self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
-      RwLockNonCloneSimpleTwinSync self, SseSerializer serializer);
+      NonCloneSimpleTwinSync self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
-      RwLockNonCloneSimpleTwinSyncSse self, SseSerializer serializer);
+      NonCloneSimpleTwinSyncSse self, SseSerializer serializer);
 
   @protected
   void
       sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
-          RwLockStructWithGoodAndOpaqueFieldTwinNormal self,
+          StructWithGoodAndOpaqueFieldTwinNormal self,
           SseSerializer serializer);
 
   @protected
   void
       sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSse self,
-          SseSerializer serializer);
+          StructWithGoodAndOpaqueFieldTwinSse self, SseSerializer serializer);
 
   @protected
   void
       sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
-          RwLockStructWithGoodAndOpaqueFieldTwinSync self,
-          SseSerializer serializer);
+          StructWithGoodAndOpaqueFieldTwinSync self, SseSerializer serializer);
 
   @protected
   void
       sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSyncSse self,
+          StructWithGoodAndOpaqueFieldTwinSyncSse self,
           SseSerializer serializer);
 
   @protected
   void
       sse_encode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
-          RwLockBoxHelloTraitTwinNormal self, SseSerializer serializer);
+          BoxHelloTraitTwinNormal self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
-      RwLockBoxHelloTraitTwinSse self, SseSerializer serializer);
+      BoxHelloTraitTwinSse self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
-      RwLockBoxHelloTraitTwinSync self, SseSerializer serializer);
+      BoxHelloTraitTwinSync self, SseSerializer serializer);
 
   @protected
   void
       sse_encode_Auto_RefMut_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
-          RwLockBoxHelloTraitTwinSyncSse self, SseSerializer serializer);
+          BoxHelloTraitTwinSyncSse self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
-      RwLockNonCloneSimpleTwinNormal self, SseSerializer serializer);
+      NonCloneSimpleTwinNormal self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
-      RwLockNonCloneSimpleTwinSse self, SseSerializer serializer);
+      NonCloneSimpleTwinSse self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
-      RwLockNonCloneSimpleTwinSync self, SseSerializer serializer);
+      NonCloneSimpleTwinSync self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_RefMut_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
-      RwLockNonCloneSimpleTwinSyncSse self, SseSerializer serializer);
+      NonCloneSimpleTwinSyncSse self, SseSerializer serializer);
 
   @protected
   void
       sse_encode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
-          RwLockStructWithGoodAndOpaqueFieldTwinNormal self,
+          StructWithGoodAndOpaqueFieldTwinNormal self,
           SseSerializer serializer);
 
   @protected
   void
       sse_encode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSse self,
-          SseSerializer serializer);
+          StructWithGoodAndOpaqueFieldTwinSse self, SseSerializer serializer);
 
   @protected
   void
       sse_encode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
-          RwLockStructWithGoodAndOpaqueFieldTwinSync self,
-          SseSerializer serializer);
+          StructWithGoodAndOpaqueFieldTwinSync self, SseSerializer serializer);
 
   @protected
   void
       sse_encode_Auto_RefMut_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSyncSse self,
+          StructWithGoodAndOpaqueFieldTwinSyncSse self,
           SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
-      RwLockBoxHelloTraitTwinNormal self, SseSerializer serializer);
+      BoxHelloTraitTwinNormal self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
-      RwLockBoxHelloTraitTwinSse self, SseSerializer serializer);
+      BoxHelloTraitTwinSse self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
-      RwLockBoxHelloTraitTwinSync self, SseSerializer serializer);
+      BoxHelloTraitTwinSync self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_Ref_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
-      RwLockBoxHelloTraitTwinSyncSse self, SseSerializer serializer);
+      BoxHelloTraitTwinSyncSse self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
-      RwLockNonCloneSimpleTwinNormal self, SseSerializer serializer);
+      NonCloneSimpleTwinNormal self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
-      RwLockNonCloneSimpleTwinSse self, SseSerializer serializer);
+      NonCloneSimpleTwinSse self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
-      RwLockNonCloneSimpleTwinSync self, SseSerializer serializer);
+      NonCloneSimpleTwinSync self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_Ref_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
-      RwLockNonCloneSimpleTwinSyncSse self, SseSerializer serializer);
+      NonCloneSimpleTwinSyncSse self, SseSerializer serializer);
 
   @protected
   void
       sse_encode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
-          RwLockStructWithGoodAndOpaqueFieldTwinNormal self,
+          StructWithGoodAndOpaqueFieldTwinNormal self,
           SseSerializer serializer);
 
   @protected
   void
       sse_encode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSse self,
-          SseSerializer serializer);
+          StructWithGoodAndOpaqueFieldTwinSse self, SseSerializer serializer);
 
   @protected
   void
       sse_encode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
-          RwLockStructWithGoodAndOpaqueFieldTwinSync self,
-          SseSerializer serializer);
+          StructWithGoodAndOpaqueFieldTwinSync self, SseSerializer serializer);
 
   @protected
   void
       sse_encode_Auto_Ref_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSyncSse self,
+          StructWithGoodAndOpaqueFieldTwinSyncSse self,
           SseSerializer serializer);
 
   @protected
@@ -17126,75 +17120,74 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void
       sse_encode_RustOpaque_stdsyncRwLockBoxdynFnStringStringSendSyncUnwindSafeRefUnwindSafe(
-          RwLockBoxFnStringString self, SseSerializer serializer);
+          BoxFnStringString self, SseSerializer serializer);
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinNormal(
-      RwLockBoxHelloTraitTwinNormal self, SseSerializer serializer);
+      BoxHelloTraitTwinNormal self, SseSerializer serializer);
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSse(
-      RwLockBoxHelloTraitTwinSse self, SseSerializer serializer);
+      BoxHelloTraitTwinSse self, SseSerializer serializer);
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSync(
-      RwLockBoxHelloTraitTwinSync self, SseSerializer serializer);
+      BoxHelloTraitTwinSync self, SseSerializer serializer);
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockBoxdynHelloTraitTwinSyncSse(
-      RwLockBoxHelloTraitTwinSyncSse self, SseSerializer serializer);
+      BoxHelloTraitTwinSyncSse self, SseSerializer serializer);
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinNormalSendSync(
-      RwLockBoxMyTraitTwinNormal self, SseSerializer serializer);
+      BoxMyTraitTwinNormal self, SseSerializer serializer);
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSseSendSync(
-      RwLockBoxMyTraitTwinSse self, SseSerializer serializer);
+      BoxMyTraitTwinSse self, SseSerializer serializer);
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSendSync(
-      RwLockBoxMyTraitTwinSync self, SseSerializer serializer);
+      BoxMyTraitTwinSync self, SseSerializer serializer);
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockBoxdynMyTraitTwinSyncSseSendSync(
-      RwLockBoxMyTraitTwinSyncSse self, SseSerializer serializer);
+      BoxMyTraitTwinSyncSse self, SseSerializer serializer);
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinNormal(
-      RwLockNonCloneSimpleTwinNormal self, SseSerializer serializer);
+      NonCloneSimpleTwinNormal self, SseSerializer serializer);
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSse(
-      RwLockNonCloneSimpleTwinSse self, SseSerializer serializer);
+      NonCloneSimpleTwinSse self, SseSerializer serializer);
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSync(
-      RwLockNonCloneSimpleTwinSync self, SseSerializer serializer);
+      NonCloneSimpleTwinSync self, SseSerializer serializer);
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockNonCloneSimpleTwinSyncSse(
-      RwLockNonCloneSimpleTwinSyncSse self, SseSerializer serializer);
+      NonCloneSimpleTwinSyncSse self, SseSerializer serializer);
 
   @protected
   void
       sse_encode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinNormal(
-          RwLockStructWithGoodAndOpaqueFieldTwinNormal self,
+          StructWithGoodAndOpaqueFieldTwinNormal self,
           SseSerializer serializer);
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSse(
-      RwLockStructWithGoodAndOpaqueFieldTwinSse self, SseSerializer serializer);
+      StructWithGoodAndOpaqueFieldTwinSse self, SseSerializer serializer);
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSync(
-      RwLockStructWithGoodAndOpaqueFieldTwinSync self,
-      SseSerializer serializer);
+      StructWithGoodAndOpaqueFieldTwinSync self, SseSerializer serializer);
 
   @protected
   void
       sse_encode_RustOpaque_stdsyncRwLockStructWithGoodAndOpaqueFieldTwinSyncSse(
-          RwLockStructWithGoodAndOpaqueFieldTwinSyncSse self,
+          StructWithGoodAndOpaqueFieldTwinSyncSse self,
           SseSerializer serializer);
 
   @protected

--- a/frb_example/pure_dart/test/api/pseudo_manual/rust_auto_opaque_twin_sse_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/rust_auto_opaque_twin_sse_test.dart
@@ -190,7 +190,7 @@ Future<void> main({bool skipRustLibInit = false}) async {
   });
 
   group('trait object', () {
-    Future<void> _body(RwLockBoxHelloTraitTwinSse obj, String expect) async {
+    Future<void> _body(BoxHelloTraitTwinSse obj, String expect) async {
       await futurizeVoidTwinSse(
           rustAutoOpaqueTraitObjectArgBorrowTwinSse(arg: obj, expect: expect));
       await futurizeVoidTwinSse(rustAutoOpaqueTraitObjectArgMutBorrowTwinSse(
@@ -210,18 +210,17 @@ Future<void> main({bool skipRustLibInit = false}) async {
   });
 
   test('static method', () async {
-    final obj =
-        await RwLockNonCloneSimpleTwinSse.staticMethodReturnOwnTwinSse();
+    final obj = await NonCloneSimpleTwinSse.staticMethodReturnOwnTwinSse();
     await futurizeVoidTwinSse(
-        RwLockNonCloneSimpleTwinSse.staticMethodArgBorrowTwinSse(arg: obj));
+        NonCloneSimpleTwinSse.staticMethodArgBorrowTwinSse(arg: obj));
     await futurizeVoidTwinSse(
-        RwLockNonCloneSimpleTwinSse.staticMethodArgMutBorrowTwinSse(arg: obj));
+        NonCloneSimpleTwinSse.staticMethodArgMutBorrowTwinSse(arg: obj));
     await futurizeVoidTwinSse(
-        RwLockNonCloneSimpleTwinSse.staticMethodArgOwnTwinSse(arg: obj));
+        NonCloneSimpleTwinSse.staticMethodArgOwnTwinSse(arg: obj));
   });
 
   test('instance method', () async {
-    final obj = await RwLockNonCloneSimpleTwinSse.newTwinSse();
+    final obj = await NonCloneSimpleTwinSse.newTwinSse();
     await futurizeVoidTwinSse(obj.instanceMethodArgBorrowTwinSse());
     await futurizeVoidTwinSse(obj.instanceMethodArgMutBorrowTwinSse());
     await futurizeVoidTwinSse(obj.instanceMethodReturnOwnTwinSse());

--- a/frb_example/pure_dart/test/api/pseudo_manual/rust_auto_opaque_twin_sync_sse_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/rust_auto_opaque_twin_sync_sse_test.dart
@@ -193,8 +193,7 @@ Future<void> main({bool skipRustLibInit = false}) async {
   });
 
   group('trait object', () {
-    Future<void> _body(
-        RwLockBoxHelloTraitTwinSyncSse obj, String expect) async {
+    Future<void> _body(BoxHelloTraitTwinSyncSse obj, String expect) async {
       await futurizeVoidTwinSyncSse(
           rustAutoOpaqueTraitObjectArgBorrowTwinSyncSse(
               arg: obj, expect: expect));
@@ -216,21 +215,19 @@ Future<void> main({bool skipRustLibInit = false}) async {
   });
 
   test('static method', () async {
-    final obj = await RwLockNonCloneSimpleTwinSyncSse
-        .staticMethodReturnOwnTwinSyncSse();
+    final obj =
+        await NonCloneSimpleTwinSyncSse.staticMethodReturnOwnTwinSyncSse();
     await futurizeVoidTwinSyncSse(
-        RwLockNonCloneSimpleTwinSyncSse.staticMethodArgBorrowTwinSyncSse(
+        NonCloneSimpleTwinSyncSse.staticMethodArgBorrowTwinSyncSse(arg: obj));
+    await futurizeVoidTwinSyncSse(
+        NonCloneSimpleTwinSyncSse.staticMethodArgMutBorrowTwinSyncSse(
             arg: obj));
     await futurizeVoidTwinSyncSse(
-        RwLockNonCloneSimpleTwinSyncSse.staticMethodArgMutBorrowTwinSyncSse(
-            arg: obj));
-    await futurizeVoidTwinSyncSse(
-        RwLockNonCloneSimpleTwinSyncSse.staticMethodArgOwnTwinSyncSse(
-            arg: obj));
+        NonCloneSimpleTwinSyncSse.staticMethodArgOwnTwinSyncSse(arg: obj));
   });
 
   test('instance method', () async {
-    final obj = await RwLockNonCloneSimpleTwinSyncSse.newTwinSyncSse();
+    final obj = await NonCloneSimpleTwinSyncSse.newTwinSyncSse();
     await futurizeVoidTwinSyncSse(obj.instanceMethodArgBorrowTwinSyncSse());
     await futurizeVoidTwinSyncSse(obj.instanceMethodArgMutBorrowTwinSyncSse());
     await futurizeVoidTwinSyncSse(obj.instanceMethodReturnOwnTwinSyncSse());

--- a/frb_example/pure_dart/test/api/pseudo_manual/rust_auto_opaque_twin_sync_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/rust_auto_opaque_twin_sync_test.dart
@@ -190,7 +190,7 @@ Future<void> main({bool skipRustLibInit = false}) async {
   });
 
   group('trait object', () {
-    Future<void> _body(RwLockBoxHelloTraitTwinSync obj, String expect) async {
+    Future<void> _body(BoxHelloTraitTwinSync obj, String expect) async {
       await futurizeVoidTwinSync(
           rustAutoOpaqueTraitObjectArgBorrowTwinSync(arg: obj, expect: expect));
       await futurizeVoidTwinSync(rustAutoOpaqueTraitObjectArgMutBorrowTwinSync(
@@ -210,19 +210,17 @@ Future<void> main({bool skipRustLibInit = false}) async {
   });
 
   test('static method', () async {
-    final obj =
-        await RwLockNonCloneSimpleTwinSync.staticMethodReturnOwnTwinSync();
+    final obj = await NonCloneSimpleTwinSync.staticMethodReturnOwnTwinSync();
     await futurizeVoidTwinSync(
-        RwLockNonCloneSimpleTwinSync.staticMethodArgBorrowTwinSync(arg: obj));
+        NonCloneSimpleTwinSync.staticMethodArgBorrowTwinSync(arg: obj));
     await futurizeVoidTwinSync(
-        RwLockNonCloneSimpleTwinSync.staticMethodArgMutBorrowTwinSync(
-            arg: obj));
+        NonCloneSimpleTwinSync.staticMethodArgMutBorrowTwinSync(arg: obj));
     await futurizeVoidTwinSync(
-        RwLockNonCloneSimpleTwinSync.staticMethodArgOwnTwinSync(arg: obj));
+        NonCloneSimpleTwinSync.staticMethodArgOwnTwinSync(arg: obj));
   });
 
   test('instance method', () async {
-    final obj = await RwLockNonCloneSimpleTwinSync.newTwinSync();
+    final obj = await NonCloneSimpleTwinSync.newTwinSync();
     await futurizeVoidTwinSync(obj.instanceMethodArgBorrowTwinSync());
     await futurizeVoidTwinSync(obj.instanceMethodArgMutBorrowTwinSync());
     await futurizeVoidTwinSync(obj.instanceMethodReturnOwnTwinSync());

--- a/frb_example/pure_dart/test/api/rust_auto_opaque_test.dart
+++ b/frb_example/pure_dart/test/api/rust_auto_opaque_test.dart
@@ -188,7 +188,7 @@ Future<void> main({bool skipRustLibInit = false}) async {
   });
 
   group('trait object', () {
-    Future<void> _body(RwLockBoxHelloTraitTwinNormal obj, String expect) async {
+    Future<void> _body(BoxHelloTraitTwinNormal obj, String expect) async {
       await futurizeVoidTwinNormal(rustAutoOpaqueTraitObjectArgBorrowTwinNormal(
           arg: obj, expect: expect));
       await futurizeVoidTwinNormal(
@@ -210,19 +210,17 @@ Future<void> main({bool skipRustLibInit = false}) async {
 
   test('static method', () async {
     final obj =
-        await RwLockNonCloneSimpleTwinNormal.staticMethodReturnOwnTwinNormal();
+        await NonCloneSimpleTwinNormal.staticMethodReturnOwnTwinNormal();
     await futurizeVoidTwinNormal(
-        RwLockNonCloneSimpleTwinNormal.staticMethodArgBorrowTwinNormal(
-            arg: obj));
+        NonCloneSimpleTwinNormal.staticMethodArgBorrowTwinNormal(arg: obj));
     await futurizeVoidTwinNormal(
-        RwLockNonCloneSimpleTwinNormal.staticMethodArgMutBorrowTwinNormal(
-            arg: obj));
+        NonCloneSimpleTwinNormal.staticMethodArgMutBorrowTwinNormal(arg: obj));
     await futurizeVoidTwinNormal(
-        RwLockNonCloneSimpleTwinNormal.staticMethodArgOwnTwinNormal(arg: obj));
+        NonCloneSimpleTwinNormal.staticMethodArgOwnTwinNormal(arg: obj));
   });
 
   test('instance method', () async {
-    final obj = await RwLockNonCloneSimpleTwinNormal.newTwinNormal();
+    final obj = await NonCloneSimpleTwinNormal.newTwinNormal();
     await futurizeVoidTwinNormal(obj.instanceMethodArgBorrowTwinNormal());
     await futurizeVoidTwinNormal(obj.instanceMethodArgMutBorrowTwinNormal());
     await futurizeVoidTwinNormal(obj.instanceMethodReturnOwnTwinNormal());


### PR DESCRIPTION
## Changes

_Please list issues fixed by this PR here, using format "Fixes #the-issue-number"._

## Checklist

- [ ] An issue to be fixed by this PR is listed above.
- [ ] New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api/whatever.rs` and `test/api/whatever_test.dart`.
- [ ] `./frb_internal precommit --mode slow` (or `fast`) is run (it internal runs code generator, does auto formatting, etc).
- [ ] If this PR adds/changes features, documentations (in the `./website` folder) are updated.
- [ ] CI is passing. (Operations are reproducible using corresponding `./frb_internal something` commands shown in CI.)

## Remark for PR creator

- `./frb_internal --help` shows utilities for development.
- If fzyzcjy does not reply for a few days, maybe he just did not see it, so please ping him.
