### PR TITLE
fix: Don't impl test for WASM targets.

### DIFF
--- a/frb_rust/src/misc/into_into_dart.rs
+++ b/frb_rust/src/misc/into_into_dart.rs
@@ -152,14 +152,13 @@ mod chrono_impls {
 }
 
 #[cfg(test)]
-#[cfg(not(target_family = "wasm"))]
 mod tests {
     use crate::misc::into_into_dart::IntoIntoDart;
-    use allo_isolate::ZeroCopyBuffer;
 
+    #[cfg(not(target_family = "wasm"))]
     #[test]
     fn test_zero_copy_buffer() {
-        let raw: ZeroCopyBuffer<Vec<u8>> = ZeroCopyBuffer(vec![10]);
+        let raw: allo_isolate::ZeroCopyBuffer<Vec<u8>> = allo_isolate::ZeroCopyBuffer(vec![10]);
         assert_eq!(raw.into_into_dart().0, vec![10]);
     }
 }

--- a/frb_rust/src/misc/into_into_dart.rs
+++ b/frb_rust/src/misc/into_into_dart.rs
@@ -152,6 +152,7 @@ mod chrono_impls {
 }
 
 #[cfg(test)]
+#[cfg(not(target_family = "wasm"))]
 mod tests {
     use crate::misc::into_into_dart::IntoIntoDart;
     use allo_isolate::ZeroCopyBuffer;


### PR DESCRIPTION
For WASM allo-isolate is not used.
This let's for example `./frb_internal precommit --mode fast` fail.


## Changes

_Please list issues fixed by this PR here, using format "Fixes #the-issue-number"._

## Checklist

- [ ] An issue to be fixed by this PR is listed above.
- [ ] New tests are added to ensure new features are working. End-to-end tests are usually in the `./frb_example/pure_dart` example, more specifically, `rust/src/api/whatever.rs` and `test/api/whatever_test.dart`.
- [ ] `./frb_internal precommit --mode slow` (or `fast`) is run (it internal runs code generator, does auto formatting, etc).
- [ ] If this PR adds/changes features, documentations (in the `./website` folder) are updated.
- [ ] CI is passing. (Operations are reproducible using corresponding `./frb_internal something` commands shown in CI.)

## Remark for PR creator

- `./frb_internal --help` shows utilities for development.
- If fzyzcjy does not reply for a few days, maybe he just did not see it, so please ping him.
