### PR TITLE
refactor: remove double-allocation for enum CST decode

### DIFF
--- a/frb_codegen/assets/integration_template/rust/src/frb_generated.io.rs
+++ b/frb_codegen/assets/integration_template/rust/src/frb_generated.io.rs
@@ -68,7 +68,7 @@ pub extern "C" fn cst_new_list_prim_u_8(len: i32) -> *mut wire_cst_list_prim_u_8
 }
 
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_prim_u_8 {
     ptr: *mut u8,
     len: i32,

--- a/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/codec/cst/encoder/ty/enumeration.rs
+++ b/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/codec/cst/encoder/ty/enumeration.rs
@@ -44,7 +44,6 @@ impl<'a> WireDartCodecCstGeneratorEncoderTrait for EnumRefWireDartCodecCstGenera
 
 impl<'a> EnumRefWireDartCodecCstGenerator<'a> {
     fn generate_api_fill_to_wire_body_variant(&self, index: usize, variant: &IrVariant) -> String {
-        let ident = &self.ir.ident.0.name;
         let wrapper_name = &variant.wrapper_name;
         let variant_name = &variant.name;
 
@@ -64,19 +63,16 @@ impl<'a> EnumRefWireDartCodecCstGenerator<'a> {
                     })
                     .join("\n");
 
-                let stmt_set_kind =
-                    format!("wireObj.kind = wire.cst_inflate_{ident}_{variant_name}();");
-
-                let r = format!("wireObj.kind.ref.{variant_name}.ref");
+                let r = format!("wireObj.kind.{variant_name}");
                 let body = st
                     .fields
                     .iter()
                     .map(|field| {
-                        format!("{r}.{name} = pre_{name};", name = field.name.rust_style(),)
+                        format!("{r}.{name} = pre_{name};", name = field.name.rust_style())
                     })
                     .join("\n");
 
-                (pre_field, stmt_set_kind + &body)
+                (pre_field, body)
             }
         };
 

--- a/frb_codegen/src/library/codegen/generator/wire/rust/spec_generator/codec/cst/decoder/ty/enumeration.rs
+++ b/frb_codegen/src/library/codegen/generator/wire/rust/spec_generator/codec/cst/decoder/ty/enumeration.rs
@@ -1,15 +1,17 @@
 use crate::codegen::generator::acc::Acc;
 use crate::codegen::generator::misc::target::{Target, TargetOrCommon};
-use crate::codegen::generator::wire::rust::spec_generator::extern_func::{ExternClass, ExternClassMode, ExternFunc};
+use crate::codegen::generator::wire::rust::spec_generator::extern_func::{ExternClass, ExternClassMode};
 use crate::codegen::generator::wire::rust::spec_generator::output_code::WireRustOutputCode;
 use crate::codegen::generator::wire::rust::spec_generator::codec::cst::base::*;
 use crate::codegen::generator::wire::rust::spec_generator::codec::cst::decoder::ty::WireRustCodecCstGeneratorDecoderTrait;
-use crate::codegen::ir::field::IrField;
+use crate::codegen::ir::ident::IrIdent;
 use crate::codegen::ir::ty::enumeration::{IrEnum, IrEnumMode, IrVariant, IrVariantKind};
-use crate::codegen::ir::ty::IrType;
+use crate::codegen::ir::ty::structure::IrStruct;
 use itertools::Itertools;
 use crate::codegen::generator::wire::rust::spec_generator::codec::cst::decoder::impl_new_with_nullptr::generate_impl_new_with_nullptr_code_block;
 use crate::codegen::generator::wire::rust::spec_generator::codec::cst::decoder::misc::rust_wire_type_add_prefix_or_js_value;
+
+const NIL_FIELD: &str = "nil__";
 
 impl<'a> WireRustCodecCstGeneratorDecoderTrait for EnumRefWireRustCodecCstGenerator<'a> {
     fn generate_decoder_class(&self) -> Option<WireRustOutputCode> {
@@ -22,32 +24,37 @@ impl<'a> WireRustCodecCstGeneratorDecoderTrait for EnumRefWireRustCodecCstGenera
 
         let union_fields = variants
             .iter()
-            .map(|variant| {
-                format!(
-                    "{0}: *mut wire_cst_{1}_{0},",
+            .filter_map(|variant| match variant.kind {
+                IrVariantKind::Value => None,
+                IrVariantKind::Struct(_) => Some(format!(
+                    "{0}: wire_cst_{1}_{0},",
                     variant.name, self.ir.ident.0.name
-                )
+                )),
             })
+            .chain(Some(format!("{NIL_FIELD}: (),")))
             .join("\n");
 
         let rust_wire_type = self.rust_wire_type(Target::Io);
         let name = &self.ir.ident.0.name;
+        let union_kind = format!("{name}Kind");
 
         let mut extern_classes = vec![
             ExternClass {
                 name: rust_wire_type,
                 mode: ExternClassMode::Struct,
-                body: format!("tag: i32, kind: *mut {name}Kind",),
+                body: format!("tag: i32, kind: {union_kind},"),
             },
             ExternClass {
-                name: format!("{name}Kind"),
+                name: union_kind,
                 mode: ExternClassMode::Union,
                 body: union_fields,
             },
         ];
 
-        extern_classes
-            .extend((variants.iter()).map(|variant| self.generate_decoder_class_variant(variant)));
+        extern_classes.extend(variants.iter().filter_map(|variant| match &variant.kind {
+            IrVariantKind::Value => None,
+            IrVariantKind::Struct(s) => Some(self.generate_decoder_enum_variant(&variant.name, s)),
+        }));
 
         Some(WireRustOutputCode {
             extern_classes,
@@ -93,21 +100,13 @@ impl<'a> WireRustCodecCstGeneratorDecoderTrait for EnumRefWireRustCodecCstGenera
     }
 
     fn generate_impl_new_with_nullptr(&self) -> Option<WireRustOutputCode> {
-        let src = self.ir.get(self.context.ir_pack);
-
-        let inflators = src
-            .variants()
-            .iter()
-            .filter_map(|variant| self.generate_impl_new_with_nullptr_variant(variant))
-            .collect_vec();
-
+        let name = &self.ir.ident.0.name;
         Some(WireRustOutputCode {
             body: generate_impl_new_with_nullptr_code_block(
                 self.ir.clone(),
                 self.context,
-                "Self { tag: -1, kind: core::ptr::null_mut() }",
+                &format!("Self {{ tag: -1, kind: {name}Kind {{ {NIL_FIELD}: () }} }}"),
             ),
-            extern_funcs: inflators,
             ..Default::default()
         })
     }
@@ -118,73 +117,30 @@ impl<'a> WireRustCodecCstGeneratorDecoderTrait for EnumRefWireRustCodecCstGenera
 }
 
 impl<'a> EnumRefWireRustCodecCstGenerator<'a> {
-    fn generate_decoder_class_variant(&self, variant: &IrVariant) -> ExternClass {
-        let fields = match &variant.kind {
-            IrVariantKind::Value => vec![],
-            IrVariantKind::Struct(s) => s
-                .fields
-                .iter()
-                .map(|field| {
-                    let field_generator =
-                        WireRustCodecCstGenerator::new(field.ty.clone(), self.context);
-                    format!(
-                        "{}: {}{},",
-                        field.name.rust_style(),
-                        field_generator.rust_wire_modifier(Target::Io),
-                        field_generator.rust_wire_type(Target::Io)
-                    )
-                })
-                .collect(),
-        };
+    fn generate_decoder_enum_variant(
+        &self,
+        variant_name: &IrIdent,
+        r#struct: &IrStruct,
+    ) -> ExternClass {
+        let fields = r#struct
+            .fields
+            .iter()
+            .map(|field| {
+                let field_generator =
+                    WireRustCodecCstGenerator::new(field.ty.clone(), self.context);
+                format!(
+                    "{}: {}{},",
+                    field.name.rust_style(),
+                    field_generator.rust_wire_modifier(Target::Io),
+                    field_generator.rust_wire_type(Target::Io)
+                )
+            })
+            .collect::<Vec<_>>();
         ExternClass {
-            name: format!("wire_cst_{}_{}", self.ir.ident.0.name, variant.name,),
+            name: format!("wire_cst_{}_{}", self.ir.ident.0.name, variant_name),
             mode: ExternClassMode::Struct,
             body: fields.join("\n"),
         }
-    }
-
-    fn generate_impl_new_with_nullptr_variant(&self, variant: &IrVariant) -> Option<ExternFunc> {
-        let typ = format!("{}_{}", self.ir.ident.0.name, variant.name);
-        let body = if let IrVariantKind::Struct(st) = &variant.kind {
-            st.fields
-                .iter()
-                .map(|field| self.generate_impl_new_with_nullptr_variant_field(field))
-                .collect_vec()
-        } else {
-            return None;
-        };
-
-        Some(ExternFunc {
-            func_name: format!("cst_inflate_{typ}"),
-            params: vec![],
-            return_type: Some(format!("*mut {}Kind", self.ir.ident.0.name)),
-            body: format!(
-                "flutter_rust_bridge::for_generated::new_leak_box_ptr({}Kind {{
-                    {}: flutter_rust_bridge::for_generated::new_leak_box_ptr({} {{
-                        {}
-                    }})
-                }})",
-                self.ir.ident.0.name,
-                variant.name.rust_style(),
-                format_args!("wire_cst_{typ}"),
-                body.join(",")
-            ),
-            target: Target::Io,
-        })
-    }
-
-    fn generate_impl_new_with_nullptr_variant_field(&self, field: &IrField) -> String {
-        let ty_generator = WireRustCodecCstGenerator::new(field.ty.clone(), self.context);
-
-        let init = if ty_generator.rust_wire_is_pointer(Target::Io)
-            || matches!(field.ty, IrType::RustOpaque(_) | IrType::DartOpaque(_))
-        {
-            "core::ptr::null_mut()".to_owned()
-        } else {
-            "Default::default()".to_owned()
-        };
-
-        format!("{field_name}: {init}", field_name = field.name.rust_style())
     }
 }
 
@@ -227,9 +183,8 @@ fn generate_impl_cst_decode_body_variant(
                 format!("{idx} => {{ {enum_name}::{variant_name}{left}{fields}{right} }},")
             } else {
                 format!(
-                    "{idx} => unsafe {{
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.{variant_name});
+                    "{idx} => {{
+                        let ans = unsafe {{ self.kind.{variant_name} }};
                         {enum_name}::{variant_name}{left}{fields}{right}
                     }}",
                 )

--- a/frb_codegen/src/library/codegen/generator/wire/rust/spec_generator/extern_func.rs
+++ b/frb_codegen/src/library/codegen/generator/wire/rust/spec_generator/extern_func.rs
@@ -102,16 +102,11 @@ impl ExternClass {
     pub(crate) fn generate(&self) -> String {
         let ExternClass { name, mode, body } = self;
 
-        let derive = match mode {
-            ExternClassMode::Struct => "#[derive(Clone)]",
-            ExternClassMode::Union => "",
-        };
-
         let mode = match mode {
             ExternClassMode::Struct => "struct",
             ExternClassMode::Union => "union",
         };
 
-        format!("#[repr(C)] {derive} pub {mode} {name} {{ {body} }}")
+        format!("#[repr(C)] #[derive(Clone, Copy)] pub {mode} {name} {{ {body} }}")
     }
 }

--- a/frb_example/flutter_via_create/rust/src/frb_generated.io.rs
+++ b/frb_example/flutter_via_create/rust/src/frb_generated.io.rs
@@ -68,7 +68,7 @@ pub extern "C" fn cst_new_list_prim_u_8(len: i32) -> *mut wire_cst_list_prim_u_8
 }
 
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_prim_u_8 {
     ptr: *mut u8,
     len: i32,

--- a/frb_example/flutter_via_integrate/rust/src/frb_generated.io.rs
+++ b/frb_example/flutter_via_integrate/rust/src/frb_generated.io.rs
@@ -68,7 +68,7 @@ pub extern "C" fn cst_new_list_prim_u_8(len: i32) -> *mut wire_cst_list_prim_u_8
 }
 
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_prim_u_8 {
     ptr: *mut u8,
     len: i32,

--- a/frb_example/gallery/lib/src/ignore_me/polars_related.dart
+++ b/frb_example/gallery/lib/src/ignore_me/polars_related.dart
@@ -8,8 +8,7 @@ class SimpleTable {
   const SimpleTable({required this.names, required this.data});
 }
 
-// TODO remove this "RwLock" prefix
-Future<SimpleTable> convertToSimpleTable(RwLockDataFrame df) async {
+Future<SimpleTable> convertToSimpleTable(DataFrame df) async {
   final columnNames = df.getColumnNames();
   return SimpleTable(
     names: columnNames,

--- a/frb_example/gallery/lib/src/rust/api/polars.dart
+++ b/frb_example/gallery/lib/src/rust/api/polars.dart
@@ -6,30 +6,30 @@
 import '../frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-Future<RwLockDataFrame> readSampleDataset({dynamic hint}) =>
+Future<DataFrame> readSampleDataset({dynamic hint}) =>
     RustLib.instance.api.readSampleDataset(hint: hint);
 
-RwLockExpr col({required String name, dynamic hint}) =>
+Expr col({required String name, dynamic hint}) =>
     RustLib.instance.api.col(name: name, hint: hint);
 
-RwLockExpr lit({required double t, dynamic hint}) =>
+Expr lit({required double t, dynamic hint}) =>
     RustLib.instance.api.lit(t: t, hint: hint);
 
 // Rust type: flutter_rust_bridge::RustOpaque<std::sync::RwLock<DataFrame>>
 @sealed
-class RwLockDataFrame extends RustOpaque {
-  RwLockDataFrame.dcoDecode(dynamic wire) : super.dcoDecode(wire, _kStaticData);
+class DataFrame extends RustOpaque {
+  DataFrame.dcoDecode(dynamic wire) : super.dcoDecode(wire, _kStaticData);
 
-  RwLockDataFrame.sseDecode(int ptr, int externalSizeOnNative)
+  DataFrame.sseDecode(int ptr, int externalSizeOnNative)
       : super.sseDecode(ptr, externalSizeOnNative, _kStaticData);
 
   static final _kStaticData = RustArcStaticData(
     rustArcIncrementStrongCount:
-        RustLib.instance.api.rust_arc_increment_strong_count_RwLockDataFrame,
+        RustLib.instance.api.rust_arc_increment_strong_count_DataFrame,
     rustArcDecrementStrongCount:
-        RustLib.instance.api.rust_arc_decrement_strong_count_RwLockDataFrame,
+        RustLib.instance.api.rust_arc_decrement_strong_count_DataFrame,
     rustArcDecrementStrongCountPtr:
-        RustLib.instance.api.rust_arc_decrement_strong_count_RwLockDataFramePtr,
+        RustLib.instance.api.rust_arc_decrement_strong_count_DataFramePtr,
   );
 
   Future<List<String>> getColumn({required String name, dynamic hint}) =>
@@ -43,68 +43,67 @@ class RwLockDataFrame extends RustOpaque {
         that: this,
       );
 
-  RwLockLazyFrame lazy({dynamic hint}) => RustLib.instance.api.dataFrameLazy(
+  LazyFrame lazy({dynamic hint}) => RustLib.instance.api.dataFrameLazy(
         that: this,
       );
 }
 
 // Rust type: flutter_rust_bridge::RustOpaque<std::sync::RwLock<Expr>>
 @sealed
-class RwLockExpr extends RustOpaque {
-  RwLockExpr.dcoDecode(dynamic wire) : super.dcoDecode(wire, _kStaticData);
+class Expr extends RustOpaque {
+  Expr.dcoDecode(dynamic wire) : super.dcoDecode(wire, _kStaticData);
 
-  RwLockExpr.sseDecode(int ptr, int externalSizeOnNative)
+  Expr.sseDecode(int ptr, int externalSizeOnNative)
       : super.sseDecode(ptr, externalSizeOnNative, _kStaticData);
 
   static final _kStaticData = RustArcStaticData(
     rustArcIncrementStrongCount:
-        RustLib.instance.api.rust_arc_increment_strong_count_RwLockExpr,
+        RustLib.instance.api.rust_arc_increment_strong_count_Expr,
     rustArcDecrementStrongCount:
-        RustLib.instance.api.rust_arc_decrement_strong_count_RwLockExpr,
+        RustLib.instance.api.rust_arc_decrement_strong_count_Expr,
     rustArcDecrementStrongCountPtr:
-        RustLib.instance.api.rust_arc_decrement_strong_count_RwLockExprPtr,
+        RustLib.instance.api.rust_arc_decrement_strong_count_ExprPtr,
   );
 
-  RwLockExpr gt({required RwLockExpr other, dynamic hint}) =>
-      RustLib.instance.api.exprGt(
+  Expr gt({required Expr other, dynamic hint}) => RustLib.instance.api.exprGt(
         that: this,
         other: other,
       );
 
-  RwLockExpr sum({dynamic hint}) => RustLib.instance.api.exprSum(
+  Expr sum({dynamic hint}) => RustLib.instance.api.exprSum(
         that: this,
       );
 }
 
 // Rust type: flutter_rust_bridge::RustOpaque<std::sync::RwLock<LazyFrame>>
 @sealed
-class RwLockLazyFrame extends RustOpaque {
-  RwLockLazyFrame.dcoDecode(dynamic wire) : super.dcoDecode(wire, _kStaticData);
+class LazyFrame extends RustOpaque {
+  LazyFrame.dcoDecode(dynamic wire) : super.dcoDecode(wire, _kStaticData);
 
-  RwLockLazyFrame.sseDecode(int ptr, int externalSizeOnNative)
+  LazyFrame.sseDecode(int ptr, int externalSizeOnNative)
       : super.sseDecode(ptr, externalSizeOnNative, _kStaticData);
 
   static final _kStaticData = RustArcStaticData(
     rustArcIncrementStrongCount:
-        RustLib.instance.api.rust_arc_increment_strong_count_RwLockLazyFrame,
+        RustLib.instance.api.rust_arc_increment_strong_count_LazyFrame,
     rustArcDecrementStrongCount:
-        RustLib.instance.api.rust_arc_decrement_strong_count_RwLockLazyFrame,
+        RustLib.instance.api.rust_arc_decrement_strong_count_LazyFrame,
     rustArcDecrementStrongCountPtr:
-        RustLib.instance.api.rust_arc_decrement_strong_count_RwLockLazyFramePtr,
+        RustLib.instance.api.rust_arc_decrement_strong_count_LazyFramePtr,
   );
 
-  Future<RwLockDataFrame> collect({dynamic hint}) =>
+  Future<DataFrame> collect({dynamic hint}) =>
       RustLib.instance.api.lazyFrameCollect(
         that: this,
       );
 
-  RwLockLazyFrame filter({required RwLockExpr predicate, dynamic hint}) =>
+  LazyFrame filter({required Expr predicate, dynamic hint}) =>
       RustLib.instance.api.lazyFrameFilter(
         that: this,
         predicate: predicate,
       );
 
-  RwLockLazyGroupBy groupBy({required RwLockExpr expr, dynamic hint}) =>
+  LazyGroupBy groupBy({required Expr expr, dynamic hint}) =>
       RustLib.instance.api.lazyFrameGroupBy(
         that: this,
         expr: expr,
@@ -113,23 +112,22 @@ class RwLockLazyFrame extends RustOpaque {
 
 // Rust type: flutter_rust_bridge::RustOpaque<std::sync::RwLock<LazyGroupBy>>
 @sealed
-class RwLockLazyGroupBy extends RustOpaque {
-  RwLockLazyGroupBy.dcoDecode(dynamic wire)
-      : super.dcoDecode(wire, _kStaticData);
+class LazyGroupBy extends RustOpaque {
+  LazyGroupBy.dcoDecode(dynamic wire) : super.dcoDecode(wire, _kStaticData);
 
-  RwLockLazyGroupBy.sseDecode(int ptr, int externalSizeOnNative)
+  LazyGroupBy.sseDecode(int ptr, int externalSizeOnNative)
       : super.sseDecode(ptr, externalSizeOnNative, _kStaticData);
 
   static final _kStaticData = RustArcStaticData(
     rustArcIncrementStrongCount:
-        RustLib.instance.api.rust_arc_increment_strong_count_RwLockLazyGroupBy,
+        RustLib.instance.api.rust_arc_increment_strong_count_LazyGroupBy,
     rustArcDecrementStrongCount:
-        RustLib.instance.api.rust_arc_decrement_strong_count_RwLockLazyGroupBy,
-    rustArcDecrementStrongCountPtr: RustLib
-        .instance.api.rust_arc_decrement_strong_count_RwLockLazyGroupByPtr,
+        RustLib.instance.api.rust_arc_decrement_strong_count_LazyGroupBy,
+    rustArcDecrementStrongCountPtr:
+        RustLib.instance.api.rust_arc_decrement_strong_count_LazyGroupByPtr,
   );
 
-  RwLockLazyFrame agg({required RwLockExpr expr, dynamic hint}) =>
+  LazyFrame agg({required Expr expr, dynamic hint}) =>
       RustLib.instance.api.lazyGroupByAgg(
         that: this,
         expr: expr,

--- a/frb_example/gallery/lib/src/rust/frb_generated.dart
+++ b/frb_example/gallery/lib/src/rust/frb_generated.dart
@@ -65,74 +65,62 @@ abstract class RustLibApi extends BaseApi {
       dynamic hint});
 
   Future<List<String>> dataFrameGetColumn(
-      {required RwLockDataFrame that, required String name, dynamic hint});
+      {required DataFrame that, required String name, dynamic hint});
 
-  List<String> dataFrameGetColumnNames(
-      {required RwLockDataFrame that, dynamic hint});
+  List<String> dataFrameGetColumnNames({required DataFrame that, dynamic hint});
 
-  RwLockLazyFrame dataFrameLazy({required RwLockDataFrame that, dynamic hint});
+  LazyFrame dataFrameLazy({required DataFrame that, dynamic hint});
 
-  RwLockExpr exprGt(
-      {required RwLockExpr that, required RwLockExpr other, dynamic hint});
+  Expr exprGt({required Expr that, required Expr other, dynamic hint});
 
-  RwLockExpr exprSum({required RwLockExpr that, dynamic hint});
+  Expr exprSum({required Expr that, dynamic hint});
 
-  Future<RwLockDataFrame> lazyFrameCollect(
-      {required RwLockLazyFrame that, dynamic hint});
+  Future<DataFrame> lazyFrameCollect({required LazyFrame that, dynamic hint});
 
-  RwLockLazyFrame lazyFrameFilter(
-      {required RwLockLazyFrame that,
-      required RwLockExpr predicate,
-      dynamic hint});
+  LazyFrame lazyFrameFilter(
+      {required LazyFrame that, required Expr predicate, dynamic hint});
 
-  RwLockLazyGroupBy lazyFrameGroupBy(
-      {required RwLockLazyFrame that, required RwLockExpr expr, dynamic hint});
+  LazyGroupBy lazyFrameGroupBy(
+      {required LazyFrame that, required Expr expr, dynamic hint});
 
-  RwLockLazyFrame lazyGroupByAgg(
-      {required RwLockLazyGroupBy that,
-      required RwLockExpr expr,
-      dynamic hint});
+  LazyFrame lazyGroupByAgg(
+      {required LazyGroupBy that, required Expr expr, dynamic hint});
 
-  RwLockExpr col({required String name, dynamic hint});
+  Expr col({required String name, dynamic hint});
 
-  RwLockExpr lit({required double t, dynamic hint});
+  Expr lit({required double t, dynamic hint});
 
-  Future<RwLockDataFrame> readSampleDataset({dynamic hint});
+  Future<DataFrame> readSampleDataset({dynamic hint});
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockDataFrame;
+      get rust_arc_increment_strong_count_DataFrame;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockDataFrame;
+      get rust_arc_decrement_strong_count_DataFrame;
 
-  CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockDataFramePtr;
+  CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_DataFramePtr;
+
+  RustArcIncrementStrongCountFnType get rust_arc_increment_strong_count_Expr;
+
+  RustArcDecrementStrongCountFnType get rust_arc_decrement_strong_count_Expr;
+
+  CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_ExprPtr;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockExpr;
+      get rust_arc_increment_strong_count_LazyFrame;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockExpr;
+      get rust_arc_decrement_strong_count_LazyFrame;
 
-  CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_RwLockExprPtr;
+  CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_LazyFramePtr;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockLazyFrame;
+      get rust_arc_increment_strong_count_LazyGroupBy;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockLazyFrame;
+      get rust_arc_decrement_strong_count_LazyGroupBy;
 
-  CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockLazyFramePtr;
-
-  RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockLazyGroupBy;
-
-  RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockLazyGroupBy;
-
-  CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockLazyGroupByPtr;
+  CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_LazyGroupByPtr;
 }
 
 class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
@@ -176,7 +164,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<List<String>> dataFrameGetColumn(
-      {required RwLockDataFrame that, required String name, dynamic hint}) {
+      {required DataFrame that, required String name, dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         var arg0 = cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockDataFrame(that);
@@ -201,7 +189,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   List<String> dataFrameGetColumnNames(
-      {required RwLockDataFrame that, dynamic hint}) {
+      {required DataFrame that, dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         var arg0 = cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockDataFrame(that);
@@ -224,7 +212,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  RwLockLazyFrame dataFrameLazy({required RwLockDataFrame that, dynamic hint}) {
+  LazyFrame dataFrameLazy({required DataFrame that, dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         var arg0 =
@@ -249,8 +237,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  RwLockExpr exprGt(
-      {required RwLockExpr that, required RwLockExpr other, dynamic hint}) {
+  Expr exprGt({required Expr that, required Expr other, dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         var arg0 = cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockExpr(that);
@@ -274,7 +261,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  RwLockExpr exprSum({required RwLockExpr that, dynamic hint}) {
+  Expr exprSum({required Expr that, dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         var arg0 = cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockExpr(that);
@@ -297,8 +284,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<RwLockDataFrame> lazyFrameCollect(
-      {required RwLockLazyFrame that, dynamic hint}) {
+  Future<DataFrame> lazyFrameCollect({required LazyFrame that, dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         var arg0 =
@@ -323,10 +309,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  RwLockLazyFrame lazyFrameFilter(
-      {required RwLockLazyFrame that,
-      required RwLockExpr predicate,
-      dynamic hint}) {
+  LazyFrame lazyFrameFilter(
+      {required LazyFrame that, required Expr predicate, dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         var arg0 =
@@ -353,8 +337,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  RwLockLazyGroupBy lazyFrameGroupBy(
-      {required RwLockLazyFrame that, required RwLockExpr expr, dynamic hint}) {
+  LazyGroupBy lazyFrameGroupBy(
+      {required LazyFrame that, required Expr expr, dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         var arg0 =
@@ -380,10 +364,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  RwLockLazyFrame lazyGroupByAgg(
-      {required RwLockLazyGroupBy that,
-      required RwLockExpr expr,
-      dynamic hint}) {
+  LazyFrame lazyGroupByAgg(
+      {required LazyGroupBy that, required Expr expr, dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         var arg0 =
@@ -409,7 +391,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  RwLockExpr col({required String name, dynamic hint}) {
+  Expr col({required String name, dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         var arg0 = cst_encode_String(name);
@@ -432,7 +414,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  RwLockExpr lit({required double t, dynamic hint}) {
+  Expr lit({required double t, dynamic hint}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         var arg0 = cst_encode_f_64(t);
@@ -455,7 +437,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<RwLockDataFrame> readSampleDataset({dynamic hint}) {
+  Future<DataFrame> readSampleDataset({dynamic hint}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         return wire.wire_read_sample_dataset(port_);
@@ -478,35 +460,33 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockDataFrame => wire
+      get rust_arc_increment_strong_count_DataFrame => wire
           .rust_arc_increment_strong_count_RustOpaque_stdsyncRwLockDataFrame;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockDataFrame => wire
+      get rust_arc_decrement_strong_count_DataFrame => wire
           .rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockDataFrame;
 
-  RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockExpr =>
-          wire.rust_arc_increment_strong_count_RustOpaque_stdsyncRwLockExpr;
+  RustArcIncrementStrongCountFnType get rust_arc_increment_strong_count_Expr =>
+      wire.rust_arc_increment_strong_count_RustOpaque_stdsyncRwLockExpr;
 
-  RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockExpr =>
-          wire.rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockExpr;
+  RustArcDecrementStrongCountFnType get rust_arc_decrement_strong_count_Expr =>
+      wire.rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockExpr;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockLazyFrame => wire
+      get rust_arc_increment_strong_count_LazyFrame => wire
           .rust_arc_increment_strong_count_RustOpaque_stdsyncRwLockLazyFrame;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockLazyFrame => wire
+      get rust_arc_decrement_strong_count_LazyFrame => wire
           .rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockLazyFrame;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_RwLockLazyGroupBy => wire
+      get rust_arc_increment_strong_count_LazyGroupBy => wire
           .rust_arc_increment_strong_count_RustOpaque_stdsyncRwLockLazyGroupBy;
 
   RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_RwLockLazyGroupBy => wire
+      get rust_arc_decrement_strong_count_LazyGroupBy => wire
           .rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockLazyGroupBy;
 
   @protected
@@ -515,53 +495,51 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  RwLockDataFrame dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockDataFrame(
+  DataFrame dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockDataFrame(
       dynamic raw) {
-    return RwLockDataFrame.dcoDecode(raw);
+    return DataFrame.dcoDecode(raw);
   }
 
   @protected
-  RwLockExpr dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockExpr(dynamic raw) {
-    return RwLockExpr.dcoDecode(raw);
+  Expr dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockExpr(dynamic raw) {
+    return Expr.dcoDecode(raw);
   }
 
   @protected
-  RwLockLazyFrame dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockLazyFrame(
+  LazyFrame dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockLazyFrame(
       dynamic raw) {
-    return RwLockLazyFrame.dcoDecode(raw);
+    return LazyFrame.dcoDecode(raw);
   }
 
   @protected
-  RwLockLazyGroupBy dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockLazyGroupBy(
+  LazyGroupBy dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockLazyGroupBy(
       dynamic raw) {
-    return RwLockLazyGroupBy.dcoDecode(raw);
+    return LazyGroupBy.dcoDecode(raw);
   }
 
   @protected
-  RwLockDataFrame dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockDataFrame(
-      dynamic raw) {
-    return RwLockDataFrame.dcoDecode(raw);
+  DataFrame dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockDataFrame(dynamic raw) {
+    return DataFrame.dcoDecode(raw);
   }
 
   @protected
-  RwLockDataFrame dco_decode_RustOpaque_stdsyncRwLockDataFrame(dynamic raw) {
-    return RwLockDataFrame.dcoDecode(raw);
+  DataFrame dco_decode_RustOpaque_stdsyncRwLockDataFrame(dynamic raw) {
+    return DataFrame.dcoDecode(raw);
   }
 
   @protected
-  RwLockExpr dco_decode_RustOpaque_stdsyncRwLockExpr(dynamic raw) {
-    return RwLockExpr.dcoDecode(raw);
+  Expr dco_decode_RustOpaque_stdsyncRwLockExpr(dynamic raw) {
+    return Expr.dcoDecode(raw);
   }
 
   @protected
-  RwLockLazyFrame dco_decode_RustOpaque_stdsyncRwLockLazyFrame(dynamic raw) {
-    return RwLockLazyFrame.dcoDecode(raw);
+  LazyFrame dco_decode_RustOpaque_stdsyncRwLockLazyFrame(dynamic raw) {
+    return LazyFrame.dcoDecode(raw);
   }
 
   @protected
-  RwLockLazyGroupBy dco_decode_RustOpaque_stdsyncRwLockLazyGroupBy(
-      dynamic raw) {
-    return RwLockLazyGroupBy.dcoDecode(raw);
+  LazyGroupBy dco_decode_RustOpaque_stdsyncRwLockLazyGroupBy(dynamic raw) {
+    return LazyGroupBy.dcoDecode(raw);
   }
 
   @protected
@@ -643,65 +621,64 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  RwLockDataFrame sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockDataFrame(
+  DataFrame sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockDataFrame(
       SseDeserializer deserializer) {
-    return RwLockDataFrame.sseDecode(
+    return DataFrame.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockExpr sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockExpr(
+  Expr sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockExpr(
       SseDeserializer deserializer) {
-    return RwLockExpr.sseDecode(
+    return Expr.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockLazyFrame sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockLazyFrame(
+  LazyFrame sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockLazyFrame(
       SseDeserializer deserializer) {
-    return RwLockLazyFrame.sseDecode(
+    return LazyFrame.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockLazyGroupBy sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockLazyGroupBy(
+  LazyGroupBy sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockLazyGroupBy(
       SseDeserializer deserializer) {
-    return RwLockLazyGroupBy.sseDecode(
+    return LazyGroupBy.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockDataFrame sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockDataFrame(
+  DataFrame sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockDataFrame(
       SseDeserializer deserializer) {
-    return RwLockDataFrame.sseDecode(
+    return DataFrame.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockDataFrame sse_decode_RustOpaque_stdsyncRwLockDataFrame(
+  DataFrame sse_decode_RustOpaque_stdsyncRwLockDataFrame(
       SseDeserializer deserializer) {
-    return RwLockDataFrame.sseDecode(
+    return DataFrame.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockExpr sse_decode_RustOpaque_stdsyncRwLockExpr(
-      SseDeserializer deserializer) {
-    return RwLockExpr.sseDecode(
+  Expr sse_decode_RustOpaque_stdsyncRwLockExpr(SseDeserializer deserializer) {
+    return Expr.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockLazyFrame sse_decode_RustOpaque_stdsyncRwLockLazyFrame(
+  LazyFrame sse_decode_RustOpaque_stdsyncRwLockLazyFrame(
       SseDeserializer deserializer) {
-    return RwLockLazyFrame.sseDecode(
+    return LazyFrame.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
   @protected
-  RwLockLazyGroupBy sse_decode_RustOpaque_stdsyncRwLockLazyGroupBy(
+  LazyGroupBy sse_decode_RustOpaque_stdsyncRwLockLazyGroupBy(
       SseDeserializer deserializer) {
-    return RwLockLazyGroupBy.sseDecode(
+    return LazyGroupBy.sseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
@@ -781,62 +758,59 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @protected
   PlatformPointer cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockDataFrame(
-      RwLockDataFrame raw) {
+      DataFrame raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: true);
   }
 
   @protected
-  PlatformPointer cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockExpr(
-      RwLockExpr raw) {
+  PlatformPointer cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockExpr(Expr raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: true);
   }
 
   @protected
   PlatformPointer cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockLazyFrame(
-      RwLockLazyFrame raw) {
+      LazyFrame raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: true);
   }
 
   @protected
   PlatformPointer cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockLazyGroupBy(
-      RwLockLazyGroupBy raw) {
+      LazyGroupBy raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: true);
   }
 
   @protected
   PlatformPointer cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockDataFrame(
-      RwLockDataFrame raw) {
+      DataFrame raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode(move: false);
   }
 
   @protected
-  PlatformPointer cst_encode_RustOpaque_stdsyncRwLockDataFrame(
-      RwLockDataFrame raw) {
+  PlatformPointer cst_encode_RustOpaque_stdsyncRwLockDataFrame(DataFrame raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode();
   }
 
   @protected
-  PlatformPointer cst_encode_RustOpaque_stdsyncRwLockExpr(RwLockExpr raw) {
+  PlatformPointer cst_encode_RustOpaque_stdsyncRwLockExpr(Expr raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode();
   }
 
   @protected
-  PlatformPointer cst_encode_RustOpaque_stdsyncRwLockLazyFrame(
-      RwLockLazyFrame raw) {
+  PlatformPointer cst_encode_RustOpaque_stdsyncRwLockLazyFrame(LazyFrame raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode();
   }
 
   @protected
   PlatformPointer cst_encode_RustOpaque_stdsyncRwLockLazyGroupBy(
-      RwLockLazyGroupBy raw) {
+      LazyGroupBy raw) {
     // ignore: invalid_use_of_internal_member
     return raw.cstEncode();
   }
@@ -875,55 +849,55 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @protected
   void sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockDataFrame(
-      RwLockDataFrame self, SseSerializer serializer) {
+      DataFrame self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: true), serializer);
   }
 
   @protected
   void sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockExpr(
-      RwLockExpr self, SseSerializer serializer) {
+      Expr self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: true), serializer);
   }
 
   @protected
   void sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockLazyFrame(
-      RwLockLazyFrame self, SseSerializer serializer) {
+      LazyFrame self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: true), serializer);
   }
 
   @protected
   void sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockLazyGroupBy(
-      RwLockLazyGroupBy self, SseSerializer serializer) {
+      LazyGroupBy self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: true), serializer);
   }
 
   @protected
   void sse_encode_Auto_Ref_RustOpaque_stdsyncRwLockDataFrame(
-      RwLockDataFrame self, SseSerializer serializer) {
+      DataFrame self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: false), serializer);
   }
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockDataFrame(
-      RwLockDataFrame self, SseSerializer serializer) {
+      DataFrame self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: null), serializer);
   }
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockExpr(
-      RwLockExpr self, SseSerializer serializer) {
+      Expr self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: null), serializer);
   }
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockLazyFrame(
-      RwLockLazyFrame self, SseSerializer serializer) {
+      LazyFrame self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: null), serializer);
   }
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockLazyGroupBy(
-      RwLockLazyGroupBy self, SseSerializer serializer) {
+      LazyGroupBy self, SseSerializer serializer) {
     sse_encode_usize(self.sseEncode(move: null), serializer);
   }
 

--- a/frb_example/gallery/lib/src/rust/frb_generated.io.dart
+++ b/frb_example/gallery/lib/src/rust/frb_generated.io.dart
@@ -19,54 +19,51 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     required super.portManager,
   });
 
-  CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockDataFramePtr => wire
-          ._rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockDataFramePtr;
+  CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_DataFramePtr =>
+      wire._rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockDataFramePtr;
 
-  CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_RwLockExprPtr =>
+  CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_ExprPtr =>
       wire._rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockExprPtr;
 
-  CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockLazyFramePtr => wire
-          ._rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockLazyFramePtr;
+  CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_LazyFramePtr =>
+      wire._rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockLazyFramePtr;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockLazyGroupByPtr => wire
+      get rust_arc_decrement_strong_count_LazyGroupByPtr => wire
           ._rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockLazyGroupByPtr;
 
   @protected
   AnyhowException dco_decode_AnyhowException(dynamic raw);
 
   @protected
-  RwLockDataFrame dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockDataFrame(
+  DataFrame dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockDataFrame(
       dynamic raw);
 
   @protected
-  RwLockExpr dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockExpr(dynamic raw);
+  Expr dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockExpr(dynamic raw);
 
   @protected
-  RwLockLazyFrame dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockLazyFrame(
+  LazyFrame dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockLazyFrame(
       dynamic raw);
 
   @protected
-  RwLockLazyGroupBy dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockLazyGroupBy(
+  LazyGroupBy dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockLazyGroupBy(
       dynamic raw);
 
   @protected
-  RwLockDataFrame dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockDataFrame(
-      dynamic raw);
+  DataFrame dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockDataFrame(dynamic raw);
 
   @protected
-  RwLockDataFrame dco_decode_RustOpaque_stdsyncRwLockDataFrame(dynamic raw);
+  DataFrame dco_decode_RustOpaque_stdsyncRwLockDataFrame(dynamic raw);
 
   @protected
-  RwLockExpr dco_decode_RustOpaque_stdsyncRwLockExpr(dynamic raw);
+  Expr dco_decode_RustOpaque_stdsyncRwLockExpr(dynamic raw);
 
   @protected
-  RwLockLazyFrame dco_decode_RustOpaque_stdsyncRwLockLazyFrame(dynamic raw);
+  LazyFrame dco_decode_RustOpaque_stdsyncRwLockLazyFrame(dynamic raw);
 
   @protected
-  RwLockLazyGroupBy dco_decode_RustOpaque_stdsyncRwLockLazyGroupBy(dynamic raw);
+  LazyGroupBy dco_decode_RustOpaque_stdsyncRwLockLazyGroupBy(dynamic raw);
 
   @protected
   String dco_decode_String(dynamic raw);
@@ -108,39 +105,38 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   AnyhowException sse_decode_AnyhowException(SseDeserializer deserializer);
 
   @protected
-  RwLockDataFrame sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockDataFrame(
+  DataFrame sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockDataFrame(
       SseDeserializer deserializer);
 
   @protected
-  RwLockExpr sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockExpr(
+  Expr sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockExpr(
       SseDeserializer deserializer);
 
   @protected
-  RwLockLazyFrame sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockLazyFrame(
+  LazyFrame sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockLazyFrame(
       SseDeserializer deserializer);
 
   @protected
-  RwLockLazyGroupBy sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockLazyGroupBy(
+  LazyGroupBy sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockLazyGroupBy(
       SseDeserializer deserializer);
 
   @protected
-  RwLockDataFrame sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockDataFrame(
+  DataFrame sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockDataFrame(
       SseDeserializer deserializer);
 
   @protected
-  RwLockDataFrame sse_decode_RustOpaque_stdsyncRwLockDataFrame(
+  DataFrame sse_decode_RustOpaque_stdsyncRwLockDataFrame(
       SseDeserializer deserializer);
 
   @protected
-  RwLockExpr sse_decode_RustOpaque_stdsyncRwLockExpr(
+  Expr sse_decode_RustOpaque_stdsyncRwLockExpr(SseDeserializer deserializer);
+
+  @protected
+  LazyFrame sse_decode_RustOpaque_stdsyncRwLockLazyFrame(
       SseDeserializer deserializer);
 
   @protected
-  RwLockLazyFrame sse_decode_RustOpaque_stdsyncRwLockLazyFrame(
-      SseDeserializer deserializer);
-
-  @protected
-  RwLockLazyGroupBy sse_decode_RustOpaque_stdsyncRwLockLazyGroupBy(
+  LazyGroupBy sse_decode_RustOpaque_stdsyncRwLockLazyGroupBy(
       SseDeserializer deserializer);
 
   @protected
@@ -249,38 +245,35 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   PlatformPointer cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockDataFrame(
-      RwLockDataFrame raw);
+      DataFrame raw);
 
   @protected
-  PlatformPointer cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockExpr(
-      RwLockExpr raw);
+  PlatformPointer cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockExpr(Expr raw);
 
   @protected
   PlatformPointer cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockLazyFrame(
-      RwLockLazyFrame raw);
+      LazyFrame raw);
 
   @protected
   PlatformPointer cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockLazyGroupBy(
-      RwLockLazyGroupBy raw);
+      LazyGroupBy raw);
 
   @protected
   PlatformPointer cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockDataFrame(
-      RwLockDataFrame raw);
+      DataFrame raw);
 
   @protected
-  PlatformPointer cst_encode_RustOpaque_stdsyncRwLockDataFrame(
-      RwLockDataFrame raw);
+  PlatformPointer cst_encode_RustOpaque_stdsyncRwLockDataFrame(DataFrame raw);
 
   @protected
-  PlatformPointer cst_encode_RustOpaque_stdsyncRwLockExpr(RwLockExpr raw);
+  PlatformPointer cst_encode_RustOpaque_stdsyncRwLockExpr(Expr raw);
 
   @protected
-  PlatformPointer cst_encode_RustOpaque_stdsyncRwLockLazyFrame(
-      RwLockLazyFrame raw);
+  PlatformPointer cst_encode_RustOpaque_stdsyncRwLockLazyFrame(LazyFrame raw);
 
   @protected
   PlatformPointer cst_encode_RustOpaque_stdsyncRwLockLazyGroupBy(
-      RwLockLazyGroupBy raw);
+      LazyGroupBy raw);
 
   @protected
   double cst_encode_f_64(double raw);
@@ -303,39 +296,39 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockDataFrame(
-      RwLockDataFrame self, SseSerializer serializer);
+      DataFrame self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockExpr(
-      RwLockExpr self, SseSerializer serializer);
+      Expr self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockLazyFrame(
-      RwLockLazyFrame self, SseSerializer serializer);
+      LazyFrame self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockLazyGroupBy(
-      RwLockLazyGroupBy self, SseSerializer serializer);
+      LazyGroupBy self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_Ref_RustOpaque_stdsyncRwLockDataFrame(
-      RwLockDataFrame self, SseSerializer serializer);
+      DataFrame self, SseSerializer serializer);
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockDataFrame(
-      RwLockDataFrame self, SseSerializer serializer);
+      DataFrame self, SseSerializer serializer);
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockExpr(
-      RwLockExpr self, SseSerializer serializer);
+      Expr self, SseSerializer serializer);
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockLazyFrame(
-      RwLockLazyFrame self, SseSerializer serializer);
+      LazyFrame self, SseSerializer serializer);
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockLazyGroupBy(
-      RwLockLazyGroupBy self, SseSerializer serializer);
+      LazyGroupBy self, SseSerializer serializer);
 
   @protected
   void sse_encode_String(String self, SseSerializer serializer);

--- a/frb_example/gallery/lib/src/rust/frb_generated.web.dart
+++ b/frb_example/gallery/lib/src/rust/frb_generated.web.dart
@@ -18,54 +18,51 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     required super.portManager,
   });
 
-  CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockDataFramePtr => wire
-          .rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockDataFrame;
+  CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_DataFramePtr =>
+      wire.rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockDataFrame;
 
-  CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_RwLockExprPtr =>
+  CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_ExprPtr =>
       wire.rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockExpr;
 
-  CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockLazyFramePtr => wire
-          .rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockLazyFrame;
+  CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_LazyFramePtr =>
+      wire.rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockLazyFrame;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_RwLockLazyGroupByPtr => wire
+      get rust_arc_decrement_strong_count_LazyGroupByPtr => wire
           .rust_arc_decrement_strong_count_RustOpaque_stdsyncRwLockLazyGroupBy;
 
   @protected
   AnyhowException dco_decode_AnyhowException(dynamic raw);
 
   @protected
-  RwLockDataFrame dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockDataFrame(
+  DataFrame dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockDataFrame(
       dynamic raw);
 
   @protected
-  RwLockExpr dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockExpr(dynamic raw);
+  Expr dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockExpr(dynamic raw);
 
   @protected
-  RwLockLazyFrame dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockLazyFrame(
+  LazyFrame dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockLazyFrame(
       dynamic raw);
 
   @protected
-  RwLockLazyGroupBy dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockLazyGroupBy(
+  LazyGroupBy dco_decode_Auto_Owned_RustOpaque_stdsyncRwLockLazyGroupBy(
       dynamic raw);
 
   @protected
-  RwLockDataFrame dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockDataFrame(
-      dynamic raw);
+  DataFrame dco_decode_Auto_Ref_RustOpaque_stdsyncRwLockDataFrame(dynamic raw);
 
   @protected
-  RwLockDataFrame dco_decode_RustOpaque_stdsyncRwLockDataFrame(dynamic raw);
+  DataFrame dco_decode_RustOpaque_stdsyncRwLockDataFrame(dynamic raw);
 
   @protected
-  RwLockExpr dco_decode_RustOpaque_stdsyncRwLockExpr(dynamic raw);
+  Expr dco_decode_RustOpaque_stdsyncRwLockExpr(dynamic raw);
 
   @protected
-  RwLockLazyFrame dco_decode_RustOpaque_stdsyncRwLockLazyFrame(dynamic raw);
+  LazyFrame dco_decode_RustOpaque_stdsyncRwLockLazyFrame(dynamic raw);
 
   @protected
-  RwLockLazyGroupBy dco_decode_RustOpaque_stdsyncRwLockLazyGroupBy(dynamic raw);
+  LazyGroupBy dco_decode_RustOpaque_stdsyncRwLockLazyGroupBy(dynamic raw);
 
   @protected
   String dco_decode_String(dynamic raw);
@@ -107,39 +104,38 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   AnyhowException sse_decode_AnyhowException(SseDeserializer deserializer);
 
   @protected
-  RwLockDataFrame sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockDataFrame(
+  DataFrame sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockDataFrame(
       SseDeserializer deserializer);
 
   @protected
-  RwLockExpr sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockExpr(
+  Expr sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockExpr(
       SseDeserializer deserializer);
 
   @protected
-  RwLockLazyFrame sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockLazyFrame(
+  LazyFrame sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockLazyFrame(
       SseDeserializer deserializer);
 
   @protected
-  RwLockLazyGroupBy sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockLazyGroupBy(
+  LazyGroupBy sse_decode_Auto_Owned_RustOpaque_stdsyncRwLockLazyGroupBy(
       SseDeserializer deserializer);
 
   @protected
-  RwLockDataFrame sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockDataFrame(
+  DataFrame sse_decode_Auto_Ref_RustOpaque_stdsyncRwLockDataFrame(
       SseDeserializer deserializer);
 
   @protected
-  RwLockDataFrame sse_decode_RustOpaque_stdsyncRwLockDataFrame(
+  DataFrame sse_decode_RustOpaque_stdsyncRwLockDataFrame(
       SseDeserializer deserializer);
 
   @protected
-  RwLockExpr sse_decode_RustOpaque_stdsyncRwLockExpr(
+  Expr sse_decode_RustOpaque_stdsyncRwLockExpr(SseDeserializer deserializer);
+
+  @protected
+  LazyFrame sse_decode_RustOpaque_stdsyncRwLockLazyFrame(
       SseDeserializer deserializer);
 
   @protected
-  RwLockLazyFrame sse_decode_RustOpaque_stdsyncRwLockLazyFrame(
-      SseDeserializer deserializer);
-
-  @protected
-  RwLockLazyGroupBy sse_decode_RustOpaque_stdsyncRwLockLazyGroupBy(
+  LazyGroupBy sse_decode_RustOpaque_stdsyncRwLockLazyGroupBy(
       SseDeserializer deserializer);
 
   @protected
@@ -223,38 +219,35 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   PlatformPointer cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockDataFrame(
-      RwLockDataFrame raw);
+      DataFrame raw);
 
   @protected
-  PlatformPointer cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockExpr(
-      RwLockExpr raw);
+  PlatformPointer cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockExpr(Expr raw);
 
   @protected
   PlatformPointer cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockLazyFrame(
-      RwLockLazyFrame raw);
+      LazyFrame raw);
 
   @protected
   PlatformPointer cst_encode_Auto_Owned_RustOpaque_stdsyncRwLockLazyGroupBy(
-      RwLockLazyGroupBy raw);
+      LazyGroupBy raw);
 
   @protected
   PlatformPointer cst_encode_Auto_Ref_RustOpaque_stdsyncRwLockDataFrame(
-      RwLockDataFrame raw);
+      DataFrame raw);
 
   @protected
-  PlatformPointer cst_encode_RustOpaque_stdsyncRwLockDataFrame(
-      RwLockDataFrame raw);
+  PlatformPointer cst_encode_RustOpaque_stdsyncRwLockDataFrame(DataFrame raw);
 
   @protected
-  PlatformPointer cst_encode_RustOpaque_stdsyncRwLockExpr(RwLockExpr raw);
+  PlatformPointer cst_encode_RustOpaque_stdsyncRwLockExpr(Expr raw);
 
   @protected
-  PlatformPointer cst_encode_RustOpaque_stdsyncRwLockLazyFrame(
-      RwLockLazyFrame raw);
+  PlatformPointer cst_encode_RustOpaque_stdsyncRwLockLazyFrame(LazyFrame raw);
 
   @protected
   PlatformPointer cst_encode_RustOpaque_stdsyncRwLockLazyGroupBy(
-      RwLockLazyGroupBy raw);
+      LazyGroupBy raw);
 
   @protected
   double cst_encode_f_64(double raw);
@@ -277,39 +270,39 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockDataFrame(
-      RwLockDataFrame self, SseSerializer serializer);
+      DataFrame self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockExpr(
-      RwLockExpr self, SseSerializer serializer);
+      Expr self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockLazyFrame(
-      RwLockLazyFrame self, SseSerializer serializer);
+      LazyFrame self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_Owned_RustOpaque_stdsyncRwLockLazyGroupBy(
-      RwLockLazyGroupBy self, SseSerializer serializer);
+      LazyGroupBy self, SseSerializer serializer);
 
   @protected
   void sse_encode_Auto_Ref_RustOpaque_stdsyncRwLockDataFrame(
-      RwLockDataFrame self, SseSerializer serializer);
+      DataFrame self, SseSerializer serializer);
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockDataFrame(
-      RwLockDataFrame self, SseSerializer serializer);
+      DataFrame self, SseSerializer serializer);
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockExpr(
-      RwLockExpr self, SseSerializer serializer);
+      Expr self, SseSerializer serializer);
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockLazyFrame(
-      RwLockLazyFrame self, SseSerializer serializer);
+      LazyFrame self, SseSerializer serializer);
 
   @protected
   void sse_encode_RustOpaque_stdsyncRwLockLazyGroupBy(
-      RwLockLazyGroupBy self, SseSerializer serializer);
+      LazyGroupBy self, SseSerializer serializer);
 
   @protected
   void sse_encode_String(String self, SseSerializer serializer);

--- a/frb_example/gallery/rust/src/frb_generated.io.rs
+++ b/frb_example/gallery/rust/src/frb_generated.io.rs
@@ -363,25 +363,25 @@ pub extern "C" fn cst_new_list_prim_u_8(len: i32) -> *mut wire_cst_list_prim_u_8
 }
 
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_String {
     ptr: *mut *mut wire_cst_list_prim_u_8,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_prim_u_8 {
     ptr: *mut u8,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_point {
     x: f64,
     y: f64,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_size {
     width: i32,
     height: i32,

--- a/frb_example/pure_dart/frb_generated.h
+++ b/frb_example/pure_dart/frb_generated.h
@@ -90,13 +90,13 @@ typedef struct wire_cst_EnumDartOpaqueTwinNormal_Opaque {
 } wire_cst_EnumDartOpaqueTwinNormal_Opaque;
 
 typedef union EnumDartOpaqueTwinNormalKind {
-  struct wire_cst_EnumDartOpaqueTwinNormal_Primitive *Primitive;
-  struct wire_cst_EnumDartOpaqueTwinNormal_Opaque *Opaque;
+  struct wire_cst_EnumDartOpaqueTwinNormal_Primitive Primitive;
+  struct wire_cst_EnumDartOpaqueTwinNormal_Opaque Opaque;
 } EnumDartOpaqueTwinNormalKind;
 
 typedef struct wire_cst_enum_dart_opaque_twin_normal {
   int32_t tag;
-  union EnumDartOpaqueTwinNormalKind *kind;
+  union EnumDartOpaqueTwinNormalKind kind;
 } wire_cst_enum_dart_opaque_twin_normal;
 
 typedef struct wire_cst_dart_opaque_nested_twin_normal {
@@ -109,10 +109,6 @@ typedef struct wire_cst_list_DartOpaque {
   int32_t len;
 } wire_cst_list_DartOpaque;
 
-typedef struct wire_cst_EnumWithItemMixedTwinNormal_A {
-
-} wire_cst_EnumWithItemMixedTwinNormal_A;
-
 typedef struct wire_cst_EnumWithItemMixedTwinNormal_B {
   struct wire_cst_list_prim_u_8 *field0;
 } wire_cst_EnumWithItemMixedTwinNormal_B;
@@ -122,14 +118,13 @@ typedef struct wire_cst_EnumWithItemMixedTwinNormal_C {
 } wire_cst_EnumWithItemMixedTwinNormal_C;
 
 typedef union EnumWithItemMixedTwinNormalKind {
-  struct wire_cst_EnumWithItemMixedTwinNormal_A *A;
-  struct wire_cst_EnumWithItemMixedTwinNormal_B *B;
-  struct wire_cst_EnumWithItemMixedTwinNormal_C *C;
+  struct wire_cst_EnumWithItemMixedTwinNormal_B B;
+  struct wire_cst_EnumWithItemMixedTwinNormal_C C;
 } EnumWithItemMixedTwinNormalKind;
 
 typedef struct wire_cst_enum_with_item_mixed_twin_normal {
   int32_t tag;
-  union EnumWithItemMixedTwinNormalKind *kind;
+  union EnumWithItemMixedTwinNormalKind kind;
 } wire_cst_enum_with_item_mixed_twin_normal;
 
 typedef struct wire_cst_EnumWithItemStructTwinNormal_A {
@@ -141,13 +136,13 @@ typedef struct wire_cst_EnumWithItemStructTwinNormal_B {
 } wire_cst_EnumWithItemStructTwinNormal_B;
 
 typedef union EnumWithItemStructTwinNormalKind {
-  struct wire_cst_EnumWithItemStructTwinNormal_A *A;
-  struct wire_cst_EnumWithItemStructTwinNormal_B *B;
+  struct wire_cst_EnumWithItemStructTwinNormal_A A;
+  struct wire_cst_EnumWithItemStructTwinNormal_B B;
 } EnumWithItemStructTwinNormalKind;
 
 typedef struct wire_cst_enum_with_item_struct_twin_normal {
   int32_t tag;
-  union EnumWithItemStructTwinNormalKind *kind;
+  union EnumWithItemStructTwinNormalKind kind;
 } wire_cst_enum_with_item_struct_twin_normal;
 
 typedef struct wire_cst_EnumWithItemTupleTwinNormal_A {
@@ -159,18 +154,14 @@ typedef struct wire_cst_EnumWithItemTupleTwinNormal_B {
 } wire_cst_EnumWithItemTupleTwinNormal_B;
 
 typedef union EnumWithItemTupleTwinNormalKind {
-  struct wire_cst_EnumWithItemTupleTwinNormal_A *A;
-  struct wire_cst_EnumWithItemTupleTwinNormal_B *B;
+  struct wire_cst_EnumWithItemTupleTwinNormal_A A;
+  struct wire_cst_EnumWithItemTupleTwinNormal_B B;
 } EnumWithItemTupleTwinNormalKind;
 
 typedef struct wire_cst_enum_with_item_tuple_twin_normal {
   int32_t tag;
-  union EnumWithItemTupleTwinNormalKind *kind;
+  union EnumWithItemTupleTwinNormalKind kind;
 } wire_cst_enum_with_item_tuple_twin_normal;
-
-typedef struct wire_cst_KitchenSinkTwinNormal_Empty {
-
-} wire_cst_KitchenSinkTwinNormal_Empty;
 
 typedef struct wire_cst_KitchenSinkTwinNormal_Primitives {
   int32_t int32;
@@ -197,57 +188,46 @@ typedef struct wire_cst_KitchenSinkTwinNormal_Enums {
 } wire_cst_KitchenSinkTwinNormal_Enums;
 
 typedef union KitchenSinkTwinNormalKind {
-  struct wire_cst_KitchenSinkTwinNormal_Empty *Empty;
-  struct wire_cst_KitchenSinkTwinNormal_Primitives *Primitives;
-  struct wire_cst_KitchenSinkTwinNormal_Nested *Nested;
-  struct wire_cst_KitchenSinkTwinNormal_Optional *Optional;
-  struct wire_cst_KitchenSinkTwinNormal_Buffer *Buffer;
-  struct wire_cst_KitchenSinkTwinNormal_Enums *Enums;
+  struct wire_cst_KitchenSinkTwinNormal_Primitives Primitives;
+  struct wire_cst_KitchenSinkTwinNormal_Nested Nested;
+  struct wire_cst_KitchenSinkTwinNormal_Optional Optional;
+  struct wire_cst_KitchenSinkTwinNormal_Buffer Buffer;
+  struct wire_cst_KitchenSinkTwinNormal_Enums Enums;
 } KitchenSinkTwinNormalKind;
 
 typedef struct wire_cst_kitchen_sink_twin_normal {
   int32_t tag;
-  union KitchenSinkTwinNormalKind *kind;
+  union KitchenSinkTwinNormalKind kind;
 } wire_cst_kitchen_sink_twin_normal;
-
-typedef struct wire_cst_SpeedTwinNormal_Unknown {
-
-} wire_cst_SpeedTwinNormal_Unknown;
 
 typedef struct wire_cst_SpeedTwinNormal_GPS {
   double field0;
 } wire_cst_SpeedTwinNormal_GPS;
 
 typedef union SpeedTwinNormalKind {
-  struct wire_cst_SpeedTwinNormal_Unknown *Unknown;
-  struct wire_cst_SpeedTwinNormal_GPS *GPS;
+  struct wire_cst_SpeedTwinNormal_GPS GPS;
 } SpeedTwinNormalKind;
 
 typedef struct wire_cst_speed_twin_normal {
   int32_t tag;
-  union SpeedTwinNormalKind *kind;
+  union SpeedTwinNormalKind kind;
 } wire_cst_speed_twin_normal;
 
 typedef struct wire_cst_MeasureTwinNormal_Speed {
   struct wire_cst_speed_twin_normal *field0;
 } wire_cst_MeasureTwinNormal_Speed;
 
-typedef struct wire_cst_DistanceTwinNormal_Unknown {
-
-} wire_cst_DistanceTwinNormal_Unknown;
-
 typedef struct wire_cst_DistanceTwinNormal_Map {
   double field0;
 } wire_cst_DistanceTwinNormal_Map;
 
 typedef union DistanceTwinNormalKind {
-  struct wire_cst_DistanceTwinNormal_Unknown *Unknown;
-  struct wire_cst_DistanceTwinNormal_Map *Map;
+  struct wire_cst_DistanceTwinNormal_Map Map;
 } DistanceTwinNormalKind;
 
 typedef struct wire_cst_distance_twin_normal {
   int32_t tag;
-  union DistanceTwinNormalKind *kind;
+  union DistanceTwinNormalKind kind;
 } wire_cst_distance_twin_normal;
 
 typedef struct wire_cst_MeasureTwinNormal_Distance {
@@ -255,13 +235,13 @@ typedef struct wire_cst_MeasureTwinNormal_Distance {
 } wire_cst_MeasureTwinNormal_Distance;
 
 typedef union MeasureTwinNormalKind {
-  struct wire_cst_MeasureTwinNormal_Speed *Speed;
-  struct wire_cst_MeasureTwinNormal_Distance *Distance;
+  struct wire_cst_MeasureTwinNormal_Speed Speed;
+  struct wire_cst_MeasureTwinNormal_Distance Distance;
 } MeasureTwinNormalKind;
 
 typedef struct wire_cst_measure_twin_normal {
   int32_t tag;
-  union MeasureTwinNormalKind *kind;
+  union MeasureTwinNormalKind kind;
 } wire_cst_measure_twin_normal;
 
 typedef struct wire_cst_note_twin_normal {
@@ -295,13 +275,13 @@ typedef struct wire_cst_CustomNestedErrorInnerTwinNormal_Four {
 } wire_cst_CustomNestedErrorInnerTwinNormal_Four;
 
 typedef union CustomNestedErrorInnerTwinNormalKind {
-  struct wire_cst_CustomNestedErrorInnerTwinNormal_Three *Three;
-  struct wire_cst_CustomNestedErrorInnerTwinNormal_Four *Four;
+  struct wire_cst_CustomNestedErrorInnerTwinNormal_Three Three;
+  struct wire_cst_CustomNestedErrorInnerTwinNormal_Four Four;
 } CustomNestedErrorInnerTwinNormalKind;
 
 typedef struct wire_cst_custom_nested_error_inner_twin_normal {
   int32_t tag;
-  union CustomNestedErrorInnerTwinNormalKind *kind;
+  union CustomNestedErrorInnerTwinNormalKind kind;
 } wire_cst_custom_nested_error_inner_twin_normal;
 
 typedef struct wire_cst_CustomNestedErrorOuterTwinNormal_Two {
@@ -309,13 +289,13 @@ typedef struct wire_cst_CustomNestedErrorOuterTwinNormal_Two {
 } wire_cst_CustomNestedErrorOuterTwinNormal_Two;
 
 typedef union CustomNestedErrorOuterTwinNormalKind {
-  struct wire_cst_CustomNestedErrorOuterTwinNormal_One *One;
-  struct wire_cst_CustomNestedErrorOuterTwinNormal_Two *Two;
+  struct wire_cst_CustomNestedErrorOuterTwinNormal_One One;
+  struct wire_cst_CustomNestedErrorOuterTwinNormal_Two Two;
 } CustomNestedErrorOuterTwinNormalKind;
 
 typedef struct wire_cst_custom_nested_error_outer_twin_normal {
   int32_t tag;
-  union CustomNestedErrorOuterTwinNormalKind *kind;
+  union CustomNestedErrorOuterTwinNormalKind kind;
 } wire_cst_custom_nested_error_outer_twin_normal;
 
 typedef struct wire_cst_custom_struct_error_twin_normal {
@@ -424,15 +404,15 @@ typedef struct wire_cst_AbcTwinNormal_JustInt {
 } wire_cst_AbcTwinNormal_JustInt;
 
 typedef union AbcTwinNormalKind {
-  struct wire_cst_AbcTwinNormal_A *A;
-  struct wire_cst_AbcTwinNormal_B *B;
-  struct wire_cst_AbcTwinNormal_C *C;
-  struct wire_cst_AbcTwinNormal_JustInt *JustInt;
+  struct wire_cst_AbcTwinNormal_A A;
+  struct wire_cst_AbcTwinNormal_B B;
+  struct wire_cst_AbcTwinNormal_C C;
+  struct wire_cst_AbcTwinNormal_JustInt JustInt;
 } AbcTwinNormalKind;
 
 typedef struct wire_cst_abc_twin_normal {
   int32_t tag;
-  union AbcTwinNormalKind *kind;
+  union AbcTwinNormalKind kind;
 } wire_cst_abc_twin_normal;
 
 typedef struct wire_cst_struct_with_enum_twin_normal {
@@ -654,13 +634,13 @@ typedef struct wire_cst_EnumDartOpaqueTwinRustAsync_Opaque {
 } wire_cst_EnumDartOpaqueTwinRustAsync_Opaque;
 
 typedef union EnumDartOpaqueTwinRustAsyncKind {
-  struct wire_cst_EnumDartOpaqueTwinRustAsync_Primitive *Primitive;
-  struct wire_cst_EnumDartOpaqueTwinRustAsync_Opaque *Opaque;
+  struct wire_cst_EnumDartOpaqueTwinRustAsync_Primitive Primitive;
+  struct wire_cst_EnumDartOpaqueTwinRustAsync_Opaque Opaque;
 } EnumDartOpaqueTwinRustAsyncKind;
 
 typedef struct wire_cst_enum_dart_opaque_twin_rust_async {
   int32_t tag;
-  union EnumDartOpaqueTwinRustAsyncKind *kind;
+  union EnumDartOpaqueTwinRustAsyncKind kind;
 } wire_cst_enum_dart_opaque_twin_rust_async;
 
 typedef struct wire_cst_dart_opaque_nested_twin_rust_async {
@@ -677,23 +657,19 @@ typedef struct wire_cst_EnumDartOpaqueTwinSync_Opaque {
 } wire_cst_EnumDartOpaqueTwinSync_Opaque;
 
 typedef union EnumDartOpaqueTwinSyncKind {
-  struct wire_cst_EnumDartOpaqueTwinSync_Primitive *Primitive;
-  struct wire_cst_EnumDartOpaqueTwinSync_Opaque *Opaque;
+  struct wire_cst_EnumDartOpaqueTwinSync_Primitive Primitive;
+  struct wire_cst_EnumDartOpaqueTwinSync_Opaque Opaque;
 } EnumDartOpaqueTwinSyncKind;
 
 typedef struct wire_cst_enum_dart_opaque_twin_sync {
   int32_t tag;
-  union EnumDartOpaqueTwinSyncKind *kind;
+  union EnumDartOpaqueTwinSyncKind kind;
 } wire_cst_enum_dart_opaque_twin_sync;
 
 typedef struct wire_cst_dart_opaque_nested_twin_sync {
   const void *first;
   const void *second;
 } wire_cst_dart_opaque_nested_twin_sync;
-
-typedef struct wire_cst_EnumWithItemMixedTwinRustAsync_A {
-
-} wire_cst_EnumWithItemMixedTwinRustAsync_A;
 
 typedef struct wire_cst_EnumWithItemMixedTwinRustAsync_B {
   struct wire_cst_list_prim_u_8 *field0;
@@ -704,14 +680,13 @@ typedef struct wire_cst_EnumWithItemMixedTwinRustAsync_C {
 } wire_cst_EnumWithItemMixedTwinRustAsync_C;
 
 typedef union EnumWithItemMixedTwinRustAsyncKind {
-  struct wire_cst_EnumWithItemMixedTwinRustAsync_A *A;
-  struct wire_cst_EnumWithItemMixedTwinRustAsync_B *B;
-  struct wire_cst_EnumWithItemMixedTwinRustAsync_C *C;
+  struct wire_cst_EnumWithItemMixedTwinRustAsync_B B;
+  struct wire_cst_EnumWithItemMixedTwinRustAsync_C C;
 } EnumWithItemMixedTwinRustAsyncKind;
 
 typedef struct wire_cst_enum_with_item_mixed_twin_rust_async {
   int32_t tag;
-  union EnumWithItemMixedTwinRustAsyncKind *kind;
+  union EnumWithItemMixedTwinRustAsyncKind kind;
 } wire_cst_enum_with_item_mixed_twin_rust_async;
 
 typedef struct wire_cst_EnumWithItemStructTwinRustAsync_A {
@@ -723,13 +698,13 @@ typedef struct wire_cst_EnumWithItemStructTwinRustAsync_B {
 } wire_cst_EnumWithItemStructTwinRustAsync_B;
 
 typedef union EnumWithItemStructTwinRustAsyncKind {
-  struct wire_cst_EnumWithItemStructTwinRustAsync_A *A;
-  struct wire_cst_EnumWithItemStructTwinRustAsync_B *B;
+  struct wire_cst_EnumWithItemStructTwinRustAsync_A A;
+  struct wire_cst_EnumWithItemStructTwinRustAsync_B B;
 } EnumWithItemStructTwinRustAsyncKind;
 
 typedef struct wire_cst_enum_with_item_struct_twin_rust_async {
   int32_t tag;
-  union EnumWithItemStructTwinRustAsyncKind *kind;
+  union EnumWithItemStructTwinRustAsyncKind kind;
 } wire_cst_enum_with_item_struct_twin_rust_async;
 
 typedef struct wire_cst_EnumWithItemTupleTwinRustAsync_A {
@@ -741,18 +716,14 @@ typedef struct wire_cst_EnumWithItemTupleTwinRustAsync_B {
 } wire_cst_EnumWithItemTupleTwinRustAsync_B;
 
 typedef union EnumWithItemTupleTwinRustAsyncKind {
-  struct wire_cst_EnumWithItemTupleTwinRustAsync_A *A;
-  struct wire_cst_EnumWithItemTupleTwinRustAsync_B *B;
+  struct wire_cst_EnumWithItemTupleTwinRustAsync_A A;
+  struct wire_cst_EnumWithItemTupleTwinRustAsync_B B;
 } EnumWithItemTupleTwinRustAsyncKind;
 
 typedef struct wire_cst_enum_with_item_tuple_twin_rust_async {
   int32_t tag;
-  union EnumWithItemTupleTwinRustAsyncKind *kind;
+  union EnumWithItemTupleTwinRustAsyncKind kind;
 } wire_cst_enum_with_item_tuple_twin_rust_async;
-
-typedef struct wire_cst_KitchenSinkTwinRustAsync_Empty {
-
-} wire_cst_KitchenSinkTwinRustAsync_Empty;
 
 typedef struct wire_cst_KitchenSinkTwinRustAsync_Primitives {
   int32_t int32;
@@ -779,57 +750,46 @@ typedef struct wire_cst_KitchenSinkTwinRustAsync_Enums {
 } wire_cst_KitchenSinkTwinRustAsync_Enums;
 
 typedef union KitchenSinkTwinRustAsyncKind {
-  struct wire_cst_KitchenSinkTwinRustAsync_Empty *Empty;
-  struct wire_cst_KitchenSinkTwinRustAsync_Primitives *Primitives;
-  struct wire_cst_KitchenSinkTwinRustAsync_Nested *Nested;
-  struct wire_cst_KitchenSinkTwinRustAsync_Optional *Optional;
-  struct wire_cst_KitchenSinkTwinRustAsync_Buffer *Buffer;
-  struct wire_cst_KitchenSinkTwinRustAsync_Enums *Enums;
+  struct wire_cst_KitchenSinkTwinRustAsync_Primitives Primitives;
+  struct wire_cst_KitchenSinkTwinRustAsync_Nested Nested;
+  struct wire_cst_KitchenSinkTwinRustAsync_Optional Optional;
+  struct wire_cst_KitchenSinkTwinRustAsync_Buffer Buffer;
+  struct wire_cst_KitchenSinkTwinRustAsync_Enums Enums;
 } KitchenSinkTwinRustAsyncKind;
 
 typedef struct wire_cst_kitchen_sink_twin_rust_async {
   int32_t tag;
-  union KitchenSinkTwinRustAsyncKind *kind;
+  union KitchenSinkTwinRustAsyncKind kind;
 } wire_cst_kitchen_sink_twin_rust_async;
-
-typedef struct wire_cst_SpeedTwinRustAsync_Unknown {
-
-} wire_cst_SpeedTwinRustAsync_Unknown;
 
 typedef struct wire_cst_SpeedTwinRustAsync_GPS {
   double field0;
 } wire_cst_SpeedTwinRustAsync_GPS;
 
 typedef union SpeedTwinRustAsyncKind {
-  struct wire_cst_SpeedTwinRustAsync_Unknown *Unknown;
-  struct wire_cst_SpeedTwinRustAsync_GPS *GPS;
+  struct wire_cst_SpeedTwinRustAsync_GPS GPS;
 } SpeedTwinRustAsyncKind;
 
 typedef struct wire_cst_speed_twin_rust_async {
   int32_t tag;
-  union SpeedTwinRustAsyncKind *kind;
+  union SpeedTwinRustAsyncKind kind;
 } wire_cst_speed_twin_rust_async;
 
 typedef struct wire_cst_MeasureTwinRustAsync_Speed {
   struct wire_cst_speed_twin_rust_async *field0;
 } wire_cst_MeasureTwinRustAsync_Speed;
 
-typedef struct wire_cst_DistanceTwinRustAsync_Unknown {
-
-} wire_cst_DistanceTwinRustAsync_Unknown;
-
 typedef struct wire_cst_DistanceTwinRustAsync_Map {
   double field0;
 } wire_cst_DistanceTwinRustAsync_Map;
 
 typedef union DistanceTwinRustAsyncKind {
-  struct wire_cst_DistanceTwinRustAsync_Unknown *Unknown;
-  struct wire_cst_DistanceTwinRustAsync_Map *Map;
+  struct wire_cst_DistanceTwinRustAsync_Map Map;
 } DistanceTwinRustAsyncKind;
 
 typedef struct wire_cst_distance_twin_rust_async {
   int32_t tag;
-  union DistanceTwinRustAsyncKind *kind;
+  union DistanceTwinRustAsyncKind kind;
 } wire_cst_distance_twin_rust_async;
 
 typedef struct wire_cst_MeasureTwinRustAsync_Distance {
@@ -837,23 +797,19 @@ typedef struct wire_cst_MeasureTwinRustAsync_Distance {
 } wire_cst_MeasureTwinRustAsync_Distance;
 
 typedef union MeasureTwinRustAsyncKind {
-  struct wire_cst_MeasureTwinRustAsync_Speed *Speed;
-  struct wire_cst_MeasureTwinRustAsync_Distance *Distance;
+  struct wire_cst_MeasureTwinRustAsync_Speed Speed;
+  struct wire_cst_MeasureTwinRustAsync_Distance Distance;
 } MeasureTwinRustAsyncKind;
 
 typedef struct wire_cst_measure_twin_rust_async {
   int32_t tag;
-  union MeasureTwinRustAsyncKind *kind;
+  union MeasureTwinRustAsyncKind kind;
 } wire_cst_measure_twin_rust_async;
 
 typedef struct wire_cst_note_twin_rust_async {
   int32_t *day;
   struct wire_cst_list_prim_u_8 *body;
 } wire_cst_note_twin_rust_async;
-
-typedef struct wire_cst_EnumWithItemMixedTwinSync_A {
-
-} wire_cst_EnumWithItemMixedTwinSync_A;
 
 typedef struct wire_cst_EnumWithItemMixedTwinSync_B {
   struct wire_cst_list_prim_u_8 *field0;
@@ -864,14 +820,13 @@ typedef struct wire_cst_EnumWithItemMixedTwinSync_C {
 } wire_cst_EnumWithItemMixedTwinSync_C;
 
 typedef union EnumWithItemMixedTwinSyncKind {
-  struct wire_cst_EnumWithItemMixedTwinSync_A *A;
-  struct wire_cst_EnumWithItemMixedTwinSync_B *B;
-  struct wire_cst_EnumWithItemMixedTwinSync_C *C;
+  struct wire_cst_EnumWithItemMixedTwinSync_B B;
+  struct wire_cst_EnumWithItemMixedTwinSync_C C;
 } EnumWithItemMixedTwinSyncKind;
 
 typedef struct wire_cst_enum_with_item_mixed_twin_sync {
   int32_t tag;
-  union EnumWithItemMixedTwinSyncKind *kind;
+  union EnumWithItemMixedTwinSyncKind kind;
 } wire_cst_enum_with_item_mixed_twin_sync;
 
 typedef struct wire_cst_EnumWithItemStructTwinSync_A {
@@ -883,13 +838,13 @@ typedef struct wire_cst_EnumWithItemStructTwinSync_B {
 } wire_cst_EnumWithItemStructTwinSync_B;
 
 typedef union EnumWithItemStructTwinSyncKind {
-  struct wire_cst_EnumWithItemStructTwinSync_A *A;
-  struct wire_cst_EnumWithItemStructTwinSync_B *B;
+  struct wire_cst_EnumWithItemStructTwinSync_A A;
+  struct wire_cst_EnumWithItemStructTwinSync_B B;
 } EnumWithItemStructTwinSyncKind;
 
 typedef struct wire_cst_enum_with_item_struct_twin_sync {
   int32_t tag;
-  union EnumWithItemStructTwinSyncKind *kind;
+  union EnumWithItemStructTwinSyncKind kind;
 } wire_cst_enum_with_item_struct_twin_sync;
 
 typedef struct wire_cst_EnumWithItemTupleTwinSync_A {
@@ -901,18 +856,14 @@ typedef struct wire_cst_EnumWithItemTupleTwinSync_B {
 } wire_cst_EnumWithItemTupleTwinSync_B;
 
 typedef union EnumWithItemTupleTwinSyncKind {
-  struct wire_cst_EnumWithItemTupleTwinSync_A *A;
-  struct wire_cst_EnumWithItemTupleTwinSync_B *B;
+  struct wire_cst_EnumWithItemTupleTwinSync_A A;
+  struct wire_cst_EnumWithItemTupleTwinSync_B B;
 } EnumWithItemTupleTwinSyncKind;
 
 typedef struct wire_cst_enum_with_item_tuple_twin_sync {
   int32_t tag;
-  union EnumWithItemTupleTwinSyncKind *kind;
+  union EnumWithItemTupleTwinSyncKind kind;
 } wire_cst_enum_with_item_tuple_twin_sync;
-
-typedef struct wire_cst_KitchenSinkTwinSync_Empty {
-
-} wire_cst_KitchenSinkTwinSync_Empty;
 
 typedef struct wire_cst_KitchenSinkTwinSync_Primitives {
   int32_t int32;
@@ -939,57 +890,46 @@ typedef struct wire_cst_KitchenSinkTwinSync_Enums {
 } wire_cst_KitchenSinkTwinSync_Enums;
 
 typedef union KitchenSinkTwinSyncKind {
-  struct wire_cst_KitchenSinkTwinSync_Empty *Empty;
-  struct wire_cst_KitchenSinkTwinSync_Primitives *Primitives;
-  struct wire_cst_KitchenSinkTwinSync_Nested *Nested;
-  struct wire_cst_KitchenSinkTwinSync_Optional *Optional;
-  struct wire_cst_KitchenSinkTwinSync_Buffer *Buffer;
-  struct wire_cst_KitchenSinkTwinSync_Enums *Enums;
+  struct wire_cst_KitchenSinkTwinSync_Primitives Primitives;
+  struct wire_cst_KitchenSinkTwinSync_Nested Nested;
+  struct wire_cst_KitchenSinkTwinSync_Optional Optional;
+  struct wire_cst_KitchenSinkTwinSync_Buffer Buffer;
+  struct wire_cst_KitchenSinkTwinSync_Enums Enums;
 } KitchenSinkTwinSyncKind;
 
 typedef struct wire_cst_kitchen_sink_twin_sync {
   int32_t tag;
-  union KitchenSinkTwinSyncKind *kind;
+  union KitchenSinkTwinSyncKind kind;
 } wire_cst_kitchen_sink_twin_sync;
-
-typedef struct wire_cst_SpeedTwinSync_Unknown {
-
-} wire_cst_SpeedTwinSync_Unknown;
 
 typedef struct wire_cst_SpeedTwinSync_GPS {
   double field0;
 } wire_cst_SpeedTwinSync_GPS;
 
 typedef union SpeedTwinSyncKind {
-  struct wire_cst_SpeedTwinSync_Unknown *Unknown;
-  struct wire_cst_SpeedTwinSync_GPS *GPS;
+  struct wire_cst_SpeedTwinSync_GPS GPS;
 } SpeedTwinSyncKind;
 
 typedef struct wire_cst_speed_twin_sync {
   int32_t tag;
-  union SpeedTwinSyncKind *kind;
+  union SpeedTwinSyncKind kind;
 } wire_cst_speed_twin_sync;
 
 typedef struct wire_cst_MeasureTwinSync_Speed {
   struct wire_cst_speed_twin_sync *field0;
 } wire_cst_MeasureTwinSync_Speed;
 
-typedef struct wire_cst_DistanceTwinSync_Unknown {
-
-} wire_cst_DistanceTwinSync_Unknown;
-
 typedef struct wire_cst_DistanceTwinSync_Map {
   double field0;
 } wire_cst_DistanceTwinSync_Map;
 
 typedef union DistanceTwinSyncKind {
-  struct wire_cst_DistanceTwinSync_Unknown *Unknown;
-  struct wire_cst_DistanceTwinSync_Map *Map;
+  struct wire_cst_DistanceTwinSync_Map Map;
 } DistanceTwinSyncKind;
 
 typedef struct wire_cst_distance_twin_sync {
   int32_t tag;
-  union DistanceTwinSyncKind *kind;
+  union DistanceTwinSyncKind kind;
 } wire_cst_distance_twin_sync;
 
 typedef struct wire_cst_MeasureTwinSync_Distance {
@@ -997,13 +937,13 @@ typedef struct wire_cst_MeasureTwinSync_Distance {
 } wire_cst_MeasureTwinSync_Distance;
 
 typedef union MeasureTwinSyncKind {
-  struct wire_cst_MeasureTwinSync_Speed *Speed;
-  struct wire_cst_MeasureTwinSync_Distance *Distance;
+  struct wire_cst_MeasureTwinSync_Speed Speed;
+  struct wire_cst_MeasureTwinSync_Distance Distance;
 } MeasureTwinSyncKind;
 
 typedef struct wire_cst_measure_twin_sync {
   int32_t tag;
-  union MeasureTwinSyncKind *kind;
+  union MeasureTwinSyncKind kind;
 } wire_cst_measure_twin_sync;
 
 typedef struct wire_cst_note_twin_sync {
@@ -1037,13 +977,13 @@ typedef struct wire_cst_CustomNestedErrorInnerTwinRustAsync_Four {
 } wire_cst_CustomNestedErrorInnerTwinRustAsync_Four;
 
 typedef union CustomNestedErrorInnerTwinRustAsyncKind {
-  struct wire_cst_CustomNestedErrorInnerTwinRustAsync_Three *Three;
-  struct wire_cst_CustomNestedErrorInnerTwinRustAsync_Four *Four;
+  struct wire_cst_CustomNestedErrorInnerTwinRustAsync_Three Three;
+  struct wire_cst_CustomNestedErrorInnerTwinRustAsync_Four Four;
 } CustomNestedErrorInnerTwinRustAsyncKind;
 
 typedef struct wire_cst_custom_nested_error_inner_twin_rust_async {
   int32_t tag;
-  union CustomNestedErrorInnerTwinRustAsyncKind *kind;
+  union CustomNestedErrorInnerTwinRustAsyncKind kind;
 } wire_cst_custom_nested_error_inner_twin_rust_async;
 
 typedef struct wire_cst_CustomNestedErrorOuterTwinRustAsync_Two {
@@ -1051,13 +991,13 @@ typedef struct wire_cst_CustomNestedErrorOuterTwinRustAsync_Two {
 } wire_cst_CustomNestedErrorOuterTwinRustAsync_Two;
 
 typedef union CustomNestedErrorOuterTwinRustAsyncKind {
-  struct wire_cst_CustomNestedErrorOuterTwinRustAsync_One *One;
-  struct wire_cst_CustomNestedErrorOuterTwinRustAsync_Two *Two;
+  struct wire_cst_CustomNestedErrorOuterTwinRustAsync_One One;
+  struct wire_cst_CustomNestedErrorOuterTwinRustAsync_Two Two;
 } CustomNestedErrorOuterTwinRustAsyncKind;
 
 typedef struct wire_cst_custom_nested_error_outer_twin_rust_async {
   int32_t tag;
-  union CustomNestedErrorOuterTwinRustAsyncKind *kind;
+  union CustomNestedErrorOuterTwinRustAsyncKind kind;
 } wire_cst_custom_nested_error_outer_twin_rust_async;
 
 typedef struct wire_cst_custom_struct_error_twin_rust_async {
@@ -1085,13 +1025,13 @@ typedef struct wire_cst_CustomNestedErrorInnerTwinSync_Four {
 } wire_cst_CustomNestedErrorInnerTwinSync_Four;
 
 typedef union CustomNestedErrorInnerTwinSyncKind {
-  struct wire_cst_CustomNestedErrorInnerTwinSync_Three *Three;
-  struct wire_cst_CustomNestedErrorInnerTwinSync_Four *Four;
+  struct wire_cst_CustomNestedErrorInnerTwinSync_Three Three;
+  struct wire_cst_CustomNestedErrorInnerTwinSync_Four Four;
 } CustomNestedErrorInnerTwinSyncKind;
 
 typedef struct wire_cst_custom_nested_error_inner_twin_sync {
   int32_t tag;
-  union CustomNestedErrorInnerTwinSyncKind *kind;
+  union CustomNestedErrorInnerTwinSyncKind kind;
 } wire_cst_custom_nested_error_inner_twin_sync;
 
 typedef struct wire_cst_CustomNestedErrorOuterTwinSync_Two {
@@ -1099,13 +1039,13 @@ typedef struct wire_cst_CustomNestedErrorOuterTwinSync_Two {
 } wire_cst_CustomNestedErrorOuterTwinSync_Two;
 
 typedef union CustomNestedErrorOuterTwinSyncKind {
-  struct wire_cst_CustomNestedErrorOuterTwinSync_One *One;
-  struct wire_cst_CustomNestedErrorOuterTwinSync_Two *Two;
+  struct wire_cst_CustomNestedErrorOuterTwinSync_One One;
+  struct wire_cst_CustomNestedErrorOuterTwinSync_Two Two;
 } CustomNestedErrorOuterTwinSyncKind;
 
 typedef struct wire_cst_custom_nested_error_outer_twin_sync {
   int32_t tag;
-  union CustomNestedErrorOuterTwinSyncKind *kind;
+  union CustomNestedErrorOuterTwinSyncKind kind;
 } wire_cst_custom_nested_error_outer_twin_sync;
 
 typedef struct wire_cst_custom_struct_error_twin_sync {
@@ -1179,15 +1119,15 @@ typedef struct wire_cst_AbcTwinRustAsync_JustInt {
 } wire_cst_AbcTwinRustAsync_JustInt;
 
 typedef union AbcTwinRustAsyncKind {
-  struct wire_cst_AbcTwinRustAsync_A *A;
-  struct wire_cst_AbcTwinRustAsync_B *B;
-  struct wire_cst_AbcTwinRustAsync_C *C;
-  struct wire_cst_AbcTwinRustAsync_JustInt *JustInt;
+  struct wire_cst_AbcTwinRustAsync_A A;
+  struct wire_cst_AbcTwinRustAsync_B B;
+  struct wire_cst_AbcTwinRustAsync_C C;
+  struct wire_cst_AbcTwinRustAsync_JustInt JustInt;
 } AbcTwinRustAsyncKind;
 
 typedef struct wire_cst_abc_twin_rust_async {
   int32_t tag;
-  union AbcTwinRustAsyncKind *kind;
+  union AbcTwinRustAsyncKind kind;
 } wire_cst_abc_twin_rust_async;
 
 typedef struct wire_cst_struct_with_enum_twin_rust_async {
@@ -1246,15 +1186,15 @@ typedef struct wire_cst_AbcTwinSync_JustInt {
 } wire_cst_AbcTwinSync_JustInt;
 
 typedef union AbcTwinSyncKind {
-  struct wire_cst_AbcTwinSync_A *A;
-  struct wire_cst_AbcTwinSync_B *B;
-  struct wire_cst_AbcTwinSync_C *C;
-  struct wire_cst_AbcTwinSync_JustInt *JustInt;
+  struct wire_cst_AbcTwinSync_A A;
+  struct wire_cst_AbcTwinSync_B B;
+  struct wire_cst_AbcTwinSync_C C;
+  struct wire_cst_AbcTwinSync_JustInt JustInt;
 } AbcTwinSyncKind;
 
 typedef struct wire_cst_abc_twin_sync {
   int32_t tag;
-  union AbcTwinSyncKind *kind;
+  union AbcTwinSyncKind kind;
 } wire_cst_abc_twin_sync;
 
 typedef struct wire_cst_struct_with_enum_twin_sync {
@@ -1422,16 +1362,16 @@ typedef struct wire_cst_EnumOpaqueTwinRustAsync_RwLock {
 } wire_cst_EnumOpaqueTwinRustAsync_RwLock;
 
 typedef union EnumOpaqueTwinRustAsyncKind {
-  struct wire_cst_EnumOpaqueTwinRustAsync_Struct *Struct;
-  struct wire_cst_EnumOpaqueTwinRustAsync_Primitive *Primitive;
-  struct wire_cst_EnumOpaqueTwinRustAsync_TraitObj *TraitObj;
-  struct wire_cst_EnumOpaqueTwinRustAsync_Mutex *Mutex;
-  struct wire_cst_EnumOpaqueTwinRustAsync_RwLock *RwLock;
+  struct wire_cst_EnumOpaqueTwinRustAsync_Struct Struct;
+  struct wire_cst_EnumOpaqueTwinRustAsync_Primitive Primitive;
+  struct wire_cst_EnumOpaqueTwinRustAsync_TraitObj TraitObj;
+  struct wire_cst_EnumOpaqueTwinRustAsync_Mutex Mutex;
+  struct wire_cst_EnumOpaqueTwinRustAsync_RwLock RwLock;
 } EnumOpaqueTwinRustAsyncKind;
 
 typedef struct wire_cst_enum_opaque_twin_rust_async {
   int32_t tag;
-  union EnumOpaqueTwinRustAsyncKind *kind;
+  union EnumOpaqueTwinRustAsyncKind kind;
 } wire_cst_enum_opaque_twin_rust_async;
 
 typedef struct wire_cst_opaque_nested_twin_rust_async {
@@ -1460,16 +1400,16 @@ typedef struct wire_cst_EnumOpaqueTwinSync_RwLock {
 } wire_cst_EnumOpaqueTwinSync_RwLock;
 
 typedef union EnumOpaqueTwinSyncKind {
-  struct wire_cst_EnumOpaqueTwinSync_Struct *Struct;
-  struct wire_cst_EnumOpaqueTwinSync_Primitive *Primitive;
-  struct wire_cst_EnumOpaqueTwinSync_TraitObj *TraitObj;
-  struct wire_cst_EnumOpaqueTwinSync_Mutex *Mutex;
-  struct wire_cst_EnumOpaqueTwinSync_RwLock *RwLock;
+  struct wire_cst_EnumOpaqueTwinSync_Struct Struct;
+  struct wire_cst_EnumOpaqueTwinSync_Primitive Primitive;
+  struct wire_cst_EnumOpaqueTwinSync_TraitObj TraitObj;
+  struct wire_cst_EnumOpaqueTwinSync_Mutex Mutex;
+  struct wire_cst_EnumOpaqueTwinSync_RwLock RwLock;
 } EnumOpaqueTwinSyncKind;
 
 typedef struct wire_cst_enum_opaque_twin_sync {
   int32_t tag;
-  union EnumOpaqueTwinSyncKind *kind;
+  union EnumOpaqueTwinSyncKind kind;
 } wire_cst_enum_opaque_twin_sync;
 
 typedef struct wire_cst_opaque_nested_twin_sync {
@@ -1560,16 +1500,16 @@ typedef struct wire_cst_EnumOpaqueTwinNormal_RwLock {
 } wire_cst_EnumOpaqueTwinNormal_RwLock;
 
 typedef union EnumOpaqueTwinNormalKind {
-  struct wire_cst_EnumOpaqueTwinNormal_Struct *Struct;
-  struct wire_cst_EnumOpaqueTwinNormal_Primitive *Primitive;
-  struct wire_cst_EnumOpaqueTwinNormal_TraitObj *TraitObj;
-  struct wire_cst_EnumOpaqueTwinNormal_Mutex *Mutex;
-  struct wire_cst_EnumOpaqueTwinNormal_RwLock *RwLock;
+  struct wire_cst_EnumOpaqueTwinNormal_Struct Struct;
+  struct wire_cst_EnumOpaqueTwinNormal_Primitive Primitive;
+  struct wire_cst_EnumOpaqueTwinNormal_TraitObj TraitObj;
+  struct wire_cst_EnumOpaqueTwinNormal_Mutex Mutex;
+  struct wire_cst_EnumOpaqueTwinNormal_RwLock RwLock;
 } EnumOpaqueTwinNormalKind;
 
 typedef struct wire_cst_enum_opaque_twin_normal {
   int32_t tag;
-  union EnumOpaqueTwinNormalKind *kind;
+  union EnumOpaqueTwinNormalKind kind;
 } wire_cst_enum_opaque_twin_normal;
 
 typedef struct wire_cst_opaque_nested_twin_normal {
@@ -1640,15 +1580,15 @@ typedef struct wire_cst_AbcTwinRustAsyncSse_JustInt {
 } wire_cst_AbcTwinRustAsyncSse_JustInt;
 
 typedef union AbcTwinRustAsyncSseKind {
-  struct wire_cst_AbcTwinRustAsyncSse_A *A;
-  struct wire_cst_AbcTwinRustAsyncSse_B *B;
-  struct wire_cst_AbcTwinRustAsyncSse_C *C;
-  struct wire_cst_AbcTwinRustAsyncSse_JustInt *JustInt;
+  struct wire_cst_AbcTwinRustAsyncSse_A A;
+  struct wire_cst_AbcTwinRustAsyncSse_B B;
+  struct wire_cst_AbcTwinRustAsyncSse_C C;
+  struct wire_cst_AbcTwinRustAsyncSse_JustInt JustInt;
 } AbcTwinRustAsyncSseKind;
 
 typedef struct wire_cst_abc_twin_rust_async_sse {
   int32_t tag;
-  union AbcTwinRustAsyncSseKind *kind;
+  union AbcTwinRustAsyncSseKind kind;
 } wire_cst_abc_twin_rust_async_sse;
 
 typedef struct wire_cst_AbcTwinSse_A {
@@ -1676,15 +1616,15 @@ typedef struct wire_cst_AbcTwinSse_JustInt {
 } wire_cst_AbcTwinSse_JustInt;
 
 typedef union AbcTwinSseKind {
-  struct wire_cst_AbcTwinSse_A *A;
-  struct wire_cst_AbcTwinSse_B *B;
-  struct wire_cst_AbcTwinSse_C *C;
-  struct wire_cst_AbcTwinSse_JustInt *JustInt;
+  struct wire_cst_AbcTwinSse_A A;
+  struct wire_cst_AbcTwinSse_B B;
+  struct wire_cst_AbcTwinSse_C C;
+  struct wire_cst_AbcTwinSse_JustInt JustInt;
 } AbcTwinSseKind;
 
 typedef struct wire_cst_abc_twin_sse {
   int32_t tag;
-  union AbcTwinSseKind *kind;
+  union AbcTwinSseKind kind;
 } wire_cst_abc_twin_sse;
 
 typedef struct wire_cst_AbcTwinSyncSse_A {
@@ -1712,15 +1652,15 @@ typedef struct wire_cst_AbcTwinSyncSse_JustInt {
 } wire_cst_AbcTwinSyncSse_JustInt;
 
 typedef union AbcTwinSyncSseKind {
-  struct wire_cst_AbcTwinSyncSse_A *A;
-  struct wire_cst_AbcTwinSyncSse_B *B;
-  struct wire_cst_AbcTwinSyncSse_C *C;
-  struct wire_cst_AbcTwinSyncSse_JustInt *JustInt;
+  struct wire_cst_AbcTwinSyncSse_A A;
+  struct wire_cst_AbcTwinSyncSse_B B;
+  struct wire_cst_AbcTwinSyncSse_C C;
+  struct wire_cst_AbcTwinSyncSse_JustInt JustInt;
 } AbcTwinSyncSseKind;
 
 typedef struct wire_cst_abc_twin_sync_sse {
   int32_t tag;
-  union AbcTwinSyncSseKind *kind;
+  union AbcTwinSyncSseKind kind;
 } wire_cst_abc_twin_sync_sse;
 
 typedef struct wire_cst_attribute_twin_rust_async_sse {
@@ -1795,13 +1735,13 @@ typedef struct wire_cst_CustomNestedError2TwinNormal_CustomNested2Number {
 } wire_cst_CustomNestedError2TwinNormal_CustomNested2Number;
 
 typedef union CustomNestedError2TwinNormalKind {
-  struct wire_cst_CustomNestedError2TwinNormal_CustomNested2 *CustomNested2;
-  struct wire_cst_CustomNestedError2TwinNormal_CustomNested2Number *CustomNested2Number;
+  struct wire_cst_CustomNestedError2TwinNormal_CustomNested2 CustomNested2;
+  struct wire_cst_CustomNestedError2TwinNormal_CustomNested2Number CustomNested2Number;
 } CustomNestedError2TwinNormalKind;
 
 typedef struct wire_cst_custom_nested_error_2_twin_normal {
   int32_t tag;
-  union CustomNestedError2TwinNormalKind *kind;
+  union CustomNestedError2TwinNormalKind kind;
 } wire_cst_custom_nested_error_2_twin_normal;
 
 typedef struct wire_cst_CustomNestedError2TwinRustAsync_CustomNested2 {
@@ -1813,13 +1753,13 @@ typedef struct wire_cst_CustomNestedError2TwinRustAsync_CustomNested2Number {
 } wire_cst_CustomNestedError2TwinRustAsync_CustomNested2Number;
 
 typedef union CustomNestedError2TwinRustAsyncKind {
-  struct wire_cst_CustomNestedError2TwinRustAsync_CustomNested2 *CustomNested2;
-  struct wire_cst_CustomNestedError2TwinRustAsync_CustomNested2Number *CustomNested2Number;
+  struct wire_cst_CustomNestedError2TwinRustAsync_CustomNested2 CustomNested2;
+  struct wire_cst_CustomNestedError2TwinRustAsync_CustomNested2Number CustomNested2Number;
 } CustomNestedError2TwinRustAsyncKind;
 
 typedef struct wire_cst_custom_nested_error_2_twin_rust_async {
   int32_t tag;
-  union CustomNestedError2TwinRustAsyncKind *kind;
+  union CustomNestedError2TwinRustAsyncKind kind;
 } wire_cst_custom_nested_error_2_twin_rust_async;
 
 typedef struct wire_cst_CustomNestedError2TwinRustAsyncSse_CustomNested2 {
@@ -1831,13 +1771,13 @@ typedef struct wire_cst_CustomNestedError2TwinRustAsyncSse_CustomNested2Number {
 } wire_cst_CustomNestedError2TwinRustAsyncSse_CustomNested2Number;
 
 typedef union CustomNestedError2TwinRustAsyncSseKind {
-  struct wire_cst_CustomNestedError2TwinRustAsyncSse_CustomNested2 *CustomNested2;
-  struct wire_cst_CustomNestedError2TwinRustAsyncSse_CustomNested2Number *CustomNested2Number;
+  struct wire_cst_CustomNestedError2TwinRustAsyncSse_CustomNested2 CustomNested2;
+  struct wire_cst_CustomNestedError2TwinRustAsyncSse_CustomNested2Number CustomNested2Number;
 } CustomNestedError2TwinRustAsyncSseKind;
 
 typedef struct wire_cst_custom_nested_error_2_twin_rust_async_sse {
   int32_t tag;
-  union CustomNestedError2TwinRustAsyncSseKind *kind;
+  union CustomNestedError2TwinRustAsyncSseKind kind;
 } wire_cst_custom_nested_error_2_twin_rust_async_sse;
 
 typedef struct wire_cst_CustomNestedError2TwinSse_CustomNested2 {
@@ -1849,13 +1789,13 @@ typedef struct wire_cst_CustomNestedError2TwinSse_CustomNested2Number {
 } wire_cst_CustomNestedError2TwinSse_CustomNested2Number;
 
 typedef union CustomNestedError2TwinSseKind {
-  struct wire_cst_CustomNestedError2TwinSse_CustomNested2 *CustomNested2;
-  struct wire_cst_CustomNestedError2TwinSse_CustomNested2Number *CustomNested2Number;
+  struct wire_cst_CustomNestedError2TwinSse_CustomNested2 CustomNested2;
+  struct wire_cst_CustomNestedError2TwinSse_CustomNested2Number CustomNested2Number;
 } CustomNestedError2TwinSseKind;
 
 typedef struct wire_cst_custom_nested_error_2_twin_sse {
   int32_t tag;
-  union CustomNestedError2TwinSseKind *kind;
+  union CustomNestedError2TwinSseKind kind;
 } wire_cst_custom_nested_error_2_twin_sse;
 
 typedef struct wire_cst_CustomNestedError2TwinSync_CustomNested2 {
@@ -1867,13 +1807,13 @@ typedef struct wire_cst_CustomNestedError2TwinSync_CustomNested2Number {
 } wire_cst_CustomNestedError2TwinSync_CustomNested2Number;
 
 typedef union CustomNestedError2TwinSyncKind {
-  struct wire_cst_CustomNestedError2TwinSync_CustomNested2 *CustomNested2;
-  struct wire_cst_CustomNestedError2TwinSync_CustomNested2Number *CustomNested2Number;
+  struct wire_cst_CustomNestedError2TwinSync_CustomNested2 CustomNested2;
+  struct wire_cst_CustomNestedError2TwinSync_CustomNested2Number CustomNested2Number;
 } CustomNestedError2TwinSyncKind;
 
 typedef struct wire_cst_custom_nested_error_2_twin_sync {
   int32_t tag;
-  union CustomNestedError2TwinSyncKind *kind;
+  union CustomNestedError2TwinSyncKind kind;
 } wire_cst_custom_nested_error_2_twin_sync;
 
 typedef struct wire_cst_CustomNestedError2TwinSyncSse_CustomNested2 {
@@ -1885,13 +1825,13 @@ typedef struct wire_cst_CustomNestedError2TwinSyncSse_CustomNested2Number {
 } wire_cst_CustomNestedError2TwinSyncSse_CustomNested2Number;
 
 typedef union CustomNestedError2TwinSyncSseKind {
-  struct wire_cst_CustomNestedError2TwinSyncSse_CustomNested2 *CustomNested2;
-  struct wire_cst_CustomNestedError2TwinSyncSse_CustomNested2Number *CustomNested2Number;
+  struct wire_cst_CustomNestedError2TwinSyncSse_CustomNested2 CustomNested2;
+  struct wire_cst_CustomNestedError2TwinSyncSse_CustomNested2Number CustomNested2Number;
 } CustomNestedError2TwinSyncSseKind;
 
 typedef struct wire_cst_custom_nested_error_2_twin_sync_sse {
   int32_t tag;
-  union CustomNestedError2TwinSyncSseKind *kind;
+  union CustomNestedError2TwinSyncSseKind kind;
 } wire_cst_custom_nested_error_2_twin_sync_sse;
 
 typedef struct wire_cst_CustomNestedErrorInnerTwinRustAsyncSse_Three {
@@ -1903,13 +1843,13 @@ typedef struct wire_cst_CustomNestedErrorInnerTwinRustAsyncSse_Four {
 } wire_cst_CustomNestedErrorInnerTwinRustAsyncSse_Four;
 
 typedef union CustomNestedErrorInnerTwinRustAsyncSseKind {
-  struct wire_cst_CustomNestedErrorInnerTwinRustAsyncSse_Three *Three;
-  struct wire_cst_CustomNestedErrorInnerTwinRustAsyncSse_Four *Four;
+  struct wire_cst_CustomNestedErrorInnerTwinRustAsyncSse_Three Three;
+  struct wire_cst_CustomNestedErrorInnerTwinRustAsyncSse_Four Four;
 } CustomNestedErrorInnerTwinRustAsyncSseKind;
 
 typedef struct wire_cst_custom_nested_error_inner_twin_rust_async_sse {
   int32_t tag;
-  union CustomNestedErrorInnerTwinRustAsyncSseKind *kind;
+  union CustomNestedErrorInnerTwinRustAsyncSseKind kind;
 } wire_cst_custom_nested_error_inner_twin_rust_async_sse;
 
 typedef struct wire_cst_CustomNestedErrorInnerTwinSse_Three {
@@ -1921,13 +1861,13 @@ typedef struct wire_cst_CustomNestedErrorInnerTwinSse_Four {
 } wire_cst_CustomNestedErrorInnerTwinSse_Four;
 
 typedef union CustomNestedErrorInnerTwinSseKind {
-  struct wire_cst_CustomNestedErrorInnerTwinSse_Three *Three;
-  struct wire_cst_CustomNestedErrorInnerTwinSse_Four *Four;
+  struct wire_cst_CustomNestedErrorInnerTwinSse_Three Three;
+  struct wire_cst_CustomNestedErrorInnerTwinSse_Four Four;
 } CustomNestedErrorInnerTwinSseKind;
 
 typedef struct wire_cst_custom_nested_error_inner_twin_sse {
   int32_t tag;
-  union CustomNestedErrorInnerTwinSseKind *kind;
+  union CustomNestedErrorInnerTwinSseKind kind;
 } wire_cst_custom_nested_error_inner_twin_sse;
 
 typedef struct wire_cst_CustomNestedErrorInnerTwinSyncSse_Three {
@@ -1939,13 +1879,13 @@ typedef struct wire_cst_CustomNestedErrorInnerTwinSyncSse_Four {
 } wire_cst_CustomNestedErrorInnerTwinSyncSse_Four;
 
 typedef union CustomNestedErrorInnerTwinSyncSseKind {
-  struct wire_cst_CustomNestedErrorInnerTwinSyncSse_Three *Three;
-  struct wire_cst_CustomNestedErrorInnerTwinSyncSse_Four *Four;
+  struct wire_cst_CustomNestedErrorInnerTwinSyncSse_Three Three;
+  struct wire_cst_CustomNestedErrorInnerTwinSyncSse_Four Four;
 } CustomNestedErrorInnerTwinSyncSseKind;
 
 typedef struct wire_cst_custom_nested_error_inner_twin_sync_sse {
   int32_t tag;
-  union CustomNestedErrorInnerTwinSyncSseKind *kind;
+  union CustomNestedErrorInnerTwinSyncSseKind kind;
 } wire_cst_custom_nested_error_inner_twin_sync_sse;
 
 typedef struct wire_cst_CustomNestedErrorOuterTwinRustAsyncSse_One {
@@ -1957,13 +1897,13 @@ typedef struct wire_cst_CustomNestedErrorOuterTwinRustAsyncSse_Two {
 } wire_cst_CustomNestedErrorOuterTwinRustAsyncSse_Two;
 
 typedef union CustomNestedErrorOuterTwinRustAsyncSseKind {
-  struct wire_cst_CustomNestedErrorOuterTwinRustAsyncSse_One *One;
-  struct wire_cst_CustomNestedErrorOuterTwinRustAsyncSse_Two *Two;
+  struct wire_cst_CustomNestedErrorOuterTwinRustAsyncSse_One One;
+  struct wire_cst_CustomNestedErrorOuterTwinRustAsyncSse_Two Two;
 } CustomNestedErrorOuterTwinRustAsyncSseKind;
 
 typedef struct wire_cst_custom_nested_error_outer_twin_rust_async_sse {
   int32_t tag;
-  union CustomNestedErrorOuterTwinRustAsyncSseKind *kind;
+  union CustomNestedErrorOuterTwinRustAsyncSseKind kind;
 } wire_cst_custom_nested_error_outer_twin_rust_async_sse;
 
 typedef struct wire_cst_CustomNestedErrorOuterTwinSse_One {
@@ -1975,13 +1915,13 @@ typedef struct wire_cst_CustomNestedErrorOuterTwinSse_Two {
 } wire_cst_CustomNestedErrorOuterTwinSse_Two;
 
 typedef union CustomNestedErrorOuterTwinSseKind {
-  struct wire_cst_CustomNestedErrorOuterTwinSse_One *One;
-  struct wire_cst_CustomNestedErrorOuterTwinSse_Two *Two;
+  struct wire_cst_CustomNestedErrorOuterTwinSse_One One;
+  struct wire_cst_CustomNestedErrorOuterTwinSse_Two Two;
 } CustomNestedErrorOuterTwinSseKind;
 
 typedef struct wire_cst_custom_nested_error_outer_twin_sse {
   int32_t tag;
-  union CustomNestedErrorOuterTwinSseKind *kind;
+  union CustomNestedErrorOuterTwinSseKind kind;
 } wire_cst_custom_nested_error_outer_twin_sse;
 
 typedef struct wire_cst_CustomNestedErrorOuterTwinSyncSse_One {
@@ -1993,13 +1933,13 @@ typedef struct wire_cst_CustomNestedErrorOuterTwinSyncSse_Two {
 } wire_cst_CustomNestedErrorOuterTwinSyncSse_Two;
 
 typedef union CustomNestedErrorOuterTwinSyncSseKind {
-  struct wire_cst_CustomNestedErrorOuterTwinSyncSse_One *One;
-  struct wire_cst_CustomNestedErrorOuterTwinSyncSse_Two *Two;
+  struct wire_cst_CustomNestedErrorOuterTwinSyncSse_One One;
+  struct wire_cst_CustomNestedErrorOuterTwinSyncSse_Two Two;
 } CustomNestedErrorOuterTwinSyncSseKind;
 
 typedef struct wire_cst_custom_nested_error_outer_twin_sync_sse {
   int32_t tag;
-  union CustomNestedErrorOuterTwinSyncSseKind *kind;
+  union CustomNestedErrorOuterTwinSyncSseKind kind;
 } wire_cst_custom_nested_error_outer_twin_sync_sse;
 
 typedef struct wire_cst_custom_struct_error_twin_rust_async_sse {
@@ -2164,13 +2104,13 @@ typedef struct wire_cst_EnumDartOpaqueTwinRustAsyncSse_Opaque {
 } wire_cst_EnumDartOpaqueTwinRustAsyncSse_Opaque;
 
 typedef union EnumDartOpaqueTwinRustAsyncSseKind {
-  struct wire_cst_EnumDartOpaqueTwinRustAsyncSse_Primitive *Primitive;
-  struct wire_cst_EnumDartOpaqueTwinRustAsyncSse_Opaque *Opaque;
+  struct wire_cst_EnumDartOpaqueTwinRustAsyncSse_Primitive Primitive;
+  struct wire_cst_EnumDartOpaqueTwinRustAsyncSse_Opaque Opaque;
 } EnumDartOpaqueTwinRustAsyncSseKind;
 
 typedef struct wire_cst_enum_dart_opaque_twin_rust_async_sse {
   int32_t tag;
-  union EnumDartOpaqueTwinRustAsyncSseKind *kind;
+  union EnumDartOpaqueTwinRustAsyncSseKind kind;
 } wire_cst_enum_dart_opaque_twin_rust_async_sse;
 
 typedef struct wire_cst_EnumDartOpaqueTwinSse_Primitive {
@@ -2182,13 +2122,13 @@ typedef struct wire_cst_EnumDartOpaqueTwinSse_Opaque {
 } wire_cst_EnumDartOpaqueTwinSse_Opaque;
 
 typedef union EnumDartOpaqueTwinSseKind {
-  struct wire_cst_EnumDartOpaqueTwinSse_Primitive *Primitive;
-  struct wire_cst_EnumDartOpaqueTwinSse_Opaque *Opaque;
+  struct wire_cst_EnumDartOpaqueTwinSse_Primitive Primitive;
+  struct wire_cst_EnumDartOpaqueTwinSse_Opaque Opaque;
 } EnumDartOpaqueTwinSseKind;
 
 typedef struct wire_cst_enum_dart_opaque_twin_sse {
   int32_t tag;
-  union EnumDartOpaqueTwinSseKind *kind;
+  union EnumDartOpaqueTwinSseKind kind;
 } wire_cst_enum_dart_opaque_twin_sse;
 
 typedef struct wire_cst_EnumDartOpaqueTwinSyncSse_Primitive {
@@ -2200,13 +2140,13 @@ typedef struct wire_cst_EnumDartOpaqueTwinSyncSse_Opaque {
 } wire_cst_EnumDartOpaqueTwinSyncSse_Opaque;
 
 typedef union EnumDartOpaqueTwinSyncSseKind {
-  struct wire_cst_EnumDartOpaqueTwinSyncSse_Primitive *Primitive;
-  struct wire_cst_EnumDartOpaqueTwinSyncSse_Opaque *Opaque;
+  struct wire_cst_EnumDartOpaqueTwinSyncSse_Primitive Primitive;
+  struct wire_cst_EnumDartOpaqueTwinSyncSse_Opaque Opaque;
 } EnumDartOpaqueTwinSyncSseKind;
 
 typedef struct wire_cst_enum_dart_opaque_twin_sync_sse {
   int32_t tag;
-  union EnumDartOpaqueTwinSyncSseKind *kind;
+  union EnumDartOpaqueTwinSyncSseKind kind;
 } wire_cst_enum_dart_opaque_twin_sync_sse;
 
 typedef struct wire_cst_EnumOpaqueTwinRustAsyncSse_Struct {
@@ -2230,16 +2170,16 @@ typedef struct wire_cst_EnumOpaqueTwinRustAsyncSse_RwLock {
 } wire_cst_EnumOpaqueTwinRustAsyncSse_RwLock;
 
 typedef union EnumOpaqueTwinRustAsyncSseKind {
-  struct wire_cst_EnumOpaqueTwinRustAsyncSse_Struct *Struct;
-  struct wire_cst_EnumOpaqueTwinRustAsyncSse_Primitive *Primitive;
-  struct wire_cst_EnumOpaqueTwinRustAsyncSse_TraitObj *TraitObj;
-  struct wire_cst_EnumOpaqueTwinRustAsyncSse_Mutex *Mutex;
-  struct wire_cst_EnumOpaqueTwinRustAsyncSse_RwLock *RwLock;
+  struct wire_cst_EnumOpaqueTwinRustAsyncSse_Struct Struct;
+  struct wire_cst_EnumOpaqueTwinRustAsyncSse_Primitive Primitive;
+  struct wire_cst_EnumOpaqueTwinRustAsyncSse_TraitObj TraitObj;
+  struct wire_cst_EnumOpaqueTwinRustAsyncSse_Mutex Mutex;
+  struct wire_cst_EnumOpaqueTwinRustAsyncSse_RwLock RwLock;
 } EnumOpaqueTwinRustAsyncSseKind;
 
 typedef struct wire_cst_enum_opaque_twin_rust_async_sse {
   int32_t tag;
-  union EnumOpaqueTwinRustAsyncSseKind *kind;
+  union EnumOpaqueTwinRustAsyncSseKind kind;
 } wire_cst_enum_opaque_twin_rust_async_sse;
 
 typedef struct wire_cst_EnumOpaqueTwinSse_Struct {
@@ -2263,16 +2203,16 @@ typedef struct wire_cst_EnumOpaqueTwinSse_RwLock {
 } wire_cst_EnumOpaqueTwinSse_RwLock;
 
 typedef union EnumOpaqueTwinSseKind {
-  struct wire_cst_EnumOpaqueTwinSse_Struct *Struct;
-  struct wire_cst_EnumOpaqueTwinSse_Primitive *Primitive;
-  struct wire_cst_EnumOpaqueTwinSse_TraitObj *TraitObj;
-  struct wire_cst_EnumOpaqueTwinSse_Mutex *Mutex;
-  struct wire_cst_EnumOpaqueTwinSse_RwLock *RwLock;
+  struct wire_cst_EnumOpaqueTwinSse_Struct Struct;
+  struct wire_cst_EnumOpaqueTwinSse_Primitive Primitive;
+  struct wire_cst_EnumOpaqueTwinSse_TraitObj TraitObj;
+  struct wire_cst_EnumOpaqueTwinSse_Mutex Mutex;
+  struct wire_cst_EnumOpaqueTwinSse_RwLock RwLock;
 } EnumOpaqueTwinSseKind;
 
 typedef struct wire_cst_enum_opaque_twin_sse {
   int32_t tag;
-  union EnumOpaqueTwinSseKind *kind;
+  union EnumOpaqueTwinSseKind kind;
 } wire_cst_enum_opaque_twin_sse;
 
 typedef struct wire_cst_EnumOpaqueTwinSyncSse_Struct {
@@ -2296,21 +2236,17 @@ typedef struct wire_cst_EnumOpaqueTwinSyncSse_RwLock {
 } wire_cst_EnumOpaqueTwinSyncSse_RwLock;
 
 typedef union EnumOpaqueTwinSyncSseKind {
-  struct wire_cst_EnumOpaqueTwinSyncSse_Struct *Struct;
-  struct wire_cst_EnumOpaqueTwinSyncSse_Primitive *Primitive;
-  struct wire_cst_EnumOpaqueTwinSyncSse_TraitObj *TraitObj;
-  struct wire_cst_EnumOpaqueTwinSyncSse_Mutex *Mutex;
-  struct wire_cst_EnumOpaqueTwinSyncSse_RwLock *RwLock;
+  struct wire_cst_EnumOpaqueTwinSyncSse_Struct Struct;
+  struct wire_cst_EnumOpaqueTwinSyncSse_Primitive Primitive;
+  struct wire_cst_EnumOpaqueTwinSyncSse_TraitObj TraitObj;
+  struct wire_cst_EnumOpaqueTwinSyncSse_Mutex Mutex;
+  struct wire_cst_EnumOpaqueTwinSyncSse_RwLock RwLock;
 } EnumOpaqueTwinSyncSseKind;
 
 typedef struct wire_cst_enum_opaque_twin_sync_sse {
   int32_t tag;
-  union EnumOpaqueTwinSyncSseKind *kind;
+  union EnumOpaqueTwinSyncSseKind kind;
 } wire_cst_enum_opaque_twin_sync_sse;
-
-typedef struct wire_cst_EnumWithItemMixedTwinRustAsyncSse_A {
-
-} wire_cst_EnumWithItemMixedTwinRustAsyncSse_A;
 
 typedef struct wire_cst_EnumWithItemMixedTwinRustAsyncSse_B {
   struct wire_cst_list_prim_u_8 *field0;
@@ -2321,19 +2257,14 @@ typedef struct wire_cst_EnumWithItemMixedTwinRustAsyncSse_C {
 } wire_cst_EnumWithItemMixedTwinRustAsyncSse_C;
 
 typedef union EnumWithItemMixedTwinRustAsyncSseKind {
-  struct wire_cst_EnumWithItemMixedTwinRustAsyncSse_A *A;
-  struct wire_cst_EnumWithItemMixedTwinRustAsyncSse_B *B;
-  struct wire_cst_EnumWithItemMixedTwinRustAsyncSse_C *C;
+  struct wire_cst_EnumWithItemMixedTwinRustAsyncSse_B B;
+  struct wire_cst_EnumWithItemMixedTwinRustAsyncSse_C C;
 } EnumWithItemMixedTwinRustAsyncSseKind;
 
 typedef struct wire_cst_enum_with_item_mixed_twin_rust_async_sse {
   int32_t tag;
-  union EnumWithItemMixedTwinRustAsyncSseKind *kind;
+  union EnumWithItemMixedTwinRustAsyncSseKind kind;
 } wire_cst_enum_with_item_mixed_twin_rust_async_sse;
-
-typedef struct wire_cst_EnumWithItemMixedTwinSse_A {
-
-} wire_cst_EnumWithItemMixedTwinSse_A;
 
 typedef struct wire_cst_EnumWithItemMixedTwinSse_B {
   struct wire_cst_list_prim_u_8 *field0;
@@ -2344,19 +2275,14 @@ typedef struct wire_cst_EnumWithItemMixedTwinSse_C {
 } wire_cst_EnumWithItemMixedTwinSse_C;
 
 typedef union EnumWithItemMixedTwinSseKind {
-  struct wire_cst_EnumWithItemMixedTwinSse_A *A;
-  struct wire_cst_EnumWithItemMixedTwinSse_B *B;
-  struct wire_cst_EnumWithItemMixedTwinSse_C *C;
+  struct wire_cst_EnumWithItemMixedTwinSse_B B;
+  struct wire_cst_EnumWithItemMixedTwinSse_C C;
 } EnumWithItemMixedTwinSseKind;
 
 typedef struct wire_cst_enum_with_item_mixed_twin_sse {
   int32_t tag;
-  union EnumWithItemMixedTwinSseKind *kind;
+  union EnumWithItemMixedTwinSseKind kind;
 } wire_cst_enum_with_item_mixed_twin_sse;
-
-typedef struct wire_cst_EnumWithItemMixedTwinSyncSse_A {
-
-} wire_cst_EnumWithItemMixedTwinSyncSse_A;
 
 typedef struct wire_cst_EnumWithItemMixedTwinSyncSse_B {
   struct wire_cst_list_prim_u_8 *field0;
@@ -2367,14 +2293,13 @@ typedef struct wire_cst_EnumWithItemMixedTwinSyncSse_C {
 } wire_cst_EnumWithItemMixedTwinSyncSse_C;
 
 typedef union EnumWithItemMixedTwinSyncSseKind {
-  struct wire_cst_EnumWithItemMixedTwinSyncSse_A *A;
-  struct wire_cst_EnumWithItemMixedTwinSyncSse_B *B;
-  struct wire_cst_EnumWithItemMixedTwinSyncSse_C *C;
+  struct wire_cst_EnumWithItemMixedTwinSyncSse_B B;
+  struct wire_cst_EnumWithItemMixedTwinSyncSse_C C;
 } EnumWithItemMixedTwinSyncSseKind;
 
 typedef struct wire_cst_enum_with_item_mixed_twin_sync_sse {
   int32_t tag;
-  union EnumWithItemMixedTwinSyncSseKind *kind;
+  union EnumWithItemMixedTwinSyncSseKind kind;
 } wire_cst_enum_with_item_mixed_twin_sync_sse;
 
 typedef struct wire_cst_EnumWithItemStructTwinRustAsyncSse_A {
@@ -2386,13 +2311,13 @@ typedef struct wire_cst_EnumWithItemStructTwinRustAsyncSse_B {
 } wire_cst_EnumWithItemStructTwinRustAsyncSse_B;
 
 typedef union EnumWithItemStructTwinRustAsyncSseKind {
-  struct wire_cst_EnumWithItemStructTwinRustAsyncSse_A *A;
-  struct wire_cst_EnumWithItemStructTwinRustAsyncSse_B *B;
+  struct wire_cst_EnumWithItemStructTwinRustAsyncSse_A A;
+  struct wire_cst_EnumWithItemStructTwinRustAsyncSse_B B;
 } EnumWithItemStructTwinRustAsyncSseKind;
 
 typedef struct wire_cst_enum_with_item_struct_twin_rust_async_sse {
   int32_t tag;
-  union EnumWithItemStructTwinRustAsyncSseKind *kind;
+  union EnumWithItemStructTwinRustAsyncSseKind kind;
 } wire_cst_enum_with_item_struct_twin_rust_async_sse;
 
 typedef struct wire_cst_EnumWithItemStructTwinSse_A {
@@ -2404,13 +2329,13 @@ typedef struct wire_cst_EnumWithItemStructTwinSse_B {
 } wire_cst_EnumWithItemStructTwinSse_B;
 
 typedef union EnumWithItemStructTwinSseKind {
-  struct wire_cst_EnumWithItemStructTwinSse_A *A;
-  struct wire_cst_EnumWithItemStructTwinSse_B *B;
+  struct wire_cst_EnumWithItemStructTwinSse_A A;
+  struct wire_cst_EnumWithItemStructTwinSse_B B;
 } EnumWithItemStructTwinSseKind;
 
 typedef struct wire_cst_enum_with_item_struct_twin_sse {
   int32_t tag;
-  union EnumWithItemStructTwinSseKind *kind;
+  union EnumWithItemStructTwinSseKind kind;
 } wire_cst_enum_with_item_struct_twin_sse;
 
 typedef struct wire_cst_EnumWithItemStructTwinSyncSse_A {
@@ -2422,13 +2347,13 @@ typedef struct wire_cst_EnumWithItemStructTwinSyncSse_B {
 } wire_cst_EnumWithItemStructTwinSyncSse_B;
 
 typedef union EnumWithItemStructTwinSyncSseKind {
-  struct wire_cst_EnumWithItemStructTwinSyncSse_A *A;
-  struct wire_cst_EnumWithItemStructTwinSyncSse_B *B;
+  struct wire_cst_EnumWithItemStructTwinSyncSse_A A;
+  struct wire_cst_EnumWithItemStructTwinSyncSse_B B;
 } EnumWithItemStructTwinSyncSseKind;
 
 typedef struct wire_cst_enum_with_item_struct_twin_sync_sse {
   int32_t tag;
-  union EnumWithItemStructTwinSyncSseKind *kind;
+  union EnumWithItemStructTwinSyncSseKind kind;
 } wire_cst_enum_with_item_struct_twin_sync_sse;
 
 typedef struct wire_cst_EnumWithItemTupleTwinRustAsyncSse_A {
@@ -2440,13 +2365,13 @@ typedef struct wire_cst_EnumWithItemTupleTwinRustAsyncSse_B {
 } wire_cst_EnumWithItemTupleTwinRustAsyncSse_B;
 
 typedef union EnumWithItemTupleTwinRustAsyncSseKind {
-  struct wire_cst_EnumWithItemTupleTwinRustAsyncSse_A *A;
-  struct wire_cst_EnumWithItemTupleTwinRustAsyncSse_B *B;
+  struct wire_cst_EnumWithItemTupleTwinRustAsyncSse_A A;
+  struct wire_cst_EnumWithItemTupleTwinRustAsyncSse_B B;
 } EnumWithItemTupleTwinRustAsyncSseKind;
 
 typedef struct wire_cst_enum_with_item_tuple_twin_rust_async_sse {
   int32_t tag;
-  union EnumWithItemTupleTwinRustAsyncSseKind *kind;
+  union EnumWithItemTupleTwinRustAsyncSseKind kind;
 } wire_cst_enum_with_item_tuple_twin_rust_async_sse;
 
 typedef struct wire_cst_EnumWithItemTupleTwinSse_A {
@@ -2458,13 +2383,13 @@ typedef struct wire_cst_EnumWithItemTupleTwinSse_B {
 } wire_cst_EnumWithItemTupleTwinSse_B;
 
 typedef union EnumWithItemTupleTwinSseKind {
-  struct wire_cst_EnumWithItemTupleTwinSse_A *A;
-  struct wire_cst_EnumWithItemTupleTwinSse_B *B;
+  struct wire_cst_EnumWithItemTupleTwinSse_A A;
+  struct wire_cst_EnumWithItemTupleTwinSse_B B;
 } EnumWithItemTupleTwinSseKind;
 
 typedef struct wire_cst_enum_with_item_tuple_twin_sse {
   int32_t tag;
-  union EnumWithItemTupleTwinSseKind *kind;
+  union EnumWithItemTupleTwinSseKind kind;
 } wire_cst_enum_with_item_tuple_twin_sse;
 
 typedef struct wire_cst_EnumWithItemTupleTwinSyncSse_A {
@@ -2476,13 +2401,13 @@ typedef struct wire_cst_EnumWithItemTupleTwinSyncSse_B {
 } wire_cst_EnumWithItemTupleTwinSyncSse_B;
 
 typedef union EnumWithItemTupleTwinSyncSseKind {
-  struct wire_cst_EnumWithItemTupleTwinSyncSse_A *A;
-  struct wire_cst_EnumWithItemTupleTwinSyncSse_B *B;
+  struct wire_cst_EnumWithItemTupleTwinSyncSse_A A;
+  struct wire_cst_EnumWithItemTupleTwinSyncSse_B B;
 } EnumWithItemTupleTwinSyncSseKind;
 
 typedef struct wire_cst_enum_with_item_tuple_twin_sync_sse {
   int32_t tag;
-  union EnumWithItemTupleTwinSyncSseKind *kind;
+  union EnumWithItemTupleTwinSyncSseKind kind;
 } wire_cst_enum_with_item_tuple_twin_sync_sse;
 
 typedef struct wire_cst_event_twin_rust_async_sse {
@@ -2585,10 +2510,6 @@ typedef struct wire_cst_feed_id_twin_sync_sse {
   struct wire_cst_list_prim_u_8 *field0;
 } wire_cst_feed_id_twin_sync_sse;
 
-typedef struct wire_cst_KitchenSinkTwinRustAsyncSse_Empty {
-
-} wire_cst_KitchenSinkTwinRustAsyncSse_Empty;
-
 typedef struct wire_cst_KitchenSinkTwinRustAsyncSse_Primitives {
   int32_t int32;
   double float64;
@@ -2614,22 +2535,17 @@ typedef struct wire_cst_KitchenSinkTwinRustAsyncSse_Enums {
 } wire_cst_KitchenSinkTwinRustAsyncSse_Enums;
 
 typedef union KitchenSinkTwinRustAsyncSseKind {
-  struct wire_cst_KitchenSinkTwinRustAsyncSse_Empty *Empty;
-  struct wire_cst_KitchenSinkTwinRustAsyncSse_Primitives *Primitives;
-  struct wire_cst_KitchenSinkTwinRustAsyncSse_Nested *Nested;
-  struct wire_cst_KitchenSinkTwinRustAsyncSse_Optional *Optional;
-  struct wire_cst_KitchenSinkTwinRustAsyncSse_Buffer *Buffer;
-  struct wire_cst_KitchenSinkTwinRustAsyncSse_Enums *Enums;
+  struct wire_cst_KitchenSinkTwinRustAsyncSse_Primitives Primitives;
+  struct wire_cst_KitchenSinkTwinRustAsyncSse_Nested Nested;
+  struct wire_cst_KitchenSinkTwinRustAsyncSse_Optional Optional;
+  struct wire_cst_KitchenSinkTwinRustAsyncSse_Buffer Buffer;
+  struct wire_cst_KitchenSinkTwinRustAsyncSse_Enums Enums;
 } KitchenSinkTwinRustAsyncSseKind;
 
 typedef struct wire_cst_kitchen_sink_twin_rust_async_sse {
   int32_t tag;
-  union KitchenSinkTwinRustAsyncSseKind *kind;
+  union KitchenSinkTwinRustAsyncSseKind kind;
 } wire_cst_kitchen_sink_twin_rust_async_sse;
-
-typedef struct wire_cst_KitchenSinkTwinSse_Empty {
-
-} wire_cst_KitchenSinkTwinSse_Empty;
 
 typedef struct wire_cst_KitchenSinkTwinSse_Primitives {
   int32_t int32;
@@ -2656,22 +2572,17 @@ typedef struct wire_cst_KitchenSinkTwinSse_Enums {
 } wire_cst_KitchenSinkTwinSse_Enums;
 
 typedef union KitchenSinkTwinSseKind {
-  struct wire_cst_KitchenSinkTwinSse_Empty *Empty;
-  struct wire_cst_KitchenSinkTwinSse_Primitives *Primitives;
-  struct wire_cst_KitchenSinkTwinSse_Nested *Nested;
-  struct wire_cst_KitchenSinkTwinSse_Optional *Optional;
-  struct wire_cst_KitchenSinkTwinSse_Buffer *Buffer;
-  struct wire_cst_KitchenSinkTwinSse_Enums *Enums;
+  struct wire_cst_KitchenSinkTwinSse_Primitives Primitives;
+  struct wire_cst_KitchenSinkTwinSse_Nested Nested;
+  struct wire_cst_KitchenSinkTwinSse_Optional Optional;
+  struct wire_cst_KitchenSinkTwinSse_Buffer Buffer;
+  struct wire_cst_KitchenSinkTwinSse_Enums Enums;
 } KitchenSinkTwinSseKind;
 
 typedef struct wire_cst_kitchen_sink_twin_sse {
   int32_t tag;
-  union KitchenSinkTwinSseKind *kind;
+  union KitchenSinkTwinSseKind kind;
 } wire_cst_kitchen_sink_twin_sse;
-
-typedef struct wire_cst_KitchenSinkTwinSyncSse_Empty {
-
-} wire_cst_KitchenSinkTwinSyncSse_Empty;
 
 typedef struct wire_cst_KitchenSinkTwinSyncSse_Primitives {
   int32_t int32;
@@ -2698,17 +2609,16 @@ typedef struct wire_cst_KitchenSinkTwinSyncSse_Enums {
 } wire_cst_KitchenSinkTwinSyncSse_Enums;
 
 typedef union KitchenSinkTwinSyncSseKind {
-  struct wire_cst_KitchenSinkTwinSyncSse_Empty *Empty;
-  struct wire_cst_KitchenSinkTwinSyncSse_Primitives *Primitives;
-  struct wire_cst_KitchenSinkTwinSyncSse_Nested *Nested;
-  struct wire_cst_KitchenSinkTwinSyncSse_Optional *Optional;
-  struct wire_cst_KitchenSinkTwinSyncSse_Buffer *Buffer;
-  struct wire_cst_KitchenSinkTwinSyncSse_Enums *Enums;
+  struct wire_cst_KitchenSinkTwinSyncSse_Primitives Primitives;
+  struct wire_cst_KitchenSinkTwinSyncSse_Nested Nested;
+  struct wire_cst_KitchenSinkTwinSyncSse_Optional Optional;
+  struct wire_cst_KitchenSinkTwinSyncSse_Buffer Buffer;
+  struct wire_cst_KitchenSinkTwinSyncSse_Enums Enums;
 } KitchenSinkTwinSyncSseKind;
 
 typedef struct wire_cst_kitchen_sink_twin_sync_sse {
   int32_t tag;
-  union KitchenSinkTwinSyncSseKind *kind;
+  union KitchenSinkTwinSyncSseKind kind;
 } wire_cst_kitchen_sink_twin_sync_sse;
 
 typedef struct wire_cst_raw_string_mirrored {
@@ -2728,44 +2638,34 @@ typedef struct wire_cst_list_of_nested_raw_string_mirrored {
   struct wire_cst_list_nested_raw_string_mirrored *raw;
 } wire_cst_list_of_nested_raw_string_mirrored;
 
-typedef struct wire_cst_SpeedTwinRustAsyncSse_Unknown {
-
-} wire_cst_SpeedTwinRustAsyncSse_Unknown;
-
 typedef struct wire_cst_SpeedTwinRustAsyncSse_GPS {
   double field0;
 } wire_cst_SpeedTwinRustAsyncSse_GPS;
 
 typedef union SpeedTwinRustAsyncSseKind {
-  struct wire_cst_SpeedTwinRustAsyncSse_Unknown *Unknown;
-  struct wire_cst_SpeedTwinRustAsyncSse_GPS *GPS;
+  struct wire_cst_SpeedTwinRustAsyncSse_GPS GPS;
 } SpeedTwinRustAsyncSseKind;
 
 typedef struct wire_cst_speed_twin_rust_async_sse {
   int32_t tag;
-  union SpeedTwinRustAsyncSseKind *kind;
+  union SpeedTwinRustAsyncSseKind kind;
 } wire_cst_speed_twin_rust_async_sse;
 
 typedef struct wire_cst_MeasureTwinRustAsyncSse_Speed {
   struct wire_cst_speed_twin_rust_async_sse *field0;
 } wire_cst_MeasureTwinRustAsyncSse_Speed;
 
-typedef struct wire_cst_DistanceTwinRustAsyncSse_Unknown {
-
-} wire_cst_DistanceTwinRustAsyncSse_Unknown;
-
 typedef struct wire_cst_DistanceTwinRustAsyncSse_Map {
   double field0;
 } wire_cst_DistanceTwinRustAsyncSse_Map;
 
 typedef union DistanceTwinRustAsyncSseKind {
-  struct wire_cst_DistanceTwinRustAsyncSse_Unknown *Unknown;
-  struct wire_cst_DistanceTwinRustAsyncSse_Map *Map;
+  struct wire_cst_DistanceTwinRustAsyncSse_Map Map;
 } DistanceTwinRustAsyncSseKind;
 
 typedef struct wire_cst_distance_twin_rust_async_sse {
   int32_t tag;
-  union DistanceTwinRustAsyncSseKind *kind;
+  union DistanceTwinRustAsyncSseKind kind;
 } wire_cst_distance_twin_rust_async_sse;
 
 typedef struct wire_cst_MeasureTwinRustAsyncSse_Distance {
@@ -2773,53 +2673,43 @@ typedef struct wire_cst_MeasureTwinRustAsyncSse_Distance {
 } wire_cst_MeasureTwinRustAsyncSse_Distance;
 
 typedef union MeasureTwinRustAsyncSseKind {
-  struct wire_cst_MeasureTwinRustAsyncSse_Speed *Speed;
-  struct wire_cst_MeasureTwinRustAsyncSse_Distance *Distance;
+  struct wire_cst_MeasureTwinRustAsyncSse_Speed Speed;
+  struct wire_cst_MeasureTwinRustAsyncSse_Distance Distance;
 } MeasureTwinRustAsyncSseKind;
 
 typedef struct wire_cst_measure_twin_rust_async_sse {
   int32_t tag;
-  union MeasureTwinRustAsyncSseKind *kind;
+  union MeasureTwinRustAsyncSseKind kind;
 } wire_cst_measure_twin_rust_async_sse;
-
-typedef struct wire_cst_SpeedTwinSse_Unknown {
-
-} wire_cst_SpeedTwinSse_Unknown;
 
 typedef struct wire_cst_SpeedTwinSse_GPS {
   double field0;
 } wire_cst_SpeedTwinSse_GPS;
 
 typedef union SpeedTwinSseKind {
-  struct wire_cst_SpeedTwinSse_Unknown *Unknown;
-  struct wire_cst_SpeedTwinSse_GPS *GPS;
+  struct wire_cst_SpeedTwinSse_GPS GPS;
 } SpeedTwinSseKind;
 
 typedef struct wire_cst_speed_twin_sse {
   int32_t tag;
-  union SpeedTwinSseKind *kind;
+  union SpeedTwinSseKind kind;
 } wire_cst_speed_twin_sse;
 
 typedef struct wire_cst_MeasureTwinSse_Speed {
   struct wire_cst_speed_twin_sse *field0;
 } wire_cst_MeasureTwinSse_Speed;
 
-typedef struct wire_cst_DistanceTwinSse_Unknown {
-
-} wire_cst_DistanceTwinSse_Unknown;
-
 typedef struct wire_cst_DistanceTwinSse_Map {
   double field0;
 } wire_cst_DistanceTwinSse_Map;
 
 typedef union DistanceTwinSseKind {
-  struct wire_cst_DistanceTwinSse_Unknown *Unknown;
-  struct wire_cst_DistanceTwinSse_Map *Map;
+  struct wire_cst_DistanceTwinSse_Map Map;
 } DistanceTwinSseKind;
 
 typedef struct wire_cst_distance_twin_sse {
   int32_t tag;
-  union DistanceTwinSseKind *kind;
+  union DistanceTwinSseKind kind;
 } wire_cst_distance_twin_sse;
 
 typedef struct wire_cst_MeasureTwinSse_Distance {
@@ -2827,53 +2717,43 @@ typedef struct wire_cst_MeasureTwinSse_Distance {
 } wire_cst_MeasureTwinSse_Distance;
 
 typedef union MeasureTwinSseKind {
-  struct wire_cst_MeasureTwinSse_Speed *Speed;
-  struct wire_cst_MeasureTwinSse_Distance *Distance;
+  struct wire_cst_MeasureTwinSse_Speed Speed;
+  struct wire_cst_MeasureTwinSse_Distance Distance;
 } MeasureTwinSseKind;
 
 typedef struct wire_cst_measure_twin_sse {
   int32_t tag;
-  union MeasureTwinSseKind *kind;
+  union MeasureTwinSseKind kind;
 } wire_cst_measure_twin_sse;
-
-typedef struct wire_cst_SpeedTwinSyncSse_Unknown {
-
-} wire_cst_SpeedTwinSyncSse_Unknown;
 
 typedef struct wire_cst_SpeedTwinSyncSse_GPS {
   double field0;
 } wire_cst_SpeedTwinSyncSse_GPS;
 
 typedef union SpeedTwinSyncSseKind {
-  struct wire_cst_SpeedTwinSyncSse_Unknown *Unknown;
-  struct wire_cst_SpeedTwinSyncSse_GPS *GPS;
+  struct wire_cst_SpeedTwinSyncSse_GPS GPS;
 } SpeedTwinSyncSseKind;
 
 typedef struct wire_cst_speed_twin_sync_sse {
   int32_t tag;
-  union SpeedTwinSyncSseKind *kind;
+  union SpeedTwinSyncSseKind kind;
 } wire_cst_speed_twin_sync_sse;
 
 typedef struct wire_cst_MeasureTwinSyncSse_Speed {
   struct wire_cst_speed_twin_sync_sse *field0;
 } wire_cst_MeasureTwinSyncSse_Speed;
 
-typedef struct wire_cst_DistanceTwinSyncSse_Unknown {
-
-} wire_cst_DistanceTwinSyncSse_Unknown;
-
 typedef struct wire_cst_DistanceTwinSyncSse_Map {
   double field0;
 } wire_cst_DistanceTwinSyncSse_Map;
 
 typedef union DistanceTwinSyncSseKind {
-  struct wire_cst_DistanceTwinSyncSse_Unknown *Unknown;
-  struct wire_cst_DistanceTwinSyncSse_Map *Map;
+  struct wire_cst_DistanceTwinSyncSse_Map Map;
 } DistanceTwinSyncSseKind;
 
 typedef struct wire_cst_distance_twin_sync_sse {
   int32_t tag;
-  union DistanceTwinSyncSseKind *kind;
+  union DistanceTwinSyncSseKind kind;
 } wire_cst_distance_twin_sync_sse;
 
 typedef struct wire_cst_MeasureTwinSyncSse_Distance {
@@ -2881,13 +2761,13 @@ typedef struct wire_cst_MeasureTwinSyncSse_Distance {
 } wire_cst_MeasureTwinSyncSse_Distance;
 
 typedef union MeasureTwinSyncSseKind {
-  struct wire_cst_MeasureTwinSyncSse_Speed *Speed;
-  struct wire_cst_MeasureTwinSyncSse_Distance *Distance;
+  struct wire_cst_MeasureTwinSyncSse_Speed Speed;
+  struct wire_cst_MeasureTwinSyncSse_Distance Distance;
 } MeasureTwinSyncSseKind;
 
 typedef struct wire_cst_measure_twin_sync_sse {
   int32_t tag;
-  union MeasureTwinSyncSseKind *kind;
+  union MeasureTwinSyncSseKind kind;
 } wire_cst_measure_twin_sync_sse;
 
 typedef struct wire_cst_message_id_twin_rust_async_sse {
@@ -3290,14 +3170,14 @@ typedef struct wire_cst_RawStringEnumMirrored_ListOfNested {
 } wire_cst_RawStringEnumMirrored_ListOfNested;
 
 typedef union RawStringEnumMirroredKind {
-  struct wire_cst_RawStringEnumMirrored_Raw *Raw;
-  struct wire_cst_RawStringEnumMirrored_Nested *Nested;
-  struct wire_cst_RawStringEnumMirrored_ListOfNested *ListOfNested;
+  struct wire_cst_RawStringEnumMirrored_Raw Raw;
+  struct wire_cst_RawStringEnumMirrored_Nested Nested;
+  struct wire_cst_RawStringEnumMirrored_ListOfNested ListOfNested;
 } RawStringEnumMirroredKind;
 
 typedef struct wire_cst_raw_string_enum_mirrored {
   int32_t tag;
-  union RawStringEnumMirroredKind *kind;
+  union RawStringEnumMirroredKind kind;
 } wire_cst_raw_string_enum_mirrored;
 
 typedef struct wire_cst_list_raw_string_enum_mirrored {
@@ -3370,283 +3250,6 @@ typedef struct wire_cst_list_weekdays_twin_sync_sse {
   int32_t len;
 } wire_cst_list_weekdays_twin_sync_sse;
 
-typedef struct wire_cst_ApplicationMessage_DisplayMessage {
-  struct wire_cst_list_prim_u_8 *field0;
-} wire_cst_ApplicationMessage_DisplayMessage;
-
-typedef struct wire_cst_ApplicationMessage_RenderPixel {
-  int32_t x;
-  int32_t y;
-} wire_cst_ApplicationMessage_RenderPixel;
-
-typedef struct wire_cst_ApplicationMessage_Exit {
-
-} wire_cst_ApplicationMessage_Exit;
-
-typedef union ApplicationMessageKind {
-  struct wire_cst_ApplicationMessage_DisplayMessage *DisplayMessage;
-  struct wire_cst_ApplicationMessage_RenderPixel *RenderPixel;
-  struct wire_cst_ApplicationMessage_Exit *Exit;
-} ApplicationMessageKind;
-
-typedef struct wire_cst_CustomEnumErrorTwinNormal_One {
-  struct wire_cst_list_prim_u_8 *message;
-  struct wire_cst_list_prim_u_8 *backtrace;
-} wire_cst_CustomEnumErrorTwinNormal_One;
-
-typedef struct wire_cst_CustomEnumErrorTwinNormal_Two {
-  uint32_t message;
-  struct wire_cst_list_prim_u_8 *backtrace;
-} wire_cst_CustomEnumErrorTwinNormal_Two;
-
-typedef union CustomEnumErrorTwinNormalKind {
-  struct wire_cst_CustomEnumErrorTwinNormal_One *One;
-  struct wire_cst_CustomEnumErrorTwinNormal_Two *Two;
-} CustomEnumErrorTwinNormalKind;
-
-typedef struct wire_cst_CustomEnumErrorTwinRustAsync_One {
-  struct wire_cst_list_prim_u_8 *message;
-  struct wire_cst_list_prim_u_8 *backtrace;
-} wire_cst_CustomEnumErrorTwinRustAsync_One;
-
-typedef struct wire_cst_CustomEnumErrorTwinRustAsync_Two {
-  uint32_t message;
-  struct wire_cst_list_prim_u_8 *backtrace;
-} wire_cst_CustomEnumErrorTwinRustAsync_Two;
-
-typedef union CustomEnumErrorTwinRustAsyncKind {
-  struct wire_cst_CustomEnumErrorTwinRustAsync_One *One;
-  struct wire_cst_CustomEnumErrorTwinRustAsync_Two *Two;
-} CustomEnumErrorTwinRustAsyncKind;
-
-typedef struct wire_cst_CustomEnumErrorTwinRustAsyncSse_One {
-  struct wire_cst_list_prim_u_8 *message;
-  struct wire_cst_list_prim_u_8 *backtrace;
-} wire_cst_CustomEnumErrorTwinRustAsyncSse_One;
-
-typedef struct wire_cst_CustomEnumErrorTwinRustAsyncSse_Two {
-  uint32_t message;
-  struct wire_cst_list_prim_u_8 *backtrace;
-} wire_cst_CustomEnumErrorTwinRustAsyncSse_Two;
-
-typedef union CustomEnumErrorTwinRustAsyncSseKind {
-  struct wire_cst_CustomEnumErrorTwinRustAsyncSse_One *One;
-  struct wire_cst_CustomEnumErrorTwinRustAsyncSse_Two *Two;
-} CustomEnumErrorTwinRustAsyncSseKind;
-
-typedef struct wire_cst_CustomEnumErrorTwinSse_One {
-  struct wire_cst_list_prim_u_8 *message;
-  struct wire_cst_list_prim_u_8 *backtrace;
-} wire_cst_CustomEnumErrorTwinSse_One;
-
-typedef struct wire_cst_CustomEnumErrorTwinSse_Two {
-  uint32_t message;
-  struct wire_cst_list_prim_u_8 *backtrace;
-} wire_cst_CustomEnumErrorTwinSse_Two;
-
-typedef union CustomEnumErrorTwinSseKind {
-  struct wire_cst_CustomEnumErrorTwinSse_One *One;
-  struct wire_cst_CustomEnumErrorTwinSse_Two *Two;
-} CustomEnumErrorTwinSseKind;
-
-typedef struct wire_cst_CustomEnumErrorTwinSync_One {
-  struct wire_cst_list_prim_u_8 *message;
-  struct wire_cst_list_prim_u_8 *backtrace;
-} wire_cst_CustomEnumErrorTwinSync_One;
-
-typedef struct wire_cst_CustomEnumErrorTwinSync_Two {
-  uint32_t message;
-  struct wire_cst_list_prim_u_8 *backtrace;
-} wire_cst_CustomEnumErrorTwinSync_Two;
-
-typedef union CustomEnumErrorTwinSyncKind {
-  struct wire_cst_CustomEnumErrorTwinSync_One *One;
-  struct wire_cst_CustomEnumErrorTwinSync_Two *Two;
-} CustomEnumErrorTwinSyncKind;
-
-typedef struct wire_cst_CustomEnumErrorTwinSyncSse_One {
-  struct wire_cst_list_prim_u_8 *message;
-  struct wire_cst_list_prim_u_8 *backtrace;
-} wire_cst_CustomEnumErrorTwinSyncSse_One;
-
-typedef struct wire_cst_CustomEnumErrorTwinSyncSse_Two {
-  uint32_t message;
-  struct wire_cst_list_prim_u_8 *backtrace;
-} wire_cst_CustomEnumErrorTwinSyncSse_Two;
-
-typedef union CustomEnumErrorTwinSyncSseKind {
-  struct wire_cst_CustomEnumErrorTwinSyncSse_One *One;
-  struct wire_cst_CustomEnumErrorTwinSyncSse_Two *Two;
-} CustomEnumErrorTwinSyncSseKind;
-
-typedef struct wire_cst_CustomErrorTwinNormal_Error0 {
-  struct wire_cst_list_prim_u_8 *e;
-  struct wire_cst_list_prim_u_8 *backtrace;
-} wire_cst_CustomErrorTwinNormal_Error0;
-
-typedef struct wire_cst_CustomErrorTwinNormal_Error1 {
-  uint32_t e;
-  struct wire_cst_list_prim_u_8 *backtrace;
-} wire_cst_CustomErrorTwinNormal_Error1;
-
-typedef union CustomErrorTwinNormalKind {
-  struct wire_cst_CustomErrorTwinNormal_Error0 *Error0;
-  struct wire_cst_CustomErrorTwinNormal_Error1 *Error1;
-} CustomErrorTwinNormalKind;
-
-typedef struct wire_cst_CustomErrorTwinRustAsync_Error0 {
-  struct wire_cst_list_prim_u_8 *e;
-  struct wire_cst_list_prim_u_8 *backtrace;
-} wire_cst_CustomErrorTwinRustAsync_Error0;
-
-typedef struct wire_cst_CustomErrorTwinRustAsync_Error1 {
-  uint32_t e;
-  struct wire_cst_list_prim_u_8 *backtrace;
-} wire_cst_CustomErrorTwinRustAsync_Error1;
-
-typedef union CustomErrorTwinRustAsyncKind {
-  struct wire_cst_CustomErrorTwinRustAsync_Error0 *Error0;
-  struct wire_cst_CustomErrorTwinRustAsync_Error1 *Error1;
-} CustomErrorTwinRustAsyncKind;
-
-typedef struct wire_cst_CustomErrorTwinRustAsyncSse_Error0 {
-  struct wire_cst_list_prim_u_8 *e;
-  struct wire_cst_list_prim_u_8 *backtrace;
-} wire_cst_CustomErrorTwinRustAsyncSse_Error0;
-
-typedef struct wire_cst_CustomErrorTwinRustAsyncSse_Error1 {
-  uint32_t e;
-  struct wire_cst_list_prim_u_8 *backtrace;
-} wire_cst_CustomErrorTwinRustAsyncSse_Error1;
-
-typedef union CustomErrorTwinRustAsyncSseKind {
-  struct wire_cst_CustomErrorTwinRustAsyncSse_Error0 *Error0;
-  struct wire_cst_CustomErrorTwinRustAsyncSse_Error1 *Error1;
-} CustomErrorTwinRustAsyncSseKind;
-
-typedef struct wire_cst_CustomErrorTwinSse_Error0 {
-  struct wire_cst_list_prim_u_8 *e;
-  struct wire_cst_list_prim_u_8 *backtrace;
-} wire_cst_CustomErrorTwinSse_Error0;
-
-typedef struct wire_cst_CustomErrorTwinSse_Error1 {
-  uint32_t e;
-  struct wire_cst_list_prim_u_8 *backtrace;
-} wire_cst_CustomErrorTwinSse_Error1;
-
-typedef union CustomErrorTwinSseKind {
-  struct wire_cst_CustomErrorTwinSse_Error0 *Error0;
-  struct wire_cst_CustomErrorTwinSse_Error1 *Error1;
-} CustomErrorTwinSseKind;
-
-typedef struct wire_cst_CustomErrorTwinSync_Error0 {
-  struct wire_cst_list_prim_u_8 *e;
-  struct wire_cst_list_prim_u_8 *backtrace;
-} wire_cst_CustomErrorTwinSync_Error0;
-
-typedef struct wire_cst_CustomErrorTwinSync_Error1 {
-  uint32_t e;
-  struct wire_cst_list_prim_u_8 *backtrace;
-} wire_cst_CustomErrorTwinSync_Error1;
-
-typedef union CustomErrorTwinSyncKind {
-  struct wire_cst_CustomErrorTwinSync_Error0 *Error0;
-  struct wire_cst_CustomErrorTwinSync_Error1 *Error1;
-} CustomErrorTwinSyncKind;
-
-typedef struct wire_cst_CustomErrorTwinSyncSse_Error0 {
-  struct wire_cst_list_prim_u_8 *e;
-  struct wire_cst_list_prim_u_8 *backtrace;
-} wire_cst_CustomErrorTwinSyncSse_Error0;
-
-typedef struct wire_cst_CustomErrorTwinSyncSse_Error1 {
-  uint32_t e;
-  struct wire_cst_list_prim_u_8 *backtrace;
-} wire_cst_CustomErrorTwinSyncSse_Error1;
-
-typedef union CustomErrorTwinSyncSseKind {
-  struct wire_cst_CustomErrorTwinSyncSse_Error0 *Error0;
-  struct wire_cst_CustomErrorTwinSyncSse_Error1 *Error1;
-} CustomErrorTwinSyncSseKind;
-
-typedef struct wire_cst_CustomNestedError1TwinNormal_CustomNested1 {
-  struct wire_cst_list_prim_u_8 *field0;
-} wire_cst_CustomNestedError1TwinNormal_CustomNested1;
-
-typedef struct wire_cst_CustomNestedError1TwinNormal_ErrorNested {
-  struct wire_cst_custom_nested_error_2_twin_normal *field0;
-} wire_cst_CustomNestedError1TwinNormal_ErrorNested;
-
-typedef union CustomNestedError1TwinNormalKind {
-  struct wire_cst_CustomNestedError1TwinNormal_CustomNested1 *CustomNested1;
-  struct wire_cst_CustomNestedError1TwinNormal_ErrorNested *ErrorNested;
-} CustomNestedError1TwinNormalKind;
-
-typedef struct wire_cst_CustomNestedError1TwinRustAsync_CustomNested1 {
-  struct wire_cst_list_prim_u_8 *field0;
-} wire_cst_CustomNestedError1TwinRustAsync_CustomNested1;
-
-typedef struct wire_cst_CustomNestedError1TwinRustAsync_ErrorNested {
-  struct wire_cst_custom_nested_error_2_twin_rust_async *field0;
-} wire_cst_CustomNestedError1TwinRustAsync_ErrorNested;
-
-typedef union CustomNestedError1TwinRustAsyncKind {
-  struct wire_cst_CustomNestedError1TwinRustAsync_CustomNested1 *CustomNested1;
-  struct wire_cst_CustomNestedError1TwinRustAsync_ErrorNested *ErrorNested;
-} CustomNestedError1TwinRustAsyncKind;
-
-typedef struct wire_cst_CustomNestedError1TwinRustAsyncSse_CustomNested1 {
-  struct wire_cst_list_prim_u_8 *field0;
-} wire_cst_CustomNestedError1TwinRustAsyncSse_CustomNested1;
-
-typedef struct wire_cst_CustomNestedError1TwinRustAsyncSse_ErrorNested {
-  struct wire_cst_custom_nested_error_2_twin_rust_async_sse *field0;
-} wire_cst_CustomNestedError1TwinRustAsyncSse_ErrorNested;
-
-typedef union CustomNestedError1TwinRustAsyncSseKind {
-  struct wire_cst_CustomNestedError1TwinRustAsyncSse_CustomNested1 *CustomNested1;
-  struct wire_cst_CustomNestedError1TwinRustAsyncSse_ErrorNested *ErrorNested;
-} CustomNestedError1TwinRustAsyncSseKind;
-
-typedef struct wire_cst_CustomNestedError1TwinSse_CustomNested1 {
-  struct wire_cst_list_prim_u_8 *field0;
-} wire_cst_CustomNestedError1TwinSse_CustomNested1;
-
-typedef struct wire_cst_CustomNestedError1TwinSse_ErrorNested {
-  struct wire_cst_custom_nested_error_2_twin_sse *field0;
-} wire_cst_CustomNestedError1TwinSse_ErrorNested;
-
-typedef union CustomNestedError1TwinSseKind {
-  struct wire_cst_CustomNestedError1TwinSse_CustomNested1 *CustomNested1;
-  struct wire_cst_CustomNestedError1TwinSse_ErrorNested *ErrorNested;
-} CustomNestedError1TwinSseKind;
-
-typedef struct wire_cst_CustomNestedError1TwinSync_CustomNested1 {
-  struct wire_cst_list_prim_u_8 *field0;
-} wire_cst_CustomNestedError1TwinSync_CustomNested1;
-
-typedef struct wire_cst_CustomNestedError1TwinSync_ErrorNested {
-  struct wire_cst_custom_nested_error_2_twin_sync *field0;
-} wire_cst_CustomNestedError1TwinSync_ErrorNested;
-
-typedef union CustomNestedError1TwinSyncKind {
-  struct wire_cst_CustomNestedError1TwinSync_CustomNested1 *CustomNested1;
-  struct wire_cst_CustomNestedError1TwinSync_ErrorNested *ErrorNested;
-} CustomNestedError1TwinSyncKind;
-
-typedef struct wire_cst_CustomNestedError1TwinSyncSse_CustomNested1 {
-  struct wire_cst_list_prim_u_8 *field0;
-} wire_cst_CustomNestedError1TwinSyncSse_CustomNested1;
-
-typedef struct wire_cst_CustomNestedError1TwinSyncSse_ErrorNested {
-  struct wire_cst_custom_nested_error_2_twin_sync_sse *field0;
-} wire_cst_CustomNestedError1TwinSyncSse_ErrorNested;
-
-typedef union CustomNestedError1TwinSyncSseKind {
-  struct wire_cst_CustomNestedError1TwinSyncSse_CustomNested1 *CustomNested1;
-  struct wire_cst_CustomNestedError1TwinSyncSse_ErrorNested *ErrorNested;
-} CustomNestedError1TwinSyncSseKind;
-
 typedef struct wire_cst_another_macro_struct_twin_normal {
   int32_t data;
   int32_t non_final_data;
@@ -3676,9 +3279,23 @@ typedef struct wire_cst_another_twin_sync_sse {
   struct wire_cst_list_prim_u_8 *a;
 } wire_cst_another_twin_sync_sse;
 
+typedef struct wire_cst_ApplicationMessage_DisplayMessage {
+  struct wire_cst_list_prim_u_8 *field0;
+} wire_cst_ApplicationMessage_DisplayMessage;
+
+typedef struct wire_cst_ApplicationMessage_RenderPixel {
+  int32_t x;
+  int32_t y;
+} wire_cst_ApplicationMessage_RenderPixel;
+
+typedef union ApplicationMessageKind {
+  struct wire_cst_ApplicationMessage_DisplayMessage DisplayMessage;
+  struct wire_cst_ApplicationMessage_RenderPixel RenderPixel;
+} ApplicationMessageKind;
+
 typedef struct wire_cst_application_message {
   int32_t tag;
-  union ApplicationMessageKind *kind;
+  union ApplicationMessageKind kind;
 } wire_cst_application_message;
 
 typedef struct wire_cst_big_buffers_twin_normal {
@@ -3741,94 +3358,352 @@ typedef struct wire_cst_contains_mirrored_sub_struct_twin_sync_sse {
   struct wire_cst_another_twin_sync_sse test2;
 } wire_cst_contains_mirrored_sub_struct_twin_sync_sse;
 
+typedef struct wire_cst_CustomEnumErrorTwinNormal_One {
+  struct wire_cst_list_prim_u_8 *message;
+  struct wire_cst_list_prim_u_8 *backtrace;
+} wire_cst_CustomEnumErrorTwinNormal_One;
+
+typedef struct wire_cst_CustomEnumErrorTwinNormal_Two {
+  uint32_t message;
+  struct wire_cst_list_prim_u_8 *backtrace;
+} wire_cst_CustomEnumErrorTwinNormal_Two;
+
+typedef union CustomEnumErrorTwinNormalKind {
+  struct wire_cst_CustomEnumErrorTwinNormal_One One;
+  struct wire_cst_CustomEnumErrorTwinNormal_Two Two;
+} CustomEnumErrorTwinNormalKind;
+
 typedef struct wire_cst_custom_enum_error_twin_normal {
   int32_t tag;
-  union CustomEnumErrorTwinNormalKind *kind;
+  union CustomEnumErrorTwinNormalKind kind;
 } wire_cst_custom_enum_error_twin_normal;
+
+typedef struct wire_cst_CustomEnumErrorTwinRustAsync_One {
+  struct wire_cst_list_prim_u_8 *message;
+  struct wire_cst_list_prim_u_8 *backtrace;
+} wire_cst_CustomEnumErrorTwinRustAsync_One;
+
+typedef struct wire_cst_CustomEnumErrorTwinRustAsync_Two {
+  uint32_t message;
+  struct wire_cst_list_prim_u_8 *backtrace;
+} wire_cst_CustomEnumErrorTwinRustAsync_Two;
+
+typedef union CustomEnumErrorTwinRustAsyncKind {
+  struct wire_cst_CustomEnumErrorTwinRustAsync_One One;
+  struct wire_cst_CustomEnumErrorTwinRustAsync_Two Two;
+} CustomEnumErrorTwinRustAsyncKind;
 
 typedef struct wire_cst_custom_enum_error_twin_rust_async {
   int32_t tag;
-  union CustomEnumErrorTwinRustAsyncKind *kind;
+  union CustomEnumErrorTwinRustAsyncKind kind;
 } wire_cst_custom_enum_error_twin_rust_async;
+
+typedef struct wire_cst_CustomEnumErrorTwinRustAsyncSse_One {
+  struct wire_cst_list_prim_u_8 *message;
+  struct wire_cst_list_prim_u_8 *backtrace;
+} wire_cst_CustomEnumErrorTwinRustAsyncSse_One;
+
+typedef struct wire_cst_CustomEnumErrorTwinRustAsyncSse_Two {
+  uint32_t message;
+  struct wire_cst_list_prim_u_8 *backtrace;
+} wire_cst_CustomEnumErrorTwinRustAsyncSse_Two;
+
+typedef union CustomEnumErrorTwinRustAsyncSseKind {
+  struct wire_cst_CustomEnumErrorTwinRustAsyncSse_One One;
+  struct wire_cst_CustomEnumErrorTwinRustAsyncSse_Two Two;
+} CustomEnumErrorTwinRustAsyncSseKind;
 
 typedef struct wire_cst_custom_enum_error_twin_rust_async_sse {
   int32_t tag;
-  union CustomEnumErrorTwinRustAsyncSseKind *kind;
+  union CustomEnumErrorTwinRustAsyncSseKind kind;
 } wire_cst_custom_enum_error_twin_rust_async_sse;
+
+typedef struct wire_cst_CustomEnumErrorTwinSse_One {
+  struct wire_cst_list_prim_u_8 *message;
+  struct wire_cst_list_prim_u_8 *backtrace;
+} wire_cst_CustomEnumErrorTwinSse_One;
+
+typedef struct wire_cst_CustomEnumErrorTwinSse_Two {
+  uint32_t message;
+  struct wire_cst_list_prim_u_8 *backtrace;
+} wire_cst_CustomEnumErrorTwinSse_Two;
+
+typedef union CustomEnumErrorTwinSseKind {
+  struct wire_cst_CustomEnumErrorTwinSse_One One;
+  struct wire_cst_CustomEnumErrorTwinSse_Two Two;
+} CustomEnumErrorTwinSseKind;
 
 typedef struct wire_cst_custom_enum_error_twin_sse {
   int32_t tag;
-  union CustomEnumErrorTwinSseKind *kind;
+  union CustomEnumErrorTwinSseKind kind;
 } wire_cst_custom_enum_error_twin_sse;
+
+typedef struct wire_cst_CustomEnumErrorTwinSync_One {
+  struct wire_cst_list_prim_u_8 *message;
+  struct wire_cst_list_prim_u_8 *backtrace;
+} wire_cst_CustomEnumErrorTwinSync_One;
+
+typedef struct wire_cst_CustomEnumErrorTwinSync_Two {
+  uint32_t message;
+  struct wire_cst_list_prim_u_8 *backtrace;
+} wire_cst_CustomEnumErrorTwinSync_Two;
+
+typedef union CustomEnumErrorTwinSyncKind {
+  struct wire_cst_CustomEnumErrorTwinSync_One One;
+  struct wire_cst_CustomEnumErrorTwinSync_Two Two;
+} CustomEnumErrorTwinSyncKind;
 
 typedef struct wire_cst_custom_enum_error_twin_sync {
   int32_t tag;
-  union CustomEnumErrorTwinSyncKind *kind;
+  union CustomEnumErrorTwinSyncKind kind;
 } wire_cst_custom_enum_error_twin_sync;
+
+typedef struct wire_cst_CustomEnumErrorTwinSyncSse_One {
+  struct wire_cst_list_prim_u_8 *message;
+  struct wire_cst_list_prim_u_8 *backtrace;
+} wire_cst_CustomEnumErrorTwinSyncSse_One;
+
+typedef struct wire_cst_CustomEnumErrorTwinSyncSse_Two {
+  uint32_t message;
+  struct wire_cst_list_prim_u_8 *backtrace;
+} wire_cst_CustomEnumErrorTwinSyncSse_Two;
+
+typedef union CustomEnumErrorTwinSyncSseKind {
+  struct wire_cst_CustomEnumErrorTwinSyncSse_One One;
+  struct wire_cst_CustomEnumErrorTwinSyncSse_Two Two;
+} CustomEnumErrorTwinSyncSseKind;
 
 typedef struct wire_cst_custom_enum_error_twin_sync_sse {
   int32_t tag;
-  union CustomEnumErrorTwinSyncSseKind *kind;
+  union CustomEnumErrorTwinSyncSseKind kind;
 } wire_cst_custom_enum_error_twin_sync_sse;
+
+typedef struct wire_cst_CustomErrorTwinNormal_Error0 {
+  struct wire_cst_list_prim_u_8 *e;
+  struct wire_cst_list_prim_u_8 *backtrace;
+} wire_cst_CustomErrorTwinNormal_Error0;
+
+typedef struct wire_cst_CustomErrorTwinNormal_Error1 {
+  uint32_t e;
+  struct wire_cst_list_prim_u_8 *backtrace;
+} wire_cst_CustomErrorTwinNormal_Error1;
+
+typedef union CustomErrorTwinNormalKind {
+  struct wire_cst_CustomErrorTwinNormal_Error0 Error0;
+  struct wire_cst_CustomErrorTwinNormal_Error1 Error1;
+} CustomErrorTwinNormalKind;
 
 typedef struct wire_cst_custom_error_twin_normal {
   int32_t tag;
-  union CustomErrorTwinNormalKind *kind;
+  union CustomErrorTwinNormalKind kind;
 } wire_cst_custom_error_twin_normal;
+
+typedef struct wire_cst_CustomErrorTwinRustAsync_Error0 {
+  struct wire_cst_list_prim_u_8 *e;
+  struct wire_cst_list_prim_u_8 *backtrace;
+} wire_cst_CustomErrorTwinRustAsync_Error0;
+
+typedef struct wire_cst_CustomErrorTwinRustAsync_Error1 {
+  uint32_t e;
+  struct wire_cst_list_prim_u_8 *backtrace;
+} wire_cst_CustomErrorTwinRustAsync_Error1;
+
+typedef union CustomErrorTwinRustAsyncKind {
+  struct wire_cst_CustomErrorTwinRustAsync_Error0 Error0;
+  struct wire_cst_CustomErrorTwinRustAsync_Error1 Error1;
+} CustomErrorTwinRustAsyncKind;
 
 typedef struct wire_cst_custom_error_twin_rust_async {
   int32_t tag;
-  union CustomErrorTwinRustAsyncKind *kind;
+  union CustomErrorTwinRustAsyncKind kind;
 } wire_cst_custom_error_twin_rust_async;
+
+typedef struct wire_cst_CustomErrorTwinRustAsyncSse_Error0 {
+  struct wire_cst_list_prim_u_8 *e;
+  struct wire_cst_list_prim_u_8 *backtrace;
+} wire_cst_CustomErrorTwinRustAsyncSse_Error0;
+
+typedef struct wire_cst_CustomErrorTwinRustAsyncSse_Error1 {
+  uint32_t e;
+  struct wire_cst_list_prim_u_8 *backtrace;
+} wire_cst_CustomErrorTwinRustAsyncSse_Error1;
+
+typedef union CustomErrorTwinRustAsyncSseKind {
+  struct wire_cst_CustomErrorTwinRustAsyncSse_Error0 Error0;
+  struct wire_cst_CustomErrorTwinRustAsyncSse_Error1 Error1;
+} CustomErrorTwinRustAsyncSseKind;
 
 typedef struct wire_cst_custom_error_twin_rust_async_sse {
   int32_t tag;
-  union CustomErrorTwinRustAsyncSseKind *kind;
+  union CustomErrorTwinRustAsyncSseKind kind;
 } wire_cst_custom_error_twin_rust_async_sse;
+
+typedef struct wire_cst_CustomErrorTwinSse_Error0 {
+  struct wire_cst_list_prim_u_8 *e;
+  struct wire_cst_list_prim_u_8 *backtrace;
+} wire_cst_CustomErrorTwinSse_Error0;
+
+typedef struct wire_cst_CustomErrorTwinSse_Error1 {
+  uint32_t e;
+  struct wire_cst_list_prim_u_8 *backtrace;
+} wire_cst_CustomErrorTwinSse_Error1;
+
+typedef union CustomErrorTwinSseKind {
+  struct wire_cst_CustomErrorTwinSse_Error0 Error0;
+  struct wire_cst_CustomErrorTwinSse_Error1 Error1;
+} CustomErrorTwinSseKind;
 
 typedef struct wire_cst_custom_error_twin_sse {
   int32_t tag;
-  union CustomErrorTwinSseKind *kind;
+  union CustomErrorTwinSseKind kind;
 } wire_cst_custom_error_twin_sse;
+
+typedef struct wire_cst_CustomErrorTwinSync_Error0 {
+  struct wire_cst_list_prim_u_8 *e;
+  struct wire_cst_list_prim_u_8 *backtrace;
+} wire_cst_CustomErrorTwinSync_Error0;
+
+typedef struct wire_cst_CustomErrorTwinSync_Error1 {
+  uint32_t e;
+  struct wire_cst_list_prim_u_8 *backtrace;
+} wire_cst_CustomErrorTwinSync_Error1;
+
+typedef union CustomErrorTwinSyncKind {
+  struct wire_cst_CustomErrorTwinSync_Error0 Error0;
+  struct wire_cst_CustomErrorTwinSync_Error1 Error1;
+} CustomErrorTwinSyncKind;
 
 typedef struct wire_cst_custom_error_twin_sync {
   int32_t tag;
-  union CustomErrorTwinSyncKind *kind;
+  union CustomErrorTwinSyncKind kind;
 } wire_cst_custom_error_twin_sync;
+
+typedef struct wire_cst_CustomErrorTwinSyncSse_Error0 {
+  struct wire_cst_list_prim_u_8 *e;
+  struct wire_cst_list_prim_u_8 *backtrace;
+} wire_cst_CustomErrorTwinSyncSse_Error0;
+
+typedef struct wire_cst_CustomErrorTwinSyncSse_Error1 {
+  uint32_t e;
+  struct wire_cst_list_prim_u_8 *backtrace;
+} wire_cst_CustomErrorTwinSyncSse_Error1;
+
+typedef union CustomErrorTwinSyncSseKind {
+  struct wire_cst_CustomErrorTwinSyncSse_Error0 Error0;
+  struct wire_cst_CustomErrorTwinSyncSse_Error1 Error1;
+} CustomErrorTwinSyncSseKind;
 
 typedef struct wire_cst_custom_error_twin_sync_sse {
   int32_t tag;
-  union CustomErrorTwinSyncSseKind *kind;
+  union CustomErrorTwinSyncSseKind kind;
 } wire_cst_custom_error_twin_sync_sse;
+
+typedef struct wire_cst_CustomNestedError1TwinNormal_CustomNested1 {
+  struct wire_cst_list_prim_u_8 *field0;
+} wire_cst_CustomNestedError1TwinNormal_CustomNested1;
+
+typedef struct wire_cst_CustomNestedError1TwinNormal_ErrorNested {
+  struct wire_cst_custom_nested_error_2_twin_normal *field0;
+} wire_cst_CustomNestedError1TwinNormal_ErrorNested;
+
+typedef union CustomNestedError1TwinNormalKind {
+  struct wire_cst_CustomNestedError1TwinNormal_CustomNested1 CustomNested1;
+  struct wire_cst_CustomNestedError1TwinNormal_ErrorNested ErrorNested;
+} CustomNestedError1TwinNormalKind;
 
 typedef struct wire_cst_custom_nested_error_1_twin_normal {
   int32_t tag;
-  union CustomNestedError1TwinNormalKind *kind;
+  union CustomNestedError1TwinNormalKind kind;
 } wire_cst_custom_nested_error_1_twin_normal;
+
+typedef struct wire_cst_CustomNestedError1TwinRustAsync_CustomNested1 {
+  struct wire_cst_list_prim_u_8 *field0;
+} wire_cst_CustomNestedError1TwinRustAsync_CustomNested1;
+
+typedef struct wire_cst_CustomNestedError1TwinRustAsync_ErrorNested {
+  struct wire_cst_custom_nested_error_2_twin_rust_async *field0;
+} wire_cst_CustomNestedError1TwinRustAsync_ErrorNested;
+
+typedef union CustomNestedError1TwinRustAsyncKind {
+  struct wire_cst_CustomNestedError1TwinRustAsync_CustomNested1 CustomNested1;
+  struct wire_cst_CustomNestedError1TwinRustAsync_ErrorNested ErrorNested;
+} CustomNestedError1TwinRustAsyncKind;
 
 typedef struct wire_cst_custom_nested_error_1_twin_rust_async {
   int32_t tag;
-  union CustomNestedError1TwinRustAsyncKind *kind;
+  union CustomNestedError1TwinRustAsyncKind kind;
 } wire_cst_custom_nested_error_1_twin_rust_async;
+
+typedef struct wire_cst_CustomNestedError1TwinRustAsyncSse_CustomNested1 {
+  struct wire_cst_list_prim_u_8 *field0;
+} wire_cst_CustomNestedError1TwinRustAsyncSse_CustomNested1;
+
+typedef struct wire_cst_CustomNestedError1TwinRustAsyncSse_ErrorNested {
+  struct wire_cst_custom_nested_error_2_twin_rust_async_sse *field0;
+} wire_cst_CustomNestedError1TwinRustAsyncSse_ErrorNested;
+
+typedef union CustomNestedError1TwinRustAsyncSseKind {
+  struct wire_cst_CustomNestedError1TwinRustAsyncSse_CustomNested1 CustomNested1;
+  struct wire_cst_CustomNestedError1TwinRustAsyncSse_ErrorNested ErrorNested;
+} CustomNestedError1TwinRustAsyncSseKind;
 
 typedef struct wire_cst_custom_nested_error_1_twin_rust_async_sse {
   int32_t tag;
-  union CustomNestedError1TwinRustAsyncSseKind *kind;
+  union CustomNestedError1TwinRustAsyncSseKind kind;
 } wire_cst_custom_nested_error_1_twin_rust_async_sse;
+
+typedef struct wire_cst_CustomNestedError1TwinSse_CustomNested1 {
+  struct wire_cst_list_prim_u_8 *field0;
+} wire_cst_CustomNestedError1TwinSse_CustomNested1;
+
+typedef struct wire_cst_CustomNestedError1TwinSse_ErrorNested {
+  struct wire_cst_custom_nested_error_2_twin_sse *field0;
+} wire_cst_CustomNestedError1TwinSse_ErrorNested;
+
+typedef union CustomNestedError1TwinSseKind {
+  struct wire_cst_CustomNestedError1TwinSse_CustomNested1 CustomNested1;
+  struct wire_cst_CustomNestedError1TwinSse_ErrorNested ErrorNested;
+} CustomNestedError1TwinSseKind;
 
 typedef struct wire_cst_custom_nested_error_1_twin_sse {
   int32_t tag;
-  union CustomNestedError1TwinSseKind *kind;
+  union CustomNestedError1TwinSseKind kind;
 } wire_cst_custom_nested_error_1_twin_sse;
+
+typedef struct wire_cst_CustomNestedError1TwinSync_CustomNested1 {
+  struct wire_cst_list_prim_u_8 *field0;
+} wire_cst_CustomNestedError1TwinSync_CustomNested1;
+
+typedef struct wire_cst_CustomNestedError1TwinSync_ErrorNested {
+  struct wire_cst_custom_nested_error_2_twin_sync *field0;
+} wire_cst_CustomNestedError1TwinSync_ErrorNested;
+
+typedef union CustomNestedError1TwinSyncKind {
+  struct wire_cst_CustomNestedError1TwinSync_CustomNested1 CustomNested1;
+  struct wire_cst_CustomNestedError1TwinSync_ErrorNested ErrorNested;
+} CustomNestedError1TwinSyncKind;
 
 typedef struct wire_cst_custom_nested_error_1_twin_sync {
   int32_t tag;
-  union CustomNestedError1TwinSyncKind *kind;
+  union CustomNestedError1TwinSyncKind kind;
 } wire_cst_custom_nested_error_1_twin_sync;
+
+typedef struct wire_cst_CustomNestedError1TwinSyncSse_CustomNested1 {
+  struct wire_cst_list_prim_u_8 *field0;
+} wire_cst_CustomNestedError1TwinSyncSse_CustomNested1;
+
+typedef struct wire_cst_CustomNestedError1TwinSyncSse_ErrorNested {
+  struct wire_cst_custom_nested_error_2_twin_sync_sse *field0;
+} wire_cst_CustomNestedError1TwinSyncSse_ErrorNested;
+
+typedef union CustomNestedError1TwinSyncSseKind {
+  struct wire_cst_CustomNestedError1TwinSyncSse_CustomNested1 CustomNested1;
+  struct wire_cst_CustomNestedError1TwinSyncSse_ErrorNested ErrorNested;
+} CustomNestedError1TwinSyncSseKind;
 
 typedef struct wire_cst_custom_nested_error_1_twin_sync_sse {
   int32_t tag;
-  union CustomNestedError1TwinSyncSseKind *kind;
+  union CustomNestedError1TwinSyncSseKind kind;
 } wire_cst_custom_nested_error_1_twin_sync_sse;
 
 typedef struct wire_cst_custom_struct_error_another_twin_normal {
@@ -10484,707 +10359,8 @@ struct wire_cst_list_weekdays_twin_sse *cst_new_list_weekdays_twin_sse(int32_t l
 struct wire_cst_list_weekdays_twin_sync *cst_new_list_weekdays_twin_sync(int32_t len);
 
 struct wire_cst_list_weekdays_twin_sync_sse *cst_new_list_weekdays_twin_sync_sse(int32_t len);
-
-union AbcTwinNormalKind *cst_inflate_AbcTwinNormal_A(void);
-
-union AbcTwinNormalKind *cst_inflate_AbcTwinNormal_B(void);
-
-union AbcTwinNormalKind *cst_inflate_AbcTwinNormal_C(void);
-
-union AbcTwinNormalKind *cst_inflate_AbcTwinNormal_JustInt(void);
-
-union AbcTwinRustAsyncKind *cst_inflate_AbcTwinRustAsync_A(void);
-
-union AbcTwinRustAsyncKind *cst_inflate_AbcTwinRustAsync_B(void);
-
-union AbcTwinRustAsyncKind *cst_inflate_AbcTwinRustAsync_C(void);
-
-union AbcTwinRustAsyncKind *cst_inflate_AbcTwinRustAsync_JustInt(void);
-
-union AbcTwinRustAsyncSseKind *cst_inflate_AbcTwinRustAsyncSse_A(void);
-
-union AbcTwinRustAsyncSseKind *cst_inflate_AbcTwinRustAsyncSse_B(void);
-
-union AbcTwinRustAsyncSseKind *cst_inflate_AbcTwinRustAsyncSse_C(void);
-
-union AbcTwinRustAsyncSseKind *cst_inflate_AbcTwinRustAsyncSse_JustInt(void);
-
-union AbcTwinSseKind *cst_inflate_AbcTwinSse_A(void);
-
-union AbcTwinSseKind *cst_inflate_AbcTwinSse_B(void);
-
-union AbcTwinSseKind *cst_inflate_AbcTwinSse_C(void);
-
-union AbcTwinSseKind *cst_inflate_AbcTwinSse_JustInt(void);
-
-union AbcTwinSyncKind *cst_inflate_AbcTwinSync_A(void);
-
-union AbcTwinSyncKind *cst_inflate_AbcTwinSync_B(void);
-
-union AbcTwinSyncKind *cst_inflate_AbcTwinSync_C(void);
-
-union AbcTwinSyncKind *cst_inflate_AbcTwinSync_JustInt(void);
-
-union AbcTwinSyncSseKind *cst_inflate_AbcTwinSyncSse_A(void);
-
-union AbcTwinSyncSseKind *cst_inflate_AbcTwinSyncSse_B(void);
-
-union AbcTwinSyncSseKind *cst_inflate_AbcTwinSyncSse_C(void);
-
-union AbcTwinSyncSseKind *cst_inflate_AbcTwinSyncSse_JustInt(void);
-
-union ApplicationMessageKind *cst_inflate_ApplicationMessage_DisplayMessage(void);
-
-union ApplicationMessageKind *cst_inflate_ApplicationMessage_RenderPixel(void);
-
-union CustomEnumErrorTwinNormalKind *cst_inflate_CustomEnumErrorTwinNormal_One(void);
-
-union CustomEnumErrorTwinNormalKind *cst_inflate_CustomEnumErrorTwinNormal_Two(void);
-
-union CustomEnumErrorTwinRustAsyncKind *cst_inflate_CustomEnumErrorTwinRustAsync_One(void);
-
-union CustomEnumErrorTwinRustAsyncKind *cst_inflate_CustomEnumErrorTwinRustAsync_Two(void);
-
-union CustomEnumErrorTwinRustAsyncSseKind *cst_inflate_CustomEnumErrorTwinRustAsyncSse_One(void);
-
-union CustomEnumErrorTwinRustAsyncSseKind *cst_inflate_CustomEnumErrorTwinRustAsyncSse_Two(void);
-
-union CustomEnumErrorTwinSseKind *cst_inflate_CustomEnumErrorTwinSse_One(void);
-
-union CustomEnumErrorTwinSseKind *cst_inflate_CustomEnumErrorTwinSse_Two(void);
-
-union CustomEnumErrorTwinSyncKind *cst_inflate_CustomEnumErrorTwinSync_One(void);
-
-union CustomEnumErrorTwinSyncKind *cst_inflate_CustomEnumErrorTwinSync_Two(void);
-
-union CustomEnumErrorTwinSyncSseKind *cst_inflate_CustomEnumErrorTwinSyncSse_One(void);
-
-union CustomEnumErrorTwinSyncSseKind *cst_inflate_CustomEnumErrorTwinSyncSse_Two(void);
-
-union CustomErrorTwinNormalKind *cst_inflate_CustomErrorTwinNormal_Error0(void);
-
-union CustomErrorTwinNormalKind *cst_inflate_CustomErrorTwinNormal_Error1(void);
-
-union CustomErrorTwinRustAsyncKind *cst_inflate_CustomErrorTwinRustAsync_Error0(void);
-
-union CustomErrorTwinRustAsyncKind *cst_inflate_CustomErrorTwinRustAsync_Error1(void);
-
-union CustomErrorTwinRustAsyncSseKind *cst_inflate_CustomErrorTwinRustAsyncSse_Error0(void);
-
-union CustomErrorTwinRustAsyncSseKind *cst_inflate_CustomErrorTwinRustAsyncSse_Error1(void);
-
-union CustomErrorTwinSseKind *cst_inflate_CustomErrorTwinSse_Error0(void);
-
-union CustomErrorTwinSseKind *cst_inflate_CustomErrorTwinSse_Error1(void);
-
-union CustomErrorTwinSyncKind *cst_inflate_CustomErrorTwinSync_Error0(void);
-
-union CustomErrorTwinSyncKind *cst_inflate_CustomErrorTwinSync_Error1(void);
-
-union CustomErrorTwinSyncSseKind *cst_inflate_CustomErrorTwinSyncSse_Error0(void);
-
-union CustomErrorTwinSyncSseKind *cst_inflate_CustomErrorTwinSyncSse_Error1(void);
-
-union CustomNestedError1TwinNormalKind *cst_inflate_CustomNestedError1TwinNormal_CustomNested1(void);
-
-union CustomNestedError1TwinNormalKind *cst_inflate_CustomNestedError1TwinNormal_ErrorNested(void);
-
-union CustomNestedError1TwinRustAsyncKind *cst_inflate_CustomNestedError1TwinRustAsync_CustomNested1(void);
-
-union CustomNestedError1TwinRustAsyncKind *cst_inflate_CustomNestedError1TwinRustAsync_ErrorNested(void);
-
-union CustomNestedError1TwinRustAsyncSseKind *cst_inflate_CustomNestedError1TwinRustAsyncSse_CustomNested1(void);
-
-union CustomNestedError1TwinRustAsyncSseKind *cst_inflate_CustomNestedError1TwinRustAsyncSse_ErrorNested(void);
-
-union CustomNestedError1TwinSseKind *cst_inflate_CustomNestedError1TwinSse_CustomNested1(void);
-
-union CustomNestedError1TwinSseKind *cst_inflate_CustomNestedError1TwinSse_ErrorNested(void);
-
-union CustomNestedError1TwinSyncKind *cst_inflate_CustomNestedError1TwinSync_CustomNested1(void);
-
-union CustomNestedError1TwinSyncKind *cst_inflate_CustomNestedError1TwinSync_ErrorNested(void);
-
-union CustomNestedError1TwinSyncSseKind *cst_inflate_CustomNestedError1TwinSyncSse_CustomNested1(void);
-
-union CustomNestedError1TwinSyncSseKind *cst_inflate_CustomNestedError1TwinSyncSse_ErrorNested(void);
-
-union CustomNestedError2TwinNormalKind *cst_inflate_CustomNestedError2TwinNormal_CustomNested2(void);
-
-union CustomNestedError2TwinNormalKind *cst_inflate_CustomNestedError2TwinNormal_CustomNested2Number(void);
-
-union CustomNestedError2TwinRustAsyncKind *cst_inflate_CustomNestedError2TwinRustAsync_CustomNested2(void);
-
-union CustomNestedError2TwinRustAsyncKind *cst_inflate_CustomNestedError2TwinRustAsync_CustomNested2Number(void);
-
-union CustomNestedError2TwinRustAsyncSseKind *cst_inflate_CustomNestedError2TwinRustAsyncSse_CustomNested2(void);
-
-union CustomNestedError2TwinRustAsyncSseKind *cst_inflate_CustomNestedError2TwinRustAsyncSse_CustomNested2Number(void);
-
-union CustomNestedError2TwinSseKind *cst_inflate_CustomNestedError2TwinSse_CustomNested2(void);
-
-union CustomNestedError2TwinSseKind *cst_inflate_CustomNestedError2TwinSse_CustomNested2Number(void);
-
-union CustomNestedError2TwinSyncKind *cst_inflate_CustomNestedError2TwinSync_CustomNested2(void);
-
-union CustomNestedError2TwinSyncKind *cst_inflate_CustomNestedError2TwinSync_CustomNested2Number(void);
-
-union CustomNestedError2TwinSyncSseKind *cst_inflate_CustomNestedError2TwinSyncSse_CustomNested2(void);
-
-union CustomNestedError2TwinSyncSseKind *cst_inflate_CustomNestedError2TwinSyncSse_CustomNested2Number(void);
-
-union CustomNestedErrorInnerTwinNormalKind *cst_inflate_CustomNestedErrorInnerTwinNormal_Three(void);
-
-union CustomNestedErrorInnerTwinNormalKind *cst_inflate_CustomNestedErrorInnerTwinNormal_Four(void);
-
-union CustomNestedErrorInnerTwinRustAsyncKind *cst_inflate_CustomNestedErrorInnerTwinRustAsync_Three(void);
-
-union CustomNestedErrorInnerTwinRustAsyncKind *cst_inflate_CustomNestedErrorInnerTwinRustAsync_Four(void);
-
-union CustomNestedErrorInnerTwinRustAsyncSseKind *cst_inflate_CustomNestedErrorInnerTwinRustAsyncSse_Three(void);
-
-union CustomNestedErrorInnerTwinRustAsyncSseKind *cst_inflate_CustomNestedErrorInnerTwinRustAsyncSse_Four(void);
-
-union CustomNestedErrorInnerTwinSseKind *cst_inflate_CustomNestedErrorInnerTwinSse_Three(void);
-
-union CustomNestedErrorInnerTwinSseKind *cst_inflate_CustomNestedErrorInnerTwinSse_Four(void);
-
-union CustomNestedErrorInnerTwinSyncKind *cst_inflate_CustomNestedErrorInnerTwinSync_Three(void);
-
-union CustomNestedErrorInnerTwinSyncKind *cst_inflate_CustomNestedErrorInnerTwinSync_Four(void);
-
-union CustomNestedErrorInnerTwinSyncSseKind *cst_inflate_CustomNestedErrorInnerTwinSyncSse_Three(void);
-
-union CustomNestedErrorInnerTwinSyncSseKind *cst_inflate_CustomNestedErrorInnerTwinSyncSse_Four(void);
-
-union CustomNestedErrorOuterTwinNormalKind *cst_inflate_CustomNestedErrorOuterTwinNormal_One(void);
-
-union CustomNestedErrorOuterTwinNormalKind *cst_inflate_CustomNestedErrorOuterTwinNormal_Two(void);
-
-union CustomNestedErrorOuterTwinRustAsyncKind *cst_inflate_CustomNestedErrorOuterTwinRustAsync_One(void);
-
-union CustomNestedErrorOuterTwinRustAsyncKind *cst_inflate_CustomNestedErrorOuterTwinRustAsync_Two(void);
-
-union CustomNestedErrorOuterTwinRustAsyncSseKind *cst_inflate_CustomNestedErrorOuterTwinRustAsyncSse_One(void);
-
-union CustomNestedErrorOuterTwinRustAsyncSseKind *cst_inflate_CustomNestedErrorOuterTwinRustAsyncSse_Two(void);
-
-union CustomNestedErrorOuterTwinSseKind *cst_inflate_CustomNestedErrorOuterTwinSse_One(void);
-
-union CustomNestedErrorOuterTwinSseKind *cst_inflate_CustomNestedErrorOuterTwinSse_Two(void);
-
-union CustomNestedErrorOuterTwinSyncKind *cst_inflate_CustomNestedErrorOuterTwinSync_One(void);
-
-union CustomNestedErrorOuterTwinSyncKind *cst_inflate_CustomNestedErrorOuterTwinSync_Two(void);
-
-union CustomNestedErrorOuterTwinSyncSseKind *cst_inflate_CustomNestedErrorOuterTwinSyncSse_One(void);
-
-union CustomNestedErrorOuterTwinSyncSseKind *cst_inflate_CustomNestedErrorOuterTwinSyncSse_Two(void);
-
-union DistanceTwinNormalKind *cst_inflate_DistanceTwinNormal_Map(void);
-
-union DistanceTwinRustAsyncKind *cst_inflate_DistanceTwinRustAsync_Map(void);
-
-union DistanceTwinRustAsyncSseKind *cst_inflate_DistanceTwinRustAsyncSse_Map(void);
-
-union DistanceTwinSseKind *cst_inflate_DistanceTwinSse_Map(void);
-
-union DistanceTwinSyncKind *cst_inflate_DistanceTwinSync_Map(void);
-
-union DistanceTwinSyncSseKind *cst_inflate_DistanceTwinSyncSse_Map(void);
-
-union EnumDartOpaqueTwinNormalKind *cst_inflate_EnumDartOpaqueTwinNormal_Primitive(void);
-
-union EnumDartOpaqueTwinNormalKind *cst_inflate_EnumDartOpaqueTwinNormal_Opaque(void);
-
-union EnumDartOpaqueTwinRustAsyncKind *cst_inflate_EnumDartOpaqueTwinRustAsync_Primitive(void);
-
-union EnumDartOpaqueTwinRustAsyncKind *cst_inflate_EnumDartOpaqueTwinRustAsync_Opaque(void);
-
-union EnumDartOpaqueTwinRustAsyncSseKind *cst_inflate_EnumDartOpaqueTwinRustAsyncSse_Primitive(void);
-
-union EnumDartOpaqueTwinRustAsyncSseKind *cst_inflate_EnumDartOpaqueTwinRustAsyncSse_Opaque(void);
-
-union EnumDartOpaqueTwinSseKind *cst_inflate_EnumDartOpaqueTwinSse_Primitive(void);
-
-union EnumDartOpaqueTwinSseKind *cst_inflate_EnumDartOpaqueTwinSse_Opaque(void);
-
-union EnumDartOpaqueTwinSyncKind *cst_inflate_EnumDartOpaqueTwinSync_Primitive(void);
-
-union EnumDartOpaqueTwinSyncKind *cst_inflate_EnumDartOpaqueTwinSync_Opaque(void);
-
-union EnumDartOpaqueTwinSyncSseKind *cst_inflate_EnumDartOpaqueTwinSyncSse_Primitive(void);
-
-union EnumDartOpaqueTwinSyncSseKind *cst_inflate_EnumDartOpaqueTwinSyncSse_Opaque(void);
-
-union EnumOpaqueTwinNormalKind *cst_inflate_EnumOpaqueTwinNormal_Struct(void);
-
-union EnumOpaqueTwinNormalKind *cst_inflate_EnumOpaqueTwinNormal_Primitive(void);
-
-union EnumOpaqueTwinNormalKind *cst_inflate_EnumOpaqueTwinNormal_TraitObj(void);
-
-union EnumOpaqueTwinNormalKind *cst_inflate_EnumOpaqueTwinNormal_Mutex(void);
-
-union EnumOpaqueTwinNormalKind *cst_inflate_EnumOpaqueTwinNormal_RwLock(void);
-
-union EnumOpaqueTwinRustAsyncKind *cst_inflate_EnumOpaqueTwinRustAsync_Struct(void);
-
-union EnumOpaqueTwinRustAsyncKind *cst_inflate_EnumOpaqueTwinRustAsync_Primitive(void);
-
-union EnumOpaqueTwinRustAsyncKind *cst_inflate_EnumOpaqueTwinRustAsync_TraitObj(void);
-
-union EnumOpaqueTwinRustAsyncKind *cst_inflate_EnumOpaqueTwinRustAsync_Mutex(void);
-
-union EnumOpaqueTwinRustAsyncKind *cst_inflate_EnumOpaqueTwinRustAsync_RwLock(void);
-
-union EnumOpaqueTwinRustAsyncSseKind *cst_inflate_EnumOpaqueTwinRustAsyncSse_Struct(void);
-
-union EnumOpaqueTwinRustAsyncSseKind *cst_inflate_EnumOpaqueTwinRustAsyncSse_Primitive(void);
-
-union EnumOpaqueTwinRustAsyncSseKind *cst_inflate_EnumOpaqueTwinRustAsyncSse_TraitObj(void);
-
-union EnumOpaqueTwinRustAsyncSseKind *cst_inflate_EnumOpaqueTwinRustAsyncSse_Mutex(void);
-
-union EnumOpaqueTwinRustAsyncSseKind *cst_inflate_EnumOpaqueTwinRustAsyncSse_RwLock(void);
-
-union EnumOpaqueTwinSseKind *cst_inflate_EnumOpaqueTwinSse_Struct(void);
-
-union EnumOpaqueTwinSseKind *cst_inflate_EnumOpaqueTwinSse_Primitive(void);
-
-union EnumOpaqueTwinSseKind *cst_inflate_EnumOpaqueTwinSse_TraitObj(void);
-
-union EnumOpaqueTwinSseKind *cst_inflate_EnumOpaqueTwinSse_Mutex(void);
-
-union EnumOpaqueTwinSseKind *cst_inflate_EnumOpaqueTwinSse_RwLock(void);
-
-union EnumOpaqueTwinSyncKind *cst_inflate_EnumOpaqueTwinSync_Struct(void);
-
-union EnumOpaqueTwinSyncKind *cst_inflate_EnumOpaqueTwinSync_Primitive(void);
-
-union EnumOpaqueTwinSyncKind *cst_inflate_EnumOpaqueTwinSync_TraitObj(void);
-
-union EnumOpaqueTwinSyncKind *cst_inflate_EnumOpaqueTwinSync_Mutex(void);
-
-union EnumOpaqueTwinSyncKind *cst_inflate_EnumOpaqueTwinSync_RwLock(void);
-
-union EnumOpaqueTwinSyncSseKind *cst_inflate_EnumOpaqueTwinSyncSse_Struct(void);
-
-union EnumOpaqueTwinSyncSseKind *cst_inflate_EnumOpaqueTwinSyncSse_Primitive(void);
-
-union EnumOpaqueTwinSyncSseKind *cst_inflate_EnumOpaqueTwinSyncSse_TraitObj(void);
-
-union EnumOpaqueTwinSyncSseKind *cst_inflate_EnumOpaqueTwinSyncSse_Mutex(void);
-
-union EnumOpaqueTwinSyncSseKind *cst_inflate_EnumOpaqueTwinSyncSse_RwLock(void);
-
-union EnumWithItemMixedTwinNormalKind *cst_inflate_EnumWithItemMixedTwinNormal_B(void);
-
-union EnumWithItemMixedTwinNormalKind *cst_inflate_EnumWithItemMixedTwinNormal_C(void);
-
-union EnumWithItemMixedTwinRustAsyncKind *cst_inflate_EnumWithItemMixedTwinRustAsync_B(void);
-
-union EnumWithItemMixedTwinRustAsyncKind *cst_inflate_EnumWithItemMixedTwinRustAsync_C(void);
-
-union EnumWithItemMixedTwinRustAsyncSseKind *cst_inflate_EnumWithItemMixedTwinRustAsyncSse_B(void);
-
-union EnumWithItemMixedTwinRustAsyncSseKind *cst_inflate_EnumWithItemMixedTwinRustAsyncSse_C(void);
-
-union EnumWithItemMixedTwinSseKind *cst_inflate_EnumWithItemMixedTwinSse_B(void);
-
-union EnumWithItemMixedTwinSseKind *cst_inflate_EnumWithItemMixedTwinSse_C(void);
-
-union EnumWithItemMixedTwinSyncKind *cst_inflate_EnumWithItemMixedTwinSync_B(void);
-
-union EnumWithItemMixedTwinSyncKind *cst_inflate_EnumWithItemMixedTwinSync_C(void);
-
-union EnumWithItemMixedTwinSyncSseKind *cst_inflate_EnumWithItemMixedTwinSyncSse_B(void);
-
-union EnumWithItemMixedTwinSyncSseKind *cst_inflate_EnumWithItemMixedTwinSyncSse_C(void);
-
-union EnumWithItemStructTwinNormalKind *cst_inflate_EnumWithItemStructTwinNormal_A(void);
-
-union EnumWithItemStructTwinNormalKind *cst_inflate_EnumWithItemStructTwinNormal_B(void);
-
-union EnumWithItemStructTwinRustAsyncKind *cst_inflate_EnumWithItemStructTwinRustAsync_A(void);
-
-union EnumWithItemStructTwinRustAsyncKind *cst_inflate_EnumWithItemStructTwinRustAsync_B(void);
-
-union EnumWithItemStructTwinRustAsyncSseKind *cst_inflate_EnumWithItemStructTwinRustAsyncSse_A(void);
-
-union EnumWithItemStructTwinRustAsyncSseKind *cst_inflate_EnumWithItemStructTwinRustAsyncSse_B(void);
-
-union EnumWithItemStructTwinSseKind *cst_inflate_EnumWithItemStructTwinSse_A(void);
-
-union EnumWithItemStructTwinSseKind *cst_inflate_EnumWithItemStructTwinSse_B(void);
-
-union EnumWithItemStructTwinSyncKind *cst_inflate_EnumWithItemStructTwinSync_A(void);
-
-union EnumWithItemStructTwinSyncKind *cst_inflate_EnumWithItemStructTwinSync_B(void);
-
-union EnumWithItemStructTwinSyncSseKind *cst_inflate_EnumWithItemStructTwinSyncSse_A(void);
-
-union EnumWithItemStructTwinSyncSseKind *cst_inflate_EnumWithItemStructTwinSyncSse_B(void);
-
-union EnumWithItemTupleTwinNormalKind *cst_inflate_EnumWithItemTupleTwinNormal_A(void);
-
-union EnumWithItemTupleTwinNormalKind *cst_inflate_EnumWithItemTupleTwinNormal_B(void);
-
-union EnumWithItemTupleTwinRustAsyncKind *cst_inflate_EnumWithItemTupleTwinRustAsync_A(void);
-
-union EnumWithItemTupleTwinRustAsyncKind *cst_inflate_EnumWithItemTupleTwinRustAsync_B(void);
-
-union EnumWithItemTupleTwinRustAsyncSseKind *cst_inflate_EnumWithItemTupleTwinRustAsyncSse_A(void);
-
-union EnumWithItemTupleTwinRustAsyncSseKind *cst_inflate_EnumWithItemTupleTwinRustAsyncSse_B(void);
-
-union EnumWithItemTupleTwinSseKind *cst_inflate_EnumWithItemTupleTwinSse_A(void);
-
-union EnumWithItemTupleTwinSseKind *cst_inflate_EnumWithItemTupleTwinSse_B(void);
-
-union EnumWithItemTupleTwinSyncKind *cst_inflate_EnumWithItemTupleTwinSync_A(void);
-
-union EnumWithItemTupleTwinSyncKind *cst_inflate_EnumWithItemTupleTwinSync_B(void);
-
-union EnumWithItemTupleTwinSyncSseKind *cst_inflate_EnumWithItemTupleTwinSyncSse_A(void);
-
-union EnumWithItemTupleTwinSyncSseKind *cst_inflate_EnumWithItemTupleTwinSyncSse_B(void);
-
-union KitchenSinkTwinNormalKind *cst_inflate_KitchenSinkTwinNormal_Primitives(void);
-
-union KitchenSinkTwinNormalKind *cst_inflate_KitchenSinkTwinNormal_Nested(void);
-
-union KitchenSinkTwinNormalKind *cst_inflate_KitchenSinkTwinNormal_Optional(void);
-
-union KitchenSinkTwinNormalKind *cst_inflate_KitchenSinkTwinNormal_Buffer(void);
-
-union KitchenSinkTwinNormalKind *cst_inflate_KitchenSinkTwinNormal_Enums(void);
-
-union KitchenSinkTwinRustAsyncKind *cst_inflate_KitchenSinkTwinRustAsync_Primitives(void);
-
-union KitchenSinkTwinRustAsyncKind *cst_inflate_KitchenSinkTwinRustAsync_Nested(void);
-
-union KitchenSinkTwinRustAsyncKind *cst_inflate_KitchenSinkTwinRustAsync_Optional(void);
-
-union KitchenSinkTwinRustAsyncKind *cst_inflate_KitchenSinkTwinRustAsync_Buffer(void);
-
-union KitchenSinkTwinRustAsyncKind *cst_inflate_KitchenSinkTwinRustAsync_Enums(void);
-
-union KitchenSinkTwinRustAsyncSseKind *cst_inflate_KitchenSinkTwinRustAsyncSse_Primitives(void);
-
-union KitchenSinkTwinRustAsyncSseKind *cst_inflate_KitchenSinkTwinRustAsyncSse_Nested(void);
-
-union KitchenSinkTwinRustAsyncSseKind *cst_inflate_KitchenSinkTwinRustAsyncSse_Optional(void);
-
-union KitchenSinkTwinRustAsyncSseKind *cst_inflate_KitchenSinkTwinRustAsyncSse_Buffer(void);
-
-union KitchenSinkTwinRustAsyncSseKind *cst_inflate_KitchenSinkTwinRustAsyncSse_Enums(void);
-
-union KitchenSinkTwinSseKind *cst_inflate_KitchenSinkTwinSse_Primitives(void);
-
-union KitchenSinkTwinSseKind *cst_inflate_KitchenSinkTwinSse_Nested(void);
-
-union KitchenSinkTwinSseKind *cst_inflate_KitchenSinkTwinSse_Optional(void);
-
-union KitchenSinkTwinSseKind *cst_inflate_KitchenSinkTwinSse_Buffer(void);
-
-union KitchenSinkTwinSseKind *cst_inflate_KitchenSinkTwinSse_Enums(void);
-
-union KitchenSinkTwinSyncKind *cst_inflate_KitchenSinkTwinSync_Primitives(void);
-
-union KitchenSinkTwinSyncKind *cst_inflate_KitchenSinkTwinSync_Nested(void);
-
-union KitchenSinkTwinSyncKind *cst_inflate_KitchenSinkTwinSync_Optional(void);
-
-union KitchenSinkTwinSyncKind *cst_inflate_KitchenSinkTwinSync_Buffer(void);
-
-union KitchenSinkTwinSyncKind *cst_inflate_KitchenSinkTwinSync_Enums(void);
-
-union KitchenSinkTwinSyncSseKind *cst_inflate_KitchenSinkTwinSyncSse_Primitives(void);
-
-union KitchenSinkTwinSyncSseKind *cst_inflate_KitchenSinkTwinSyncSse_Nested(void);
-
-union KitchenSinkTwinSyncSseKind *cst_inflate_KitchenSinkTwinSyncSse_Optional(void);
-
-union KitchenSinkTwinSyncSseKind *cst_inflate_KitchenSinkTwinSyncSse_Buffer(void);
-
-union KitchenSinkTwinSyncSseKind *cst_inflate_KitchenSinkTwinSyncSse_Enums(void);
-
-union MeasureTwinNormalKind *cst_inflate_MeasureTwinNormal_Speed(void);
-
-union MeasureTwinNormalKind *cst_inflate_MeasureTwinNormal_Distance(void);
-
-union MeasureTwinRustAsyncKind *cst_inflate_MeasureTwinRustAsync_Speed(void);
-
-union MeasureTwinRustAsyncKind *cst_inflate_MeasureTwinRustAsync_Distance(void);
-
-union MeasureTwinRustAsyncSseKind *cst_inflate_MeasureTwinRustAsyncSse_Speed(void);
-
-union MeasureTwinRustAsyncSseKind *cst_inflate_MeasureTwinRustAsyncSse_Distance(void);
-
-union MeasureTwinSseKind *cst_inflate_MeasureTwinSse_Speed(void);
-
-union MeasureTwinSseKind *cst_inflate_MeasureTwinSse_Distance(void);
-
-union MeasureTwinSyncKind *cst_inflate_MeasureTwinSync_Speed(void);
-
-union MeasureTwinSyncKind *cst_inflate_MeasureTwinSync_Distance(void);
-
-union MeasureTwinSyncSseKind *cst_inflate_MeasureTwinSyncSse_Speed(void);
-
-union MeasureTwinSyncSseKind *cst_inflate_MeasureTwinSyncSse_Distance(void);
-
-union RawStringEnumMirroredKind *cst_inflate_RawStringEnumMirrored_Raw(void);
-
-union RawStringEnumMirroredKind *cst_inflate_RawStringEnumMirrored_Nested(void);
-
-union RawStringEnumMirroredKind *cst_inflate_RawStringEnumMirrored_ListOfNested(void);
-
-union SpeedTwinNormalKind *cst_inflate_SpeedTwinNormal_GPS(void);
-
-union SpeedTwinRustAsyncKind *cst_inflate_SpeedTwinRustAsync_GPS(void);
-
-union SpeedTwinRustAsyncSseKind *cst_inflate_SpeedTwinRustAsyncSse_GPS(void);
-
-union SpeedTwinSseKind *cst_inflate_SpeedTwinSse_GPS(void);
-
-union SpeedTwinSyncKind *cst_inflate_SpeedTwinSync_GPS(void);
-
-union SpeedTwinSyncSseKind *cst_inflate_SpeedTwinSyncSse_GPS(void);
 static int64_t dummy_method_to_enforce_bundling(void) {
     int64_t dummy_var = 0;
-    dummy_var ^= ((int64_t) (void*) cst_inflate_AbcTwinNormal_A);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_AbcTwinNormal_B);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_AbcTwinNormal_C);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_AbcTwinNormal_JustInt);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_AbcTwinRustAsyncSse_A);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_AbcTwinRustAsyncSse_B);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_AbcTwinRustAsyncSse_C);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_AbcTwinRustAsyncSse_JustInt);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_AbcTwinRustAsync_A);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_AbcTwinRustAsync_B);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_AbcTwinRustAsync_C);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_AbcTwinRustAsync_JustInt);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_AbcTwinSse_A);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_AbcTwinSse_B);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_AbcTwinSse_C);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_AbcTwinSse_JustInt);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_AbcTwinSyncSse_A);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_AbcTwinSyncSse_B);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_AbcTwinSyncSse_C);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_AbcTwinSyncSse_JustInt);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_AbcTwinSync_A);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_AbcTwinSync_B);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_AbcTwinSync_C);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_AbcTwinSync_JustInt);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_ApplicationMessage_DisplayMessage);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_ApplicationMessage_RenderPixel);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomEnumErrorTwinNormal_One);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomEnumErrorTwinNormal_Two);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomEnumErrorTwinRustAsyncSse_One);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomEnumErrorTwinRustAsyncSse_Two);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomEnumErrorTwinRustAsync_One);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomEnumErrorTwinRustAsync_Two);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomEnumErrorTwinSse_One);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomEnumErrorTwinSse_Two);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomEnumErrorTwinSyncSse_One);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomEnumErrorTwinSyncSse_Two);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomEnumErrorTwinSync_One);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomEnumErrorTwinSync_Two);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomErrorTwinNormal_Error0);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomErrorTwinNormal_Error1);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomErrorTwinRustAsyncSse_Error0);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomErrorTwinRustAsyncSse_Error1);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomErrorTwinRustAsync_Error0);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomErrorTwinRustAsync_Error1);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomErrorTwinSse_Error0);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomErrorTwinSse_Error1);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomErrorTwinSyncSse_Error0);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomErrorTwinSyncSse_Error1);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomErrorTwinSync_Error0);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomErrorTwinSync_Error1);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedError1TwinNormal_CustomNested1);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedError1TwinNormal_ErrorNested);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedError1TwinRustAsyncSse_CustomNested1);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedError1TwinRustAsyncSse_ErrorNested);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedError1TwinRustAsync_CustomNested1);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedError1TwinRustAsync_ErrorNested);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedError1TwinSse_CustomNested1);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedError1TwinSse_ErrorNested);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedError1TwinSyncSse_CustomNested1);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedError1TwinSyncSse_ErrorNested);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedError1TwinSync_CustomNested1);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedError1TwinSync_ErrorNested);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedError2TwinNormal_CustomNested2);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedError2TwinNormal_CustomNested2Number);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedError2TwinRustAsyncSse_CustomNested2);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedError2TwinRustAsyncSse_CustomNested2Number);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedError2TwinRustAsync_CustomNested2);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedError2TwinRustAsync_CustomNested2Number);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedError2TwinSse_CustomNested2);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedError2TwinSse_CustomNested2Number);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedError2TwinSyncSse_CustomNested2);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedError2TwinSyncSse_CustomNested2Number);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedError2TwinSync_CustomNested2);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedError2TwinSync_CustomNested2Number);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedErrorInnerTwinNormal_Four);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedErrorInnerTwinNormal_Three);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedErrorInnerTwinRustAsyncSse_Four);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedErrorInnerTwinRustAsyncSse_Three);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedErrorInnerTwinRustAsync_Four);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedErrorInnerTwinRustAsync_Three);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedErrorInnerTwinSse_Four);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedErrorInnerTwinSse_Three);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedErrorInnerTwinSyncSse_Four);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedErrorInnerTwinSyncSse_Three);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedErrorInnerTwinSync_Four);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedErrorInnerTwinSync_Three);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedErrorOuterTwinNormal_One);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedErrorOuterTwinNormal_Two);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedErrorOuterTwinRustAsyncSse_One);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedErrorOuterTwinRustAsyncSse_Two);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedErrorOuterTwinRustAsync_One);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedErrorOuterTwinRustAsync_Two);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedErrorOuterTwinSse_One);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedErrorOuterTwinSse_Two);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedErrorOuterTwinSyncSse_One);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedErrorOuterTwinSyncSse_Two);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedErrorOuterTwinSync_One);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_CustomNestedErrorOuterTwinSync_Two);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_DistanceTwinNormal_Map);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_DistanceTwinRustAsyncSse_Map);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_DistanceTwinRustAsync_Map);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_DistanceTwinSse_Map);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_DistanceTwinSyncSse_Map);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_DistanceTwinSync_Map);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumDartOpaqueTwinNormal_Opaque);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumDartOpaqueTwinNormal_Primitive);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumDartOpaqueTwinRustAsyncSse_Opaque);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumDartOpaqueTwinRustAsyncSse_Primitive);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumDartOpaqueTwinRustAsync_Opaque);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumDartOpaqueTwinRustAsync_Primitive);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumDartOpaqueTwinSse_Opaque);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumDartOpaqueTwinSse_Primitive);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumDartOpaqueTwinSyncSse_Opaque);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumDartOpaqueTwinSyncSse_Primitive);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumDartOpaqueTwinSync_Opaque);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumDartOpaqueTwinSync_Primitive);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumOpaqueTwinNormal_Mutex);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumOpaqueTwinNormal_Primitive);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumOpaqueTwinNormal_RwLock);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumOpaqueTwinNormal_Struct);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumOpaqueTwinNormal_TraitObj);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumOpaqueTwinRustAsyncSse_Mutex);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumOpaqueTwinRustAsyncSse_Primitive);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumOpaqueTwinRustAsyncSse_RwLock);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumOpaqueTwinRustAsyncSse_Struct);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumOpaqueTwinRustAsyncSse_TraitObj);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumOpaqueTwinRustAsync_Mutex);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumOpaqueTwinRustAsync_Primitive);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumOpaqueTwinRustAsync_RwLock);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumOpaqueTwinRustAsync_Struct);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumOpaqueTwinRustAsync_TraitObj);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumOpaqueTwinSse_Mutex);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumOpaqueTwinSse_Primitive);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumOpaqueTwinSse_RwLock);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumOpaqueTwinSse_Struct);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumOpaqueTwinSse_TraitObj);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumOpaqueTwinSyncSse_Mutex);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumOpaqueTwinSyncSse_Primitive);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumOpaqueTwinSyncSse_RwLock);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumOpaqueTwinSyncSse_Struct);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumOpaqueTwinSyncSse_TraitObj);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumOpaqueTwinSync_Mutex);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumOpaqueTwinSync_Primitive);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumOpaqueTwinSync_RwLock);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumOpaqueTwinSync_Struct);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumOpaqueTwinSync_TraitObj);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumWithItemMixedTwinNormal_B);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumWithItemMixedTwinNormal_C);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumWithItemMixedTwinRustAsyncSse_B);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumWithItemMixedTwinRustAsyncSse_C);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumWithItemMixedTwinRustAsync_B);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumWithItemMixedTwinRustAsync_C);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumWithItemMixedTwinSse_B);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumWithItemMixedTwinSse_C);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumWithItemMixedTwinSyncSse_B);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumWithItemMixedTwinSyncSse_C);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumWithItemMixedTwinSync_B);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumWithItemMixedTwinSync_C);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumWithItemStructTwinNormal_A);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumWithItemStructTwinNormal_B);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumWithItemStructTwinRustAsyncSse_A);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumWithItemStructTwinRustAsyncSse_B);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumWithItemStructTwinRustAsync_A);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumWithItemStructTwinRustAsync_B);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumWithItemStructTwinSse_A);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumWithItemStructTwinSse_B);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumWithItemStructTwinSyncSse_A);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumWithItemStructTwinSyncSse_B);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumWithItemStructTwinSync_A);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumWithItemStructTwinSync_B);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumWithItemTupleTwinNormal_A);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumWithItemTupleTwinNormal_B);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumWithItemTupleTwinRustAsyncSse_A);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumWithItemTupleTwinRustAsyncSse_B);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumWithItemTupleTwinRustAsync_A);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumWithItemTupleTwinRustAsync_B);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumWithItemTupleTwinSse_A);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumWithItemTupleTwinSse_B);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumWithItemTupleTwinSyncSse_A);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumWithItemTupleTwinSyncSse_B);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumWithItemTupleTwinSync_A);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_EnumWithItemTupleTwinSync_B);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_KitchenSinkTwinNormal_Buffer);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_KitchenSinkTwinNormal_Enums);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_KitchenSinkTwinNormal_Nested);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_KitchenSinkTwinNormal_Optional);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_KitchenSinkTwinNormal_Primitives);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_KitchenSinkTwinRustAsyncSse_Buffer);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_KitchenSinkTwinRustAsyncSse_Enums);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_KitchenSinkTwinRustAsyncSse_Nested);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_KitchenSinkTwinRustAsyncSse_Optional);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_KitchenSinkTwinRustAsyncSse_Primitives);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_KitchenSinkTwinRustAsync_Buffer);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_KitchenSinkTwinRustAsync_Enums);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_KitchenSinkTwinRustAsync_Nested);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_KitchenSinkTwinRustAsync_Optional);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_KitchenSinkTwinRustAsync_Primitives);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_KitchenSinkTwinSse_Buffer);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_KitchenSinkTwinSse_Enums);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_KitchenSinkTwinSse_Nested);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_KitchenSinkTwinSse_Optional);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_KitchenSinkTwinSse_Primitives);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_KitchenSinkTwinSyncSse_Buffer);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_KitchenSinkTwinSyncSse_Enums);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_KitchenSinkTwinSyncSse_Nested);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_KitchenSinkTwinSyncSse_Optional);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_KitchenSinkTwinSyncSse_Primitives);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_KitchenSinkTwinSync_Buffer);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_KitchenSinkTwinSync_Enums);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_KitchenSinkTwinSync_Nested);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_KitchenSinkTwinSync_Optional);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_KitchenSinkTwinSync_Primitives);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_MeasureTwinNormal_Distance);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_MeasureTwinNormal_Speed);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_MeasureTwinRustAsyncSse_Distance);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_MeasureTwinRustAsyncSse_Speed);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_MeasureTwinRustAsync_Distance);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_MeasureTwinRustAsync_Speed);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_MeasureTwinSse_Distance);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_MeasureTwinSse_Speed);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_MeasureTwinSyncSse_Distance);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_MeasureTwinSyncSse_Speed);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_MeasureTwinSync_Distance);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_MeasureTwinSync_Speed);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_RawStringEnumMirrored_ListOfNested);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_RawStringEnumMirrored_Nested);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_RawStringEnumMirrored_Raw);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_SpeedTwinNormal_GPS);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_SpeedTwinRustAsyncSse_GPS);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_SpeedTwinRustAsync_GPS);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_SpeedTwinSse_GPS);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_SpeedTwinSyncSse_GPS);
-    dummy_var ^= ((int64_t) (void*) cst_inflate_SpeedTwinSync_GPS);
     dummy_var ^= ((int64_t) (void*) cst_new_box_application_env);
     dummy_var ^= ((int64_t) (void*) cst_new_box_autoadd_Chrono_Duration);
     dummy_var ^= ((int64_t) (void*) cst_new_box_autoadd_Chrono_Naive);

--- a/frb_example/pure_dart/lib/src/rust/frb_generated.io.dart
+++ b/frb_example/pure_dart/lib/src/rust/frb_generated.io.dart
@@ -13916,29 +13916,25 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is AbcTwinNormal_A) {
       var pre_field0 = cst_encode_box_autoadd_a_twin_normal(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_AbcTwinNormal_A();
-      wireObj.kind.ref.A.ref.field0 = pre_field0;
+      wireObj.kind.A.field0 = pre_field0;
       return;
     }
     if (apiObj is AbcTwinNormal_B) {
       var pre_field0 = cst_encode_box_autoadd_b_twin_normal(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_AbcTwinNormal_B();
-      wireObj.kind.ref.B.ref.field0 = pre_field0;
+      wireObj.kind.B.field0 = pre_field0;
       return;
     }
     if (apiObj is AbcTwinNormal_C) {
       var pre_field0 = cst_encode_box_autoadd_c_twin_normal(apiObj.field0);
       wireObj.tag = 2;
-      wireObj.kind = wire.cst_inflate_AbcTwinNormal_C();
-      wireObj.kind.ref.C.ref.field0 = pre_field0;
+      wireObj.kind.C.field0 = pre_field0;
       return;
     }
     if (apiObj is AbcTwinNormal_JustInt) {
       var pre_field0 = cst_encode_i_32(apiObj.field0);
       wireObj.tag = 3;
-      wireObj.kind = wire.cst_inflate_AbcTwinNormal_JustInt();
-      wireObj.kind.ref.JustInt.ref.field0 = pre_field0;
+      wireObj.kind.JustInt.field0 = pre_field0;
       return;
     }
   }
@@ -13949,29 +13945,25 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is AbcTwinRustAsync_A) {
       var pre_field0 = cst_encode_box_autoadd_a_twin_rust_async(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_AbcTwinRustAsync_A();
-      wireObj.kind.ref.A.ref.field0 = pre_field0;
+      wireObj.kind.A.field0 = pre_field0;
       return;
     }
     if (apiObj is AbcTwinRustAsync_B) {
       var pre_field0 = cst_encode_box_autoadd_b_twin_rust_async(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_AbcTwinRustAsync_B();
-      wireObj.kind.ref.B.ref.field0 = pre_field0;
+      wireObj.kind.B.field0 = pre_field0;
       return;
     }
     if (apiObj is AbcTwinRustAsync_C) {
       var pre_field0 = cst_encode_box_autoadd_c_twin_rust_async(apiObj.field0);
       wireObj.tag = 2;
-      wireObj.kind = wire.cst_inflate_AbcTwinRustAsync_C();
-      wireObj.kind.ref.C.ref.field0 = pre_field0;
+      wireObj.kind.C.field0 = pre_field0;
       return;
     }
     if (apiObj is AbcTwinRustAsync_JustInt) {
       var pre_field0 = cst_encode_i_32(apiObj.field0);
       wireObj.tag = 3;
-      wireObj.kind = wire.cst_inflate_AbcTwinRustAsync_JustInt();
-      wireObj.kind.ref.JustInt.ref.field0 = pre_field0;
+      wireObj.kind.JustInt.field0 = pre_field0;
       return;
     }
   }
@@ -13983,31 +13975,27 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       var pre_field0 =
           cst_encode_box_autoadd_a_twin_rust_async_sse(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_AbcTwinRustAsyncSse_A();
-      wireObj.kind.ref.A.ref.field0 = pre_field0;
+      wireObj.kind.A.field0 = pre_field0;
       return;
     }
     if (apiObj is AbcTwinRustAsyncSse_B) {
       var pre_field0 =
           cst_encode_box_autoadd_b_twin_rust_async_sse(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_AbcTwinRustAsyncSse_B();
-      wireObj.kind.ref.B.ref.field0 = pre_field0;
+      wireObj.kind.B.field0 = pre_field0;
       return;
     }
     if (apiObj is AbcTwinRustAsyncSse_C) {
       var pre_field0 =
           cst_encode_box_autoadd_c_twin_rust_async_sse(apiObj.field0);
       wireObj.tag = 2;
-      wireObj.kind = wire.cst_inflate_AbcTwinRustAsyncSse_C();
-      wireObj.kind.ref.C.ref.field0 = pre_field0;
+      wireObj.kind.C.field0 = pre_field0;
       return;
     }
     if (apiObj is AbcTwinRustAsyncSse_JustInt) {
       var pre_field0 = cst_encode_i_32(apiObj.field0);
       wireObj.tag = 3;
-      wireObj.kind = wire.cst_inflate_AbcTwinRustAsyncSse_JustInt();
-      wireObj.kind.ref.JustInt.ref.field0 = pre_field0;
+      wireObj.kind.JustInt.field0 = pre_field0;
       return;
     }
   }
@@ -14018,29 +14006,25 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is AbcTwinSse_A) {
       var pre_field0 = cst_encode_box_autoadd_a_twin_sse(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_AbcTwinSse_A();
-      wireObj.kind.ref.A.ref.field0 = pre_field0;
+      wireObj.kind.A.field0 = pre_field0;
       return;
     }
     if (apiObj is AbcTwinSse_B) {
       var pre_field0 = cst_encode_box_autoadd_b_twin_sse(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_AbcTwinSse_B();
-      wireObj.kind.ref.B.ref.field0 = pre_field0;
+      wireObj.kind.B.field0 = pre_field0;
       return;
     }
     if (apiObj is AbcTwinSse_C) {
       var pre_field0 = cst_encode_box_autoadd_c_twin_sse(apiObj.field0);
       wireObj.tag = 2;
-      wireObj.kind = wire.cst_inflate_AbcTwinSse_C();
-      wireObj.kind.ref.C.ref.field0 = pre_field0;
+      wireObj.kind.C.field0 = pre_field0;
       return;
     }
     if (apiObj is AbcTwinSse_JustInt) {
       var pre_field0 = cst_encode_i_32(apiObj.field0);
       wireObj.tag = 3;
-      wireObj.kind = wire.cst_inflate_AbcTwinSse_JustInt();
-      wireObj.kind.ref.JustInt.ref.field0 = pre_field0;
+      wireObj.kind.JustInt.field0 = pre_field0;
       return;
     }
   }
@@ -14051,29 +14035,25 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is AbcTwinSync_A) {
       var pre_field0 = cst_encode_box_autoadd_a_twin_sync(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_AbcTwinSync_A();
-      wireObj.kind.ref.A.ref.field0 = pre_field0;
+      wireObj.kind.A.field0 = pre_field0;
       return;
     }
     if (apiObj is AbcTwinSync_B) {
       var pre_field0 = cst_encode_box_autoadd_b_twin_sync(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_AbcTwinSync_B();
-      wireObj.kind.ref.B.ref.field0 = pre_field0;
+      wireObj.kind.B.field0 = pre_field0;
       return;
     }
     if (apiObj is AbcTwinSync_C) {
       var pre_field0 = cst_encode_box_autoadd_c_twin_sync(apiObj.field0);
       wireObj.tag = 2;
-      wireObj.kind = wire.cst_inflate_AbcTwinSync_C();
-      wireObj.kind.ref.C.ref.field0 = pre_field0;
+      wireObj.kind.C.field0 = pre_field0;
       return;
     }
     if (apiObj is AbcTwinSync_JustInt) {
       var pre_field0 = cst_encode_i_32(apiObj.field0);
       wireObj.tag = 3;
-      wireObj.kind = wire.cst_inflate_AbcTwinSync_JustInt();
-      wireObj.kind.ref.JustInt.ref.field0 = pre_field0;
+      wireObj.kind.JustInt.field0 = pre_field0;
       return;
     }
   }
@@ -14084,29 +14064,25 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is AbcTwinSyncSse_A) {
       var pre_field0 = cst_encode_box_autoadd_a_twin_sync_sse(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_AbcTwinSyncSse_A();
-      wireObj.kind.ref.A.ref.field0 = pre_field0;
+      wireObj.kind.A.field0 = pre_field0;
       return;
     }
     if (apiObj is AbcTwinSyncSse_B) {
       var pre_field0 = cst_encode_box_autoadd_b_twin_sync_sse(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_AbcTwinSyncSse_B();
-      wireObj.kind.ref.B.ref.field0 = pre_field0;
+      wireObj.kind.B.field0 = pre_field0;
       return;
     }
     if (apiObj is AbcTwinSyncSse_C) {
       var pre_field0 = cst_encode_box_autoadd_c_twin_sync_sse(apiObj.field0);
       wireObj.tag = 2;
-      wireObj.kind = wire.cst_inflate_AbcTwinSyncSse_C();
-      wireObj.kind.ref.C.ref.field0 = pre_field0;
+      wireObj.kind.C.field0 = pre_field0;
       return;
     }
     if (apiObj is AbcTwinSyncSse_JustInt) {
       var pre_field0 = cst_encode_i_32(apiObj.field0);
       wireObj.tag = 3;
-      wireObj.kind = wire.cst_inflate_AbcTwinSyncSse_JustInt();
-      wireObj.kind.ref.JustInt.ref.field0 = pre_field0;
+      wireObj.kind.JustInt.field0 = pre_field0;
       return;
     }
   }
@@ -14175,17 +14151,15 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is ApplicationMessage_DisplayMessage) {
       var pre_field0 = cst_encode_String(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_ApplicationMessage_DisplayMessage();
-      wireObj.kind.ref.DisplayMessage.ref.field0 = pre_field0;
+      wireObj.kind.DisplayMessage.field0 = pre_field0;
       return;
     }
     if (apiObj is ApplicationMessage_RenderPixel) {
       var pre_x = cst_encode_i_32(apiObj.x);
       var pre_y = cst_encode_i_32(apiObj.y);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_ApplicationMessage_RenderPixel();
-      wireObj.kind.ref.RenderPixel.ref.x = pre_x;
-      wireObj.kind.ref.RenderPixel.ref.y = pre_y;
+      wireObj.kind.RenderPixel.x = pre_x;
+      wireObj.kind.RenderPixel.y = pre_y;
       return;
     }
     if (apiObj is ApplicationMessage_Exit) {
@@ -16887,18 +16861,16 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       var pre_message = cst_encode_String(apiObj.message);
       var pre_backtrace = cst_encode_Backtrace(apiObj.backtrace);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_CustomEnumErrorTwinNormal_One();
-      wireObj.kind.ref.One.ref.message = pre_message;
-      wireObj.kind.ref.One.ref.backtrace = pre_backtrace;
+      wireObj.kind.One.message = pre_message;
+      wireObj.kind.One.backtrace = pre_backtrace;
       return;
     }
     if (apiObj is CustomEnumErrorTwinNormal_Two) {
       var pre_message = cst_encode_u_32(apiObj.message);
       var pre_backtrace = cst_encode_Backtrace(apiObj.backtrace);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_CustomEnumErrorTwinNormal_Two();
-      wireObj.kind.ref.Two.ref.message = pre_message;
-      wireObj.kind.ref.Two.ref.backtrace = pre_backtrace;
+      wireObj.kind.Two.message = pre_message;
+      wireObj.kind.Two.backtrace = pre_backtrace;
       return;
     }
   }
@@ -16911,18 +16883,16 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       var pre_message = cst_encode_String(apiObj.message);
       var pre_backtrace = cst_encode_Backtrace(apiObj.backtrace);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_CustomEnumErrorTwinRustAsync_One();
-      wireObj.kind.ref.One.ref.message = pre_message;
-      wireObj.kind.ref.One.ref.backtrace = pre_backtrace;
+      wireObj.kind.One.message = pre_message;
+      wireObj.kind.One.backtrace = pre_backtrace;
       return;
     }
     if (apiObj is CustomEnumErrorTwinRustAsync_Two) {
       var pre_message = cst_encode_u_32(apiObj.message);
       var pre_backtrace = cst_encode_Backtrace(apiObj.backtrace);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_CustomEnumErrorTwinRustAsync_Two();
-      wireObj.kind.ref.Two.ref.message = pre_message;
-      wireObj.kind.ref.Two.ref.backtrace = pre_backtrace;
+      wireObj.kind.Two.message = pre_message;
+      wireObj.kind.Two.backtrace = pre_backtrace;
       return;
     }
   }
@@ -16935,18 +16905,16 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       var pre_message = cst_encode_String(apiObj.message);
       var pre_backtrace = cst_encode_Backtrace(apiObj.backtrace);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_CustomEnumErrorTwinRustAsyncSse_One();
-      wireObj.kind.ref.One.ref.message = pre_message;
-      wireObj.kind.ref.One.ref.backtrace = pre_backtrace;
+      wireObj.kind.One.message = pre_message;
+      wireObj.kind.One.backtrace = pre_backtrace;
       return;
     }
     if (apiObj is CustomEnumErrorTwinRustAsyncSse_Two) {
       var pre_message = cst_encode_u_32(apiObj.message);
       var pre_backtrace = cst_encode_Backtrace(apiObj.backtrace);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_CustomEnumErrorTwinRustAsyncSse_Two();
-      wireObj.kind.ref.Two.ref.message = pre_message;
-      wireObj.kind.ref.Two.ref.backtrace = pre_backtrace;
+      wireObj.kind.Two.message = pre_message;
+      wireObj.kind.Two.backtrace = pre_backtrace;
       return;
     }
   }
@@ -16959,18 +16927,16 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       var pre_message = cst_encode_String(apiObj.message);
       var pre_backtrace = cst_encode_Backtrace(apiObj.backtrace);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_CustomEnumErrorTwinSse_One();
-      wireObj.kind.ref.One.ref.message = pre_message;
-      wireObj.kind.ref.One.ref.backtrace = pre_backtrace;
+      wireObj.kind.One.message = pre_message;
+      wireObj.kind.One.backtrace = pre_backtrace;
       return;
     }
     if (apiObj is CustomEnumErrorTwinSse_Two) {
       var pre_message = cst_encode_u_32(apiObj.message);
       var pre_backtrace = cst_encode_Backtrace(apiObj.backtrace);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_CustomEnumErrorTwinSse_Two();
-      wireObj.kind.ref.Two.ref.message = pre_message;
-      wireObj.kind.ref.Two.ref.backtrace = pre_backtrace;
+      wireObj.kind.Two.message = pre_message;
+      wireObj.kind.Two.backtrace = pre_backtrace;
       return;
     }
   }
@@ -16983,18 +16949,16 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       var pre_message = cst_encode_String(apiObj.message);
       var pre_backtrace = cst_encode_Backtrace(apiObj.backtrace);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_CustomEnumErrorTwinSync_One();
-      wireObj.kind.ref.One.ref.message = pre_message;
-      wireObj.kind.ref.One.ref.backtrace = pre_backtrace;
+      wireObj.kind.One.message = pre_message;
+      wireObj.kind.One.backtrace = pre_backtrace;
       return;
     }
     if (apiObj is CustomEnumErrorTwinSync_Two) {
       var pre_message = cst_encode_u_32(apiObj.message);
       var pre_backtrace = cst_encode_Backtrace(apiObj.backtrace);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_CustomEnumErrorTwinSync_Two();
-      wireObj.kind.ref.Two.ref.message = pre_message;
-      wireObj.kind.ref.Two.ref.backtrace = pre_backtrace;
+      wireObj.kind.Two.message = pre_message;
+      wireObj.kind.Two.backtrace = pre_backtrace;
       return;
     }
   }
@@ -17007,18 +16971,16 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       var pre_message = cst_encode_String(apiObj.message);
       var pre_backtrace = cst_encode_Backtrace(apiObj.backtrace);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_CustomEnumErrorTwinSyncSse_One();
-      wireObj.kind.ref.One.ref.message = pre_message;
-      wireObj.kind.ref.One.ref.backtrace = pre_backtrace;
+      wireObj.kind.One.message = pre_message;
+      wireObj.kind.One.backtrace = pre_backtrace;
       return;
     }
     if (apiObj is CustomEnumErrorTwinSyncSse_Two) {
       var pre_message = cst_encode_u_32(apiObj.message);
       var pre_backtrace = cst_encode_Backtrace(apiObj.backtrace);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_CustomEnumErrorTwinSyncSse_Two();
-      wireObj.kind.ref.Two.ref.message = pre_message;
-      wireObj.kind.ref.Two.ref.backtrace = pre_backtrace;
+      wireObj.kind.Two.message = pre_message;
+      wireObj.kind.Two.backtrace = pre_backtrace;
       return;
     }
   }
@@ -17030,18 +16992,16 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       var pre_e = cst_encode_String(apiObj.e);
       var pre_backtrace = cst_encode_Backtrace(apiObj.backtrace);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_CustomErrorTwinNormal_Error0();
-      wireObj.kind.ref.Error0.ref.e = pre_e;
-      wireObj.kind.ref.Error0.ref.backtrace = pre_backtrace;
+      wireObj.kind.Error0.e = pre_e;
+      wireObj.kind.Error0.backtrace = pre_backtrace;
       return;
     }
     if (apiObj is CustomErrorTwinNormal_Error1) {
       var pre_e = cst_encode_u_32(apiObj.e);
       var pre_backtrace = cst_encode_Backtrace(apiObj.backtrace);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_CustomErrorTwinNormal_Error1();
-      wireObj.kind.ref.Error1.ref.e = pre_e;
-      wireObj.kind.ref.Error1.ref.backtrace = pre_backtrace;
+      wireObj.kind.Error1.e = pre_e;
+      wireObj.kind.Error1.backtrace = pre_backtrace;
       return;
     }
   }
@@ -17054,18 +17014,16 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       var pre_e = cst_encode_String(apiObj.e);
       var pre_backtrace = cst_encode_Backtrace(apiObj.backtrace);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_CustomErrorTwinRustAsync_Error0();
-      wireObj.kind.ref.Error0.ref.e = pre_e;
-      wireObj.kind.ref.Error0.ref.backtrace = pre_backtrace;
+      wireObj.kind.Error0.e = pre_e;
+      wireObj.kind.Error0.backtrace = pre_backtrace;
       return;
     }
     if (apiObj is CustomErrorTwinRustAsync_Error1) {
       var pre_e = cst_encode_u_32(apiObj.e);
       var pre_backtrace = cst_encode_Backtrace(apiObj.backtrace);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_CustomErrorTwinRustAsync_Error1();
-      wireObj.kind.ref.Error1.ref.e = pre_e;
-      wireObj.kind.ref.Error1.ref.backtrace = pre_backtrace;
+      wireObj.kind.Error1.e = pre_e;
+      wireObj.kind.Error1.backtrace = pre_backtrace;
       return;
     }
   }
@@ -17078,18 +17036,16 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       var pre_e = cst_encode_String(apiObj.e);
       var pre_backtrace = cst_encode_Backtrace(apiObj.backtrace);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_CustomErrorTwinRustAsyncSse_Error0();
-      wireObj.kind.ref.Error0.ref.e = pre_e;
-      wireObj.kind.ref.Error0.ref.backtrace = pre_backtrace;
+      wireObj.kind.Error0.e = pre_e;
+      wireObj.kind.Error0.backtrace = pre_backtrace;
       return;
     }
     if (apiObj is CustomErrorTwinRustAsyncSse_Error1) {
       var pre_e = cst_encode_u_32(apiObj.e);
       var pre_backtrace = cst_encode_Backtrace(apiObj.backtrace);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_CustomErrorTwinRustAsyncSse_Error1();
-      wireObj.kind.ref.Error1.ref.e = pre_e;
-      wireObj.kind.ref.Error1.ref.backtrace = pre_backtrace;
+      wireObj.kind.Error1.e = pre_e;
+      wireObj.kind.Error1.backtrace = pre_backtrace;
       return;
     }
   }
@@ -17101,18 +17057,16 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       var pre_e = cst_encode_String(apiObj.e);
       var pre_backtrace = cst_encode_Backtrace(apiObj.backtrace);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_CustomErrorTwinSse_Error0();
-      wireObj.kind.ref.Error0.ref.e = pre_e;
-      wireObj.kind.ref.Error0.ref.backtrace = pre_backtrace;
+      wireObj.kind.Error0.e = pre_e;
+      wireObj.kind.Error0.backtrace = pre_backtrace;
       return;
     }
     if (apiObj is CustomErrorTwinSse_Error1) {
       var pre_e = cst_encode_u_32(apiObj.e);
       var pre_backtrace = cst_encode_Backtrace(apiObj.backtrace);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_CustomErrorTwinSse_Error1();
-      wireObj.kind.ref.Error1.ref.e = pre_e;
-      wireObj.kind.ref.Error1.ref.backtrace = pre_backtrace;
+      wireObj.kind.Error1.e = pre_e;
+      wireObj.kind.Error1.backtrace = pre_backtrace;
       return;
     }
   }
@@ -17124,18 +17078,16 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       var pre_e = cst_encode_String(apiObj.e);
       var pre_backtrace = cst_encode_Backtrace(apiObj.backtrace);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_CustomErrorTwinSync_Error0();
-      wireObj.kind.ref.Error0.ref.e = pre_e;
-      wireObj.kind.ref.Error0.ref.backtrace = pre_backtrace;
+      wireObj.kind.Error0.e = pre_e;
+      wireObj.kind.Error0.backtrace = pre_backtrace;
       return;
     }
     if (apiObj is CustomErrorTwinSync_Error1) {
       var pre_e = cst_encode_u_32(apiObj.e);
       var pre_backtrace = cst_encode_Backtrace(apiObj.backtrace);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_CustomErrorTwinSync_Error1();
-      wireObj.kind.ref.Error1.ref.e = pre_e;
-      wireObj.kind.ref.Error1.ref.backtrace = pre_backtrace;
+      wireObj.kind.Error1.e = pre_e;
+      wireObj.kind.Error1.backtrace = pre_backtrace;
       return;
     }
   }
@@ -17148,18 +17100,16 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       var pre_e = cst_encode_String(apiObj.e);
       var pre_backtrace = cst_encode_Backtrace(apiObj.backtrace);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_CustomErrorTwinSyncSse_Error0();
-      wireObj.kind.ref.Error0.ref.e = pre_e;
-      wireObj.kind.ref.Error0.ref.backtrace = pre_backtrace;
+      wireObj.kind.Error0.e = pre_e;
+      wireObj.kind.Error0.backtrace = pre_backtrace;
       return;
     }
     if (apiObj is CustomErrorTwinSyncSse_Error1) {
       var pre_e = cst_encode_u_32(apiObj.e);
       var pre_backtrace = cst_encode_Backtrace(apiObj.backtrace);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_CustomErrorTwinSyncSse_Error1();
-      wireObj.kind.ref.Error1.ref.e = pre_e;
-      wireObj.kind.ref.Error1.ref.backtrace = pre_backtrace;
+      wireObj.kind.Error1.e = pre_e;
+      wireObj.kind.Error1.backtrace = pre_backtrace;
       return;
     }
   }
@@ -17171,18 +17121,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is CustomNestedError1TwinNormal_CustomNested1) {
       var pre_field0 = cst_encode_String(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind =
-          wire.cst_inflate_CustomNestedError1TwinNormal_CustomNested1();
-      wireObj.kind.ref.CustomNested1.ref.field0 = pre_field0;
+      wireObj.kind.CustomNested1.field0 = pre_field0;
       return;
     }
     if (apiObj is CustomNestedError1TwinNormal_ErrorNested) {
       var pre_field0 = cst_encode_box_autoadd_custom_nested_error_2_twin_normal(
           apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind =
-          wire.cst_inflate_CustomNestedError1TwinNormal_ErrorNested();
-      wireObj.kind.ref.ErrorNested.ref.field0 = pre_field0;
+      wireObj.kind.ErrorNested.field0 = pre_field0;
       return;
     }
   }
@@ -17194,9 +17140,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is CustomNestedError1TwinRustAsync_CustomNested1) {
       var pre_field0 = cst_encode_String(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind =
-          wire.cst_inflate_CustomNestedError1TwinRustAsync_CustomNested1();
-      wireObj.kind.ref.CustomNested1.ref.field0 = pre_field0;
+      wireObj.kind.CustomNested1.field0 = pre_field0;
       return;
     }
     if (apiObj is CustomNestedError1TwinRustAsync_ErrorNested) {
@@ -17204,9 +17148,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
           cst_encode_box_autoadd_custom_nested_error_2_twin_rust_async(
               apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind =
-          wire.cst_inflate_CustomNestedError1TwinRustAsync_ErrorNested();
-      wireObj.kind.ref.ErrorNested.ref.field0 = pre_field0;
+      wireObj.kind.ErrorNested.field0 = pre_field0;
       return;
     }
   }
@@ -17218,9 +17160,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is CustomNestedError1TwinRustAsyncSse_CustomNested1) {
       var pre_field0 = cst_encode_String(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind =
-          wire.cst_inflate_CustomNestedError1TwinRustAsyncSse_CustomNested1();
-      wireObj.kind.ref.CustomNested1.ref.field0 = pre_field0;
+      wireObj.kind.CustomNested1.field0 = pre_field0;
       return;
     }
     if (apiObj is CustomNestedError1TwinRustAsyncSse_ErrorNested) {
@@ -17228,9 +17168,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
           cst_encode_box_autoadd_custom_nested_error_2_twin_rust_async_sse(
               apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind =
-          wire.cst_inflate_CustomNestedError1TwinRustAsyncSse_ErrorNested();
-      wireObj.kind.ref.ErrorNested.ref.field0 = pre_field0;
+      wireObj.kind.ErrorNested.field0 = pre_field0;
       return;
     }
   }
@@ -17242,16 +17180,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is CustomNestedError1TwinSse_CustomNested1) {
       var pre_field0 = cst_encode_String(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_CustomNestedError1TwinSse_CustomNested1();
-      wireObj.kind.ref.CustomNested1.ref.field0 = pre_field0;
+      wireObj.kind.CustomNested1.field0 = pre_field0;
       return;
     }
     if (apiObj is CustomNestedError1TwinSse_ErrorNested) {
       var pre_field0 =
           cst_encode_box_autoadd_custom_nested_error_2_twin_sse(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_CustomNestedError1TwinSse_ErrorNested();
-      wireObj.kind.ref.ErrorNested.ref.field0 = pre_field0;
+      wireObj.kind.ErrorNested.field0 = pre_field0;
       return;
     }
   }
@@ -17263,17 +17199,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is CustomNestedError1TwinSync_CustomNested1) {
       var pre_field0 = cst_encode_String(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind =
-          wire.cst_inflate_CustomNestedError1TwinSync_CustomNested1();
-      wireObj.kind.ref.CustomNested1.ref.field0 = pre_field0;
+      wireObj.kind.CustomNested1.field0 = pre_field0;
       return;
     }
     if (apiObj is CustomNestedError1TwinSync_ErrorNested) {
       var pre_field0 =
           cst_encode_box_autoadd_custom_nested_error_2_twin_sync(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_CustomNestedError1TwinSync_ErrorNested();
-      wireObj.kind.ref.ErrorNested.ref.field0 = pre_field0;
+      wireObj.kind.ErrorNested.field0 = pre_field0;
       return;
     }
   }
@@ -17285,9 +17218,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is CustomNestedError1TwinSyncSse_CustomNested1) {
       var pre_field0 = cst_encode_String(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind =
-          wire.cst_inflate_CustomNestedError1TwinSyncSse_CustomNested1();
-      wireObj.kind.ref.CustomNested1.ref.field0 = pre_field0;
+      wireObj.kind.CustomNested1.field0 = pre_field0;
       return;
     }
     if (apiObj is CustomNestedError1TwinSyncSse_ErrorNested) {
@@ -17295,9 +17226,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
           cst_encode_box_autoadd_custom_nested_error_2_twin_sync_sse(
               apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind =
-          wire.cst_inflate_CustomNestedError1TwinSyncSse_ErrorNested();
-      wireObj.kind.ref.ErrorNested.ref.field0 = pre_field0;
+      wireObj.kind.ErrorNested.field0 = pre_field0;
       return;
     }
   }
@@ -17309,17 +17238,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is CustomNestedError2TwinNormal_CustomNested2) {
       var pre_field0 = cst_encode_String(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind =
-          wire.cst_inflate_CustomNestedError2TwinNormal_CustomNested2();
-      wireObj.kind.ref.CustomNested2.ref.field0 = pre_field0;
+      wireObj.kind.CustomNested2.field0 = pre_field0;
       return;
     }
     if (apiObj is CustomNestedError2TwinNormal_CustomNested2Number) {
       var pre_field0 = cst_encode_u_32(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind =
-          wire.cst_inflate_CustomNestedError2TwinNormal_CustomNested2Number();
-      wireObj.kind.ref.CustomNested2Number.ref.field0 = pre_field0;
+      wireObj.kind.CustomNested2Number.field0 = pre_field0;
       return;
     }
   }
@@ -17331,17 +17256,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is CustomNestedError2TwinRustAsync_CustomNested2) {
       var pre_field0 = cst_encode_String(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind =
-          wire.cst_inflate_CustomNestedError2TwinRustAsync_CustomNested2();
-      wireObj.kind.ref.CustomNested2.ref.field0 = pre_field0;
+      wireObj.kind.CustomNested2.field0 = pre_field0;
       return;
     }
     if (apiObj is CustomNestedError2TwinRustAsync_CustomNested2Number) {
       var pre_field0 = cst_encode_u_32(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire
-          .cst_inflate_CustomNestedError2TwinRustAsync_CustomNested2Number();
-      wireObj.kind.ref.CustomNested2Number.ref.field0 = pre_field0;
+      wireObj.kind.CustomNested2Number.field0 = pre_field0;
       return;
     }
   }
@@ -17353,17 +17274,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is CustomNestedError2TwinRustAsyncSse_CustomNested2) {
       var pre_field0 = cst_encode_String(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind =
-          wire.cst_inflate_CustomNestedError2TwinRustAsyncSse_CustomNested2();
-      wireObj.kind.ref.CustomNested2.ref.field0 = pre_field0;
+      wireObj.kind.CustomNested2.field0 = pre_field0;
       return;
     }
     if (apiObj is CustomNestedError2TwinRustAsyncSse_CustomNested2Number) {
       var pre_field0 = cst_encode_u_32(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire
-          .cst_inflate_CustomNestedError2TwinRustAsyncSse_CustomNested2Number();
-      wireObj.kind.ref.CustomNested2Number.ref.field0 = pre_field0;
+      wireObj.kind.CustomNested2Number.field0 = pre_field0;
       return;
     }
   }
@@ -17375,16 +17292,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is CustomNestedError2TwinSse_CustomNested2) {
       var pre_field0 = cst_encode_String(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_CustomNestedError2TwinSse_CustomNested2();
-      wireObj.kind.ref.CustomNested2.ref.field0 = pre_field0;
+      wireObj.kind.CustomNested2.field0 = pre_field0;
       return;
     }
     if (apiObj is CustomNestedError2TwinSse_CustomNested2Number) {
       var pre_field0 = cst_encode_u_32(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind =
-          wire.cst_inflate_CustomNestedError2TwinSse_CustomNested2Number();
-      wireObj.kind.ref.CustomNested2Number.ref.field0 = pre_field0;
+      wireObj.kind.CustomNested2Number.field0 = pre_field0;
       return;
     }
   }
@@ -17396,17 +17310,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is CustomNestedError2TwinSync_CustomNested2) {
       var pre_field0 = cst_encode_String(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind =
-          wire.cst_inflate_CustomNestedError2TwinSync_CustomNested2();
-      wireObj.kind.ref.CustomNested2.ref.field0 = pre_field0;
+      wireObj.kind.CustomNested2.field0 = pre_field0;
       return;
     }
     if (apiObj is CustomNestedError2TwinSync_CustomNested2Number) {
       var pre_field0 = cst_encode_u_32(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind =
-          wire.cst_inflate_CustomNestedError2TwinSync_CustomNested2Number();
-      wireObj.kind.ref.CustomNested2Number.ref.field0 = pre_field0;
+      wireObj.kind.CustomNested2Number.field0 = pre_field0;
       return;
     }
   }
@@ -17418,17 +17328,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is CustomNestedError2TwinSyncSse_CustomNested2) {
       var pre_field0 = cst_encode_String(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind =
-          wire.cst_inflate_CustomNestedError2TwinSyncSse_CustomNested2();
-      wireObj.kind.ref.CustomNested2.ref.field0 = pre_field0;
+      wireObj.kind.CustomNested2.field0 = pre_field0;
       return;
     }
     if (apiObj is CustomNestedError2TwinSyncSse_CustomNested2Number) {
       var pre_field0 = cst_encode_u_32(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind =
-          wire.cst_inflate_CustomNestedError2TwinSyncSse_CustomNested2Number();
-      wireObj.kind.ref.CustomNested2Number.ref.field0 = pre_field0;
+      wireObj.kind.CustomNested2Number.field0 = pre_field0;
       return;
     }
   }
@@ -17440,15 +17346,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is CustomNestedErrorInnerTwinNormal_Three) {
       var pre_field0 = cst_encode_String(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_CustomNestedErrorInnerTwinNormal_Three();
-      wireObj.kind.ref.Three.ref.field0 = pre_field0;
+      wireObj.kind.Three.field0 = pre_field0;
       return;
     }
     if (apiObj is CustomNestedErrorInnerTwinNormal_Four) {
       var pre_field0 = cst_encode_u_32(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_CustomNestedErrorInnerTwinNormal_Four();
-      wireObj.kind.ref.Four.ref.field0 = pre_field0;
+      wireObj.kind.Four.field0 = pre_field0;
       return;
     }
   }
@@ -17460,17 +17364,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is CustomNestedErrorInnerTwinRustAsync_Three) {
       var pre_field0 = cst_encode_String(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind =
-          wire.cst_inflate_CustomNestedErrorInnerTwinRustAsync_Three();
-      wireObj.kind.ref.Three.ref.field0 = pre_field0;
+      wireObj.kind.Three.field0 = pre_field0;
       return;
     }
     if (apiObj is CustomNestedErrorInnerTwinRustAsync_Four) {
       var pre_field0 = cst_encode_u_32(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind =
-          wire.cst_inflate_CustomNestedErrorInnerTwinRustAsync_Four();
-      wireObj.kind.ref.Four.ref.field0 = pre_field0;
+      wireObj.kind.Four.field0 = pre_field0;
       return;
     }
   }
@@ -17482,17 +17382,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is CustomNestedErrorInnerTwinRustAsyncSse_Three) {
       var pre_field0 = cst_encode_String(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind =
-          wire.cst_inflate_CustomNestedErrorInnerTwinRustAsyncSse_Three();
-      wireObj.kind.ref.Three.ref.field0 = pre_field0;
+      wireObj.kind.Three.field0 = pre_field0;
       return;
     }
     if (apiObj is CustomNestedErrorInnerTwinRustAsyncSse_Four) {
       var pre_field0 = cst_encode_u_32(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind =
-          wire.cst_inflate_CustomNestedErrorInnerTwinRustAsyncSse_Four();
-      wireObj.kind.ref.Four.ref.field0 = pre_field0;
+      wireObj.kind.Four.field0 = pre_field0;
       return;
     }
   }
@@ -17504,15 +17400,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is CustomNestedErrorInnerTwinSse_Three) {
       var pre_field0 = cst_encode_String(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_CustomNestedErrorInnerTwinSse_Three();
-      wireObj.kind.ref.Three.ref.field0 = pre_field0;
+      wireObj.kind.Three.field0 = pre_field0;
       return;
     }
     if (apiObj is CustomNestedErrorInnerTwinSse_Four) {
       var pre_field0 = cst_encode_u_32(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_CustomNestedErrorInnerTwinSse_Four();
-      wireObj.kind.ref.Four.ref.field0 = pre_field0;
+      wireObj.kind.Four.field0 = pre_field0;
       return;
     }
   }
@@ -17524,15 +17418,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is CustomNestedErrorInnerTwinSync_Three) {
       var pre_field0 = cst_encode_String(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_CustomNestedErrorInnerTwinSync_Three();
-      wireObj.kind.ref.Three.ref.field0 = pre_field0;
+      wireObj.kind.Three.field0 = pre_field0;
       return;
     }
     if (apiObj is CustomNestedErrorInnerTwinSync_Four) {
       var pre_field0 = cst_encode_u_32(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_CustomNestedErrorInnerTwinSync_Four();
-      wireObj.kind.ref.Four.ref.field0 = pre_field0;
+      wireObj.kind.Four.field0 = pre_field0;
       return;
     }
   }
@@ -17544,15 +17436,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is CustomNestedErrorInnerTwinSyncSse_Three) {
       var pre_field0 = cst_encode_String(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_CustomNestedErrorInnerTwinSyncSse_Three();
-      wireObj.kind.ref.Three.ref.field0 = pre_field0;
+      wireObj.kind.Three.field0 = pre_field0;
       return;
     }
     if (apiObj is CustomNestedErrorInnerTwinSyncSse_Four) {
       var pre_field0 = cst_encode_u_32(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_CustomNestedErrorInnerTwinSyncSse_Four();
-      wireObj.kind.ref.Four.ref.field0 = pre_field0;
+      wireObj.kind.Four.field0 = pre_field0;
       return;
     }
   }
@@ -17564,8 +17454,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is CustomNestedErrorOuterTwinNormal_One) {
       var pre_field0 = cst_encode_String(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_CustomNestedErrorOuterTwinNormal_One();
-      wireObj.kind.ref.One.ref.field0 = pre_field0;
+      wireObj.kind.One.field0 = pre_field0;
       return;
     }
     if (apiObj is CustomNestedErrorOuterTwinNormal_Two) {
@@ -17573,8 +17462,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
           cst_encode_box_autoadd_custom_nested_error_inner_twin_normal(
               apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_CustomNestedErrorOuterTwinNormal_Two();
-      wireObj.kind.ref.Two.ref.field0 = pre_field0;
+      wireObj.kind.Two.field0 = pre_field0;
       return;
     }
   }
@@ -17586,8 +17474,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is CustomNestedErrorOuterTwinRustAsync_One) {
       var pre_field0 = cst_encode_String(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_CustomNestedErrorOuterTwinRustAsync_One();
-      wireObj.kind.ref.One.ref.field0 = pre_field0;
+      wireObj.kind.One.field0 = pre_field0;
       return;
     }
     if (apiObj is CustomNestedErrorOuterTwinRustAsync_Two) {
@@ -17595,8 +17482,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
           cst_encode_box_autoadd_custom_nested_error_inner_twin_rust_async(
               apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_CustomNestedErrorOuterTwinRustAsync_Two();
-      wireObj.kind.ref.Two.ref.field0 = pre_field0;
+      wireObj.kind.Two.field0 = pre_field0;
       return;
     }
   }
@@ -17608,9 +17494,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is CustomNestedErrorOuterTwinRustAsyncSse_One) {
       var pre_field0 = cst_encode_String(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind =
-          wire.cst_inflate_CustomNestedErrorOuterTwinRustAsyncSse_One();
-      wireObj.kind.ref.One.ref.field0 = pre_field0;
+      wireObj.kind.One.field0 = pre_field0;
       return;
     }
     if (apiObj is CustomNestedErrorOuterTwinRustAsyncSse_Two) {
@@ -17618,9 +17502,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
           cst_encode_box_autoadd_custom_nested_error_inner_twin_rust_async_sse(
               apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind =
-          wire.cst_inflate_CustomNestedErrorOuterTwinRustAsyncSse_Two();
-      wireObj.kind.ref.Two.ref.field0 = pre_field0;
+      wireObj.kind.Two.field0 = pre_field0;
       return;
     }
   }
@@ -17632,8 +17514,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is CustomNestedErrorOuterTwinSse_One) {
       var pre_field0 = cst_encode_String(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_CustomNestedErrorOuterTwinSse_One();
-      wireObj.kind.ref.One.ref.field0 = pre_field0;
+      wireObj.kind.One.field0 = pre_field0;
       return;
     }
     if (apiObj is CustomNestedErrorOuterTwinSse_Two) {
@@ -17641,8 +17522,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
           cst_encode_box_autoadd_custom_nested_error_inner_twin_sse(
               apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_CustomNestedErrorOuterTwinSse_Two();
-      wireObj.kind.ref.Two.ref.field0 = pre_field0;
+      wireObj.kind.Two.field0 = pre_field0;
       return;
     }
   }
@@ -17654,8 +17534,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is CustomNestedErrorOuterTwinSync_One) {
       var pre_field0 = cst_encode_String(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_CustomNestedErrorOuterTwinSync_One();
-      wireObj.kind.ref.One.ref.field0 = pre_field0;
+      wireObj.kind.One.field0 = pre_field0;
       return;
     }
     if (apiObj is CustomNestedErrorOuterTwinSync_Two) {
@@ -17663,8 +17542,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
           cst_encode_box_autoadd_custom_nested_error_inner_twin_sync(
               apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_CustomNestedErrorOuterTwinSync_Two();
-      wireObj.kind.ref.Two.ref.field0 = pre_field0;
+      wireObj.kind.Two.field0 = pre_field0;
       return;
     }
   }
@@ -17676,8 +17554,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is CustomNestedErrorOuterTwinSyncSse_One) {
       var pre_field0 = cst_encode_String(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_CustomNestedErrorOuterTwinSyncSse_One();
-      wireObj.kind.ref.One.ref.field0 = pre_field0;
+      wireObj.kind.One.field0 = pre_field0;
       return;
     }
     if (apiObj is CustomNestedErrorOuterTwinSyncSse_Two) {
@@ -17685,8 +17562,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
           cst_encode_box_autoadd_custom_nested_error_inner_twin_sync_sse(
               apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_CustomNestedErrorOuterTwinSyncSse_Two();
-      wireObj.kind.ref.Two.ref.field0 = pre_field0;
+      wireObj.kind.Two.field0 = pre_field0;
       return;
     }
   }
@@ -17945,8 +17821,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is DistanceTwinNormal_Map) {
       var pre_field0 = cst_encode_f_64(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_DistanceTwinNormal_Map();
-      wireObj.kind.ref.Map.ref.field0 = pre_field0;
+      wireObj.kind.Map.field0 = pre_field0;
       return;
     }
   }
@@ -17961,8 +17836,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is DistanceTwinRustAsync_Map) {
       var pre_field0 = cst_encode_f_64(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_DistanceTwinRustAsync_Map();
-      wireObj.kind.ref.Map.ref.field0 = pre_field0;
+      wireObj.kind.Map.field0 = pre_field0;
       return;
     }
   }
@@ -17978,8 +17852,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is DistanceTwinRustAsyncSse_Map) {
       var pre_field0 = cst_encode_f_64(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_DistanceTwinRustAsyncSse_Map();
-      wireObj.kind.ref.Map.ref.field0 = pre_field0;
+      wireObj.kind.Map.field0 = pre_field0;
       return;
     }
   }
@@ -17994,8 +17867,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is DistanceTwinSse_Map) {
       var pre_field0 = cst_encode_f_64(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_DistanceTwinSse_Map();
-      wireObj.kind.ref.Map.ref.field0 = pre_field0;
+      wireObj.kind.Map.field0 = pre_field0;
       return;
     }
   }
@@ -18010,8 +17882,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is DistanceTwinSync_Map) {
       var pre_field0 = cst_encode_f_64(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_DistanceTwinSync_Map();
-      wireObj.kind.ref.Map.ref.field0 = pre_field0;
+      wireObj.kind.Map.field0 = pre_field0;
       return;
     }
   }
@@ -18026,8 +17897,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is DistanceTwinSyncSse_Map) {
       var pre_field0 = cst_encode_f_64(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_DistanceTwinSyncSse_Map();
-      wireObj.kind.ref.Map.ref.field0 = pre_field0;
+      wireObj.kind.Map.field0 = pre_field0;
       return;
     }
   }
@@ -18128,15 +17998,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is EnumDartOpaqueTwinNormal_Primitive) {
       var pre_field0 = cst_encode_i_32(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_EnumDartOpaqueTwinNormal_Primitive();
-      wireObj.kind.ref.Primitive.ref.field0 = pre_field0;
+      wireObj.kind.Primitive.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumDartOpaqueTwinNormal_Opaque) {
       var pre_field0 = cst_encode_DartOpaque(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_EnumDartOpaqueTwinNormal_Opaque();
-      wireObj.kind.ref.Opaque.ref.field0 = pre_field0;
+      wireObj.kind.Opaque.field0 = pre_field0;
       return;
     }
   }
@@ -18148,15 +18016,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is EnumDartOpaqueTwinRustAsync_Primitive) {
       var pre_field0 = cst_encode_i_32(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_EnumDartOpaqueTwinRustAsync_Primitive();
-      wireObj.kind.ref.Primitive.ref.field0 = pre_field0;
+      wireObj.kind.Primitive.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumDartOpaqueTwinRustAsync_Opaque) {
       var pre_field0 = cst_encode_DartOpaque(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_EnumDartOpaqueTwinRustAsync_Opaque();
-      wireObj.kind.ref.Opaque.ref.field0 = pre_field0;
+      wireObj.kind.Opaque.field0 = pre_field0;
       return;
     }
   }
@@ -18168,16 +18034,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is EnumDartOpaqueTwinRustAsyncSse_Primitive) {
       var pre_field0 = cst_encode_i_32(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind =
-          wire.cst_inflate_EnumDartOpaqueTwinRustAsyncSse_Primitive();
-      wireObj.kind.ref.Primitive.ref.field0 = pre_field0;
+      wireObj.kind.Primitive.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumDartOpaqueTwinRustAsyncSse_Opaque) {
       var pre_field0 = cst_encode_DartOpaque(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_EnumDartOpaqueTwinRustAsyncSse_Opaque();
-      wireObj.kind.ref.Opaque.ref.field0 = pre_field0;
+      wireObj.kind.Opaque.field0 = pre_field0;
       return;
     }
   }
@@ -18189,15 +18052,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is EnumDartOpaqueTwinSse_Primitive) {
       var pre_field0 = cst_encode_i_32(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_EnumDartOpaqueTwinSse_Primitive();
-      wireObj.kind.ref.Primitive.ref.field0 = pre_field0;
+      wireObj.kind.Primitive.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumDartOpaqueTwinSse_Opaque) {
       var pre_field0 = cst_encode_DartOpaque(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_EnumDartOpaqueTwinSse_Opaque();
-      wireObj.kind.ref.Opaque.ref.field0 = pre_field0;
+      wireObj.kind.Opaque.field0 = pre_field0;
       return;
     }
   }
@@ -18209,15 +18070,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is EnumDartOpaqueTwinSync_Primitive) {
       var pre_field0 = cst_encode_i_32(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_EnumDartOpaqueTwinSync_Primitive();
-      wireObj.kind.ref.Primitive.ref.field0 = pre_field0;
+      wireObj.kind.Primitive.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumDartOpaqueTwinSync_Opaque) {
       var pre_field0 = cst_encode_DartOpaque(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_EnumDartOpaqueTwinSync_Opaque();
-      wireObj.kind.ref.Opaque.ref.field0 = pre_field0;
+      wireObj.kind.Opaque.field0 = pre_field0;
       return;
     }
   }
@@ -18229,15 +18088,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is EnumDartOpaqueTwinSyncSse_Primitive) {
       var pre_field0 = cst_encode_i_32(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_EnumDartOpaqueTwinSyncSse_Primitive();
-      wireObj.kind.ref.Primitive.ref.field0 = pre_field0;
+      wireObj.kind.Primitive.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumDartOpaqueTwinSyncSse_Opaque) {
       var pre_field0 = cst_encode_DartOpaque(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_EnumDartOpaqueTwinSyncSse_Opaque();
-      wireObj.kind.ref.Opaque.ref.field0 = pre_field0;
+      wireObj.kind.Opaque.field0 = pre_field0;
       return;
     }
   }
@@ -18248,37 +18105,32 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is EnumOpaqueTwinNormal_Struct) {
       var pre_field0 = cst_encode_RustOpaque_hide_data(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_EnumOpaqueTwinNormal_Struct();
-      wireObj.kind.ref.Struct.ref.field0 = pre_field0;
+      wireObj.kind.Struct.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumOpaqueTwinNormal_Primitive) {
       var pre_field0 = cst_encode_RustOpaque_i_32(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_EnumOpaqueTwinNormal_Primitive();
-      wireObj.kind.ref.Primitive.ref.field0 = pre_field0;
+      wireObj.kind.Primitive.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumOpaqueTwinNormal_TraitObj) {
       var pre_field0 =
           cst_encode_RustOpaque_box_dynDartDebugTwinNormal(apiObj.field0);
       wireObj.tag = 2;
-      wireObj.kind = wire.cst_inflate_EnumOpaqueTwinNormal_TraitObj();
-      wireObj.kind.ref.TraitObj.ref.field0 = pre_field0;
+      wireObj.kind.TraitObj.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumOpaqueTwinNormal_Mutex) {
       var pre_field0 = cst_encode_RustOpaque_MutexHideData(apiObj.field0);
       wireObj.tag = 3;
-      wireObj.kind = wire.cst_inflate_EnumOpaqueTwinNormal_Mutex();
-      wireObj.kind.ref.Mutex.ref.field0 = pre_field0;
+      wireObj.kind.Mutex.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumOpaqueTwinNormal_RwLock) {
       var pre_field0 = cst_encode_RustOpaque_RwLockHideData(apiObj.field0);
       wireObj.tag = 4;
-      wireObj.kind = wire.cst_inflate_EnumOpaqueTwinNormal_RwLock();
-      wireObj.kind.ref.RwLock.ref.field0 = pre_field0;
+      wireObj.kind.RwLock.field0 = pre_field0;
       return;
     }
   }
@@ -18290,37 +18142,32 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is EnumOpaqueTwinRustAsync_Struct) {
       var pre_field0 = cst_encode_RustOpaque_hide_data(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_EnumOpaqueTwinRustAsync_Struct();
-      wireObj.kind.ref.Struct.ref.field0 = pre_field0;
+      wireObj.kind.Struct.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumOpaqueTwinRustAsync_Primitive) {
       var pre_field0 = cst_encode_RustOpaque_i_32(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_EnumOpaqueTwinRustAsync_Primitive();
-      wireObj.kind.ref.Primitive.ref.field0 = pre_field0;
+      wireObj.kind.Primitive.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumOpaqueTwinRustAsync_TraitObj) {
       var pre_field0 =
           cst_encode_RustOpaque_box_dynDartDebugTwinRustAsync(apiObj.field0);
       wireObj.tag = 2;
-      wireObj.kind = wire.cst_inflate_EnumOpaqueTwinRustAsync_TraitObj();
-      wireObj.kind.ref.TraitObj.ref.field0 = pre_field0;
+      wireObj.kind.TraitObj.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumOpaqueTwinRustAsync_Mutex) {
       var pre_field0 = cst_encode_RustOpaque_MutexHideData(apiObj.field0);
       wireObj.tag = 3;
-      wireObj.kind = wire.cst_inflate_EnumOpaqueTwinRustAsync_Mutex();
-      wireObj.kind.ref.Mutex.ref.field0 = pre_field0;
+      wireObj.kind.Mutex.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumOpaqueTwinRustAsync_RwLock) {
       var pre_field0 = cst_encode_RustOpaque_RwLockHideData(apiObj.field0);
       wireObj.tag = 4;
-      wireObj.kind = wire.cst_inflate_EnumOpaqueTwinRustAsync_RwLock();
-      wireObj.kind.ref.RwLock.ref.field0 = pre_field0;
+      wireObj.kind.RwLock.field0 = pre_field0;
       return;
     }
   }
@@ -18332,37 +18179,32 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is EnumOpaqueTwinRustAsyncSse_Struct) {
       var pre_field0 = cst_encode_RustOpaque_hide_data(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_EnumOpaqueTwinRustAsyncSse_Struct();
-      wireObj.kind.ref.Struct.ref.field0 = pre_field0;
+      wireObj.kind.Struct.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumOpaqueTwinRustAsyncSse_Primitive) {
       var pre_field0 = cst_encode_RustOpaque_i_32(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_EnumOpaqueTwinRustAsyncSse_Primitive();
-      wireObj.kind.ref.Primitive.ref.field0 = pre_field0;
+      wireObj.kind.Primitive.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumOpaqueTwinRustAsyncSse_TraitObj) {
       var pre_field0 =
           cst_encode_RustOpaque_box_dynDartDebugTwinRustAsyncSse(apiObj.field0);
       wireObj.tag = 2;
-      wireObj.kind = wire.cst_inflate_EnumOpaqueTwinRustAsyncSse_TraitObj();
-      wireObj.kind.ref.TraitObj.ref.field0 = pre_field0;
+      wireObj.kind.TraitObj.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumOpaqueTwinRustAsyncSse_Mutex) {
       var pre_field0 = cst_encode_RustOpaque_MutexHideData(apiObj.field0);
       wireObj.tag = 3;
-      wireObj.kind = wire.cst_inflate_EnumOpaqueTwinRustAsyncSse_Mutex();
-      wireObj.kind.ref.Mutex.ref.field0 = pre_field0;
+      wireObj.kind.Mutex.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumOpaqueTwinRustAsyncSse_RwLock) {
       var pre_field0 = cst_encode_RustOpaque_RwLockHideData(apiObj.field0);
       wireObj.tag = 4;
-      wireObj.kind = wire.cst_inflate_EnumOpaqueTwinRustAsyncSse_RwLock();
-      wireObj.kind.ref.RwLock.ref.field0 = pre_field0;
+      wireObj.kind.RwLock.field0 = pre_field0;
       return;
     }
   }
@@ -18373,37 +18215,32 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is EnumOpaqueTwinSse_Struct) {
       var pre_field0 = cst_encode_RustOpaque_hide_data(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_EnumOpaqueTwinSse_Struct();
-      wireObj.kind.ref.Struct.ref.field0 = pre_field0;
+      wireObj.kind.Struct.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumOpaqueTwinSse_Primitive) {
       var pre_field0 = cst_encode_RustOpaque_i_32(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_EnumOpaqueTwinSse_Primitive();
-      wireObj.kind.ref.Primitive.ref.field0 = pre_field0;
+      wireObj.kind.Primitive.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumOpaqueTwinSse_TraitObj) {
       var pre_field0 =
           cst_encode_RustOpaque_box_dynDartDebugTwinSse(apiObj.field0);
       wireObj.tag = 2;
-      wireObj.kind = wire.cst_inflate_EnumOpaqueTwinSse_TraitObj();
-      wireObj.kind.ref.TraitObj.ref.field0 = pre_field0;
+      wireObj.kind.TraitObj.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumOpaqueTwinSse_Mutex) {
       var pre_field0 = cst_encode_RustOpaque_MutexHideData(apiObj.field0);
       wireObj.tag = 3;
-      wireObj.kind = wire.cst_inflate_EnumOpaqueTwinSse_Mutex();
-      wireObj.kind.ref.Mutex.ref.field0 = pre_field0;
+      wireObj.kind.Mutex.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumOpaqueTwinSse_RwLock) {
       var pre_field0 = cst_encode_RustOpaque_RwLockHideData(apiObj.field0);
       wireObj.tag = 4;
-      wireObj.kind = wire.cst_inflate_EnumOpaqueTwinSse_RwLock();
-      wireObj.kind.ref.RwLock.ref.field0 = pre_field0;
+      wireObj.kind.RwLock.field0 = pre_field0;
       return;
     }
   }
@@ -18414,37 +18251,32 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is EnumOpaqueTwinSync_Struct) {
       var pre_field0 = cst_encode_RustOpaque_hide_data(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_EnumOpaqueTwinSync_Struct();
-      wireObj.kind.ref.Struct.ref.field0 = pre_field0;
+      wireObj.kind.Struct.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumOpaqueTwinSync_Primitive) {
       var pre_field0 = cst_encode_RustOpaque_i_32(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_EnumOpaqueTwinSync_Primitive();
-      wireObj.kind.ref.Primitive.ref.field0 = pre_field0;
+      wireObj.kind.Primitive.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumOpaqueTwinSync_TraitObj) {
       var pre_field0 =
           cst_encode_RustOpaque_box_dynDartDebugTwinSync(apiObj.field0);
       wireObj.tag = 2;
-      wireObj.kind = wire.cst_inflate_EnumOpaqueTwinSync_TraitObj();
-      wireObj.kind.ref.TraitObj.ref.field0 = pre_field0;
+      wireObj.kind.TraitObj.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumOpaqueTwinSync_Mutex) {
       var pre_field0 = cst_encode_RustOpaque_MutexHideData(apiObj.field0);
       wireObj.tag = 3;
-      wireObj.kind = wire.cst_inflate_EnumOpaqueTwinSync_Mutex();
-      wireObj.kind.ref.Mutex.ref.field0 = pre_field0;
+      wireObj.kind.Mutex.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumOpaqueTwinSync_RwLock) {
       var pre_field0 = cst_encode_RustOpaque_RwLockHideData(apiObj.field0);
       wireObj.tag = 4;
-      wireObj.kind = wire.cst_inflate_EnumOpaqueTwinSync_RwLock();
-      wireObj.kind.ref.RwLock.ref.field0 = pre_field0;
+      wireObj.kind.RwLock.field0 = pre_field0;
       return;
     }
   }
@@ -18456,37 +18288,32 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is EnumOpaqueTwinSyncSse_Struct) {
       var pre_field0 = cst_encode_RustOpaque_hide_data(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_EnumOpaqueTwinSyncSse_Struct();
-      wireObj.kind.ref.Struct.ref.field0 = pre_field0;
+      wireObj.kind.Struct.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumOpaqueTwinSyncSse_Primitive) {
       var pre_field0 = cst_encode_RustOpaque_i_32(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_EnumOpaqueTwinSyncSse_Primitive();
-      wireObj.kind.ref.Primitive.ref.field0 = pre_field0;
+      wireObj.kind.Primitive.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumOpaqueTwinSyncSse_TraitObj) {
       var pre_field0 =
           cst_encode_RustOpaque_box_dynDartDebugTwinSyncSse(apiObj.field0);
       wireObj.tag = 2;
-      wireObj.kind = wire.cst_inflate_EnumOpaqueTwinSyncSse_TraitObj();
-      wireObj.kind.ref.TraitObj.ref.field0 = pre_field0;
+      wireObj.kind.TraitObj.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumOpaqueTwinSyncSse_Mutex) {
       var pre_field0 = cst_encode_RustOpaque_MutexHideData(apiObj.field0);
       wireObj.tag = 3;
-      wireObj.kind = wire.cst_inflate_EnumOpaqueTwinSyncSse_Mutex();
-      wireObj.kind.ref.Mutex.ref.field0 = pre_field0;
+      wireObj.kind.Mutex.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumOpaqueTwinSyncSse_RwLock) {
       var pre_field0 = cst_encode_RustOpaque_RwLockHideData(apiObj.field0);
       wireObj.tag = 4;
-      wireObj.kind = wire.cst_inflate_EnumOpaqueTwinSyncSse_RwLock();
-      wireObj.kind.ref.RwLock.ref.field0 = pre_field0;
+      wireObj.kind.RwLock.field0 = pre_field0;
       return;
     }
   }
@@ -18502,15 +18329,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is EnumWithItemMixedTwinNormal_B) {
       var pre_field0 = cst_encode_list_prim_u_8(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_EnumWithItemMixedTwinNormal_B();
-      wireObj.kind.ref.B.ref.field0 = pre_field0;
+      wireObj.kind.B.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumWithItemMixedTwinNormal_C) {
       var pre_c_field = cst_encode_String(apiObj.cField);
       wireObj.tag = 2;
-      wireObj.kind = wire.cst_inflate_EnumWithItemMixedTwinNormal_C();
-      wireObj.kind.ref.C.ref.c_field = pre_c_field;
+      wireObj.kind.C.c_field = pre_c_field;
       return;
     }
   }
@@ -18526,15 +18351,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is EnumWithItemMixedTwinRustAsync_B) {
       var pre_field0 = cst_encode_list_prim_u_8(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_EnumWithItemMixedTwinRustAsync_B();
-      wireObj.kind.ref.B.ref.field0 = pre_field0;
+      wireObj.kind.B.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumWithItemMixedTwinRustAsync_C) {
       var pre_c_field = cst_encode_String(apiObj.cField);
       wireObj.tag = 2;
-      wireObj.kind = wire.cst_inflate_EnumWithItemMixedTwinRustAsync_C();
-      wireObj.kind.ref.C.ref.c_field = pre_c_field;
+      wireObj.kind.C.c_field = pre_c_field;
       return;
     }
   }
@@ -18550,15 +18373,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is EnumWithItemMixedTwinRustAsyncSse_B) {
       var pre_field0 = cst_encode_list_prim_u_8(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_EnumWithItemMixedTwinRustAsyncSse_B();
-      wireObj.kind.ref.B.ref.field0 = pre_field0;
+      wireObj.kind.B.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumWithItemMixedTwinRustAsyncSse_C) {
       var pre_c_field = cst_encode_String(apiObj.cField);
       wireObj.tag = 2;
-      wireObj.kind = wire.cst_inflate_EnumWithItemMixedTwinRustAsyncSse_C();
-      wireObj.kind.ref.C.ref.c_field = pre_c_field;
+      wireObj.kind.C.c_field = pre_c_field;
       return;
     }
   }
@@ -18574,15 +18395,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is EnumWithItemMixedTwinSse_B) {
       var pre_field0 = cst_encode_list_prim_u_8(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_EnumWithItemMixedTwinSse_B();
-      wireObj.kind.ref.B.ref.field0 = pre_field0;
+      wireObj.kind.B.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumWithItemMixedTwinSse_C) {
       var pre_c_field = cst_encode_String(apiObj.cField);
       wireObj.tag = 2;
-      wireObj.kind = wire.cst_inflate_EnumWithItemMixedTwinSse_C();
-      wireObj.kind.ref.C.ref.c_field = pre_c_field;
+      wireObj.kind.C.c_field = pre_c_field;
       return;
     }
   }
@@ -18598,15 +18417,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is EnumWithItemMixedTwinSync_B) {
       var pre_field0 = cst_encode_list_prim_u_8(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_EnumWithItemMixedTwinSync_B();
-      wireObj.kind.ref.B.ref.field0 = pre_field0;
+      wireObj.kind.B.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumWithItemMixedTwinSync_C) {
       var pre_c_field = cst_encode_String(apiObj.cField);
       wireObj.tag = 2;
-      wireObj.kind = wire.cst_inflate_EnumWithItemMixedTwinSync_C();
-      wireObj.kind.ref.C.ref.c_field = pre_c_field;
+      wireObj.kind.C.c_field = pre_c_field;
       return;
     }
   }
@@ -18622,15 +18439,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is EnumWithItemMixedTwinSyncSse_B) {
       var pre_field0 = cst_encode_list_prim_u_8(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_EnumWithItemMixedTwinSyncSse_B();
-      wireObj.kind.ref.B.ref.field0 = pre_field0;
+      wireObj.kind.B.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumWithItemMixedTwinSyncSse_C) {
       var pre_c_field = cst_encode_String(apiObj.cField);
       wireObj.tag = 2;
-      wireObj.kind = wire.cst_inflate_EnumWithItemMixedTwinSyncSse_C();
-      wireObj.kind.ref.C.ref.c_field = pre_c_field;
+      wireObj.kind.C.c_field = pre_c_field;
       return;
     }
   }
@@ -18642,15 +18457,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is EnumWithItemStructTwinNormal_A) {
       var pre_a_field = cst_encode_list_prim_u_8(apiObj.aField);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_EnumWithItemStructTwinNormal_A();
-      wireObj.kind.ref.A.ref.a_field = pre_a_field;
+      wireObj.kind.A.a_field = pre_a_field;
       return;
     }
     if (apiObj is EnumWithItemStructTwinNormal_B) {
       var pre_b_field = cst_encode_list_prim_i_32(apiObj.bField);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_EnumWithItemStructTwinNormal_B();
-      wireObj.kind.ref.B.ref.b_field = pre_b_field;
+      wireObj.kind.B.b_field = pre_b_field;
       return;
     }
   }
@@ -18662,15 +18475,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is EnumWithItemStructTwinRustAsync_A) {
       var pre_a_field = cst_encode_list_prim_u_8(apiObj.aField);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_EnumWithItemStructTwinRustAsync_A();
-      wireObj.kind.ref.A.ref.a_field = pre_a_field;
+      wireObj.kind.A.a_field = pre_a_field;
       return;
     }
     if (apiObj is EnumWithItemStructTwinRustAsync_B) {
       var pre_b_field = cst_encode_list_prim_i_32(apiObj.bField);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_EnumWithItemStructTwinRustAsync_B();
-      wireObj.kind.ref.B.ref.b_field = pre_b_field;
+      wireObj.kind.B.b_field = pre_b_field;
       return;
     }
   }
@@ -18682,15 +18493,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is EnumWithItemStructTwinRustAsyncSse_A) {
       var pre_a_field = cst_encode_list_prim_u_8(apiObj.aField);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_EnumWithItemStructTwinRustAsyncSse_A();
-      wireObj.kind.ref.A.ref.a_field = pre_a_field;
+      wireObj.kind.A.a_field = pre_a_field;
       return;
     }
     if (apiObj is EnumWithItemStructTwinRustAsyncSse_B) {
       var pre_b_field = cst_encode_list_prim_i_32(apiObj.bField);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_EnumWithItemStructTwinRustAsyncSse_B();
-      wireObj.kind.ref.B.ref.b_field = pre_b_field;
+      wireObj.kind.B.b_field = pre_b_field;
       return;
     }
   }
@@ -18702,15 +18511,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is EnumWithItemStructTwinSse_A) {
       var pre_a_field = cst_encode_list_prim_u_8(apiObj.aField);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_EnumWithItemStructTwinSse_A();
-      wireObj.kind.ref.A.ref.a_field = pre_a_field;
+      wireObj.kind.A.a_field = pre_a_field;
       return;
     }
     if (apiObj is EnumWithItemStructTwinSse_B) {
       var pre_b_field = cst_encode_list_prim_i_32(apiObj.bField);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_EnumWithItemStructTwinSse_B();
-      wireObj.kind.ref.B.ref.b_field = pre_b_field;
+      wireObj.kind.B.b_field = pre_b_field;
       return;
     }
   }
@@ -18722,15 +18529,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is EnumWithItemStructTwinSync_A) {
       var pre_a_field = cst_encode_list_prim_u_8(apiObj.aField);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_EnumWithItemStructTwinSync_A();
-      wireObj.kind.ref.A.ref.a_field = pre_a_field;
+      wireObj.kind.A.a_field = pre_a_field;
       return;
     }
     if (apiObj is EnumWithItemStructTwinSync_B) {
       var pre_b_field = cst_encode_list_prim_i_32(apiObj.bField);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_EnumWithItemStructTwinSync_B();
-      wireObj.kind.ref.B.ref.b_field = pre_b_field;
+      wireObj.kind.B.b_field = pre_b_field;
       return;
     }
   }
@@ -18742,15 +18547,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is EnumWithItemStructTwinSyncSse_A) {
       var pre_a_field = cst_encode_list_prim_u_8(apiObj.aField);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_EnumWithItemStructTwinSyncSse_A();
-      wireObj.kind.ref.A.ref.a_field = pre_a_field;
+      wireObj.kind.A.a_field = pre_a_field;
       return;
     }
     if (apiObj is EnumWithItemStructTwinSyncSse_B) {
       var pre_b_field = cst_encode_list_prim_i_32(apiObj.bField);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_EnumWithItemStructTwinSyncSse_B();
-      wireObj.kind.ref.B.ref.b_field = pre_b_field;
+      wireObj.kind.B.b_field = pre_b_field;
       return;
     }
   }
@@ -18762,15 +18565,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is EnumWithItemTupleTwinNormal_A) {
       var pre_field0 = cst_encode_list_prim_u_8(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_EnumWithItemTupleTwinNormal_A();
-      wireObj.kind.ref.A.ref.field0 = pre_field0;
+      wireObj.kind.A.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumWithItemTupleTwinNormal_B) {
       var pre_field0 = cst_encode_list_prim_i_32(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_EnumWithItemTupleTwinNormal_B();
-      wireObj.kind.ref.B.ref.field0 = pre_field0;
+      wireObj.kind.B.field0 = pre_field0;
       return;
     }
   }
@@ -18782,15 +18583,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is EnumWithItemTupleTwinRustAsync_A) {
       var pre_field0 = cst_encode_list_prim_u_8(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_EnumWithItemTupleTwinRustAsync_A();
-      wireObj.kind.ref.A.ref.field0 = pre_field0;
+      wireObj.kind.A.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumWithItemTupleTwinRustAsync_B) {
       var pre_field0 = cst_encode_list_prim_i_32(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_EnumWithItemTupleTwinRustAsync_B();
-      wireObj.kind.ref.B.ref.field0 = pre_field0;
+      wireObj.kind.B.field0 = pre_field0;
       return;
     }
   }
@@ -18802,15 +18601,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is EnumWithItemTupleTwinRustAsyncSse_A) {
       var pre_field0 = cst_encode_list_prim_u_8(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_EnumWithItemTupleTwinRustAsyncSse_A();
-      wireObj.kind.ref.A.ref.field0 = pre_field0;
+      wireObj.kind.A.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumWithItemTupleTwinRustAsyncSse_B) {
       var pre_field0 = cst_encode_list_prim_i_32(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_EnumWithItemTupleTwinRustAsyncSse_B();
-      wireObj.kind.ref.B.ref.field0 = pre_field0;
+      wireObj.kind.B.field0 = pre_field0;
       return;
     }
   }
@@ -18822,15 +18619,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is EnumWithItemTupleTwinSse_A) {
       var pre_field0 = cst_encode_list_prim_u_8(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_EnumWithItemTupleTwinSse_A();
-      wireObj.kind.ref.A.ref.field0 = pre_field0;
+      wireObj.kind.A.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumWithItemTupleTwinSse_B) {
       var pre_field0 = cst_encode_list_prim_i_32(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_EnumWithItemTupleTwinSse_B();
-      wireObj.kind.ref.B.ref.field0 = pre_field0;
+      wireObj.kind.B.field0 = pre_field0;
       return;
     }
   }
@@ -18842,15 +18637,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is EnumWithItemTupleTwinSync_A) {
       var pre_field0 = cst_encode_list_prim_u_8(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_EnumWithItemTupleTwinSync_A();
-      wireObj.kind.ref.A.ref.field0 = pre_field0;
+      wireObj.kind.A.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumWithItemTupleTwinSync_B) {
       var pre_field0 = cst_encode_list_prim_i_32(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_EnumWithItemTupleTwinSync_B();
-      wireObj.kind.ref.B.ref.field0 = pre_field0;
+      wireObj.kind.B.field0 = pre_field0;
       return;
     }
   }
@@ -18862,15 +18655,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is EnumWithItemTupleTwinSyncSse_A) {
       var pre_field0 = cst_encode_list_prim_u_8(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_EnumWithItemTupleTwinSyncSse_A();
-      wireObj.kind.ref.A.ref.field0 = pre_field0;
+      wireObj.kind.A.field0 = pre_field0;
       return;
     }
     if (apiObj is EnumWithItemTupleTwinSyncSse_B) {
       var pre_field0 = cst_encode_list_prim_i_32(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_EnumWithItemTupleTwinSyncSse_B();
-      wireObj.kind.ref.B.ref.field0 = pre_field0;
+      wireObj.kind.B.field0 = pre_field0;
       return;
     }
   }
@@ -19159,42 +18950,37 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       var pre_float64 = cst_encode_f_64(apiObj.float64);
       var pre_boolean = cst_encode_bool(apiObj.boolean);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_KitchenSinkTwinNormal_Primitives();
-      wireObj.kind.ref.Primitives.ref.int32 = pre_int32;
-      wireObj.kind.ref.Primitives.ref.float64 = pre_float64;
-      wireObj.kind.ref.Primitives.ref.boolean = pre_boolean;
+      wireObj.kind.Primitives.int32 = pre_int32;
+      wireObj.kind.Primitives.float64 = pre_float64;
+      wireObj.kind.Primitives.boolean = pre_boolean;
       return;
     }
     if (apiObj is KitchenSinkTwinNormal_Nested) {
       var pre_field0 = cst_encode_i_32(apiObj.field0);
       var pre_field1 = cst_encode_box_kitchen_sink_twin_normal(apiObj.field1);
       wireObj.tag = 2;
-      wireObj.kind = wire.cst_inflate_KitchenSinkTwinNormal_Nested();
-      wireObj.kind.ref.Nested.ref.field0 = pre_field0;
-      wireObj.kind.ref.Nested.ref.field1 = pre_field1;
+      wireObj.kind.Nested.field0 = pre_field0;
+      wireObj.kind.Nested.field1 = pre_field1;
       return;
     }
     if (apiObj is KitchenSinkTwinNormal_Optional) {
       var pre_field0 = cst_encode_opt_box_autoadd_i_32(apiObj.field0);
       var pre_field1 = cst_encode_opt_box_autoadd_i_32(apiObj.field1);
       wireObj.tag = 3;
-      wireObj.kind = wire.cst_inflate_KitchenSinkTwinNormal_Optional();
-      wireObj.kind.ref.Optional.ref.field0 = pre_field0;
-      wireObj.kind.ref.Optional.ref.field1 = pre_field1;
+      wireObj.kind.Optional.field0 = pre_field0;
+      wireObj.kind.Optional.field1 = pre_field1;
       return;
     }
     if (apiObj is KitchenSinkTwinNormal_Buffer) {
       var pre_field0 = cst_encode_list_prim_u_8(apiObj.field0);
       wireObj.tag = 4;
-      wireObj.kind = wire.cst_inflate_KitchenSinkTwinNormal_Buffer();
-      wireObj.kind.ref.Buffer.ref.field0 = pre_field0;
+      wireObj.kind.Buffer.field0 = pre_field0;
       return;
     }
     if (apiObj is KitchenSinkTwinNormal_Enums) {
       var pre_field0 = cst_encode_weekdays_twin_normal(apiObj.field0);
       wireObj.tag = 5;
-      wireObj.kind = wire.cst_inflate_KitchenSinkTwinNormal_Enums();
-      wireObj.kind.ref.Enums.ref.field0 = pre_field0;
+      wireObj.kind.Enums.field0 = pre_field0;
       return;
     }
   }
@@ -19212,10 +18998,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       var pre_float64 = cst_encode_f_64(apiObj.float64);
       var pre_boolean = cst_encode_bool(apiObj.boolean);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_KitchenSinkTwinRustAsync_Primitives();
-      wireObj.kind.ref.Primitives.ref.int32 = pre_int32;
-      wireObj.kind.ref.Primitives.ref.float64 = pre_float64;
-      wireObj.kind.ref.Primitives.ref.boolean = pre_boolean;
+      wireObj.kind.Primitives.int32 = pre_int32;
+      wireObj.kind.Primitives.float64 = pre_float64;
+      wireObj.kind.Primitives.boolean = pre_boolean;
       return;
     }
     if (apiObj is KitchenSinkTwinRustAsync_Nested) {
@@ -19223,32 +19008,28 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       var pre_field1 =
           cst_encode_box_kitchen_sink_twin_rust_async(apiObj.field1);
       wireObj.tag = 2;
-      wireObj.kind = wire.cst_inflate_KitchenSinkTwinRustAsync_Nested();
-      wireObj.kind.ref.Nested.ref.field0 = pre_field0;
-      wireObj.kind.ref.Nested.ref.field1 = pre_field1;
+      wireObj.kind.Nested.field0 = pre_field0;
+      wireObj.kind.Nested.field1 = pre_field1;
       return;
     }
     if (apiObj is KitchenSinkTwinRustAsync_Optional) {
       var pre_field0 = cst_encode_opt_box_autoadd_i_32(apiObj.field0);
       var pre_field1 = cst_encode_opt_box_autoadd_i_32(apiObj.field1);
       wireObj.tag = 3;
-      wireObj.kind = wire.cst_inflate_KitchenSinkTwinRustAsync_Optional();
-      wireObj.kind.ref.Optional.ref.field0 = pre_field0;
-      wireObj.kind.ref.Optional.ref.field1 = pre_field1;
+      wireObj.kind.Optional.field0 = pre_field0;
+      wireObj.kind.Optional.field1 = pre_field1;
       return;
     }
     if (apiObj is KitchenSinkTwinRustAsync_Buffer) {
       var pre_field0 = cst_encode_list_prim_u_8(apiObj.field0);
       wireObj.tag = 4;
-      wireObj.kind = wire.cst_inflate_KitchenSinkTwinRustAsync_Buffer();
-      wireObj.kind.ref.Buffer.ref.field0 = pre_field0;
+      wireObj.kind.Buffer.field0 = pre_field0;
       return;
     }
     if (apiObj is KitchenSinkTwinRustAsync_Enums) {
       var pre_field0 = cst_encode_weekdays_twin_rust_async(apiObj.field0);
       wireObj.tag = 5;
-      wireObj.kind = wire.cst_inflate_KitchenSinkTwinRustAsync_Enums();
-      wireObj.kind.ref.Enums.ref.field0 = pre_field0;
+      wireObj.kind.Enums.field0 = pre_field0;
       return;
     }
   }
@@ -19266,10 +19047,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       var pre_float64 = cst_encode_f_64(apiObj.float64);
       var pre_boolean = cst_encode_bool(apiObj.boolean);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_KitchenSinkTwinRustAsyncSse_Primitives();
-      wireObj.kind.ref.Primitives.ref.int32 = pre_int32;
-      wireObj.kind.ref.Primitives.ref.float64 = pre_float64;
-      wireObj.kind.ref.Primitives.ref.boolean = pre_boolean;
+      wireObj.kind.Primitives.int32 = pre_int32;
+      wireObj.kind.Primitives.float64 = pre_float64;
+      wireObj.kind.Primitives.boolean = pre_boolean;
       return;
     }
     if (apiObj is KitchenSinkTwinRustAsyncSse_Nested) {
@@ -19277,32 +19057,28 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       var pre_field1 =
           cst_encode_box_kitchen_sink_twin_rust_async_sse(apiObj.field1);
       wireObj.tag = 2;
-      wireObj.kind = wire.cst_inflate_KitchenSinkTwinRustAsyncSse_Nested();
-      wireObj.kind.ref.Nested.ref.field0 = pre_field0;
-      wireObj.kind.ref.Nested.ref.field1 = pre_field1;
+      wireObj.kind.Nested.field0 = pre_field0;
+      wireObj.kind.Nested.field1 = pre_field1;
       return;
     }
     if (apiObj is KitchenSinkTwinRustAsyncSse_Optional) {
       var pre_field0 = cst_encode_opt_box_autoadd_i_32(apiObj.field0);
       var pre_field1 = cst_encode_opt_box_autoadd_i_32(apiObj.field1);
       wireObj.tag = 3;
-      wireObj.kind = wire.cst_inflate_KitchenSinkTwinRustAsyncSse_Optional();
-      wireObj.kind.ref.Optional.ref.field0 = pre_field0;
-      wireObj.kind.ref.Optional.ref.field1 = pre_field1;
+      wireObj.kind.Optional.field0 = pre_field0;
+      wireObj.kind.Optional.field1 = pre_field1;
       return;
     }
     if (apiObj is KitchenSinkTwinRustAsyncSse_Buffer) {
       var pre_field0 = cst_encode_list_prim_u_8(apiObj.field0);
       wireObj.tag = 4;
-      wireObj.kind = wire.cst_inflate_KitchenSinkTwinRustAsyncSse_Buffer();
-      wireObj.kind.ref.Buffer.ref.field0 = pre_field0;
+      wireObj.kind.Buffer.field0 = pre_field0;
       return;
     }
     if (apiObj is KitchenSinkTwinRustAsyncSse_Enums) {
       var pre_field0 = cst_encode_weekdays_twin_rust_async_sse(apiObj.field0);
       wireObj.tag = 5;
-      wireObj.kind = wire.cst_inflate_KitchenSinkTwinRustAsyncSse_Enums();
-      wireObj.kind.ref.Enums.ref.field0 = pre_field0;
+      wireObj.kind.Enums.field0 = pre_field0;
       return;
     }
   }
@@ -19319,42 +19095,37 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       var pre_float64 = cst_encode_f_64(apiObj.float64);
       var pre_boolean = cst_encode_bool(apiObj.boolean);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_KitchenSinkTwinSse_Primitives();
-      wireObj.kind.ref.Primitives.ref.int32 = pre_int32;
-      wireObj.kind.ref.Primitives.ref.float64 = pre_float64;
-      wireObj.kind.ref.Primitives.ref.boolean = pre_boolean;
+      wireObj.kind.Primitives.int32 = pre_int32;
+      wireObj.kind.Primitives.float64 = pre_float64;
+      wireObj.kind.Primitives.boolean = pre_boolean;
       return;
     }
     if (apiObj is KitchenSinkTwinSse_Nested) {
       var pre_field0 = cst_encode_i_32(apiObj.field0);
       var pre_field1 = cst_encode_box_kitchen_sink_twin_sse(apiObj.field1);
       wireObj.tag = 2;
-      wireObj.kind = wire.cst_inflate_KitchenSinkTwinSse_Nested();
-      wireObj.kind.ref.Nested.ref.field0 = pre_field0;
-      wireObj.kind.ref.Nested.ref.field1 = pre_field1;
+      wireObj.kind.Nested.field0 = pre_field0;
+      wireObj.kind.Nested.field1 = pre_field1;
       return;
     }
     if (apiObj is KitchenSinkTwinSse_Optional) {
       var pre_field0 = cst_encode_opt_box_autoadd_i_32(apiObj.field0);
       var pre_field1 = cst_encode_opt_box_autoadd_i_32(apiObj.field1);
       wireObj.tag = 3;
-      wireObj.kind = wire.cst_inflate_KitchenSinkTwinSse_Optional();
-      wireObj.kind.ref.Optional.ref.field0 = pre_field0;
-      wireObj.kind.ref.Optional.ref.field1 = pre_field1;
+      wireObj.kind.Optional.field0 = pre_field0;
+      wireObj.kind.Optional.field1 = pre_field1;
       return;
     }
     if (apiObj is KitchenSinkTwinSse_Buffer) {
       var pre_field0 = cst_encode_list_prim_u_8(apiObj.field0);
       wireObj.tag = 4;
-      wireObj.kind = wire.cst_inflate_KitchenSinkTwinSse_Buffer();
-      wireObj.kind.ref.Buffer.ref.field0 = pre_field0;
+      wireObj.kind.Buffer.field0 = pre_field0;
       return;
     }
     if (apiObj is KitchenSinkTwinSse_Enums) {
       var pre_field0 = cst_encode_weekdays_twin_sse(apiObj.field0);
       wireObj.tag = 5;
-      wireObj.kind = wire.cst_inflate_KitchenSinkTwinSse_Enums();
-      wireObj.kind.ref.Enums.ref.field0 = pre_field0;
+      wireObj.kind.Enums.field0 = pre_field0;
       return;
     }
   }
@@ -19371,42 +19142,37 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       var pre_float64 = cst_encode_f_64(apiObj.float64);
       var pre_boolean = cst_encode_bool(apiObj.boolean);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_KitchenSinkTwinSync_Primitives();
-      wireObj.kind.ref.Primitives.ref.int32 = pre_int32;
-      wireObj.kind.ref.Primitives.ref.float64 = pre_float64;
-      wireObj.kind.ref.Primitives.ref.boolean = pre_boolean;
+      wireObj.kind.Primitives.int32 = pre_int32;
+      wireObj.kind.Primitives.float64 = pre_float64;
+      wireObj.kind.Primitives.boolean = pre_boolean;
       return;
     }
     if (apiObj is KitchenSinkTwinSync_Nested) {
       var pre_field0 = cst_encode_i_32(apiObj.field0);
       var pre_field1 = cst_encode_box_kitchen_sink_twin_sync(apiObj.field1);
       wireObj.tag = 2;
-      wireObj.kind = wire.cst_inflate_KitchenSinkTwinSync_Nested();
-      wireObj.kind.ref.Nested.ref.field0 = pre_field0;
-      wireObj.kind.ref.Nested.ref.field1 = pre_field1;
+      wireObj.kind.Nested.field0 = pre_field0;
+      wireObj.kind.Nested.field1 = pre_field1;
       return;
     }
     if (apiObj is KitchenSinkTwinSync_Optional) {
       var pre_field0 = cst_encode_opt_box_autoadd_i_32(apiObj.field0);
       var pre_field1 = cst_encode_opt_box_autoadd_i_32(apiObj.field1);
       wireObj.tag = 3;
-      wireObj.kind = wire.cst_inflate_KitchenSinkTwinSync_Optional();
-      wireObj.kind.ref.Optional.ref.field0 = pre_field0;
-      wireObj.kind.ref.Optional.ref.field1 = pre_field1;
+      wireObj.kind.Optional.field0 = pre_field0;
+      wireObj.kind.Optional.field1 = pre_field1;
       return;
     }
     if (apiObj is KitchenSinkTwinSync_Buffer) {
       var pre_field0 = cst_encode_list_prim_u_8(apiObj.field0);
       wireObj.tag = 4;
-      wireObj.kind = wire.cst_inflate_KitchenSinkTwinSync_Buffer();
-      wireObj.kind.ref.Buffer.ref.field0 = pre_field0;
+      wireObj.kind.Buffer.field0 = pre_field0;
       return;
     }
     if (apiObj is KitchenSinkTwinSync_Enums) {
       var pre_field0 = cst_encode_weekdays_twin_sync(apiObj.field0);
       wireObj.tag = 5;
-      wireObj.kind = wire.cst_inflate_KitchenSinkTwinSync_Enums();
-      wireObj.kind.ref.Enums.ref.field0 = pre_field0;
+      wireObj.kind.Enums.field0 = pre_field0;
       return;
     }
   }
@@ -19424,42 +19190,37 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       var pre_float64 = cst_encode_f_64(apiObj.float64);
       var pre_boolean = cst_encode_bool(apiObj.boolean);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_KitchenSinkTwinSyncSse_Primitives();
-      wireObj.kind.ref.Primitives.ref.int32 = pre_int32;
-      wireObj.kind.ref.Primitives.ref.float64 = pre_float64;
-      wireObj.kind.ref.Primitives.ref.boolean = pre_boolean;
+      wireObj.kind.Primitives.int32 = pre_int32;
+      wireObj.kind.Primitives.float64 = pre_float64;
+      wireObj.kind.Primitives.boolean = pre_boolean;
       return;
     }
     if (apiObj is KitchenSinkTwinSyncSse_Nested) {
       var pre_field0 = cst_encode_i_32(apiObj.field0);
       var pre_field1 = cst_encode_box_kitchen_sink_twin_sync_sse(apiObj.field1);
       wireObj.tag = 2;
-      wireObj.kind = wire.cst_inflate_KitchenSinkTwinSyncSse_Nested();
-      wireObj.kind.ref.Nested.ref.field0 = pre_field0;
-      wireObj.kind.ref.Nested.ref.field1 = pre_field1;
+      wireObj.kind.Nested.field0 = pre_field0;
+      wireObj.kind.Nested.field1 = pre_field1;
       return;
     }
     if (apiObj is KitchenSinkTwinSyncSse_Optional) {
       var pre_field0 = cst_encode_opt_box_autoadd_i_32(apiObj.field0);
       var pre_field1 = cst_encode_opt_box_autoadd_i_32(apiObj.field1);
       wireObj.tag = 3;
-      wireObj.kind = wire.cst_inflate_KitchenSinkTwinSyncSse_Optional();
-      wireObj.kind.ref.Optional.ref.field0 = pre_field0;
-      wireObj.kind.ref.Optional.ref.field1 = pre_field1;
+      wireObj.kind.Optional.field0 = pre_field0;
+      wireObj.kind.Optional.field1 = pre_field1;
       return;
     }
     if (apiObj is KitchenSinkTwinSyncSse_Buffer) {
       var pre_field0 = cst_encode_list_prim_u_8(apiObj.field0);
       wireObj.tag = 4;
-      wireObj.kind = wire.cst_inflate_KitchenSinkTwinSyncSse_Buffer();
-      wireObj.kind.ref.Buffer.ref.field0 = pre_field0;
+      wireObj.kind.Buffer.field0 = pre_field0;
       return;
     }
     if (apiObj is KitchenSinkTwinSyncSse_Enums) {
       var pre_field0 = cst_encode_weekdays_twin_sync_sse(apiObj.field0);
       wireObj.tag = 5;
-      wireObj.kind = wire.cst_inflate_KitchenSinkTwinSyncSse_Enums();
-      wireObj.kind.ref.Enums.ref.field0 = pre_field0;
+      wireObj.kind.Enums.field0 = pre_field0;
       return;
     }
   }
@@ -19553,15 +19314,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is MeasureTwinNormal_Speed) {
       var pre_field0 = cst_encode_box_speed_twin_normal(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_MeasureTwinNormal_Speed();
-      wireObj.kind.ref.Speed.ref.field0 = pre_field0;
+      wireObj.kind.Speed.field0 = pre_field0;
       return;
     }
     if (apiObj is MeasureTwinNormal_Distance) {
       var pre_field0 = cst_encode_box_distance_twin_normal(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_MeasureTwinNormal_Distance();
-      wireObj.kind.ref.Distance.ref.field0 = pre_field0;
+      wireObj.kind.Distance.field0 = pre_field0;
       return;
     }
   }
@@ -19572,15 +19331,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is MeasureTwinRustAsync_Speed) {
       var pre_field0 = cst_encode_box_speed_twin_rust_async(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_MeasureTwinRustAsync_Speed();
-      wireObj.kind.ref.Speed.ref.field0 = pre_field0;
+      wireObj.kind.Speed.field0 = pre_field0;
       return;
     }
     if (apiObj is MeasureTwinRustAsync_Distance) {
       var pre_field0 = cst_encode_box_distance_twin_rust_async(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_MeasureTwinRustAsync_Distance();
-      wireObj.kind.ref.Distance.ref.field0 = pre_field0;
+      wireObj.kind.Distance.field0 = pre_field0;
       return;
     }
   }
@@ -19592,16 +19349,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is MeasureTwinRustAsyncSse_Speed) {
       var pre_field0 = cst_encode_box_speed_twin_rust_async_sse(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_MeasureTwinRustAsyncSse_Speed();
-      wireObj.kind.ref.Speed.ref.field0 = pre_field0;
+      wireObj.kind.Speed.field0 = pre_field0;
       return;
     }
     if (apiObj is MeasureTwinRustAsyncSse_Distance) {
       var pre_field0 =
           cst_encode_box_distance_twin_rust_async_sse(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_MeasureTwinRustAsyncSse_Distance();
-      wireObj.kind.ref.Distance.ref.field0 = pre_field0;
+      wireObj.kind.Distance.field0 = pre_field0;
       return;
     }
   }
@@ -19612,15 +19367,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is MeasureTwinSse_Speed) {
       var pre_field0 = cst_encode_box_speed_twin_sse(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_MeasureTwinSse_Speed();
-      wireObj.kind.ref.Speed.ref.field0 = pre_field0;
+      wireObj.kind.Speed.field0 = pre_field0;
       return;
     }
     if (apiObj is MeasureTwinSse_Distance) {
       var pre_field0 = cst_encode_box_distance_twin_sse(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_MeasureTwinSse_Distance();
-      wireObj.kind.ref.Distance.ref.field0 = pre_field0;
+      wireObj.kind.Distance.field0 = pre_field0;
       return;
     }
   }
@@ -19631,15 +19384,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is MeasureTwinSync_Speed) {
       var pre_field0 = cst_encode_box_speed_twin_sync(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_MeasureTwinSync_Speed();
-      wireObj.kind.ref.Speed.ref.field0 = pre_field0;
+      wireObj.kind.Speed.field0 = pre_field0;
       return;
     }
     if (apiObj is MeasureTwinSync_Distance) {
       var pre_field0 = cst_encode_box_distance_twin_sync(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_MeasureTwinSync_Distance();
-      wireObj.kind.ref.Distance.ref.field0 = pre_field0;
+      wireObj.kind.Distance.field0 = pre_field0;
       return;
     }
   }
@@ -19650,15 +19401,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is MeasureTwinSyncSse_Speed) {
       var pre_field0 = cst_encode_box_speed_twin_sync_sse(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_MeasureTwinSyncSse_Speed();
-      wireObj.kind.ref.Speed.ref.field0 = pre_field0;
+      wireObj.kind.Speed.field0 = pre_field0;
       return;
     }
     if (apiObj is MeasureTwinSyncSse_Distance) {
       var pre_field0 = cst_encode_box_distance_twin_sync_sse(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_MeasureTwinSyncSse_Distance();
-      wireObj.kind.ref.Distance.ref.field0 = pre_field0;
+      wireObj.kind.Distance.field0 = pre_field0;
       return;
     }
   }
@@ -20240,16 +19989,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       var pre_field0 =
           cst_encode_box_autoadd_raw_string_mirrored(apiObj.field0);
       wireObj.tag = 0;
-      wireObj.kind = wire.cst_inflate_RawStringEnumMirrored_Raw();
-      wireObj.kind.ref.Raw.ref.field0 = pre_field0;
+      wireObj.kind.Raw.field0 = pre_field0;
       return;
     }
     if (apiObj is RawStringEnumMirrored_Nested) {
       var pre_field0 =
           cst_encode_box_autoadd_nested_raw_string_mirrored(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_RawStringEnumMirrored_Nested();
-      wireObj.kind.ref.Nested.ref.field0 = pre_field0;
+      wireObj.kind.Nested.field0 = pre_field0;
       return;
     }
     if (apiObj is RawStringEnumMirrored_ListOfNested) {
@@ -20257,8 +20004,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
           cst_encode_box_autoadd_list_of_nested_raw_string_mirrored(
               apiObj.field0);
       wireObj.tag = 2;
-      wireObj.kind = wire.cst_inflate_RawStringEnumMirrored_ListOfNested();
-      wireObj.kind.ref.ListOfNested.ref.field0 = pre_field0;
+      wireObj.kind.ListOfNested.field0 = pre_field0;
       return;
     }
   }
@@ -20383,8 +20129,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is SpeedTwinNormal_GPS) {
       var pre_field0 = cst_encode_f_64(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_SpeedTwinNormal_GPS();
-      wireObj.kind.ref.GPS.ref.field0 = pre_field0;
+      wireObj.kind.GPS.field0 = pre_field0;
       return;
     }
   }
@@ -20399,8 +20144,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is SpeedTwinRustAsync_GPS) {
       var pre_field0 = cst_encode_f_64(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_SpeedTwinRustAsync_GPS();
-      wireObj.kind.ref.GPS.ref.field0 = pre_field0;
+      wireObj.kind.GPS.field0 = pre_field0;
       return;
     }
   }
@@ -20416,8 +20160,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is SpeedTwinRustAsyncSse_GPS) {
       var pre_field0 = cst_encode_f_64(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_SpeedTwinRustAsyncSse_GPS();
-      wireObj.kind.ref.GPS.ref.field0 = pre_field0;
+      wireObj.kind.GPS.field0 = pre_field0;
       return;
     }
   }
@@ -20432,8 +20175,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is SpeedTwinSse_GPS) {
       var pre_field0 = cst_encode_f_64(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_SpeedTwinSse_GPS();
-      wireObj.kind.ref.GPS.ref.field0 = pre_field0;
+      wireObj.kind.GPS.field0 = pre_field0;
       return;
     }
   }
@@ -20448,8 +20190,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is SpeedTwinSync_GPS) {
       var pre_field0 = cst_encode_f_64(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_SpeedTwinSync_GPS();
-      wireObj.kind.ref.GPS.ref.field0 = pre_field0;
+      wireObj.kind.GPS.field0 = pre_field0;
       return;
     }
   }
@@ -20464,8 +20205,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (apiObj is SpeedTwinSyncSse_GPS) {
       var pre_field0 = cst_encode_f_64(apiObj.field0);
       wireObj.tag = 1;
-      wireObj.kind = wire.cst_inflate_SpeedTwinSyncSse_GPS();
-      wireObj.kind.ref.GPS.ref.field0 = pre_field0;
+      wireObj.kind.GPS.field0 = pre_field0;
       return;
     }
   }
@@ -63198,2931 +62938,6 @@ class RustLibWire implements BaseWire {
       _cst_new_list_weekdays_twin_sync_ssePtr.asFunction<
           ffi.Pointer<wire_cst_list_weekdays_twin_sync_sse> Function(int)>();
 
-  ffi.Pointer<AbcTwinNormalKind> cst_inflate_AbcTwinNormal_A() {
-    return _cst_inflate_AbcTwinNormal_A();
-  }
-
-  late final _cst_inflate_AbcTwinNormal_APtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<AbcTwinNormalKind> Function()>>(
-          'cst_inflate_AbcTwinNormal_A');
-  late final _cst_inflate_AbcTwinNormal_A = _cst_inflate_AbcTwinNormal_APtr
-      .asFunction<ffi.Pointer<AbcTwinNormalKind> Function()>();
-
-  ffi.Pointer<AbcTwinNormalKind> cst_inflate_AbcTwinNormal_B() {
-    return _cst_inflate_AbcTwinNormal_B();
-  }
-
-  late final _cst_inflate_AbcTwinNormal_BPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<AbcTwinNormalKind> Function()>>(
-          'cst_inflate_AbcTwinNormal_B');
-  late final _cst_inflate_AbcTwinNormal_B = _cst_inflate_AbcTwinNormal_BPtr
-      .asFunction<ffi.Pointer<AbcTwinNormalKind> Function()>();
-
-  ffi.Pointer<AbcTwinNormalKind> cst_inflate_AbcTwinNormal_C() {
-    return _cst_inflate_AbcTwinNormal_C();
-  }
-
-  late final _cst_inflate_AbcTwinNormal_CPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<AbcTwinNormalKind> Function()>>(
-          'cst_inflate_AbcTwinNormal_C');
-  late final _cst_inflate_AbcTwinNormal_C = _cst_inflate_AbcTwinNormal_CPtr
-      .asFunction<ffi.Pointer<AbcTwinNormalKind> Function()>();
-
-  ffi.Pointer<AbcTwinNormalKind> cst_inflate_AbcTwinNormal_JustInt() {
-    return _cst_inflate_AbcTwinNormal_JustInt();
-  }
-
-  late final _cst_inflate_AbcTwinNormal_JustIntPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<AbcTwinNormalKind> Function()>>(
-          'cst_inflate_AbcTwinNormal_JustInt');
-  late final _cst_inflate_AbcTwinNormal_JustInt =
-      _cst_inflate_AbcTwinNormal_JustIntPtr
-          .asFunction<ffi.Pointer<AbcTwinNormalKind> Function()>();
-
-  ffi.Pointer<AbcTwinRustAsyncKind> cst_inflate_AbcTwinRustAsync_A() {
-    return _cst_inflate_AbcTwinRustAsync_A();
-  }
-
-  late final _cst_inflate_AbcTwinRustAsync_APtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<AbcTwinRustAsyncKind> Function()>>(
-          'cst_inflate_AbcTwinRustAsync_A');
-  late final _cst_inflate_AbcTwinRustAsync_A =
-      _cst_inflate_AbcTwinRustAsync_APtr
-          .asFunction<ffi.Pointer<AbcTwinRustAsyncKind> Function()>();
-
-  ffi.Pointer<AbcTwinRustAsyncKind> cst_inflate_AbcTwinRustAsync_B() {
-    return _cst_inflate_AbcTwinRustAsync_B();
-  }
-
-  late final _cst_inflate_AbcTwinRustAsync_BPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<AbcTwinRustAsyncKind> Function()>>(
-          'cst_inflate_AbcTwinRustAsync_B');
-  late final _cst_inflate_AbcTwinRustAsync_B =
-      _cst_inflate_AbcTwinRustAsync_BPtr
-          .asFunction<ffi.Pointer<AbcTwinRustAsyncKind> Function()>();
-
-  ffi.Pointer<AbcTwinRustAsyncKind> cst_inflate_AbcTwinRustAsync_C() {
-    return _cst_inflate_AbcTwinRustAsync_C();
-  }
-
-  late final _cst_inflate_AbcTwinRustAsync_CPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<AbcTwinRustAsyncKind> Function()>>(
-          'cst_inflate_AbcTwinRustAsync_C');
-  late final _cst_inflate_AbcTwinRustAsync_C =
-      _cst_inflate_AbcTwinRustAsync_CPtr
-          .asFunction<ffi.Pointer<AbcTwinRustAsyncKind> Function()>();
-
-  ffi.Pointer<AbcTwinRustAsyncKind> cst_inflate_AbcTwinRustAsync_JustInt() {
-    return _cst_inflate_AbcTwinRustAsync_JustInt();
-  }
-
-  late final _cst_inflate_AbcTwinRustAsync_JustIntPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<AbcTwinRustAsyncKind> Function()>>(
-          'cst_inflate_AbcTwinRustAsync_JustInt');
-  late final _cst_inflate_AbcTwinRustAsync_JustInt =
-      _cst_inflate_AbcTwinRustAsync_JustIntPtr
-          .asFunction<ffi.Pointer<AbcTwinRustAsyncKind> Function()>();
-
-  ffi.Pointer<AbcTwinRustAsyncSseKind> cst_inflate_AbcTwinRustAsyncSse_A() {
-    return _cst_inflate_AbcTwinRustAsyncSse_A();
-  }
-
-  late final _cst_inflate_AbcTwinRustAsyncSse_APtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<AbcTwinRustAsyncSseKind> Function()>>(
-      'cst_inflate_AbcTwinRustAsyncSse_A');
-  late final _cst_inflate_AbcTwinRustAsyncSse_A =
-      _cst_inflate_AbcTwinRustAsyncSse_APtr
-          .asFunction<ffi.Pointer<AbcTwinRustAsyncSseKind> Function()>();
-
-  ffi.Pointer<AbcTwinRustAsyncSseKind> cst_inflate_AbcTwinRustAsyncSse_B() {
-    return _cst_inflate_AbcTwinRustAsyncSse_B();
-  }
-
-  late final _cst_inflate_AbcTwinRustAsyncSse_BPtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<AbcTwinRustAsyncSseKind> Function()>>(
-      'cst_inflate_AbcTwinRustAsyncSse_B');
-  late final _cst_inflate_AbcTwinRustAsyncSse_B =
-      _cst_inflate_AbcTwinRustAsyncSse_BPtr
-          .asFunction<ffi.Pointer<AbcTwinRustAsyncSseKind> Function()>();
-
-  ffi.Pointer<AbcTwinRustAsyncSseKind> cst_inflate_AbcTwinRustAsyncSse_C() {
-    return _cst_inflate_AbcTwinRustAsyncSse_C();
-  }
-
-  late final _cst_inflate_AbcTwinRustAsyncSse_CPtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<AbcTwinRustAsyncSseKind> Function()>>(
-      'cst_inflate_AbcTwinRustAsyncSse_C');
-  late final _cst_inflate_AbcTwinRustAsyncSse_C =
-      _cst_inflate_AbcTwinRustAsyncSse_CPtr
-          .asFunction<ffi.Pointer<AbcTwinRustAsyncSseKind> Function()>();
-
-  ffi.Pointer<AbcTwinRustAsyncSseKind>
-      cst_inflate_AbcTwinRustAsyncSse_JustInt() {
-    return _cst_inflate_AbcTwinRustAsyncSse_JustInt();
-  }
-
-  late final _cst_inflate_AbcTwinRustAsyncSse_JustIntPtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<AbcTwinRustAsyncSseKind> Function()>>(
-      'cst_inflate_AbcTwinRustAsyncSse_JustInt');
-  late final _cst_inflate_AbcTwinRustAsyncSse_JustInt =
-      _cst_inflate_AbcTwinRustAsyncSse_JustIntPtr
-          .asFunction<ffi.Pointer<AbcTwinRustAsyncSseKind> Function()>();
-
-  ffi.Pointer<AbcTwinSseKind> cst_inflate_AbcTwinSse_A() {
-    return _cst_inflate_AbcTwinSse_A();
-  }
-
-  late final _cst_inflate_AbcTwinSse_APtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<AbcTwinSseKind> Function()>>(
-          'cst_inflate_AbcTwinSse_A');
-  late final _cst_inflate_AbcTwinSse_A = _cst_inflate_AbcTwinSse_APtr
-      .asFunction<ffi.Pointer<AbcTwinSseKind> Function()>();
-
-  ffi.Pointer<AbcTwinSseKind> cst_inflate_AbcTwinSse_B() {
-    return _cst_inflate_AbcTwinSse_B();
-  }
-
-  late final _cst_inflate_AbcTwinSse_BPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<AbcTwinSseKind> Function()>>(
-          'cst_inflate_AbcTwinSse_B');
-  late final _cst_inflate_AbcTwinSse_B = _cst_inflate_AbcTwinSse_BPtr
-      .asFunction<ffi.Pointer<AbcTwinSseKind> Function()>();
-
-  ffi.Pointer<AbcTwinSseKind> cst_inflate_AbcTwinSse_C() {
-    return _cst_inflate_AbcTwinSse_C();
-  }
-
-  late final _cst_inflate_AbcTwinSse_CPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<AbcTwinSseKind> Function()>>(
-          'cst_inflate_AbcTwinSse_C');
-  late final _cst_inflate_AbcTwinSse_C = _cst_inflate_AbcTwinSse_CPtr
-      .asFunction<ffi.Pointer<AbcTwinSseKind> Function()>();
-
-  ffi.Pointer<AbcTwinSseKind> cst_inflate_AbcTwinSse_JustInt() {
-    return _cst_inflate_AbcTwinSse_JustInt();
-  }
-
-  late final _cst_inflate_AbcTwinSse_JustIntPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<AbcTwinSseKind> Function()>>(
-          'cst_inflate_AbcTwinSse_JustInt');
-  late final _cst_inflate_AbcTwinSse_JustInt =
-      _cst_inflate_AbcTwinSse_JustIntPtr
-          .asFunction<ffi.Pointer<AbcTwinSseKind> Function()>();
-
-  ffi.Pointer<AbcTwinSyncKind> cst_inflate_AbcTwinSync_A() {
-    return _cst_inflate_AbcTwinSync_A();
-  }
-
-  late final _cst_inflate_AbcTwinSync_APtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<AbcTwinSyncKind> Function()>>(
-          'cst_inflate_AbcTwinSync_A');
-  late final _cst_inflate_AbcTwinSync_A = _cst_inflate_AbcTwinSync_APtr
-      .asFunction<ffi.Pointer<AbcTwinSyncKind> Function()>();
-
-  ffi.Pointer<AbcTwinSyncKind> cst_inflate_AbcTwinSync_B() {
-    return _cst_inflate_AbcTwinSync_B();
-  }
-
-  late final _cst_inflate_AbcTwinSync_BPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<AbcTwinSyncKind> Function()>>(
-          'cst_inflate_AbcTwinSync_B');
-  late final _cst_inflate_AbcTwinSync_B = _cst_inflate_AbcTwinSync_BPtr
-      .asFunction<ffi.Pointer<AbcTwinSyncKind> Function()>();
-
-  ffi.Pointer<AbcTwinSyncKind> cst_inflate_AbcTwinSync_C() {
-    return _cst_inflate_AbcTwinSync_C();
-  }
-
-  late final _cst_inflate_AbcTwinSync_CPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<AbcTwinSyncKind> Function()>>(
-          'cst_inflate_AbcTwinSync_C');
-  late final _cst_inflate_AbcTwinSync_C = _cst_inflate_AbcTwinSync_CPtr
-      .asFunction<ffi.Pointer<AbcTwinSyncKind> Function()>();
-
-  ffi.Pointer<AbcTwinSyncKind> cst_inflate_AbcTwinSync_JustInt() {
-    return _cst_inflate_AbcTwinSync_JustInt();
-  }
-
-  late final _cst_inflate_AbcTwinSync_JustIntPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<AbcTwinSyncKind> Function()>>(
-          'cst_inflate_AbcTwinSync_JustInt');
-  late final _cst_inflate_AbcTwinSync_JustInt =
-      _cst_inflate_AbcTwinSync_JustIntPtr
-          .asFunction<ffi.Pointer<AbcTwinSyncKind> Function()>();
-
-  ffi.Pointer<AbcTwinSyncSseKind> cst_inflate_AbcTwinSyncSse_A() {
-    return _cst_inflate_AbcTwinSyncSse_A();
-  }
-
-  late final _cst_inflate_AbcTwinSyncSse_APtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<AbcTwinSyncSseKind> Function()>>(
-          'cst_inflate_AbcTwinSyncSse_A');
-  late final _cst_inflate_AbcTwinSyncSse_A = _cst_inflate_AbcTwinSyncSse_APtr
-      .asFunction<ffi.Pointer<AbcTwinSyncSseKind> Function()>();
-
-  ffi.Pointer<AbcTwinSyncSseKind> cst_inflate_AbcTwinSyncSse_B() {
-    return _cst_inflate_AbcTwinSyncSse_B();
-  }
-
-  late final _cst_inflate_AbcTwinSyncSse_BPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<AbcTwinSyncSseKind> Function()>>(
-          'cst_inflate_AbcTwinSyncSse_B');
-  late final _cst_inflate_AbcTwinSyncSse_B = _cst_inflate_AbcTwinSyncSse_BPtr
-      .asFunction<ffi.Pointer<AbcTwinSyncSseKind> Function()>();
-
-  ffi.Pointer<AbcTwinSyncSseKind> cst_inflate_AbcTwinSyncSse_C() {
-    return _cst_inflate_AbcTwinSyncSse_C();
-  }
-
-  late final _cst_inflate_AbcTwinSyncSse_CPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<AbcTwinSyncSseKind> Function()>>(
-          'cst_inflate_AbcTwinSyncSse_C');
-  late final _cst_inflate_AbcTwinSyncSse_C = _cst_inflate_AbcTwinSyncSse_CPtr
-      .asFunction<ffi.Pointer<AbcTwinSyncSseKind> Function()>();
-
-  ffi.Pointer<AbcTwinSyncSseKind> cst_inflate_AbcTwinSyncSse_JustInt() {
-    return _cst_inflate_AbcTwinSyncSse_JustInt();
-  }
-
-  late final _cst_inflate_AbcTwinSyncSse_JustIntPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<AbcTwinSyncSseKind> Function()>>(
-          'cst_inflate_AbcTwinSyncSse_JustInt');
-  late final _cst_inflate_AbcTwinSyncSse_JustInt =
-      _cst_inflate_AbcTwinSyncSse_JustIntPtr
-          .asFunction<ffi.Pointer<AbcTwinSyncSseKind> Function()>();
-
-  ffi.Pointer<ApplicationMessageKind>
-      cst_inflate_ApplicationMessage_DisplayMessage() {
-    return _cst_inflate_ApplicationMessage_DisplayMessage();
-  }
-
-  late final _cst_inflate_ApplicationMessage_DisplayMessagePtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<ApplicationMessageKind> Function()>>(
-      'cst_inflate_ApplicationMessage_DisplayMessage');
-  late final _cst_inflate_ApplicationMessage_DisplayMessage =
-      _cst_inflate_ApplicationMessage_DisplayMessagePtr
-          .asFunction<ffi.Pointer<ApplicationMessageKind> Function()>();
-
-  ffi.Pointer<ApplicationMessageKind>
-      cst_inflate_ApplicationMessage_RenderPixel() {
-    return _cst_inflate_ApplicationMessage_RenderPixel();
-  }
-
-  late final _cst_inflate_ApplicationMessage_RenderPixelPtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<ApplicationMessageKind> Function()>>(
-      'cst_inflate_ApplicationMessage_RenderPixel');
-  late final _cst_inflate_ApplicationMessage_RenderPixel =
-      _cst_inflate_ApplicationMessage_RenderPixelPtr
-          .asFunction<ffi.Pointer<ApplicationMessageKind> Function()>();
-
-  ffi.Pointer<CustomEnumErrorTwinNormalKind>
-      cst_inflate_CustomEnumErrorTwinNormal_One() {
-    return _cst_inflate_CustomEnumErrorTwinNormal_One();
-  }
-
-  late final _cst_inflate_CustomEnumErrorTwinNormal_OnePtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<CustomEnumErrorTwinNormalKind>
-              Function()>>('cst_inflate_CustomEnumErrorTwinNormal_One');
-  late final _cst_inflate_CustomEnumErrorTwinNormal_One =
-      _cst_inflate_CustomEnumErrorTwinNormal_OnePtr
-          .asFunction<ffi.Pointer<CustomEnumErrorTwinNormalKind> Function()>();
-
-  ffi.Pointer<CustomEnumErrorTwinNormalKind>
-      cst_inflate_CustomEnumErrorTwinNormal_Two() {
-    return _cst_inflate_CustomEnumErrorTwinNormal_Two();
-  }
-
-  late final _cst_inflate_CustomEnumErrorTwinNormal_TwoPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<CustomEnumErrorTwinNormalKind>
-              Function()>>('cst_inflate_CustomEnumErrorTwinNormal_Two');
-  late final _cst_inflate_CustomEnumErrorTwinNormal_Two =
-      _cst_inflate_CustomEnumErrorTwinNormal_TwoPtr
-          .asFunction<ffi.Pointer<CustomEnumErrorTwinNormalKind> Function()>();
-
-  ffi.Pointer<CustomEnumErrorTwinRustAsyncKind>
-      cst_inflate_CustomEnumErrorTwinRustAsync_One() {
-    return _cst_inflate_CustomEnumErrorTwinRustAsync_One();
-  }
-
-  late final _cst_inflate_CustomEnumErrorTwinRustAsync_OnePtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<CustomEnumErrorTwinRustAsyncKind>
-              Function()>>('cst_inflate_CustomEnumErrorTwinRustAsync_One');
-  late final _cst_inflate_CustomEnumErrorTwinRustAsync_One =
-      _cst_inflate_CustomEnumErrorTwinRustAsync_OnePtr.asFunction<
-          ffi.Pointer<CustomEnumErrorTwinRustAsyncKind> Function()>();
-
-  ffi.Pointer<CustomEnumErrorTwinRustAsyncKind>
-      cst_inflate_CustomEnumErrorTwinRustAsync_Two() {
-    return _cst_inflate_CustomEnumErrorTwinRustAsync_Two();
-  }
-
-  late final _cst_inflate_CustomEnumErrorTwinRustAsync_TwoPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<CustomEnumErrorTwinRustAsyncKind>
-              Function()>>('cst_inflate_CustomEnumErrorTwinRustAsync_Two');
-  late final _cst_inflate_CustomEnumErrorTwinRustAsync_Two =
-      _cst_inflate_CustomEnumErrorTwinRustAsync_TwoPtr.asFunction<
-          ffi.Pointer<CustomEnumErrorTwinRustAsyncKind> Function()>();
-
-  ffi.Pointer<CustomEnumErrorTwinRustAsyncSseKind>
-      cst_inflate_CustomEnumErrorTwinRustAsyncSse_One() {
-    return _cst_inflate_CustomEnumErrorTwinRustAsyncSse_One();
-  }
-
-  late final _cst_inflate_CustomEnumErrorTwinRustAsyncSse_OnePtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<CustomEnumErrorTwinRustAsyncSseKind>
-              Function()>>('cst_inflate_CustomEnumErrorTwinRustAsyncSse_One');
-  late final _cst_inflate_CustomEnumErrorTwinRustAsyncSse_One =
-      _cst_inflate_CustomEnumErrorTwinRustAsyncSse_OnePtr.asFunction<
-          ffi.Pointer<CustomEnumErrorTwinRustAsyncSseKind> Function()>();
-
-  ffi.Pointer<CustomEnumErrorTwinRustAsyncSseKind>
-      cst_inflate_CustomEnumErrorTwinRustAsyncSse_Two() {
-    return _cst_inflate_CustomEnumErrorTwinRustAsyncSse_Two();
-  }
-
-  late final _cst_inflate_CustomEnumErrorTwinRustAsyncSse_TwoPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<CustomEnumErrorTwinRustAsyncSseKind>
-              Function()>>('cst_inflate_CustomEnumErrorTwinRustAsyncSse_Two');
-  late final _cst_inflate_CustomEnumErrorTwinRustAsyncSse_Two =
-      _cst_inflate_CustomEnumErrorTwinRustAsyncSse_TwoPtr.asFunction<
-          ffi.Pointer<CustomEnumErrorTwinRustAsyncSseKind> Function()>();
-
-  ffi.Pointer<CustomEnumErrorTwinSseKind>
-      cst_inflate_CustomEnumErrorTwinSse_One() {
-    return _cst_inflate_CustomEnumErrorTwinSse_One();
-  }
-
-  late final _cst_inflate_CustomEnumErrorTwinSse_OnePtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<CustomEnumErrorTwinSseKind> Function()>>(
-      'cst_inflate_CustomEnumErrorTwinSse_One');
-  late final _cst_inflate_CustomEnumErrorTwinSse_One =
-      _cst_inflate_CustomEnumErrorTwinSse_OnePtr
-          .asFunction<ffi.Pointer<CustomEnumErrorTwinSseKind> Function()>();
-
-  ffi.Pointer<CustomEnumErrorTwinSseKind>
-      cst_inflate_CustomEnumErrorTwinSse_Two() {
-    return _cst_inflate_CustomEnumErrorTwinSse_Two();
-  }
-
-  late final _cst_inflate_CustomEnumErrorTwinSse_TwoPtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<CustomEnumErrorTwinSseKind> Function()>>(
-      'cst_inflate_CustomEnumErrorTwinSse_Two');
-  late final _cst_inflate_CustomEnumErrorTwinSse_Two =
-      _cst_inflate_CustomEnumErrorTwinSse_TwoPtr
-          .asFunction<ffi.Pointer<CustomEnumErrorTwinSseKind> Function()>();
-
-  ffi.Pointer<CustomEnumErrorTwinSyncKind>
-      cst_inflate_CustomEnumErrorTwinSync_One() {
-    return _cst_inflate_CustomEnumErrorTwinSync_One();
-  }
-
-  late final _cst_inflate_CustomEnumErrorTwinSync_OnePtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<CustomEnumErrorTwinSyncKind> Function()>>(
-      'cst_inflate_CustomEnumErrorTwinSync_One');
-  late final _cst_inflate_CustomEnumErrorTwinSync_One =
-      _cst_inflate_CustomEnumErrorTwinSync_OnePtr
-          .asFunction<ffi.Pointer<CustomEnumErrorTwinSyncKind> Function()>();
-
-  ffi.Pointer<CustomEnumErrorTwinSyncKind>
-      cst_inflate_CustomEnumErrorTwinSync_Two() {
-    return _cst_inflate_CustomEnumErrorTwinSync_Two();
-  }
-
-  late final _cst_inflate_CustomEnumErrorTwinSync_TwoPtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<CustomEnumErrorTwinSyncKind> Function()>>(
-      'cst_inflate_CustomEnumErrorTwinSync_Two');
-  late final _cst_inflate_CustomEnumErrorTwinSync_Two =
-      _cst_inflate_CustomEnumErrorTwinSync_TwoPtr
-          .asFunction<ffi.Pointer<CustomEnumErrorTwinSyncKind> Function()>();
-
-  ffi.Pointer<CustomEnumErrorTwinSyncSseKind>
-      cst_inflate_CustomEnumErrorTwinSyncSse_One() {
-    return _cst_inflate_CustomEnumErrorTwinSyncSse_One();
-  }
-
-  late final _cst_inflate_CustomEnumErrorTwinSyncSse_OnePtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<CustomEnumErrorTwinSyncSseKind>
-              Function()>>('cst_inflate_CustomEnumErrorTwinSyncSse_One');
-  late final _cst_inflate_CustomEnumErrorTwinSyncSse_One =
-      _cst_inflate_CustomEnumErrorTwinSyncSse_OnePtr
-          .asFunction<ffi.Pointer<CustomEnumErrorTwinSyncSseKind> Function()>();
-
-  ffi.Pointer<CustomEnumErrorTwinSyncSseKind>
-      cst_inflate_CustomEnumErrorTwinSyncSse_Two() {
-    return _cst_inflate_CustomEnumErrorTwinSyncSse_Two();
-  }
-
-  late final _cst_inflate_CustomEnumErrorTwinSyncSse_TwoPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<CustomEnumErrorTwinSyncSseKind>
-              Function()>>('cst_inflate_CustomEnumErrorTwinSyncSse_Two');
-  late final _cst_inflate_CustomEnumErrorTwinSyncSse_Two =
-      _cst_inflate_CustomEnumErrorTwinSyncSse_TwoPtr
-          .asFunction<ffi.Pointer<CustomEnumErrorTwinSyncSseKind> Function()>();
-
-  ffi.Pointer<CustomErrorTwinNormalKind>
-      cst_inflate_CustomErrorTwinNormal_Error0() {
-    return _cst_inflate_CustomErrorTwinNormal_Error0();
-  }
-
-  late final _cst_inflate_CustomErrorTwinNormal_Error0Ptr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<CustomErrorTwinNormalKind> Function()>>(
-      'cst_inflate_CustomErrorTwinNormal_Error0');
-  late final _cst_inflate_CustomErrorTwinNormal_Error0 =
-      _cst_inflate_CustomErrorTwinNormal_Error0Ptr
-          .asFunction<ffi.Pointer<CustomErrorTwinNormalKind> Function()>();
-
-  ffi.Pointer<CustomErrorTwinNormalKind>
-      cst_inflate_CustomErrorTwinNormal_Error1() {
-    return _cst_inflate_CustomErrorTwinNormal_Error1();
-  }
-
-  late final _cst_inflate_CustomErrorTwinNormal_Error1Ptr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<CustomErrorTwinNormalKind> Function()>>(
-      'cst_inflate_CustomErrorTwinNormal_Error1');
-  late final _cst_inflate_CustomErrorTwinNormal_Error1 =
-      _cst_inflate_CustomErrorTwinNormal_Error1Ptr
-          .asFunction<ffi.Pointer<CustomErrorTwinNormalKind> Function()>();
-
-  ffi.Pointer<CustomErrorTwinRustAsyncKind>
-      cst_inflate_CustomErrorTwinRustAsync_Error0() {
-    return _cst_inflate_CustomErrorTwinRustAsync_Error0();
-  }
-
-  late final _cst_inflate_CustomErrorTwinRustAsync_Error0Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<CustomErrorTwinRustAsyncKind>
-              Function()>>('cst_inflate_CustomErrorTwinRustAsync_Error0');
-  late final _cst_inflate_CustomErrorTwinRustAsync_Error0 =
-      _cst_inflate_CustomErrorTwinRustAsync_Error0Ptr
-          .asFunction<ffi.Pointer<CustomErrorTwinRustAsyncKind> Function()>();
-
-  ffi.Pointer<CustomErrorTwinRustAsyncKind>
-      cst_inflate_CustomErrorTwinRustAsync_Error1() {
-    return _cst_inflate_CustomErrorTwinRustAsync_Error1();
-  }
-
-  late final _cst_inflate_CustomErrorTwinRustAsync_Error1Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<CustomErrorTwinRustAsyncKind>
-              Function()>>('cst_inflate_CustomErrorTwinRustAsync_Error1');
-  late final _cst_inflate_CustomErrorTwinRustAsync_Error1 =
-      _cst_inflate_CustomErrorTwinRustAsync_Error1Ptr
-          .asFunction<ffi.Pointer<CustomErrorTwinRustAsyncKind> Function()>();
-
-  ffi.Pointer<CustomErrorTwinRustAsyncSseKind>
-      cst_inflate_CustomErrorTwinRustAsyncSse_Error0() {
-    return _cst_inflate_CustomErrorTwinRustAsyncSse_Error0();
-  }
-
-  late final _cst_inflate_CustomErrorTwinRustAsyncSse_Error0Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<CustomErrorTwinRustAsyncSseKind>
-              Function()>>('cst_inflate_CustomErrorTwinRustAsyncSse_Error0');
-  late final _cst_inflate_CustomErrorTwinRustAsyncSse_Error0 =
-      _cst_inflate_CustomErrorTwinRustAsyncSse_Error0Ptr.asFunction<
-          ffi.Pointer<CustomErrorTwinRustAsyncSseKind> Function()>();
-
-  ffi.Pointer<CustomErrorTwinRustAsyncSseKind>
-      cst_inflate_CustomErrorTwinRustAsyncSse_Error1() {
-    return _cst_inflate_CustomErrorTwinRustAsyncSse_Error1();
-  }
-
-  late final _cst_inflate_CustomErrorTwinRustAsyncSse_Error1Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<CustomErrorTwinRustAsyncSseKind>
-              Function()>>('cst_inflate_CustomErrorTwinRustAsyncSse_Error1');
-  late final _cst_inflate_CustomErrorTwinRustAsyncSse_Error1 =
-      _cst_inflate_CustomErrorTwinRustAsyncSse_Error1Ptr.asFunction<
-          ffi.Pointer<CustomErrorTwinRustAsyncSseKind> Function()>();
-
-  ffi.Pointer<CustomErrorTwinSseKind> cst_inflate_CustomErrorTwinSse_Error0() {
-    return _cst_inflate_CustomErrorTwinSse_Error0();
-  }
-
-  late final _cst_inflate_CustomErrorTwinSse_Error0Ptr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<CustomErrorTwinSseKind> Function()>>(
-      'cst_inflate_CustomErrorTwinSse_Error0');
-  late final _cst_inflate_CustomErrorTwinSse_Error0 =
-      _cst_inflate_CustomErrorTwinSse_Error0Ptr
-          .asFunction<ffi.Pointer<CustomErrorTwinSseKind> Function()>();
-
-  ffi.Pointer<CustomErrorTwinSseKind> cst_inflate_CustomErrorTwinSse_Error1() {
-    return _cst_inflate_CustomErrorTwinSse_Error1();
-  }
-
-  late final _cst_inflate_CustomErrorTwinSse_Error1Ptr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<CustomErrorTwinSseKind> Function()>>(
-      'cst_inflate_CustomErrorTwinSse_Error1');
-  late final _cst_inflate_CustomErrorTwinSse_Error1 =
-      _cst_inflate_CustomErrorTwinSse_Error1Ptr
-          .asFunction<ffi.Pointer<CustomErrorTwinSseKind> Function()>();
-
-  ffi.Pointer<CustomErrorTwinSyncKind>
-      cst_inflate_CustomErrorTwinSync_Error0() {
-    return _cst_inflate_CustomErrorTwinSync_Error0();
-  }
-
-  late final _cst_inflate_CustomErrorTwinSync_Error0Ptr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<CustomErrorTwinSyncKind> Function()>>(
-      'cst_inflate_CustomErrorTwinSync_Error0');
-  late final _cst_inflate_CustomErrorTwinSync_Error0 =
-      _cst_inflate_CustomErrorTwinSync_Error0Ptr
-          .asFunction<ffi.Pointer<CustomErrorTwinSyncKind> Function()>();
-
-  ffi.Pointer<CustomErrorTwinSyncKind>
-      cst_inflate_CustomErrorTwinSync_Error1() {
-    return _cst_inflate_CustomErrorTwinSync_Error1();
-  }
-
-  late final _cst_inflate_CustomErrorTwinSync_Error1Ptr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<CustomErrorTwinSyncKind> Function()>>(
-      'cst_inflate_CustomErrorTwinSync_Error1');
-  late final _cst_inflate_CustomErrorTwinSync_Error1 =
-      _cst_inflate_CustomErrorTwinSync_Error1Ptr
-          .asFunction<ffi.Pointer<CustomErrorTwinSyncKind> Function()>();
-
-  ffi.Pointer<CustomErrorTwinSyncSseKind>
-      cst_inflate_CustomErrorTwinSyncSse_Error0() {
-    return _cst_inflate_CustomErrorTwinSyncSse_Error0();
-  }
-
-  late final _cst_inflate_CustomErrorTwinSyncSse_Error0Ptr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<CustomErrorTwinSyncSseKind> Function()>>(
-      'cst_inflate_CustomErrorTwinSyncSse_Error0');
-  late final _cst_inflate_CustomErrorTwinSyncSse_Error0 =
-      _cst_inflate_CustomErrorTwinSyncSse_Error0Ptr
-          .asFunction<ffi.Pointer<CustomErrorTwinSyncSseKind> Function()>();
-
-  ffi.Pointer<CustomErrorTwinSyncSseKind>
-      cst_inflate_CustomErrorTwinSyncSse_Error1() {
-    return _cst_inflate_CustomErrorTwinSyncSse_Error1();
-  }
-
-  late final _cst_inflate_CustomErrorTwinSyncSse_Error1Ptr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<CustomErrorTwinSyncSseKind> Function()>>(
-      'cst_inflate_CustomErrorTwinSyncSse_Error1');
-  late final _cst_inflate_CustomErrorTwinSyncSse_Error1 =
-      _cst_inflate_CustomErrorTwinSyncSse_Error1Ptr
-          .asFunction<ffi.Pointer<CustomErrorTwinSyncSseKind> Function()>();
-
-  ffi.Pointer<CustomNestedError1TwinNormalKind>
-      cst_inflate_CustomNestedError1TwinNormal_CustomNested1() {
-    return _cst_inflate_CustomNestedError1TwinNormal_CustomNested1();
-  }
-
-  late final _cst_inflate_CustomNestedError1TwinNormal_CustomNested1Ptr =
-      _lookup<
-              ffi.NativeFunction<
-                  ffi.Pointer<CustomNestedError1TwinNormalKind> Function()>>(
-          'cst_inflate_CustomNestedError1TwinNormal_CustomNested1');
-  late final _cst_inflate_CustomNestedError1TwinNormal_CustomNested1 =
-      _cst_inflate_CustomNestedError1TwinNormal_CustomNested1Ptr.asFunction<
-          ffi.Pointer<CustomNestedError1TwinNormalKind> Function()>();
-
-  ffi.Pointer<CustomNestedError1TwinNormalKind>
-      cst_inflate_CustomNestedError1TwinNormal_ErrorNested() {
-    return _cst_inflate_CustomNestedError1TwinNormal_ErrorNested();
-  }
-
-  late final _cst_inflate_CustomNestedError1TwinNormal_ErrorNestedPtr = _lookup<
-          ffi.NativeFunction<
-              ffi.Pointer<CustomNestedError1TwinNormalKind> Function()>>(
-      'cst_inflate_CustomNestedError1TwinNormal_ErrorNested');
-  late final _cst_inflate_CustomNestedError1TwinNormal_ErrorNested =
-      _cst_inflate_CustomNestedError1TwinNormal_ErrorNestedPtr.asFunction<
-          ffi.Pointer<CustomNestedError1TwinNormalKind> Function()>();
-
-  ffi.Pointer<CustomNestedError1TwinRustAsyncKind>
-      cst_inflate_CustomNestedError1TwinRustAsync_CustomNested1() {
-    return _cst_inflate_CustomNestedError1TwinRustAsync_CustomNested1();
-  }
-
-  late final _cst_inflate_CustomNestedError1TwinRustAsync_CustomNested1Ptr =
-      _lookup<
-              ffi.NativeFunction<
-                  ffi.Pointer<CustomNestedError1TwinRustAsyncKind> Function()>>(
-          'cst_inflate_CustomNestedError1TwinRustAsync_CustomNested1');
-  late final _cst_inflate_CustomNestedError1TwinRustAsync_CustomNested1 =
-      _cst_inflate_CustomNestedError1TwinRustAsync_CustomNested1Ptr.asFunction<
-          ffi.Pointer<CustomNestedError1TwinRustAsyncKind> Function()>();
-
-  ffi.Pointer<CustomNestedError1TwinRustAsyncKind>
-      cst_inflate_CustomNestedError1TwinRustAsync_ErrorNested() {
-    return _cst_inflate_CustomNestedError1TwinRustAsync_ErrorNested();
-  }
-
-  late final _cst_inflate_CustomNestedError1TwinRustAsync_ErrorNestedPtr =
-      _lookup<
-              ffi.NativeFunction<
-                  ffi.Pointer<CustomNestedError1TwinRustAsyncKind> Function()>>(
-          'cst_inflate_CustomNestedError1TwinRustAsync_ErrorNested');
-  late final _cst_inflate_CustomNestedError1TwinRustAsync_ErrorNested =
-      _cst_inflate_CustomNestedError1TwinRustAsync_ErrorNestedPtr.asFunction<
-          ffi.Pointer<CustomNestedError1TwinRustAsyncKind> Function()>();
-
-  ffi.Pointer<CustomNestedError1TwinRustAsyncSseKind>
-      cst_inflate_CustomNestedError1TwinRustAsyncSse_CustomNested1() {
-    return _cst_inflate_CustomNestedError1TwinRustAsyncSse_CustomNested1();
-  }
-
-  late final _cst_inflate_CustomNestedError1TwinRustAsyncSse_CustomNested1Ptr =
-      _lookup<
-              ffi.NativeFunction<
-                  ffi.Pointer<CustomNestedError1TwinRustAsyncSseKind>
-                      Function()>>(
-          'cst_inflate_CustomNestedError1TwinRustAsyncSse_CustomNested1');
-  late final _cst_inflate_CustomNestedError1TwinRustAsyncSse_CustomNested1 =
-      _cst_inflate_CustomNestedError1TwinRustAsyncSse_CustomNested1Ptr
-          .asFunction<
-              ffi.Pointer<CustomNestedError1TwinRustAsyncSseKind> Function()>();
-
-  ffi.Pointer<CustomNestedError1TwinRustAsyncSseKind>
-      cst_inflate_CustomNestedError1TwinRustAsyncSse_ErrorNested() {
-    return _cst_inflate_CustomNestedError1TwinRustAsyncSse_ErrorNested();
-  }
-
-  late final _cst_inflate_CustomNestedError1TwinRustAsyncSse_ErrorNestedPtr =
-      _lookup<
-              ffi.NativeFunction<
-                  ffi.Pointer<CustomNestedError1TwinRustAsyncSseKind>
-                      Function()>>(
-          'cst_inflate_CustomNestedError1TwinRustAsyncSse_ErrorNested');
-  late final _cst_inflate_CustomNestedError1TwinRustAsyncSse_ErrorNested =
-      _cst_inflate_CustomNestedError1TwinRustAsyncSse_ErrorNestedPtr.asFunction<
-          ffi.Pointer<CustomNestedError1TwinRustAsyncSseKind> Function()>();
-
-  ffi.Pointer<CustomNestedError1TwinSseKind>
-      cst_inflate_CustomNestedError1TwinSse_CustomNested1() {
-    return _cst_inflate_CustomNestedError1TwinSse_CustomNested1();
-  }
-
-  late final _cst_inflate_CustomNestedError1TwinSse_CustomNested1Ptr = _lookup<
-          ffi.NativeFunction<
-              ffi.Pointer<CustomNestedError1TwinSseKind> Function()>>(
-      'cst_inflate_CustomNestedError1TwinSse_CustomNested1');
-  late final _cst_inflate_CustomNestedError1TwinSse_CustomNested1 =
-      _cst_inflate_CustomNestedError1TwinSse_CustomNested1Ptr
-          .asFunction<ffi.Pointer<CustomNestedError1TwinSseKind> Function()>();
-
-  ffi.Pointer<CustomNestedError1TwinSseKind>
-      cst_inflate_CustomNestedError1TwinSse_ErrorNested() {
-    return _cst_inflate_CustomNestedError1TwinSse_ErrorNested();
-  }
-
-  late final _cst_inflate_CustomNestedError1TwinSse_ErrorNestedPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<CustomNestedError1TwinSseKind>
-              Function()>>('cst_inflate_CustomNestedError1TwinSse_ErrorNested');
-  late final _cst_inflate_CustomNestedError1TwinSse_ErrorNested =
-      _cst_inflate_CustomNestedError1TwinSse_ErrorNestedPtr
-          .asFunction<ffi.Pointer<CustomNestedError1TwinSseKind> Function()>();
-
-  ffi.Pointer<CustomNestedError1TwinSyncKind>
-      cst_inflate_CustomNestedError1TwinSync_CustomNested1() {
-    return _cst_inflate_CustomNestedError1TwinSync_CustomNested1();
-  }
-
-  late final _cst_inflate_CustomNestedError1TwinSync_CustomNested1Ptr = _lookup<
-          ffi.NativeFunction<
-              ffi.Pointer<CustomNestedError1TwinSyncKind> Function()>>(
-      'cst_inflate_CustomNestedError1TwinSync_CustomNested1');
-  late final _cst_inflate_CustomNestedError1TwinSync_CustomNested1 =
-      _cst_inflate_CustomNestedError1TwinSync_CustomNested1Ptr
-          .asFunction<ffi.Pointer<CustomNestedError1TwinSyncKind> Function()>();
-
-  ffi.Pointer<CustomNestedError1TwinSyncKind>
-      cst_inflate_CustomNestedError1TwinSync_ErrorNested() {
-    return _cst_inflate_CustomNestedError1TwinSync_ErrorNested();
-  }
-
-  late final _cst_inflate_CustomNestedError1TwinSync_ErrorNestedPtr = _lookup<
-          ffi.NativeFunction<
-              ffi.Pointer<CustomNestedError1TwinSyncKind> Function()>>(
-      'cst_inflate_CustomNestedError1TwinSync_ErrorNested');
-  late final _cst_inflate_CustomNestedError1TwinSync_ErrorNested =
-      _cst_inflate_CustomNestedError1TwinSync_ErrorNestedPtr
-          .asFunction<ffi.Pointer<CustomNestedError1TwinSyncKind> Function()>();
-
-  ffi.Pointer<CustomNestedError1TwinSyncSseKind>
-      cst_inflate_CustomNestedError1TwinSyncSse_CustomNested1() {
-    return _cst_inflate_CustomNestedError1TwinSyncSse_CustomNested1();
-  }
-
-  late final _cst_inflate_CustomNestedError1TwinSyncSse_CustomNested1Ptr =
-      _lookup<
-              ffi.NativeFunction<
-                  ffi.Pointer<CustomNestedError1TwinSyncSseKind> Function()>>(
-          'cst_inflate_CustomNestedError1TwinSyncSse_CustomNested1');
-  late final _cst_inflate_CustomNestedError1TwinSyncSse_CustomNested1 =
-      _cst_inflate_CustomNestedError1TwinSyncSse_CustomNested1Ptr.asFunction<
-          ffi.Pointer<CustomNestedError1TwinSyncSseKind> Function()>();
-
-  ffi.Pointer<CustomNestedError1TwinSyncSseKind>
-      cst_inflate_CustomNestedError1TwinSyncSse_ErrorNested() {
-    return _cst_inflate_CustomNestedError1TwinSyncSse_ErrorNested();
-  }
-
-  late final _cst_inflate_CustomNestedError1TwinSyncSse_ErrorNestedPtr =
-      _lookup<
-              ffi.NativeFunction<
-                  ffi.Pointer<CustomNestedError1TwinSyncSseKind> Function()>>(
-          'cst_inflate_CustomNestedError1TwinSyncSse_ErrorNested');
-  late final _cst_inflate_CustomNestedError1TwinSyncSse_ErrorNested =
-      _cst_inflate_CustomNestedError1TwinSyncSse_ErrorNestedPtr.asFunction<
-          ffi.Pointer<CustomNestedError1TwinSyncSseKind> Function()>();
-
-  ffi.Pointer<CustomNestedError2TwinNormalKind>
-      cst_inflate_CustomNestedError2TwinNormal_CustomNested2() {
-    return _cst_inflate_CustomNestedError2TwinNormal_CustomNested2();
-  }
-
-  late final _cst_inflate_CustomNestedError2TwinNormal_CustomNested2Ptr =
-      _lookup<
-              ffi.NativeFunction<
-                  ffi.Pointer<CustomNestedError2TwinNormalKind> Function()>>(
-          'cst_inflate_CustomNestedError2TwinNormal_CustomNested2');
-  late final _cst_inflate_CustomNestedError2TwinNormal_CustomNested2 =
-      _cst_inflate_CustomNestedError2TwinNormal_CustomNested2Ptr.asFunction<
-          ffi.Pointer<CustomNestedError2TwinNormalKind> Function()>();
-
-  ffi.Pointer<CustomNestedError2TwinNormalKind>
-      cst_inflate_CustomNestedError2TwinNormal_CustomNested2Number() {
-    return _cst_inflate_CustomNestedError2TwinNormal_CustomNested2Number();
-  }
-
-  late final _cst_inflate_CustomNestedError2TwinNormal_CustomNested2NumberPtr =
-      _lookup<
-              ffi.NativeFunction<
-                  ffi.Pointer<CustomNestedError2TwinNormalKind> Function()>>(
-          'cst_inflate_CustomNestedError2TwinNormal_CustomNested2Number');
-  late final _cst_inflate_CustomNestedError2TwinNormal_CustomNested2Number =
-      _cst_inflate_CustomNestedError2TwinNormal_CustomNested2NumberPtr
-          .asFunction<
-              ffi.Pointer<CustomNestedError2TwinNormalKind> Function()>();
-
-  ffi.Pointer<CustomNestedError2TwinRustAsyncKind>
-      cst_inflate_CustomNestedError2TwinRustAsync_CustomNested2() {
-    return _cst_inflate_CustomNestedError2TwinRustAsync_CustomNested2();
-  }
-
-  late final _cst_inflate_CustomNestedError2TwinRustAsync_CustomNested2Ptr =
-      _lookup<
-              ffi.NativeFunction<
-                  ffi.Pointer<CustomNestedError2TwinRustAsyncKind> Function()>>(
-          'cst_inflate_CustomNestedError2TwinRustAsync_CustomNested2');
-  late final _cst_inflate_CustomNestedError2TwinRustAsync_CustomNested2 =
-      _cst_inflate_CustomNestedError2TwinRustAsync_CustomNested2Ptr.asFunction<
-          ffi.Pointer<CustomNestedError2TwinRustAsyncKind> Function()>();
-
-  ffi.Pointer<CustomNestedError2TwinRustAsyncKind>
-      cst_inflate_CustomNestedError2TwinRustAsync_CustomNested2Number() {
-    return _cst_inflate_CustomNestedError2TwinRustAsync_CustomNested2Number();
-  }
-
-  late final _cst_inflate_CustomNestedError2TwinRustAsync_CustomNested2NumberPtr =
-      _lookup<
-              ffi.NativeFunction<
-                  ffi.Pointer<CustomNestedError2TwinRustAsyncKind> Function()>>(
-          'cst_inflate_CustomNestedError2TwinRustAsync_CustomNested2Number');
-  late final _cst_inflate_CustomNestedError2TwinRustAsync_CustomNested2Number =
-      _cst_inflate_CustomNestedError2TwinRustAsync_CustomNested2NumberPtr
-          .asFunction<
-              ffi.Pointer<CustomNestedError2TwinRustAsyncKind> Function()>();
-
-  ffi.Pointer<CustomNestedError2TwinRustAsyncSseKind>
-      cst_inflate_CustomNestedError2TwinRustAsyncSse_CustomNested2() {
-    return _cst_inflate_CustomNestedError2TwinRustAsyncSse_CustomNested2();
-  }
-
-  late final _cst_inflate_CustomNestedError2TwinRustAsyncSse_CustomNested2Ptr =
-      _lookup<
-              ffi.NativeFunction<
-                  ffi.Pointer<CustomNestedError2TwinRustAsyncSseKind>
-                      Function()>>(
-          'cst_inflate_CustomNestedError2TwinRustAsyncSse_CustomNested2');
-  late final _cst_inflate_CustomNestedError2TwinRustAsyncSse_CustomNested2 =
-      _cst_inflate_CustomNestedError2TwinRustAsyncSse_CustomNested2Ptr
-          .asFunction<
-              ffi.Pointer<CustomNestedError2TwinRustAsyncSseKind> Function()>();
-
-  ffi.Pointer<CustomNestedError2TwinRustAsyncSseKind>
-      cst_inflate_CustomNestedError2TwinRustAsyncSse_CustomNested2Number() {
-    return _cst_inflate_CustomNestedError2TwinRustAsyncSse_CustomNested2Number();
-  }
-
-  late final _cst_inflate_CustomNestedError2TwinRustAsyncSse_CustomNested2NumberPtr =
-      _lookup<
-              ffi.NativeFunction<
-                  ffi.Pointer<CustomNestedError2TwinRustAsyncSseKind>
-                      Function()>>(
-          'cst_inflate_CustomNestedError2TwinRustAsyncSse_CustomNested2Number');
-  late final _cst_inflate_CustomNestedError2TwinRustAsyncSse_CustomNested2Number =
-      _cst_inflate_CustomNestedError2TwinRustAsyncSse_CustomNested2NumberPtr
-          .asFunction<
-              ffi.Pointer<CustomNestedError2TwinRustAsyncSseKind> Function()>();
-
-  ffi.Pointer<CustomNestedError2TwinSseKind>
-      cst_inflate_CustomNestedError2TwinSse_CustomNested2() {
-    return _cst_inflate_CustomNestedError2TwinSse_CustomNested2();
-  }
-
-  late final _cst_inflate_CustomNestedError2TwinSse_CustomNested2Ptr = _lookup<
-          ffi.NativeFunction<
-              ffi.Pointer<CustomNestedError2TwinSseKind> Function()>>(
-      'cst_inflate_CustomNestedError2TwinSse_CustomNested2');
-  late final _cst_inflate_CustomNestedError2TwinSse_CustomNested2 =
-      _cst_inflate_CustomNestedError2TwinSse_CustomNested2Ptr
-          .asFunction<ffi.Pointer<CustomNestedError2TwinSseKind> Function()>();
-
-  ffi.Pointer<CustomNestedError2TwinSseKind>
-      cst_inflate_CustomNestedError2TwinSse_CustomNested2Number() {
-    return _cst_inflate_CustomNestedError2TwinSse_CustomNested2Number();
-  }
-
-  late final _cst_inflate_CustomNestedError2TwinSse_CustomNested2NumberPtr =
-      _lookup<
-              ffi.NativeFunction<
-                  ffi.Pointer<CustomNestedError2TwinSseKind> Function()>>(
-          'cst_inflate_CustomNestedError2TwinSse_CustomNested2Number');
-  late final _cst_inflate_CustomNestedError2TwinSse_CustomNested2Number =
-      _cst_inflate_CustomNestedError2TwinSse_CustomNested2NumberPtr
-          .asFunction<ffi.Pointer<CustomNestedError2TwinSseKind> Function()>();
-
-  ffi.Pointer<CustomNestedError2TwinSyncKind>
-      cst_inflate_CustomNestedError2TwinSync_CustomNested2() {
-    return _cst_inflate_CustomNestedError2TwinSync_CustomNested2();
-  }
-
-  late final _cst_inflate_CustomNestedError2TwinSync_CustomNested2Ptr = _lookup<
-          ffi.NativeFunction<
-              ffi.Pointer<CustomNestedError2TwinSyncKind> Function()>>(
-      'cst_inflate_CustomNestedError2TwinSync_CustomNested2');
-  late final _cst_inflate_CustomNestedError2TwinSync_CustomNested2 =
-      _cst_inflate_CustomNestedError2TwinSync_CustomNested2Ptr
-          .asFunction<ffi.Pointer<CustomNestedError2TwinSyncKind> Function()>();
-
-  ffi.Pointer<CustomNestedError2TwinSyncKind>
-      cst_inflate_CustomNestedError2TwinSync_CustomNested2Number() {
-    return _cst_inflate_CustomNestedError2TwinSync_CustomNested2Number();
-  }
-
-  late final _cst_inflate_CustomNestedError2TwinSync_CustomNested2NumberPtr =
-      _lookup<
-              ffi.NativeFunction<
-                  ffi.Pointer<CustomNestedError2TwinSyncKind> Function()>>(
-          'cst_inflate_CustomNestedError2TwinSync_CustomNested2Number');
-  late final _cst_inflate_CustomNestedError2TwinSync_CustomNested2Number =
-      _cst_inflate_CustomNestedError2TwinSync_CustomNested2NumberPtr
-          .asFunction<ffi.Pointer<CustomNestedError2TwinSyncKind> Function()>();
-
-  ffi.Pointer<CustomNestedError2TwinSyncSseKind>
-      cst_inflate_CustomNestedError2TwinSyncSse_CustomNested2() {
-    return _cst_inflate_CustomNestedError2TwinSyncSse_CustomNested2();
-  }
-
-  late final _cst_inflate_CustomNestedError2TwinSyncSse_CustomNested2Ptr =
-      _lookup<
-              ffi.NativeFunction<
-                  ffi.Pointer<CustomNestedError2TwinSyncSseKind> Function()>>(
-          'cst_inflate_CustomNestedError2TwinSyncSse_CustomNested2');
-  late final _cst_inflate_CustomNestedError2TwinSyncSse_CustomNested2 =
-      _cst_inflate_CustomNestedError2TwinSyncSse_CustomNested2Ptr.asFunction<
-          ffi.Pointer<CustomNestedError2TwinSyncSseKind> Function()>();
-
-  ffi.Pointer<CustomNestedError2TwinSyncSseKind>
-      cst_inflate_CustomNestedError2TwinSyncSse_CustomNested2Number() {
-    return _cst_inflate_CustomNestedError2TwinSyncSse_CustomNested2Number();
-  }
-
-  late final _cst_inflate_CustomNestedError2TwinSyncSse_CustomNested2NumberPtr =
-      _lookup<
-              ffi.NativeFunction<
-                  ffi.Pointer<CustomNestedError2TwinSyncSseKind> Function()>>(
-          'cst_inflate_CustomNestedError2TwinSyncSse_CustomNested2Number');
-  late final _cst_inflate_CustomNestedError2TwinSyncSse_CustomNested2Number =
-      _cst_inflate_CustomNestedError2TwinSyncSse_CustomNested2NumberPtr
-          .asFunction<
-              ffi.Pointer<CustomNestedError2TwinSyncSseKind> Function()>();
-
-  ffi.Pointer<CustomNestedErrorInnerTwinNormalKind>
-      cst_inflate_CustomNestedErrorInnerTwinNormal_Three() {
-    return _cst_inflate_CustomNestedErrorInnerTwinNormal_Three();
-  }
-
-  late final _cst_inflate_CustomNestedErrorInnerTwinNormal_ThreePtr = _lookup<
-          ffi.NativeFunction<
-              ffi.Pointer<CustomNestedErrorInnerTwinNormalKind> Function()>>(
-      'cst_inflate_CustomNestedErrorInnerTwinNormal_Three');
-  late final _cst_inflate_CustomNestedErrorInnerTwinNormal_Three =
-      _cst_inflate_CustomNestedErrorInnerTwinNormal_ThreePtr.asFunction<
-          ffi.Pointer<CustomNestedErrorInnerTwinNormalKind> Function()>();
-
-  ffi.Pointer<CustomNestedErrorInnerTwinNormalKind>
-      cst_inflate_CustomNestedErrorInnerTwinNormal_Four() {
-    return _cst_inflate_CustomNestedErrorInnerTwinNormal_Four();
-  }
-
-  late final _cst_inflate_CustomNestedErrorInnerTwinNormal_FourPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<CustomNestedErrorInnerTwinNormalKind>
-              Function()>>('cst_inflate_CustomNestedErrorInnerTwinNormal_Four');
-  late final _cst_inflate_CustomNestedErrorInnerTwinNormal_Four =
-      _cst_inflate_CustomNestedErrorInnerTwinNormal_FourPtr.asFunction<
-          ffi.Pointer<CustomNestedErrorInnerTwinNormalKind> Function()>();
-
-  ffi.Pointer<CustomNestedErrorInnerTwinRustAsyncKind>
-      cst_inflate_CustomNestedErrorInnerTwinRustAsync_Three() {
-    return _cst_inflate_CustomNestedErrorInnerTwinRustAsync_Three();
-  }
-
-  late final _cst_inflate_CustomNestedErrorInnerTwinRustAsync_ThreePtr =
-      _lookup<
-              ffi.NativeFunction<
-                  ffi.Pointer<CustomNestedErrorInnerTwinRustAsyncKind>
-                      Function()>>(
-          'cst_inflate_CustomNestedErrorInnerTwinRustAsync_Three');
-  late final _cst_inflate_CustomNestedErrorInnerTwinRustAsync_Three =
-      _cst_inflate_CustomNestedErrorInnerTwinRustAsync_ThreePtr.asFunction<
-          ffi.Pointer<CustomNestedErrorInnerTwinRustAsyncKind> Function()>();
-
-  ffi.Pointer<CustomNestedErrorInnerTwinRustAsyncKind>
-      cst_inflate_CustomNestedErrorInnerTwinRustAsync_Four() {
-    return _cst_inflate_CustomNestedErrorInnerTwinRustAsync_Four();
-  }
-
-  late final _cst_inflate_CustomNestedErrorInnerTwinRustAsync_FourPtr = _lookup<
-          ffi.NativeFunction<
-              ffi.Pointer<CustomNestedErrorInnerTwinRustAsyncKind> Function()>>(
-      'cst_inflate_CustomNestedErrorInnerTwinRustAsync_Four');
-  late final _cst_inflate_CustomNestedErrorInnerTwinRustAsync_Four =
-      _cst_inflate_CustomNestedErrorInnerTwinRustAsync_FourPtr.asFunction<
-          ffi.Pointer<CustomNestedErrorInnerTwinRustAsyncKind> Function()>();
-
-  ffi.Pointer<CustomNestedErrorInnerTwinRustAsyncSseKind>
-      cst_inflate_CustomNestedErrorInnerTwinRustAsyncSse_Three() {
-    return _cst_inflate_CustomNestedErrorInnerTwinRustAsyncSse_Three();
-  }
-
-  late final _cst_inflate_CustomNestedErrorInnerTwinRustAsyncSse_ThreePtr =
-      _lookup<
-              ffi.NativeFunction<
-                  ffi.Pointer<CustomNestedErrorInnerTwinRustAsyncSseKind>
-                      Function()>>(
-          'cst_inflate_CustomNestedErrorInnerTwinRustAsyncSse_Three');
-  late final _cst_inflate_CustomNestedErrorInnerTwinRustAsyncSse_Three =
-      _cst_inflate_CustomNestedErrorInnerTwinRustAsyncSse_ThreePtr.asFunction<
-          ffi.Pointer<CustomNestedErrorInnerTwinRustAsyncSseKind> Function()>();
-
-  ffi.Pointer<CustomNestedErrorInnerTwinRustAsyncSseKind>
-      cst_inflate_CustomNestedErrorInnerTwinRustAsyncSse_Four() {
-    return _cst_inflate_CustomNestedErrorInnerTwinRustAsyncSse_Four();
-  }
-
-  late final _cst_inflate_CustomNestedErrorInnerTwinRustAsyncSse_FourPtr =
-      _lookup<
-              ffi.NativeFunction<
-                  ffi.Pointer<CustomNestedErrorInnerTwinRustAsyncSseKind>
-                      Function()>>(
-          'cst_inflate_CustomNestedErrorInnerTwinRustAsyncSse_Four');
-  late final _cst_inflate_CustomNestedErrorInnerTwinRustAsyncSse_Four =
-      _cst_inflate_CustomNestedErrorInnerTwinRustAsyncSse_FourPtr.asFunction<
-          ffi.Pointer<CustomNestedErrorInnerTwinRustAsyncSseKind> Function()>();
-
-  ffi.Pointer<CustomNestedErrorInnerTwinSseKind>
-      cst_inflate_CustomNestedErrorInnerTwinSse_Three() {
-    return _cst_inflate_CustomNestedErrorInnerTwinSse_Three();
-  }
-
-  late final _cst_inflate_CustomNestedErrorInnerTwinSse_ThreePtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<CustomNestedErrorInnerTwinSseKind>
-              Function()>>('cst_inflate_CustomNestedErrorInnerTwinSse_Three');
-  late final _cst_inflate_CustomNestedErrorInnerTwinSse_Three =
-      _cst_inflate_CustomNestedErrorInnerTwinSse_ThreePtr.asFunction<
-          ffi.Pointer<CustomNestedErrorInnerTwinSseKind> Function()>();
-
-  ffi.Pointer<CustomNestedErrorInnerTwinSseKind>
-      cst_inflate_CustomNestedErrorInnerTwinSse_Four() {
-    return _cst_inflate_CustomNestedErrorInnerTwinSse_Four();
-  }
-
-  late final _cst_inflate_CustomNestedErrorInnerTwinSse_FourPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<CustomNestedErrorInnerTwinSseKind>
-              Function()>>('cst_inflate_CustomNestedErrorInnerTwinSse_Four');
-  late final _cst_inflate_CustomNestedErrorInnerTwinSse_Four =
-      _cst_inflate_CustomNestedErrorInnerTwinSse_FourPtr.asFunction<
-          ffi.Pointer<CustomNestedErrorInnerTwinSseKind> Function()>();
-
-  ffi.Pointer<CustomNestedErrorInnerTwinSyncKind>
-      cst_inflate_CustomNestedErrorInnerTwinSync_Three() {
-    return _cst_inflate_CustomNestedErrorInnerTwinSync_Three();
-  }
-
-  late final _cst_inflate_CustomNestedErrorInnerTwinSync_ThreePtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<CustomNestedErrorInnerTwinSyncKind>
-              Function()>>('cst_inflate_CustomNestedErrorInnerTwinSync_Three');
-  late final _cst_inflate_CustomNestedErrorInnerTwinSync_Three =
-      _cst_inflate_CustomNestedErrorInnerTwinSync_ThreePtr.asFunction<
-          ffi.Pointer<CustomNestedErrorInnerTwinSyncKind> Function()>();
-
-  ffi.Pointer<CustomNestedErrorInnerTwinSyncKind>
-      cst_inflate_CustomNestedErrorInnerTwinSync_Four() {
-    return _cst_inflate_CustomNestedErrorInnerTwinSync_Four();
-  }
-
-  late final _cst_inflate_CustomNestedErrorInnerTwinSync_FourPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<CustomNestedErrorInnerTwinSyncKind>
-              Function()>>('cst_inflate_CustomNestedErrorInnerTwinSync_Four');
-  late final _cst_inflate_CustomNestedErrorInnerTwinSync_Four =
-      _cst_inflate_CustomNestedErrorInnerTwinSync_FourPtr.asFunction<
-          ffi.Pointer<CustomNestedErrorInnerTwinSyncKind> Function()>();
-
-  ffi.Pointer<CustomNestedErrorInnerTwinSyncSseKind>
-      cst_inflate_CustomNestedErrorInnerTwinSyncSse_Three() {
-    return _cst_inflate_CustomNestedErrorInnerTwinSyncSse_Three();
-  }
-
-  late final _cst_inflate_CustomNestedErrorInnerTwinSyncSse_ThreePtr = _lookup<
-          ffi.NativeFunction<
-              ffi.Pointer<CustomNestedErrorInnerTwinSyncSseKind> Function()>>(
-      'cst_inflate_CustomNestedErrorInnerTwinSyncSse_Three');
-  late final _cst_inflate_CustomNestedErrorInnerTwinSyncSse_Three =
-      _cst_inflate_CustomNestedErrorInnerTwinSyncSse_ThreePtr.asFunction<
-          ffi.Pointer<CustomNestedErrorInnerTwinSyncSseKind> Function()>();
-
-  ffi.Pointer<CustomNestedErrorInnerTwinSyncSseKind>
-      cst_inflate_CustomNestedErrorInnerTwinSyncSse_Four() {
-    return _cst_inflate_CustomNestedErrorInnerTwinSyncSse_Four();
-  }
-
-  late final _cst_inflate_CustomNestedErrorInnerTwinSyncSse_FourPtr = _lookup<
-          ffi.NativeFunction<
-              ffi.Pointer<CustomNestedErrorInnerTwinSyncSseKind> Function()>>(
-      'cst_inflate_CustomNestedErrorInnerTwinSyncSse_Four');
-  late final _cst_inflate_CustomNestedErrorInnerTwinSyncSse_Four =
-      _cst_inflate_CustomNestedErrorInnerTwinSyncSse_FourPtr.asFunction<
-          ffi.Pointer<CustomNestedErrorInnerTwinSyncSseKind> Function()>();
-
-  ffi.Pointer<CustomNestedErrorOuterTwinNormalKind>
-      cst_inflate_CustomNestedErrorOuterTwinNormal_One() {
-    return _cst_inflate_CustomNestedErrorOuterTwinNormal_One();
-  }
-
-  late final _cst_inflate_CustomNestedErrorOuterTwinNormal_OnePtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<CustomNestedErrorOuterTwinNormalKind>
-              Function()>>('cst_inflate_CustomNestedErrorOuterTwinNormal_One');
-  late final _cst_inflate_CustomNestedErrorOuterTwinNormal_One =
-      _cst_inflate_CustomNestedErrorOuterTwinNormal_OnePtr.asFunction<
-          ffi.Pointer<CustomNestedErrorOuterTwinNormalKind> Function()>();
-
-  ffi.Pointer<CustomNestedErrorOuterTwinNormalKind>
-      cst_inflate_CustomNestedErrorOuterTwinNormal_Two() {
-    return _cst_inflate_CustomNestedErrorOuterTwinNormal_Two();
-  }
-
-  late final _cst_inflate_CustomNestedErrorOuterTwinNormal_TwoPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<CustomNestedErrorOuterTwinNormalKind>
-              Function()>>('cst_inflate_CustomNestedErrorOuterTwinNormal_Two');
-  late final _cst_inflate_CustomNestedErrorOuterTwinNormal_Two =
-      _cst_inflate_CustomNestedErrorOuterTwinNormal_TwoPtr.asFunction<
-          ffi.Pointer<CustomNestedErrorOuterTwinNormalKind> Function()>();
-
-  ffi.Pointer<CustomNestedErrorOuterTwinRustAsyncKind>
-      cst_inflate_CustomNestedErrorOuterTwinRustAsync_One() {
-    return _cst_inflate_CustomNestedErrorOuterTwinRustAsync_One();
-  }
-
-  late final _cst_inflate_CustomNestedErrorOuterTwinRustAsync_OnePtr = _lookup<
-          ffi.NativeFunction<
-              ffi.Pointer<CustomNestedErrorOuterTwinRustAsyncKind> Function()>>(
-      'cst_inflate_CustomNestedErrorOuterTwinRustAsync_One');
-  late final _cst_inflate_CustomNestedErrorOuterTwinRustAsync_One =
-      _cst_inflate_CustomNestedErrorOuterTwinRustAsync_OnePtr.asFunction<
-          ffi.Pointer<CustomNestedErrorOuterTwinRustAsyncKind> Function()>();
-
-  ffi.Pointer<CustomNestedErrorOuterTwinRustAsyncKind>
-      cst_inflate_CustomNestedErrorOuterTwinRustAsync_Two() {
-    return _cst_inflate_CustomNestedErrorOuterTwinRustAsync_Two();
-  }
-
-  late final _cst_inflate_CustomNestedErrorOuterTwinRustAsync_TwoPtr = _lookup<
-          ffi.NativeFunction<
-              ffi.Pointer<CustomNestedErrorOuterTwinRustAsyncKind> Function()>>(
-      'cst_inflate_CustomNestedErrorOuterTwinRustAsync_Two');
-  late final _cst_inflate_CustomNestedErrorOuterTwinRustAsync_Two =
-      _cst_inflate_CustomNestedErrorOuterTwinRustAsync_TwoPtr.asFunction<
-          ffi.Pointer<CustomNestedErrorOuterTwinRustAsyncKind> Function()>();
-
-  ffi.Pointer<CustomNestedErrorOuterTwinRustAsyncSseKind>
-      cst_inflate_CustomNestedErrorOuterTwinRustAsyncSse_One() {
-    return _cst_inflate_CustomNestedErrorOuterTwinRustAsyncSse_One();
-  }
-
-  late final _cst_inflate_CustomNestedErrorOuterTwinRustAsyncSse_OnePtr =
-      _lookup<
-              ffi.NativeFunction<
-                  ffi.Pointer<CustomNestedErrorOuterTwinRustAsyncSseKind>
-                      Function()>>(
-          'cst_inflate_CustomNestedErrorOuterTwinRustAsyncSse_One');
-  late final _cst_inflate_CustomNestedErrorOuterTwinRustAsyncSse_One =
-      _cst_inflate_CustomNestedErrorOuterTwinRustAsyncSse_OnePtr.asFunction<
-          ffi.Pointer<CustomNestedErrorOuterTwinRustAsyncSseKind> Function()>();
-
-  ffi.Pointer<CustomNestedErrorOuterTwinRustAsyncSseKind>
-      cst_inflate_CustomNestedErrorOuterTwinRustAsyncSse_Two() {
-    return _cst_inflate_CustomNestedErrorOuterTwinRustAsyncSse_Two();
-  }
-
-  late final _cst_inflate_CustomNestedErrorOuterTwinRustAsyncSse_TwoPtr =
-      _lookup<
-              ffi.NativeFunction<
-                  ffi.Pointer<CustomNestedErrorOuterTwinRustAsyncSseKind>
-                      Function()>>(
-          'cst_inflate_CustomNestedErrorOuterTwinRustAsyncSse_Two');
-  late final _cst_inflate_CustomNestedErrorOuterTwinRustAsyncSse_Two =
-      _cst_inflate_CustomNestedErrorOuterTwinRustAsyncSse_TwoPtr.asFunction<
-          ffi.Pointer<CustomNestedErrorOuterTwinRustAsyncSseKind> Function()>();
-
-  ffi.Pointer<CustomNestedErrorOuterTwinSseKind>
-      cst_inflate_CustomNestedErrorOuterTwinSse_One() {
-    return _cst_inflate_CustomNestedErrorOuterTwinSse_One();
-  }
-
-  late final _cst_inflate_CustomNestedErrorOuterTwinSse_OnePtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<CustomNestedErrorOuterTwinSseKind>
-              Function()>>('cst_inflate_CustomNestedErrorOuterTwinSse_One');
-  late final _cst_inflate_CustomNestedErrorOuterTwinSse_One =
-      _cst_inflate_CustomNestedErrorOuterTwinSse_OnePtr.asFunction<
-          ffi.Pointer<CustomNestedErrorOuterTwinSseKind> Function()>();
-
-  ffi.Pointer<CustomNestedErrorOuterTwinSseKind>
-      cst_inflate_CustomNestedErrorOuterTwinSse_Two() {
-    return _cst_inflate_CustomNestedErrorOuterTwinSse_Two();
-  }
-
-  late final _cst_inflate_CustomNestedErrorOuterTwinSse_TwoPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<CustomNestedErrorOuterTwinSseKind>
-              Function()>>('cst_inflate_CustomNestedErrorOuterTwinSse_Two');
-  late final _cst_inflate_CustomNestedErrorOuterTwinSse_Two =
-      _cst_inflate_CustomNestedErrorOuterTwinSse_TwoPtr.asFunction<
-          ffi.Pointer<CustomNestedErrorOuterTwinSseKind> Function()>();
-
-  ffi.Pointer<CustomNestedErrorOuterTwinSyncKind>
-      cst_inflate_CustomNestedErrorOuterTwinSync_One() {
-    return _cst_inflate_CustomNestedErrorOuterTwinSync_One();
-  }
-
-  late final _cst_inflate_CustomNestedErrorOuterTwinSync_OnePtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<CustomNestedErrorOuterTwinSyncKind>
-              Function()>>('cst_inflate_CustomNestedErrorOuterTwinSync_One');
-  late final _cst_inflate_CustomNestedErrorOuterTwinSync_One =
-      _cst_inflate_CustomNestedErrorOuterTwinSync_OnePtr.asFunction<
-          ffi.Pointer<CustomNestedErrorOuterTwinSyncKind> Function()>();
-
-  ffi.Pointer<CustomNestedErrorOuterTwinSyncKind>
-      cst_inflate_CustomNestedErrorOuterTwinSync_Two() {
-    return _cst_inflate_CustomNestedErrorOuterTwinSync_Two();
-  }
-
-  late final _cst_inflate_CustomNestedErrorOuterTwinSync_TwoPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<CustomNestedErrorOuterTwinSyncKind>
-              Function()>>('cst_inflate_CustomNestedErrorOuterTwinSync_Two');
-  late final _cst_inflate_CustomNestedErrorOuterTwinSync_Two =
-      _cst_inflate_CustomNestedErrorOuterTwinSync_TwoPtr.asFunction<
-          ffi.Pointer<CustomNestedErrorOuterTwinSyncKind> Function()>();
-
-  ffi.Pointer<CustomNestedErrorOuterTwinSyncSseKind>
-      cst_inflate_CustomNestedErrorOuterTwinSyncSse_One() {
-    return _cst_inflate_CustomNestedErrorOuterTwinSyncSse_One();
-  }
-
-  late final _cst_inflate_CustomNestedErrorOuterTwinSyncSse_OnePtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<CustomNestedErrorOuterTwinSyncSseKind>
-              Function()>>('cst_inflate_CustomNestedErrorOuterTwinSyncSse_One');
-  late final _cst_inflate_CustomNestedErrorOuterTwinSyncSse_One =
-      _cst_inflate_CustomNestedErrorOuterTwinSyncSse_OnePtr.asFunction<
-          ffi.Pointer<CustomNestedErrorOuterTwinSyncSseKind> Function()>();
-
-  ffi.Pointer<CustomNestedErrorOuterTwinSyncSseKind>
-      cst_inflate_CustomNestedErrorOuterTwinSyncSse_Two() {
-    return _cst_inflate_CustomNestedErrorOuterTwinSyncSse_Two();
-  }
-
-  late final _cst_inflate_CustomNestedErrorOuterTwinSyncSse_TwoPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<CustomNestedErrorOuterTwinSyncSseKind>
-              Function()>>('cst_inflate_CustomNestedErrorOuterTwinSyncSse_Two');
-  late final _cst_inflate_CustomNestedErrorOuterTwinSyncSse_Two =
-      _cst_inflate_CustomNestedErrorOuterTwinSyncSse_TwoPtr.asFunction<
-          ffi.Pointer<CustomNestedErrorOuterTwinSyncSseKind> Function()>();
-
-  ffi.Pointer<DistanceTwinNormalKind> cst_inflate_DistanceTwinNormal_Map() {
-    return _cst_inflate_DistanceTwinNormal_Map();
-  }
-
-  late final _cst_inflate_DistanceTwinNormal_MapPtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<DistanceTwinNormalKind> Function()>>(
-      'cst_inflate_DistanceTwinNormal_Map');
-  late final _cst_inflate_DistanceTwinNormal_Map =
-      _cst_inflate_DistanceTwinNormal_MapPtr
-          .asFunction<ffi.Pointer<DistanceTwinNormalKind> Function()>();
-
-  ffi.Pointer<DistanceTwinRustAsyncKind>
-      cst_inflate_DistanceTwinRustAsync_Map() {
-    return _cst_inflate_DistanceTwinRustAsync_Map();
-  }
-
-  late final _cst_inflate_DistanceTwinRustAsync_MapPtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<DistanceTwinRustAsyncKind> Function()>>(
-      'cst_inflate_DistanceTwinRustAsync_Map');
-  late final _cst_inflate_DistanceTwinRustAsync_Map =
-      _cst_inflate_DistanceTwinRustAsync_MapPtr
-          .asFunction<ffi.Pointer<DistanceTwinRustAsyncKind> Function()>();
-
-  ffi.Pointer<DistanceTwinRustAsyncSseKind>
-      cst_inflate_DistanceTwinRustAsyncSse_Map() {
-    return _cst_inflate_DistanceTwinRustAsyncSse_Map();
-  }
-
-  late final _cst_inflate_DistanceTwinRustAsyncSse_MapPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<DistanceTwinRustAsyncSseKind>
-              Function()>>('cst_inflate_DistanceTwinRustAsyncSse_Map');
-  late final _cst_inflate_DistanceTwinRustAsyncSse_Map =
-      _cst_inflate_DistanceTwinRustAsyncSse_MapPtr
-          .asFunction<ffi.Pointer<DistanceTwinRustAsyncSseKind> Function()>();
-
-  ffi.Pointer<DistanceTwinSseKind> cst_inflate_DistanceTwinSse_Map() {
-    return _cst_inflate_DistanceTwinSse_Map();
-  }
-
-  late final _cst_inflate_DistanceTwinSse_MapPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<DistanceTwinSseKind> Function()>>(
-          'cst_inflate_DistanceTwinSse_Map');
-  late final _cst_inflate_DistanceTwinSse_Map =
-      _cst_inflate_DistanceTwinSse_MapPtr
-          .asFunction<ffi.Pointer<DistanceTwinSseKind> Function()>();
-
-  ffi.Pointer<DistanceTwinSyncKind> cst_inflate_DistanceTwinSync_Map() {
-    return _cst_inflate_DistanceTwinSync_Map();
-  }
-
-  late final _cst_inflate_DistanceTwinSync_MapPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<DistanceTwinSyncKind> Function()>>(
-          'cst_inflate_DistanceTwinSync_Map');
-  late final _cst_inflate_DistanceTwinSync_Map =
-      _cst_inflate_DistanceTwinSync_MapPtr
-          .asFunction<ffi.Pointer<DistanceTwinSyncKind> Function()>();
-
-  ffi.Pointer<DistanceTwinSyncSseKind> cst_inflate_DistanceTwinSyncSse_Map() {
-    return _cst_inflate_DistanceTwinSyncSse_Map();
-  }
-
-  late final _cst_inflate_DistanceTwinSyncSse_MapPtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<DistanceTwinSyncSseKind> Function()>>(
-      'cst_inflate_DistanceTwinSyncSse_Map');
-  late final _cst_inflate_DistanceTwinSyncSse_Map =
-      _cst_inflate_DistanceTwinSyncSse_MapPtr
-          .asFunction<ffi.Pointer<DistanceTwinSyncSseKind> Function()>();
-
-  ffi.Pointer<EnumDartOpaqueTwinNormalKind>
-      cst_inflate_EnumDartOpaqueTwinNormal_Primitive() {
-    return _cst_inflate_EnumDartOpaqueTwinNormal_Primitive();
-  }
-
-  late final _cst_inflate_EnumDartOpaqueTwinNormal_PrimitivePtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumDartOpaqueTwinNormalKind>
-              Function()>>('cst_inflate_EnumDartOpaqueTwinNormal_Primitive');
-  late final _cst_inflate_EnumDartOpaqueTwinNormal_Primitive =
-      _cst_inflate_EnumDartOpaqueTwinNormal_PrimitivePtr
-          .asFunction<ffi.Pointer<EnumDartOpaqueTwinNormalKind> Function()>();
-
-  ffi.Pointer<EnumDartOpaqueTwinNormalKind>
-      cst_inflate_EnumDartOpaqueTwinNormal_Opaque() {
-    return _cst_inflate_EnumDartOpaqueTwinNormal_Opaque();
-  }
-
-  late final _cst_inflate_EnumDartOpaqueTwinNormal_OpaquePtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumDartOpaqueTwinNormalKind>
-              Function()>>('cst_inflate_EnumDartOpaqueTwinNormal_Opaque');
-  late final _cst_inflate_EnumDartOpaqueTwinNormal_Opaque =
-      _cst_inflate_EnumDartOpaqueTwinNormal_OpaquePtr
-          .asFunction<ffi.Pointer<EnumDartOpaqueTwinNormalKind> Function()>();
-
-  ffi.Pointer<EnumDartOpaqueTwinRustAsyncKind>
-      cst_inflate_EnumDartOpaqueTwinRustAsync_Primitive() {
-    return _cst_inflate_EnumDartOpaqueTwinRustAsync_Primitive();
-  }
-
-  late final _cst_inflate_EnumDartOpaqueTwinRustAsync_PrimitivePtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumDartOpaqueTwinRustAsyncKind>
-              Function()>>('cst_inflate_EnumDartOpaqueTwinRustAsync_Primitive');
-  late final _cst_inflate_EnumDartOpaqueTwinRustAsync_Primitive =
-      _cst_inflate_EnumDartOpaqueTwinRustAsync_PrimitivePtr.asFunction<
-          ffi.Pointer<EnumDartOpaqueTwinRustAsyncKind> Function()>();
-
-  ffi.Pointer<EnumDartOpaqueTwinRustAsyncKind>
-      cst_inflate_EnumDartOpaqueTwinRustAsync_Opaque() {
-    return _cst_inflate_EnumDartOpaqueTwinRustAsync_Opaque();
-  }
-
-  late final _cst_inflate_EnumDartOpaqueTwinRustAsync_OpaquePtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumDartOpaqueTwinRustAsyncKind>
-              Function()>>('cst_inflate_EnumDartOpaqueTwinRustAsync_Opaque');
-  late final _cst_inflate_EnumDartOpaqueTwinRustAsync_Opaque =
-      _cst_inflate_EnumDartOpaqueTwinRustAsync_OpaquePtr.asFunction<
-          ffi.Pointer<EnumDartOpaqueTwinRustAsyncKind> Function()>();
-
-  ffi.Pointer<EnumDartOpaqueTwinRustAsyncSseKind>
-      cst_inflate_EnumDartOpaqueTwinRustAsyncSse_Primitive() {
-    return _cst_inflate_EnumDartOpaqueTwinRustAsyncSse_Primitive();
-  }
-
-  late final _cst_inflate_EnumDartOpaqueTwinRustAsyncSse_PrimitivePtr = _lookup<
-          ffi.NativeFunction<
-              ffi.Pointer<EnumDartOpaqueTwinRustAsyncSseKind> Function()>>(
-      'cst_inflate_EnumDartOpaqueTwinRustAsyncSse_Primitive');
-  late final _cst_inflate_EnumDartOpaqueTwinRustAsyncSse_Primitive =
-      _cst_inflate_EnumDartOpaqueTwinRustAsyncSse_PrimitivePtr.asFunction<
-          ffi.Pointer<EnumDartOpaqueTwinRustAsyncSseKind> Function()>();
-
-  ffi.Pointer<EnumDartOpaqueTwinRustAsyncSseKind>
-      cst_inflate_EnumDartOpaqueTwinRustAsyncSse_Opaque() {
-    return _cst_inflate_EnumDartOpaqueTwinRustAsyncSse_Opaque();
-  }
-
-  late final _cst_inflate_EnumDartOpaqueTwinRustAsyncSse_OpaquePtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumDartOpaqueTwinRustAsyncSseKind>
-              Function()>>('cst_inflate_EnumDartOpaqueTwinRustAsyncSse_Opaque');
-  late final _cst_inflate_EnumDartOpaqueTwinRustAsyncSse_Opaque =
-      _cst_inflate_EnumDartOpaqueTwinRustAsyncSse_OpaquePtr.asFunction<
-          ffi.Pointer<EnumDartOpaqueTwinRustAsyncSseKind> Function()>();
-
-  ffi.Pointer<EnumDartOpaqueTwinSseKind>
-      cst_inflate_EnumDartOpaqueTwinSse_Primitive() {
-    return _cst_inflate_EnumDartOpaqueTwinSse_Primitive();
-  }
-
-  late final _cst_inflate_EnumDartOpaqueTwinSse_PrimitivePtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<EnumDartOpaqueTwinSseKind> Function()>>(
-      'cst_inflate_EnumDartOpaqueTwinSse_Primitive');
-  late final _cst_inflate_EnumDartOpaqueTwinSse_Primitive =
-      _cst_inflate_EnumDartOpaqueTwinSse_PrimitivePtr
-          .asFunction<ffi.Pointer<EnumDartOpaqueTwinSseKind> Function()>();
-
-  ffi.Pointer<EnumDartOpaqueTwinSseKind>
-      cst_inflate_EnumDartOpaqueTwinSse_Opaque() {
-    return _cst_inflate_EnumDartOpaqueTwinSse_Opaque();
-  }
-
-  late final _cst_inflate_EnumDartOpaqueTwinSse_OpaquePtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<EnumDartOpaqueTwinSseKind> Function()>>(
-      'cst_inflate_EnumDartOpaqueTwinSse_Opaque');
-  late final _cst_inflate_EnumDartOpaqueTwinSse_Opaque =
-      _cst_inflate_EnumDartOpaqueTwinSse_OpaquePtr
-          .asFunction<ffi.Pointer<EnumDartOpaqueTwinSseKind> Function()>();
-
-  ffi.Pointer<EnumDartOpaqueTwinSyncKind>
-      cst_inflate_EnumDartOpaqueTwinSync_Primitive() {
-    return _cst_inflate_EnumDartOpaqueTwinSync_Primitive();
-  }
-
-  late final _cst_inflate_EnumDartOpaqueTwinSync_PrimitivePtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<EnumDartOpaqueTwinSyncKind> Function()>>(
-      'cst_inflate_EnumDartOpaqueTwinSync_Primitive');
-  late final _cst_inflate_EnumDartOpaqueTwinSync_Primitive =
-      _cst_inflate_EnumDartOpaqueTwinSync_PrimitivePtr
-          .asFunction<ffi.Pointer<EnumDartOpaqueTwinSyncKind> Function()>();
-
-  ffi.Pointer<EnumDartOpaqueTwinSyncKind>
-      cst_inflate_EnumDartOpaqueTwinSync_Opaque() {
-    return _cst_inflate_EnumDartOpaqueTwinSync_Opaque();
-  }
-
-  late final _cst_inflate_EnumDartOpaqueTwinSync_OpaquePtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<EnumDartOpaqueTwinSyncKind> Function()>>(
-      'cst_inflate_EnumDartOpaqueTwinSync_Opaque');
-  late final _cst_inflate_EnumDartOpaqueTwinSync_Opaque =
-      _cst_inflate_EnumDartOpaqueTwinSync_OpaquePtr
-          .asFunction<ffi.Pointer<EnumDartOpaqueTwinSyncKind> Function()>();
-
-  ffi.Pointer<EnumDartOpaqueTwinSyncSseKind>
-      cst_inflate_EnumDartOpaqueTwinSyncSse_Primitive() {
-    return _cst_inflate_EnumDartOpaqueTwinSyncSse_Primitive();
-  }
-
-  late final _cst_inflate_EnumDartOpaqueTwinSyncSse_PrimitivePtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumDartOpaqueTwinSyncSseKind>
-              Function()>>('cst_inflate_EnumDartOpaqueTwinSyncSse_Primitive');
-  late final _cst_inflate_EnumDartOpaqueTwinSyncSse_Primitive =
-      _cst_inflate_EnumDartOpaqueTwinSyncSse_PrimitivePtr
-          .asFunction<ffi.Pointer<EnumDartOpaqueTwinSyncSseKind> Function()>();
-
-  ffi.Pointer<EnumDartOpaqueTwinSyncSseKind>
-      cst_inflate_EnumDartOpaqueTwinSyncSse_Opaque() {
-    return _cst_inflate_EnumDartOpaqueTwinSyncSse_Opaque();
-  }
-
-  late final _cst_inflate_EnumDartOpaqueTwinSyncSse_OpaquePtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumDartOpaqueTwinSyncSseKind>
-              Function()>>('cst_inflate_EnumDartOpaqueTwinSyncSse_Opaque');
-  late final _cst_inflate_EnumDartOpaqueTwinSyncSse_Opaque =
-      _cst_inflate_EnumDartOpaqueTwinSyncSse_OpaquePtr
-          .asFunction<ffi.Pointer<EnumDartOpaqueTwinSyncSseKind> Function()>();
-
-  ffi.Pointer<EnumOpaqueTwinNormalKind>
-      cst_inflate_EnumOpaqueTwinNormal_Struct() {
-    return _cst_inflate_EnumOpaqueTwinNormal_Struct();
-  }
-
-  late final _cst_inflate_EnumOpaqueTwinNormal_StructPtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<EnumOpaqueTwinNormalKind> Function()>>(
-      'cst_inflate_EnumOpaqueTwinNormal_Struct');
-  late final _cst_inflate_EnumOpaqueTwinNormal_Struct =
-      _cst_inflate_EnumOpaqueTwinNormal_StructPtr
-          .asFunction<ffi.Pointer<EnumOpaqueTwinNormalKind> Function()>();
-
-  ffi.Pointer<EnumOpaqueTwinNormalKind>
-      cst_inflate_EnumOpaqueTwinNormal_Primitive() {
-    return _cst_inflate_EnumOpaqueTwinNormal_Primitive();
-  }
-
-  late final _cst_inflate_EnumOpaqueTwinNormal_PrimitivePtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<EnumOpaqueTwinNormalKind> Function()>>(
-      'cst_inflate_EnumOpaqueTwinNormal_Primitive');
-  late final _cst_inflate_EnumOpaqueTwinNormal_Primitive =
-      _cst_inflate_EnumOpaqueTwinNormal_PrimitivePtr
-          .asFunction<ffi.Pointer<EnumOpaqueTwinNormalKind> Function()>();
-
-  ffi.Pointer<EnumOpaqueTwinNormalKind>
-      cst_inflate_EnumOpaqueTwinNormal_TraitObj() {
-    return _cst_inflate_EnumOpaqueTwinNormal_TraitObj();
-  }
-
-  late final _cst_inflate_EnumOpaqueTwinNormal_TraitObjPtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<EnumOpaqueTwinNormalKind> Function()>>(
-      'cst_inflate_EnumOpaqueTwinNormal_TraitObj');
-  late final _cst_inflate_EnumOpaqueTwinNormal_TraitObj =
-      _cst_inflate_EnumOpaqueTwinNormal_TraitObjPtr
-          .asFunction<ffi.Pointer<EnumOpaqueTwinNormalKind> Function()>();
-
-  ffi.Pointer<EnumOpaqueTwinNormalKind>
-      cst_inflate_EnumOpaqueTwinNormal_Mutex() {
-    return _cst_inflate_EnumOpaqueTwinNormal_Mutex();
-  }
-
-  late final _cst_inflate_EnumOpaqueTwinNormal_MutexPtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<EnumOpaqueTwinNormalKind> Function()>>(
-      'cst_inflate_EnumOpaqueTwinNormal_Mutex');
-  late final _cst_inflate_EnumOpaqueTwinNormal_Mutex =
-      _cst_inflate_EnumOpaqueTwinNormal_MutexPtr
-          .asFunction<ffi.Pointer<EnumOpaqueTwinNormalKind> Function()>();
-
-  ffi.Pointer<EnumOpaqueTwinNormalKind>
-      cst_inflate_EnumOpaqueTwinNormal_RwLock() {
-    return _cst_inflate_EnumOpaqueTwinNormal_RwLock();
-  }
-
-  late final _cst_inflate_EnumOpaqueTwinNormal_RwLockPtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<EnumOpaqueTwinNormalKind> Function()>>(
-      'cst_inflate_EnumOpaqueTwinNormal_RwLock');
-  late final _cst_inflate_EnumOpaqueTwinNormal_RwLock =
-      _cst_inflate_EnumOpaqueTwinNormal_RwLockPtr
-          .asFunction<ffi.Pointer<EnumOpaqueTwinNormalKind> Function()>();
-
-  ffi.Pointer<EnumOpaqueTwinRustAsyncKind>
-      cst_inflate_EnumOpaqueTwinRustAsync_Struct() {
-    return _cst_inflate_EnumOpaqueTwinRustAsync_Struct();
-  }
-
-  late final _cst_inflate_EnumOpaqueTwinRustAsync_StructPtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<EnumOpaqueTwinRustAsyncKind> Function()>>(
-      'cst_inflate_EnumOpaqueTwinRustAsync_Struct');
-  late final _cst_inflate_EnumOpaqueTwinRustAsync_Struct =
-      _cst_inflate_EnumOpaqueTwinRustAsync_StructPtr
-          .asFunction<ffi.Pointer<EnumOpaqueTwinRustAsyncKind> Function()>();
-
-  ffi.Pointer<EnumOpaqueTwinRustAsyncKind>
-      cst_inflate_EnumOpaqueTwinRustAsync_Primitive() {
-    return _cst_inflate_EnumOpaqueTwinRustAsync_Primitive();
-  }
-
-  late final _cst_inflate_EnumOpaqueTwinRustAsync_PrimitivePtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<EnumOpaqueTwinRustAsyncKind> Function()>>(
-      'cst_inflate_EnumOpaqueTwinRustAsync_Primitive');
-  late final _cst_inflate_EnumOpaqueTwinRustAsync_Primitive =
-      _cst_inflate_EnumOpaqueTwinRustAsync_PrimitivePtr
-          .asFunction<ffi.Pointer<EnumOpaqueTwinRustAsyncKind> Function()>();
-
-  ffi.Pointer<EnumOpaqueTwinRustAsyncKind>
-      cst_inflate_EnumOpaqueTwinRustAsync_TraitObj() {
-    return _cst_inflate_EnumOpaqueTwinRustAsync_TraitObj();
-  }
-
-  late final _cst_inflate_EnumOpaqueTwinRustAsync_TraitObjPtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<EnumOpaqueTwinRustAsyncKind> Function()>>(
-      'cst_inflate_EnumOpaqueTwinRustAsync_TraitObj');
-  late final _cst_inflate_EnumOpaqueTwinRustAsync_TraitObj =
-      _cst_inflate_EnumOpaqueTwinRustAsync_TraitObjPtr
-          .asFunction<ffi.Pointer<EnumOpaqueTwinRustAsyncKind> Function()>();
-
-  ffi.Pointer<EnumOpaqueTwinRustAsyncKind>
-      cst_inflate_EnumOpaqueTwinRustAsync_Mutex() {
-    return _cst_inflate_EnumOpaqueTwinRustAsync_Mutex();
-  }
-
-  late final _cst_inflate_EnumOpaqueTwinRustAsync_MutexPtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<EnumOpaqueTwinRustAsyncKind> Function()>>(
-      'cst_inflate_EnumOpaqueTwinRustAsync_Mutex');
-  late final _cst_inflate_EnumOpaqueTwinRustAsync_Mutex =
-      _cst_inflate_EnumOpaqueTwinRustAsync_MutexPtr
-          .asFunction<ffi.Pointer<EnumOpaqueTwinRustAsyncKind> Function()>();
-
-  ffi.Pointer<EnumOpaqueTwinRustAsyncKind>
-      cst_inflate_EnumOpaqueTwinRustAsync_RwLock() {
-    return _cst_inflate_EnumOpaqueTwinRustAsync_RwLock();
-  }
-
-  late final _cst_inflate_EnumOpaqueTwinRustAsync_RwLockPtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<EnumOpaqueTwinRustAsyncKind> Function()>>(
-      'cst_inflate_EnumOpaqueTwinRustAsync_RwLock');
-  late final _cst_inflate_EnumOpaqueTwinRustAsync_RwLock =
-      _cst_inflate_EnumOpaqueTwinRustAsync_RwLockPtr
-          .asFunction<ffi.Pointer<EnumOpaqueTwinRustAsyncKind> Function()>();
-
-  ffi.Pointer<EnumOpaqueTwinRustAsyncSseKind>
-      cst_inflate_EnumOpaqueTwinRustAsyncSse_Struct() {
-    return _cst_inflate_EnumOpaqueTwinRustAsyncSse_Struct();
-  }
-
-  late final _cst_inflate_EnumOpaqueTwinRustAsyncSse_StructPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumOpaqueTwinRustAsyncSseKind>
-              Function()>>('cst_inflate_EnumOpaqueTwinRustAsyncSse_Struct');
-  late final _cst_inflate_EnumOpaqueTwinRustAsyncSse_Struct =
-      _cst_inflate_EnumOpaqueTwinRustAsyncSse_StructPtr
-          .asFunction<ffi.Pointer<EnumOpaqueTwinRustAsyncSseKind> Function()>();
-
-  ffi.Pointer<EnumOpaqueTwinRustAsyncSseKind>
-      cst_inflate_EnumOpaqueTwinRustAsyncSse_Primitive() {
-    return _cst_inflate_EnumOpaqueTwinRustAsyncSse_Primitive();
-  }
-
-  late final _cst_inflate_EnumOpaqueTwinRustAsyncSse_PrimitivePtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumOpaqueTwinRustAsyncSseKind>
-              Function()>>('cst_inflate_EnumOpaqueTwinRustAsyncSse_Primitive');
-  late final _cst_inflate_EnumOpaqueTwinRustAsyncSse_Primitive =
-      _cst_inflate_EnumOpaqueTwinRustAsyncSse_PrimitivePtr
-          .asFunction<ffi.Pointer<EnumOpaqueTwinRustAsyncSseKind> Function()>();
-
-  ffi.Pointer<EnumOpaqueTwinRustAsyncSseKind>
-      cst_inflate_EnumOpaqueTwinRustAsyncSse_TraitObj() {
-    return _cst_inflate_EnumOpaqueTwinRustAsyncSse_TraitObj();
-  }
-
-  late final _cst_inflate_EnumOpaqueTwinRustAsyncSse_TraitObjPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumOpaqueTwinRustAsyncSseKind>
-              Function()>>('cst_inflate_EnumOpaqueTwinRustAsyncSse_TraitObj');
-  late final _cst_inflate_EnumOpaqueTwinRustAsyncSse_TraitObj =
-      _cst_inflate_EnumOpaqueTwinRustAsyncSse_TraitObjPtr
-          .asFunction<ffi.Pointer<EnumOpaqueTwinRustAsyncSseKind> Function()>();
-
-  ffi.Pointer<EnumOpaqueTwinRustAsyncSseKind>
-      cst_inflate_EnumOpaqueTwinRustAsyncSse_Mutex() {
-    return _cst_inflate_EnumOpaqueTwinRustAsyncSse_Mutex();
-  }
-
-  late final _cst_inflate_EnumOpaqueTwinRustAsyncSse_MutexPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumOpaqueTwinRustAsyncSseKind>
-              Function()>>('cst_inflate_EnumOpaqueTwinRustAsyncSse_Mutex');
-  late final _cst_inflate_EnumOpaqueTwinRustAsyncSse_Mutex =
-      _cst_inflate_EnumOpaqueTwinRustAsyncSse_MutexPtr
-          .asFunction<ffi.Pointer<EnumOpaqueTwinRustAsyncSseKind> Function()>();
-
-  ffi.Pointer<EnumOpaqueTwinRustAsyncSseKind>
-      cst_inflate_EnumOpaqueTwinRustAsyncSse_RwLock() {
-    return _cst_inflate_EnumOpaqueTwinRustAsyncSse_RwLock();
-  }
-
-  late final _cst_inflate_EnumOpaqueTwinRustAsyncSse_RwLockPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumOpaqueTwinRustAsyncSseKind>
-              Function()>>('cst_inflate_EnumOpaqueTwinRustAsyncSse_RwLock');
-  late final _cst_inflate_EnumOpaqueTwinRustAsyncSse_RwLock =
-      _cst_inflate_EnumOpaqueTwinRustAsyncSse_RwLockPtr
-          .asFunction<ffi.Pointer<EnumOpaqueTwinRustAsyncSseKind> Function()>();
-
-  ffi.Pointer<EnumOpaqueTwinSseKind> cst_inflate_EnumOpaqueTwinSse_Struct() {
-    return _cst_inflate_EnumOpaqueTwinSse_Struct();
-  }
-
-  late final _cst_inflate_EnumOpaqueTwinSse_StructPtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<EnumOpaqueTwinSseKind> Function()>>(
-      'cst_inflate_EnumOpaqueTwinSse_Struct');
-  late final _cst_inflate_EnumOpaqueTwinSse_Struct =
-      _cst_inflate_EnumOpaqueTwinSse_StructPtr
-          .asFunction<ffi.Pointer<EnumOpaqueTwinSseKind> Function()>();
-
-  ffi.Pointer<EnumOpaqueTwinSseKind> cst_inflate_EnumOpaqueTwinSse_Primitive() {
-    return _cst_inflate_EnumOpaqueTwinSse_Primitive();
-  }
-
-  late final _cst_inflate_EnumOpaqueTwinSse_PrimitivePtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<EnumOpaqueTwinSseKind> Function()>>(
-      'cst_inflate_EnumOpaqueTwinSse_Primitive');
-  late final _cst_inflate_EnumOpaqueTwinSse_Primitive =
-      _cst_inflate_EnumOpaqueTwinSse_PrimitivePtr
-          .asFunction<ffi.Pointer<EnumOpaqueTwinSseKind> Function()>();
-
-  ffi.Pointer<EnumOpaqueTwinSseKind> cst_inflate_EnumOpaqueTwinSse_TraitObj() {
-    return _cst_inflate_EnumOpaqueTwinSse_TraitObj();
-  }
-
-  late final _cst_inflate_EnumOpaqueTwinSse_TraitObjPtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<EnumOpaqueTwinSseKind> Function()>>(
-      'cst_inflate_EnumOpaqueTwinSse_TraitObj');
-  late final _cst_inflate_EnumOpaqueTwinSse_TraitObj =
-      _cst_inflate_EnumOpaqueTwinSse_TraitObjPtr
-          .asFunction<ffi.Pointer<EnumOpaqueTwinSseKind> Function()>();
-
-  ffi.Pointer<EnumOpaqueTwinSseKind> cst_inflate_EnumOpaqueTwinSse_Mutex() {
-    return _cst_inflate_EnumOpaqueTwinSse_Mutex();
-  }
-
-  late final _cst_inflate_EnumOpaqueTwinSse_MutexPtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<EnumOpaqueTwinSseKind> Function()>>(
-      'cst_inflate_EnumOpaqueTwinSse_Mutex');
-  late final _cst_inflate_EnumOpaqueTwinSse_Mutex =
-      _cst_inflate_EnumOpaqueTwinSse_MutexPtr
-          .asFunction<ffi.Pointer<EnumOpaqueTwinSseKind> Function()>();
-
-  ffi.Pointer<EnumOpaqueTwinSseKind> cst_inflate_EnumOpaqueTwinSse_RwLock() {
-    return _cst_inflate_EnumOpaqueTwinSse_RwLock();
-  }
-
-  late final _cst_inflate_EnumOpaqueTwinSse_RwLockPtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<EnumOpaqueTwinSseKind> Function()>>(
-      'cst_inflate_EnumOpaqueTwinSse_RwLock');
-  late final _cst_inflate_EnumOpaqueTwinSse_RwLock =
-      _cst_inflate_EnumOpaqueTwinSse_RwLockPtr
-          .asFunction<ffi.Pointer<EnumOpaqueTwinSseKind> Function()>();
-
-  ffi.Pointer<EnumOpaqueTwinSyncKind> cst_inflate_EnumOpaqueTwinSync_Struct() {
-    return _cst_inflate_EnumOpaqueTwinSync_Struct();
-  }
-
-  late final _cst_inflate_EnumOpaqueTwinSync_StructPtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<EnumOpaqueTwinSyncKind> Function()>>(
-      'cst_inflate_EnumOpaqueTwinSync_Struct');
-  late final _cst_inflate_EnumOpaqueTwinSync_Struct =
-      _cst_inflate_EnumOpaqueTwinSync_StructPtr
-          .asFunction<ffi.Pointer<EnumOpaqueTwinSyncKind> Function()>();
-
-  ffi.Pointer<EnumOpaqueTwinSyncKind>
-      cst_inflate_EnumOpaqueTwinSync_Primitive() {
-    return _cst_inflate_EnumOpaqueTwinSync_Primitive();
-  }
-
-  late final _cst_inflate_EnumOpaqueTwinSync_PrimitivePtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<EnumOpaqueTwinSyncKind> Function()>>(
-      'cst_inflate_EnumOpaqueTwinSync_Primitive');
-  late final _cst_inflate_EnumOpaqueTwinSync_Primitive =
-      _cst_inflate_EnumOpaqueTwinSync_PrimitivePtr
-          .asFunction<ffi.Pointer<EnumOpaqueTwinSyncKind> Function()>();
-
-  ffi.Pointer<EnumOpaqueTwinSyncKind>
-      cst_inflate_EnumOpaqueTwinSync_TraitObj() {
-    return _cst_inflate_EnumOpaqueTwinSync_TraitObj();
-  }
-
-  late final _cst_inflate_EnumOpaqueTwinSync_TraitObjPtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<EnumOpaqueTwinSyncKind> Function()>>(
-      'cst_inflate_EnumOpaqueTwinSync_TraitObj');
-  late final _cst_inflate_EnumOpaqueTwinSync_TraitObj =
-      _cst_inflate_EnumOpaqueTwinSync_TraitObjPtr
-          .asFunction<ffi.Pointer<EnumOpaqueTwinSyncKind> Function()>();
-
-  ffi.Pointer<EnumOpaqueTwinSyncKind> cst_inflate_EnumOpaqueTwinSync_Mutex() {
-    return _cst_inflate_EnumOpaqueTwinSync_Mutex();
-  }
-
-  late final _cst_inflate_EnumOpaqueTwinSync_MutexPtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<EnumOpaqueTwinSyncKind> Function()>>(
-      'cst_inflate_EnumOpaqueTwinSync_Mutex');
-  late final _cst_inflate_EnumOpaqueTwinSync_Mutex =
-      _cst_inflate_EnumOpaqueTwinSync_MutexPtr
-          .asFunction<ffi.Pointer<EnumOpaqueTwinSyncKind> Function()>();
-
-  ffi.Pointer<EnumOpaqueTwinSyncKind> cst_inflate_EnumOpaqueTwinSync_RwLock() {
-    return _cst_inflate_EnumOpaqueTwinSync_RwLock();
-  }
-
-  late final _cst_inflate_EnumOpaqueTwinSync_RwLockPtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<EnumOpaqueTwinSyncKind> Function()>>(
-      'cst_inflate_EnumOpaqueTwinSync_RwLock');
-  late final _cst_inflate_EnumOpaqueTwinSync_RwLock =
-      _cst_inflate_EnumOpaqueTwinSync_RwLockPtr
-          .asFunction<ffi.Pointer<EnumOpaqueTwinSyncKind> Function()>();
-
-  ffi.Pointer<EnumOpaqueTwinSyncSseKind>
-      cst_inflate_EnumOpaqueTwinSyncSse_Struct() {
-    return _cst_inflate_EnumOpaqueTwinSyncSse_Struct();
-  }
-
-  late final _cst_inflate_EnumOpaqueTwinSyncSse_StructPtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<EnumOpaqueTwinSyncSseKind> Function()>>(
-      'cst_inflate_EnumOpaqueTwinSyncSse_Struct');
-  late final _cst_inflate_EnumOpaqueTwinSyncSse_Struct =
-      _cst_inflate_EnumOpaqueTwinSyncSse_StructPtr
-          .asFunction<ffi.Pointer<EnumOpaqueTwinSyncSseKind> Function()>();
-
-  ffi.Pointer<EnumOpaqueTwinSyncSseKind>
-      cst_inflate_EnumOpaqueTwinSyncSse_Primitive() {
-    return _cst_inflate_EnumOpaqueTwinSyncSse_Primitive();
-  }
-
-  late final _cst_inflate_EnumOpaqueTwinSyncSse_PrimitivePtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<EnumOpaqueTwinSyncSseKind> Function()>>(
-      'cst_inflate_EnumOpaqueTwinSyncSse_Primitive');
-  late final _cst_inflate_EnumOpaqueTwinSyncSse_Primitive =
-      _cst_inflate_EnumOpaqueTwinSyncSse_PrimitivePtr
-          .asFunction<ffi.Pointer<EnumOpaqueTwinSyncSseKind> Function()>();
-
-  ffi.Pointer<EnumOpaqueTwinSyncSseKind>
-      cst_inflate_EnumOpaqueTwinSyncSse_TraitObj() {
-    return _cst_inflate_EnumOpaqueTwinSyncSse_TraitObj();
-  }
-
-  late final _cst_inflate_EnumOpaqueTwinSyncSse_TraitObjPtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<EnumOpaqueTwinSyncSseKind> Function()>>(
-      'cst_inflate_EnumOpaqueTwinSyncSse_TraitObj');
-  late final _cst_inflate_EnumOpaqueTwinSyncSse_TraitObj =
-      _cst_inflate_EnumOpaqueTwinSyncSse_TraitObjPtr
-          .asFunction<ffi.Pointer<EnumOpaqueTwinSyncSseKind> Function()>();
-
-  ffi.Pointer<EnumOpaqueTwinSyncSseKind>
-      cst_inflate_EnumOpaqueTwinSyncSse_Mutex() {
-    return _cst_inflate_EnumOpaqueTwinSyncSse_Mutex();
-  }
-
-  late final _cst_inflate_EnumOpaqueTwinSyncSse_MutexPtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<EnumOpaqueTwinSyncSseKind> Function()>>(
-      'cst_inflate_EnumOpaqueTwinSyncSse_Mutex');
-  late final _cst_inflate_EnumOpaqueTwinSyncSse_Mutex =
-      _cst_inflate_EnumOpaqueTwinSyncSse_MutexPtr
-          .asFunction<ffi.Pointer<EnumOpaqueTwinSyncSseKind> Function()>();
-
-  ffi.Pointer<EnumOpaqueTwinSyncSseKind>
-      cst_inflate_EnumOpaqueTwinSyncSse_RwLock() {
-    return _cst_inflate_EnumOpaqueTwinSyncSse_RwLock();
-  }
-
-  late final _cst_inflate_EnumOpaqueTwinSyncSse_RwLockPtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<EnumOpaqueTwinSyncSseKind> Function()>>(
-      'cst_inflate_EnumOpaqueTwinSyncSse_RwLock');
-  late final _cst_inflate_EnumOpaqueTwinSyncSse_RwLock =
-      _cst_inflate_EnumOpaqueTwinSyncSse_RwLockPtr
-          .asFunction<ffi.Pointer<EnumOpaqueTwinSyncSseKind> Function()>();
-
-  ffi.Pointer<EnumWithItemMixedTwinNormalKind>
-      cst_inflate_EnumWithItemMixedTwinNormal_B() {
-    return _cst_inflate_EnumWithItemMixedTwinNormal_B();
-  }
-
-  late final _cst_inflate_EnumWithItemMixedTwinNormal_BPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumWithItemMixedTwinNormalKind>
-              Function()>>('cst_inflate_EnumWithItemMixedTwinNormal_B');
-  late final _cst_inflate_EnumWithItemMixedTwinNormal_B =
-      _cst_inflate_EnumWithItemMixedTwinNormal_BPtr.asFunction<
-          ffi.Pointer<EnumWithItemMixedTwinNormalKind> Function()>();
-
-  ffi.Pointer<EnumWithItemMixedTwinNormalKind>
-      cst_inflate_EnumWithItemMixedTwinNormal_C() {
-    return _cst_inflate_EnumWithItemMixedTwinNormal_C();
-  }
-
-  late final _cst_inflate_EnumWithItemMixedTwinNormal_CPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumWithItemMixedTwinNormalKind>
-              Function()>>('cst_inflate_EnumWithItemMixedTwinNormal_C');
-  late final _cst_inflate_EnumWithItemMixedTwinNormal_C =
-      _cst_inflate_EnumWithItemMixedTwinNormal_CPtr.asFunction<
-          ffi.Pointer<EnumWithItemMixedTwinNormalKind> Function()>();
-
-  ffi.Pointer<EnumWithItemMixedTwinRustAsyncKind>
-      cst_inflate_EnumWithItemMixedTwinRustAsync_B() {
-    return _cst_inflate_EnumWithItemMixedTwinRustAsync_B();
-  }
-
-  late final _cst_inflate_EnumWithItemMixedTwinRustAsync_BPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumWithItemMixedTwinRustAsyncKind>
-              Function()>>('cst_inflate_EnumWithItemMixedTwinRustAsync_B');
-  late final _cst_inflate_EnumWithItemMixedTwinRustAsync_B =
-      _cst_inflate_EnumWithItemMixedTwinRustAsync_BPtr.asFunction<
-          ffi.Pointer<EnumWithItemMixedTwinRustAsyncKind> Function()>();
-
-  ffi.Pointer<EnumWithItemMixedTwinRustAsyncKind>
-      cst_inflate_EnumWithItemMixedTwinRustAsync_C() {
-    return _cst_inflate_EnumWithItemMixedTwinRustAsync_C();
-  }
-
-  late final _cst_inflate_EnumWithItemMixedTwinRustAsync_CPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumWithItemMixedTwinRustAsyncKind>
-              Function()>>('cst_inflate_EnumWithItemMixedTwinRustAsync_C');
-  late final _cst_inflate_EnumWithItemMixedTwinRustAsync_C =
-      _cst_inflate_EnumWithItemMixedTwinRustAsync_CPtr.asFunction<
-          ffi.Pointer<EnumWithItemMixedTwinRustAsyncKind> Function()>();
-
-  ffi.Pointer<EnumWithItemMixedTwinRustAsyncSseKind>
-      cst_inflate_EnumWithItemMixedTwinRustAsyncSse_B() {
-    return _cst_inflate_EnumWithItemMixedTwinRustAsyncSse_B();
-  }
-
-  late final _cst_inflate_EnumWithItemMixedTwinRustAsyncSse_BPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumWithItemMixedTwinRustAsyncSseKind>
-              Function()>>('cst_inflate_EnumWithItemMixedTwinRustAsyncSse_B');
-  late final _cst_inflate_EnumWithItemMixedTwinRustAsyncSse_B =
-      _cst_inflate_EnumWithItemMixedTwinRustAsyncSse_BPtr.asFunction<
-          ffi.Pointer<EnumWithItemMixedTwinRustAsyncSseKind> Function()>();
-
-  ffi.Pointer<EnumWithItemMixedTwinRustAsyncSseKind>
-      cst_inflate_EnumWithItemMixedTwinRustAsyncSse_C() {
-    return _cst_inflate_EnumWithItemMixedTwinRustAsyncSse_C();
-  }
-
-  late final _cst_inflate_EnumWithItemMixedTwinRustAsyncSse_CPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumWithItemMixedTwinRustAsyncSseKind>
-              Function()>>('cst_inflate_EnumWithItemMixedTwinRustAsyncSse_C');
-  late final _cst_inflate_EnumWithItemMixedTwinRustAsyncSse_C =
-      _cst_inflate_EnumWithItemMixedTwinRustAsyncSse_CPtr.asFunction<
-          ffi.Pointer<EnumWithItemMixedTwinRustAsyncSseKind> Function()>();
-
-  ffi.Pointer<EnumWithItemMixedTwinSseKind>
-      cst_inflate_EnumWithItemMixedTwinSse_B() {
-    return _cst_inflate_EnumWithItemMixedTwinSse_B();
-  }
-
-  late final _cst_inflate_EnumWithItemMixedTwinSse_BPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumWithItemMixedTwinSseKind>
-              Function()>>('cst_inflate_EnumWithItemMixedTwinSse_B');
-  late final _cst_inflate_EnumWithItemMixedTwinSse_B =
-      _cst_inflate_EnumWithItemMixedTwinSse_BPtr
-          .asFunction<ffi.Pointer<EnumWithItemMixedTwinSseKind> Function()>();
-
-  ffi.Pointer<EnumWithItemMixedTwinSseKind>
-      cst_inflate_EnumWithItemMixedTwinSse_C() {
-    return _cst_inflate_EnumWithItemMixedTwinSse_C();
-  }
-
-  late final _cst_inflate_EnumWithItemMixedTwinSse_CPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumWithItemMixedTwinSseKind>
-              Function()>>('cst_inflate_EnumWithItemMixedTwinSse_C');
-  late final _cst_inflate_EnumWithItemMixedTwinSse_C =
-      _cst_inflate_EnumWithItemMixedTwinSse_CPtr
-          .asFunction<ffi.Pointer<EnumWithItemMixedTwinSseKind> Function()>();
-
-  ffi.Pointer<EnumWithItemMixedTwinSyncKind>
-      cst_inflate_EnumWithItemMixedTwinSync_B() {
-    return _cst_inflate_EnumWithItemMixedTwinSync_B();
-  }
-
-  late final _cst_inflate_EnumWithItemMixedTwinSync_BPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumWithItemMixedTwinSyncKind>
-              Function()>>('cst_inflate_EnumWithItemMixedTwinSync_B');
-  late final _cst_inflate_EnumWithItemMixedTwinSync_B =
-      _cst_inflate_EnumWithItemMixedTwinSync_BPtr
-          .asFunction<ffi.Pointer<EnumWithItemMixedTwinSyncKind> Function()>();
-
-  ffi.Pointer<EnumWithItemMixedTwinSyncKind>
-      cst_inflate_EnumWithItemMixedTwinSync_C() {
-    return _cst_inflate_EnumWithItemMixedTwinSync_C();
-  }
-
-  late final _cst_inflate_EnumWithItemMixedTwinSync_CPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumWithItemMixedTwinSyncKind>
-              Function()>>('cst_inflate_EnumWithItemMixedTwinSync_C');
-  late final _cst_inflate_EnumWithItemMixedTwinSync_C =
-      _cst_inflate_EnumWithItemMixedTwinSync_CPtr
-          .asFunction<ffi.Pointer<EnumWithItemMixedTwinSyncKind> Function()>();
-
-  ffi.Pointer<EnumWithItemMixedTwinSyncSseKind>
-      cst_inflate_EnumWithItemMixedTwinSyncSse_B() {
-    return _cst_inflate_EnumWithItemMixedTwinSyncSse_B();
-  }
-
-  late final _cst_inflate_EnumWithItemMixedTwinSyncSse_BPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumWithItemMixedTwinSyncSseKind>
-              Function()>>('cst_inflate_EnumWithItemMixedTwinSyncSse_B');
-  late final _cst_inflate_EnumWithItemMixedTwinSyncSse_B =
-      _cst_inflate_EnumWithItemMixedTwinSyncSse_BPtr.asFunction<
-          ffi.Pointer<EnumWithItemMixedTwinSyncSseKind> Function()>();
-
-  ffi.Pointer<EnumWithItemMixedTwinSyncSseKind>
-      cst_inflate_EnumWithItemMixedTwinSyncSse_C() {
-    return _cst_inflate_EnumWithItemMixedTwinSyncSse_C();
-  }
-
-  late final _cst_inflate_EnumWithItemMixedTwinSyncSse_CPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumWithItemMixedTwinSyncSseKind>
-              Function()>>('cst_inflate_EnumWithItemMixedTwinSyncSse_C');
-  late final _cst_inflate_EnumWithItemMixedTwinSyncSse_C =
-      _cst_inflate_EnumWithItemMixedTwinSyncSse_CPtr.asFunction<
-          ffi.Pointer<EnumWithItemMixedTwinSyncSseKind> Function()>();
-
-  ffi.Pointer<EnumWithItemStructTwinNormalKind>
-      cst_inflate_EnumWithItemStructTwinNormal_A() {
-    return _cst_inflate_EnumWithItemStructTwinNormal_A();
-  }
-
-  late final _cst_inflate_EnumWithItemStructTwinNormal_APtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumWithItemStructTwinNormalKind>
-              Function()>>('cst_inflate_EnumWithItemStructTwinNormal_A');
-  late final _cst_inflate_EnumWithItemStructTwinNormal_A =
-      _cst_inflate_EnumWithItemStructTwinNormal_APtr.asFunction<
-          ffi.Pointer<EnumWithItemStructTwinNormalKind> Function()>();
-
-  ffi.Pointer<EnumWithItemStructTwinNormalKind>
-      cst_inflate_EnumWithItemStructTwinNormal_B() {
-    return _cst_inflate_EnumWithItemStructTwinNormal_B();
-  }
-
-  late final _cst_inflate_EnumWithItemStructTwinNormal_BPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumWithItemStructTwinNormalKind>
-              Function()>>('cst_inflate_EnumWithItemStructTwinNormal_B');
-  late final _cst_inflate_EnumWithItemStructTwinNormal_B =
-      _cst_inflate_EnumWithItemStructTwinNormal_BPtr.asFunction<
-          ffi.Pointer<EnumWithItemStructTwinNormalKind> Function()>();
-
-  ffi.Pointer<EnumWithItemStructTwinRustAsyncKind>
-      cst_inflate_EnumWithItemStructTwinRustAsync_A() {
-    return _cst_inflate_EnumWithItemStructTwinRustAsync_A();
-  }
-
-  late final _cst_inflate_EnumWithItemStructTwinRustAsync_APtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumWithItemStructTwinRustAsyncKind>
-              Function()>>('cst_inflate_EnumWithItemStructTwinRustAsync_A');
-  late final _cst_inflate_EnumWithItemStructTwinRustAsync_A =
-      _cst_inflate_EnumWithItemStructTwinRustAsync_APtr.asFunction<
-          ffi.Pointer<EnumWithItemStructTwinRustAsyncKind> Function()>();
-
-  ffi.Pointer<EnumWithItemStructTwinRustAsyncKind>
-      cst_inflate_EnumWithItemStructTwinRustAsync_B() {
-    return _cst_inflate_EnumWithItemStructTwinRustAsync_B();
-  }
-
-  late final _cst_inflate_EnumWithItemStructTwinRustAsync_BPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumWithItemStructTwinRustAsyncKind>
-              Function()>>('cst_inflate_EnumWithItemStructTwinRustAsync_B');
-  late final _cst_inflate_EnumWithItemStructTwinRustAsync_B =
-      _cst_inflate_EnumWithItemStructTwinRustAsync_BPtr.asFunction<
-          ffi.Pointer<EnumWithItemStructTwinRustAsyncKind> Function()>();
-
-  ffi.Pointer<EnumWithItemStructTwinRustAsyncSseKind>
-      cst_inflate_EnumWithItemStructTwinRustAsyncSse_A() {
-    return _cst_inflate_EnumWithItemStructTwinRustAsyncSse_A();
-  }
-
-  late final _cst_inflate_EnumWithItemStructTwinRustAsyncSse_APtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumWithItemStructTwinRustAsyncSseKind>
-              Function()>>('cst_inflate_EnumWithItemStructTwinRustAsyncSse_A');
-  late final _cst_inflate_EnumWithItemStructTwinRustAsyncSse_A =
-      _cst_inflate_EnumWithItemStructTwinRustAsyncSse_APtr.asFunction<
-          ffi.Pointer<EnumWithItemStructTwinRustAsyncSseKind> Function()>();
-
-  ffi.Pointer<EnumWithItemStructTwinRustAsyncSseKind>
-      cst_inflate_EnumWithItemStructTwinRustAsyncSse_B() {
-    return _cst_inflate_EnumWithItemStructTwinRustAsyncSse_B();
-  }
-
-  late final _cst_inflate_EnumWithItemStructTwinRustAsyncSse_BPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumWithItemStructTwinRustAsyncSseKind>
-              Function()>>('cst_inflate_EnumWithItemStructTwinRustAsyncSse_B');
-  late final _cst_inflate_EnumWithItemStructTwinRustAsyncSse_B =
-      _cst_inflate_EnumWithItemStructTwinRustAsyncSse_BPtr.asFunction<
-          ffi.Pointer<EnumWithItemStructTwinRustAsyncSseKind> Function()>();
-
-  ffi.Pointer<EnumWithItemStructTwinSseKind>
-      cst_inflate_EnumWithItemStructTwinSse_A() {
-    return _cst_inflate_EnumWithItemStructTwinSse_A();
-  }
-
-  late final _cst_inflate_EnumWithItemStructTwinSse_APtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumWithItemStructTwinSseKind>
-              Function()>>('cst_inflate_EnumWithItemStructTwinSse_A');
-  late final _cst_inflate_EnumWithItemStructTwinSse_A =
-      _cst_inflate_EnumWithItemStructTwinSse_APtr
-          .asFunction<ffi.Pointer<EnumWithItemStructTwinSseKind> Function()>();
-
-  ffi.Pointer<EnumWithItemStructTwinSseKind>
-      cst_inflate_EnumWithItemStructTwinSse_B() {
-    return _cst_inflate_EnumWithItemStructTwinSse_B();
-  }
-
-  late final _cst_inflate_EnumWithItemStructTwinSse_BPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumWithItemStructTwinSseKind>
-              Function()>>('cst_inflate_EnumWithItemStructTwinSse_B');
-  late final _cst_inflate_EnumWithItemStructTwinSse_B =
-      _cst_inflate_EnumWithItemStructTwinSse_BPtr
-          .asFunction<ffi.Pointer<EnumWithItemStructTwinSseKind> Function()>();
-
-  ffi.Pointer<EnumWithItemStructTwinSyncKind>
-      cst_inflate_EnumWithItemStructTwinSync_A() {
-    return _cst_inflate_EnumWithItemStructTwinSync_A();
-  }
-
-  late final _cst_inflate_EnumWithItemStructTwinSync_APtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumWithItemStructTwinSyncKind>
-              Function()>>('cst_inflate_EnumWithItemStructTwinSync_A');
-  late final _cst_inflate_EnumWithItemStructTwinSync_A =
-      _cst_inflate_EnumWithItemStructTwinSync_APtr
-          .asFunction<ffi.Pointer<EnumWithItemStructTwinSyncKind> Function()>();
-
-  ffi.Pointer<EnumWithItemStructTwinSyncKind>
-      cst_inflate_EnumWithItemStructTwinSync_B() {
-    return _cst_inflate_EnumWithItemStructTwinSync_B();
-  }
-
-  late final _cst_inflate_EnumWithItemStructTwinSync_BPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumWithItemStructTwinSyncKind>
-              Function()>>('cst_inflate_EnumWithItemStructTwinSync_B');
-  late final _cst_inflate_EnumWithItemStructTwinSync_B =
-      _cst_inflate_EnumWithItemStructTwinSync_BPtr
-          .asFunction<ffi.Pointer<EnumWithItemStructTwinSyncKind> Function()>();
-
-  ffi.Pointer<EnumWithItemStructTwinSyncSseKind>
-      cst_inflate_EnumWithItemStructTwinSyncSse_A() {
-    return _cst_inflate_EnumWithItemStructTwinSyncSse_A();
-  }
-
-  late final _cst_inflate_EnumWithItemStructTwinSyncSse_APtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumWithItemStructTwinSyncSseKind>
-              Function()>>('cst_inflate_EnumWithItemStructTwinSyncSse_A');
-  late final _cst_inflate_EnumWithItemStructTwinSyncSse_A =
-      _cst_inflate_EnumWithItemStructTwinSyncSse_APtr.asFunction<
-          ffi.Pointer<EnumWithItemStructTwinSyncSseKind> Function()>();
-
-  ffi.Pointer<EnumWithItemStructTwinSyncSseKind>
-      cst_inflate_EnumWithItemStructTwinSyncSse_B() {
-    return _cst_inflate_EnumWithItemStructTwinSyncSse_B();
-  }
-
-  late final _cst_inflate_EnumWithItemStructTwinSyncSse_BPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumWithItemStructTwinSyncSseKind>
-              Function()>>('cst_inflate_EnumWithItemStructTwinSyncSse_B');
-  late final _cst_inflate_EnumWithItemStructTwinSyncSse_B =
-      _cst_inflate_EnumWithItemStructTwinSyncSse_BPtr.asFunction<
-          ffi.Pointer<EnumWithItemStructTwinSyncSseKind> Function()>();
-
-  ffi.Pointer<EnumWithItemTupleTwinNormalKind>
-      cst_inflate_EnumWithItemTupleTwinNormal_A() {
-    return _cst_inflate_EnumWithItemTupleTwinNormal_A();
-  }
-
-  late final _cst_inflate_EnumWithItemTupleTwinNormal_APtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumWithItemTupleTwinNormalKind>
-              Function()>>('cst_inflate_EnumWithItemTupleTwinNormal_A');
-  late final _cst_inflate_EnumWithItemTupleTwinNormal_A =
-      _cst_inflate_EnumWithItemTupleTwinNormal_APtr.asFunction<
-          ffi.Pointer<EnumWithItemTupleTwinNormalKind> Function()>();
-
-  ffi.Pointer<EnumWithItemTupleTwinNormalKind>
-      cst_inflate_EnumWithItemTupleTwinNormal_B() {
-    return _cst_inflate_EnumWithItemTupleTwinNormal_B();
-  }
-
-  late final _cst_inflate_EnumWithItemTupleTwinNormal_BPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumWithItemTupleTwinNormalKind>
-              Function()>>('cst_inflate_EnumWithItemTupleTwinNormal_B');
-  late final _cst_inflate_EnumWithItemTupleTwinNormal_B =
-      _cst_inflate_EnumWithItemTupleTwinNormal_BPtr.asFunction<
-          ffi.Pointer<EnumWithItemTupleTwinNormalKind> Function()>();
-
-  ffi.Pointer<EnumWithItemTupleTwinRustAsyncKind>
-      cst_inflate_EnumWithItemTupleTwinRustAsync_A() {
-    return _cst_inflate_EnumWithItemTupleTwinRustAsync_A();
-  }
-
-  late final _cst_inflate_EnumWithItemTupleTwinRustAsync_APtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumWithItemTupleTwinRustAsyncKind>
-              Function()>>('cst_inflate_EnumWithItemTupleTwinRustAsync_A');
-  late final _cst_inflate_EnumWithItemTupleTwinRustAsync_A =
-      _cst_inflate_EnumWithItemTupleTwinRustAsync_APtr.asFunction<
-          ffi.Pointer<EnumWithItemTupleTwinRustAsyncKind> Function()>();
-
-  ffi.Pointer<EnumWithItemTupleTwinRustAsyncKind>
-      cst_inflate_EnumWithItemTupleTwinRustAsync_B() {
-    return _cst_inflate_EnumWithItemTupleTwinRustAsync_B();
-  }
-
-  late final _cst_inflate_EnumWithItemTupleTwinRustAsync_BPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumWithItemTupleTwinRustAsyncKind>
-              Function()>>('cst_inflate_EnumWithItemTupleTwinRustAsync_B');
-  late final _cst_inflate_EnumWithItemTupleTwinRustAsync_B =
-      _cst_inflate_EnumWithItemTupleTwinRustAsync_BPtr.asFunction<
-          ffi.Pointer<EnumWithItemTupleTwinRustAsyncKind> Function()>();
-
-  ffi.Pointer<EnumWithItemTupleTwinRustAsyncSseKind>
-      cst_inflate_EnumWithItemTupleTwinRustAsyncSse_A() {
-    return _cst_inflate_EnumWithItemTupleTwinRustAsyncSse_A();
-  }
-
-  late final _cst_inflate_EnumWithItemTupleTwinRustAsyncSse_APtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumWithItemTupleTwinRustAsyncSseKind>
-              Function()>>('cst_inflate_EnumWithItemTupleTwinRustAsyncSse_A');
-  late final _cst_inflate_EnumWithItemTupleTwinRustAsyncSse_A =
-      _cst_inflate_EnumWithItemTupleTwinRustAsyncSse_APtr.asFunction<
-          ffi.Pointer<EnumWithItemTupleTwinRustAsyncSseKind> Function()>();
-
-  ffi.Pointer<EnumWithItemTupleTwinRustAsyncSseKind>
-      cst_inflate_EnumWithItemTupleTwinRustAsyncSse_B() {
-    return _cst_inflate_EnumWithItemTupleTwinRustAsyncSse_B();
-  }
-
-  late final _cst_inflate_EnumWithItemTupleTwinRustAsyncSse_BPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumWithItemTupleTwinRustAsyncSseKind>
-              Function()>>('cst_inflate_EnumWithItemTupleTwinRustAsyncSse_B');
-  late final _cst_inflate_EnumWithItemTupleTwinRustAsyncSse_B =
-      _cst_inflate_EnumWithItemTupleTwinRustAsyncSse_BPtr.asFunction<
-          ffi.Pointer<EnumWithItemTupleTwinRustAsyncSseKind> Function()>();
-
-  ffi.Pointer<EnumWithItemTupleTwinSseKind>
-      cst_inflate_EnumWithItemTupleTwinSse_A() {
-    return _cst_inflate_EnumWithItemTupleTwinSse_A();
-  }
-
-  late final _cst_inflate_EnumWithItemTupleTwinSse_APtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumWithItemTupleTwinSseKind>
-              Function()>>('cst_inflate_EnumWithItemTupleTwinSse_A');
-  late final _cst_inflate_EnumWithItemTupleTwinSse_A =
-      _cst_inflate_EnumWithItemTupleTwinSse_APtr
-          .asFunction<ffi.Pointer<EnumWithItemTupleTwinSseKind> Function()>();
-
-  ffi.Pointer<EnumWithItemTupleTwinSseKind>
-      cst_inflate_EnumWithItemTupleTwinSse_B() {
-    return _cst_inflate_EnumWithItemTupleTwinSse_B();
-  }
-
-  late final _cst_inflate_EnumWithItemTupleTwinSse_BPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumWithItemTupleTwinSseKind>
-              Function()>>('cst_inflate_EnumWithItemTupleTwinSse_B');
-  late final _cst_inflate_EnumWithItemTupleTwinSse_B =
-      _cst_inflate_EnumWithItemTupleTwinSse_BPtr
-          .asFunction<ffi.Pointer<EnumWithItemTupleTwinSseKind> Function()>();
-
-  ffi.Pointer<EnumWithItemTupleTwinSyncKind>
-      cst_inflate_EnumWithItemTupleTwinSync_A() {
-    return _cst_inflate_EnumWithItemTupleTwinSync_A();
-  }
-
-  late final _cst_inflate_EnumWithItemTupleTwinSync_APtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumWithItemTupleTwinSyncKind>
-              Function()>>('cst_inflate_EnumWithItemTupleTwinSync_A');
-  late final _cst_inflate_EnumWithItemTupleTwinSync_A =
-      _cst_inflate_EnumWithItemTupleTwinSync_APtr
-          .asFunction<ffi.Pointer<EnumWithItemTupleTwinSyncKind> Function()>();
-
-  ffi.Pointer<EnumWithItemTupleTwinSyncKind>
-      cst_inflate_EnumWithItemTupleTwinSync_B() {
-    return _cst_inflate_EnumWithItemTupleTwinSync_B();
-  }
-
-  late final _cst_inflate_EnumWithItemTupleTwinSync_BPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumWithItemTupleTwinSyncKind>
-              Function()>>('cst_inflate_EnumWithItemTupleTwinSync_B');
-  late final _cst_inflate_EnumWithItemTupleTwinSync_B =
-      _cst_inflate_EnumWithItemTupleTwinSync_BPtr
-          .asFunction<ffi.Pointer<EnumWithItemTupleTwinSyncKind> Function()>();
-
-  ffi.Pointer<EnumWithItemTupleTwinSyncSseKind>
-      cst_inflate_EnumWithItemTupleTwinSyncSse_A() {
-    return _cst_inflate_EnumWithItemTupleTwinSyncSse_A();
-  }
-
-  late final _cst_inflate_EnumWithItemTupleTwinSyncSse_APtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumWithItemTupleTwinSyncSseKind>
-              Function()>>('cst_inflate_EnumWithItemTupleTwinSyncSse_A');
-  late final _cst_inflate_EnumWithItemTupleTwinSyncSse_A =
-      _cst_inflate_EnumWithItemTupleTwinSyncSse_APtr.asFunction<
-          ffi.Pointer<EnumWithItemTupleTwinSyncSseKind> Function()>();
-
-  ffi.Pointer<EnumWithItemTupleTwinSyncSseKind>
-      cst_inflate_EnumWithItemTupleTwinSyncSse_B() {
-    return _cst_inflate_EnumWithItemTupleTwinSyncSse_B();
-  }
-
-  late final _cst_inflate_EnumWithItemTupleTwinSyncSse_BPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<EnumWithItemTupleTwinSyncSseKind>
-              Function()>>('cst_inflate_EnumWithItemTupleTwinSyncSse_B');
-  late final _cst_inflate_EnumWithItemTupleTwinSyncSse_B =
-      _cst_inflate_EnumWithItemTupleTwinSyncSse_BPtr.asFunction<
-          ffi.Pointer<EnumWithItemTupleTwinSyncSseKind> Function()>();
-
-  ffi.Pointer<KitchenSinkTwinNormalKind>
-      cst_inflate_KitchenSinkTwinNormal_Primitives() {
-    return _cst_inflate_KitchenSinkTwinNormal_Primitives();
-  }
-
-  late final _cst_inflate_KitchenSinkTwinNormal_PrimitivesPtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<KitchenSinkTwinNormalKind> Function()>>(
-      'cst_inflate_KitchenSinkTwinNormal_Primitives');
-  late final _cst_inflate_KitchenSinkTwinNormal_Primitives =
-      _cst_inflate_KitchenSinkTwinNormal_PrimitivesPtr
-          .asFunction<ffi.Pointer<KitchenSinkTwinNormalKind> Function()>();
-
-  ffi.Pointer<KitchenSinkTwinNormalKind>
-      cst_inflate_KitchenSinkTwinNormal_Nested() {
-    return _cst_inflate_KitchenSinkTwinNormal_Nested();
-  }
-
-  late final _cst_inflate_KitchenSinkTwinNormal_NestedPtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<KitchenSinkTwinNormalKind> Function()>>(
-      'cst_inflate_KitchenSinkTwinNormal_Nested');
-  late final _cst_inflate_KitchenSinkTwinNormal_Nested =
-      _cst_inflate_KitchenSinkTwinNormal_NestedPtr
-          .asFunction<ffi.Pointer<KitchenSinkTwinNormalKind> Function()>();
-
-  ffi.Pointer<KitchenSinkTwinNormalKind>
-      cst_inflate_KitchenSinkTwinNormal_Optional() {
-    return _cst_inflate_KitchenSinkTwinNormal_Optional();
-  }
-
-  late final _cst_inflate_KitchenSinkTwinNormal_OptionalPtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<KitchenSinkTwinNormalKind> Function()>>(
-      'cst_inflate_KitchenSinkTwinNormal_Optional');
-  late final _cst_inflate_KitchenSinkTwinNormal_Optional =
-      _cst_inflate_KitchenSinkTwinNormal_OptionalPtr
-          .asFunction<ffi.Pointer<KitchenSinkTwinNormalKind> Function()>();
-
-  ffi.Pointer<KitchenSinkTwinNormalKind>
-      cst_inflate_KitchenSinkTwinNormal_Buffer() {
-    return _cst_inflate_KitchenSinkTwinNormal_Buffer();
-  }
-
-  late final _cst_inflate_KitchenSinkTwinNormal_BufferPtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<KitchenSinkTwinNormalKind> Function()>>(
-      'cst_inflate_KitchenSinkTwinNormal_Buffer');
-  late final _cst_inflate_KitchenSinkTwinNormal_Buffer =
-      _cst_inflate_KitchenSinkTwinNormal_BufferPtr
-          .asFunction<ffi.Pointer<KitchenSinkTwinNormalKind> Function()>();
-
-  ffi.Pointer<KitchenSinkTwinNormalKind>
-      cst_inflate_KitchenSinkTwinNormal_Enums() {
-    return _cst_inflate_KitchenSinkTwinNormal_Enums();
-  }
-
-  late final _cst_inflate_KitchenSinkTwinNormal_EnumsPtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<KitchenSinkTwinNormalKind> Function()>>(
-      'cst_inflate_KitchenSinkTwinNormal_Enums');
-  late final _cst_inflate_KitchenSinkTwinNormal_Enums =
-      _cst_inflate_KitchenSinkTwinNormal_EnumsPtr
-          .asFunction<ffi.Pointer<KitchenSinkTwinNormalKind> Function()>();
-
-  ffi.Pointer<KitchenSinkTwinRustAsyncKind>
-      cst_inflate_KitchenSinkTwinRustAsync_Primitives() {
-    return _cst_inflate_KitchenSinkTwinRustAsync_Primitives();
-  }
-
-  late final _cst_inflate_KitchenSinkTwinRustAsync_PrimitivesPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<KitchenSinkTwinRustAsyncKind>
-              Function()>>('cst_inflate_KitchenSinkTwinRustAsync_Primitives');
-  late final _cst_inflate_KitchenSinkTwinRustAsync_Primitives =
-      _cst_inflate_KitchenSinkTwinRustAsync_PrimitivesPtr
-          .asFunction<ffi.Pointer<KitchenSinkTwinRustAsyncKind> Function()>();
-
-  ffi.Pointer<KitchenSinkTwinRustAsyncKind>
-      cst_inflate_KitchenSinkTwinRustAsync_Nested() {
-    return _cst_inflate_KitchenSinkTwinRustAsync_Nested();
-  }
-
-  late final _cst_inflate_KitchenSinkTwinRustAsync_NestedPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<KitchenSinkTwinRustAsyncKind>
-              Function()>>('cst_inflate_KitchenSinkTwinRustAsync_Nested');
-  late final _cst_inflate_KitchenSinkTwinRustAsync_Nested =
-      _cst_inflate_KitchenSinkTwinRustAsync_NestedPtr
-          .asFunction<ffi.Pointer<KitchenSinkTwinRustAsyncKind> Function()>();
-
-  ffi.Pointer<KitchenSinkTwinRustAsyncKind>
-      cst_inflate_KitchenSinkTwinRustAsync_Optional() {
-    return _cst_inflate_KitchenSinkTwinRustAsync_Optional();
-  }
-
-  late final _cst_inflate_KitchenSinkTwinRustAsync_OptionalPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<KitchenSinkTwinRustAsyncKind>
-              Function()>>('cst_inflate_KitchenSinkTwinRustAsync_Optional');
-  late final _cst_inflate_KitchenSinkTwinRustAsync_Optional =
-      _cst_inflate_KitchenSinkTwinRustAsync_OptionalPtr
-          .asFunction<ffi.Pointer<KitchenSinkTwinRustAsyncKind> Function()>();
-
-  ffi.Pointer<KitchenSinkTwinRustAsyncKind>
-      cst_inflate_KitchenSinkTwinRustAsync_Buffer() {
-    return _cst_inflate_KitchenSinkTwinRustAsync_Buffer();
-  }
-
-  late final _cst_inflate_KitchenSinkTwinRustAsync_BufferPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<KitchenSinkTwinRustAsyncKind>
-              Function()>>('cst_inflate_KitchenSinkTwinRustAsync_Buffer');
-  late final _cst_inflate_KitchenSinkTwinRustAsync_Buffer =
-      _cst_inflate_KitchenSinkTwinRustAsync_BufferPtr
-          .asFunction<ffi.Pointer<KitchenSinkTwinRustAsyncKind> Function()>();
-
-  ffi.Pointer<KitchenSinkTwinRustAsyncKind>
-      cst_inflate_KitchenSinkTwinRustAsync_Enums() {
-    return _cst_inflate_KitchenSinkTwinRustAsync_Enums();
-  }
-
-  late final _cst_inflate_KitchenSinkTwinRustAsync_EnumsPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<KitchenSinkTwinRustAsyncKind>
-              Function()>>('cst_inflate_KitchenSinkTwinRustAsync_Enums');
-  late final _cst_inflate_KitchenSinkTwinRustAsync_Enums =
-      _cst_inflate_KitchenSinkTwinRustAsync_EnumsPtr
-          .asFunction<ffi.Pointer<KitchenSinkTwinRustAsyncKind> Function()>();
-
-  ffi.Pointer<KitchenSinkTwinRustAsyncSseKind>
-      cst_inflate_KitchenSinkTwinRustAsyncSse_Primitives() {
-    return _cst_inflate_KitchenSinkTwinRustAsyncSse_Primitives();
-  }
-
-  late final _cst_inflate_KitchenSinkTwinRustAsyncSse_PrimitivesPtr = _lookup<
-          ffi.NativeFunction<
-              ffi.Pointer<KitchenSinkTwinRustAsyncSseKind> Function()>>(
-      'cst_inflate_KitchenSinkTwinRustAsyncSse_Primitives');
-  late final _cst_inflate_KitchenSinkTwinRustAsyncSse_Primitives =
-      _cst_inflate_KitchenSinkTwinRustAsyncSse_PrimitivesPtr.asFunction<
-          ffi.Pointer<KitchenSinkTwinRustAsyncSseKind> Function()>();
-
-  ffi.Pointer<KitchenSinkTwinRustAsyncSseKind>
-      cst_inflate_KitchenSinkTwinRustAsyncSse_Nested() {
-    return _cst_inflate_KitchenSinkTwinRustAsyncSse_Nested();
-  }
-
-  late final _cst_inflate_KitchenSinkTwinRustAsyncSse_NestedPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<KitchenSinkTwinRustAsyncSseKind>
-              Function()>>('cst_inflate_KitchenSinkTwinRustAsyncSse_Nested');
-  late final _cst_inflate_KitchenSinkTwinRustAsyncSse_Nested =
-      _cst_inflate_KitchenSinkTwinRustAsyncSse_NestedPtr.asFunction<
-          ffi.Pointer<KitchenSinkTwinRustAsyncSseKind> Function()>();
-
-  ffi.Pointer<KitchenSinkTwinRustAsyncSseKind>
-      cst_inflate_KitchenSinkTwinRustAsyncSse_Optional() {
-    return _cst_inflate_KitchenSinkTwinRustAsyncSse_Optional();
-  }
-
-  late final _cst_inflate_KitchenSinkTwinRustAsyncSse_OptionalPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<KitchenSinkTwinRustAsyncSseKind>
-              Function()>>('cst_inflate_KitchenSinkTwinRustAsyncSse_Optional');
-  late final _cst_inflate_KitchenSinkTwinRustAsyncSse_Optional =
-      _cst_inflate_KitchenSinkTwinRustAsyncSse_OptionalPtr.asFunction<
-          ffi.Pointer<KitchenSinkTwinRustAsyncSseKind> Function()>();
-
-  ffi.Pointer<KitchenSinkTwinRustAsyncSseKind>
-      cst_inflate_KitchenSinkTwinRustAsyncSse_Buffer() {
-    return _cst_inflate_KitchenSinkTwinRustAsyncSse_Buffer();
-  }
-
-  late final _cst_inflate_KitchenSinkTwinRustAsyncSse_BufferPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<KitchenSinkTwinRustAsyncSseKind>
-              Function()>>('cst_inflate_KitchenSinkTwinRustAsyncSse_Buffer');
-  late final _cst_inflate_KitchenSinkTwinRustAsyncSse_Buffer =
-      _cst_inflate_KitchenSinkTwinRustAsyncSse_BufferPtr.asFunction<
-          ffi.Pointer<KitchenSinkTwinRustAsyncSseKind> Function()>();
-
-  ffi.Pointer<KitchenSinkTwinRustAsyncSseKind>
-      cst_inflate_KitchenSinkTwinRustAsyncSse_Enums() {
-    return _cst_inflate_KitchenSinkTwinRustAsyncSse_Enums();
-  }
-
-  late final _cst_inflate_KitchenSinkTwinRustAsyncSse_EnumsPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<KitchenSinkTwinRustAsyncSseKind>
-              Function()>>('cst_inflate_KitchenSinkTwinRustAsyncSse_Enums');
-  late final _cst_inflate_KitchenSinkTwinRustAsyncSse_Enums =
-      _cst_inflate_KitchenSinkTwinRustAsyncSse_EnumsPtr.asFunction<
-          ffi.Pointer<KitchenSinkTwinRustAsyncSseKind> Function()>();
-
-  ffi.Pointer<KitchenSinkTwinSseKind>
-      cst_inflate_KitchenSinkTwinSse_Primitives() {
-    return _cst_inflate_KitchenSinkTwinSse_Primitives();
-  }
-
-  late final _cst_inflate_KitchenSinkTwinSse_PrimitivesPtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<KitchenSinkTwinSseKind> Function()>>(
-      'cst_inflate_KitchenSinkTwinSse_Primitives');
-  late final _cst_inflate_KitchenSinkTwinSse_Primitives =
-      _cst_inflate_KitchenSinkTwinSse_PrimitivesPtr
-          .asFunction<ffi.Pointer<KitchenSinkTwinSseKind> Function()>();
-
-  ffi.Pointer<KitchenSinkTwinSseKind> cst_inflate_KitchenSinkTwinSse_Nested() {
-    return _cst_inflate_KitchenSinkTwinSse_Nested();
-  }
-
-  late final _cst_inflate_KitchenSinkTwinSse_NestedPtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<KitchenSinkTwinSseKind> Function()>>(
-      'cst_inflate_KitchenSinkTwinSse_Nested');
-  late final _cst_inflate_KitchenSinkTwinSse_Nested =
-      _cst_inflate_KitchenSinkTwinSse_NestedPtr
-          .asFunction<ffi.Pointer<KitchenSinkTwinSseKind> Function()>();
-
-  ffi.Pointer<KitchenSinkTwinSseKind>
-      cst_inflate_KitchenSinkTwinSse_Optional() {
-    return _cst_inflate_KitchenSinkTwinSse_Optional();
-  }
-
-  late final _cst_inflate_KitchenSinkTwinSse_OptionalPtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<KitchenSinkTwinSseKind> Function()>>(
-      'cst_inflate_KitchenSinkTwinSse_Optional');
-  late final _cst_inflate_KitchenSinkTwinSse_Optional =
-      _cst_inflate_KitchenSinkTwinSse_OptionalPtr
-          .asFunction<ffi.Pointer<KitchenSinkTwinSseKind> Function()>();
-
-  ffi.Pointer<KitchenSinkTwinSseKind> cst_inflate_KitchenSinkTwinSse_Buffer() {
-    return _cst_inflate_KitchenSinkTwinSse_Buffer();
-  }
-
-  late final _cst_inflate_KitchenSinkTwinSse_BufferPtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<KitchenSinkTwinSseKind> Function()>>(
-      'cst_inflate_KitchenSinkTwinSse_Buffer');
-  late final _cst_inflate_KitchenSinkTwinSse_Buffer =
-      _cst_inflate_KitchenSinkTwinSse_BufferPtr
-          .asFunction<ffi.Pointer<KitchenSinkTwinSseKind> Function()>();
-
-  ffi.Pointer<KitchenSinkTwinSseKind> cst_inflate_KitchenSinkTwinSse_Enums() {
-    return _cst_inflate_KitchenSinkTwinSse_Enums();
-  }
-
-  late final _cst_inflate_KitchenSinkTwinSse_EnumsPtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<KitchenSinkTwinSseKind> Function()>>(
-      'cst_inflate_KitchenSinkTwinSse_Enums');
-  late final _cst_inflate_KitchenSinkTwinSse_Enums =
-      _cst_inflate_KitchenSinkTwinSse_EnumsPtr
-          .asFunction<ffi.Pointer<KitchenSinkTwinSseKind> Function()>();
-
-  ffi.Pointer<KitchenSinkTwinSyncKind>
-      cst_inflate_KitchenSinkTwinSync_Primitives() {
-    return _cst_inflate_KitchenSinkTwinSync_Primitives();
-  }
-
-  late final _cst_inflate_KitchenSinkTwinSync_PrimitivesPtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<KitchenSinkTwinSyncKind> Function()>>(
-      'cst_inflate_KitchenSinkTwinSync_Primitives');
-  late final _cst_inflate_KitchenSinkTwinSync_Primitives =
-      _cst_inflate_KitchenSinkTwinSync_PrimitivesPtr
-          .asFunction<ffi.Pointer<KitchenSinkTwinSyncKind> Function()>();
-
-  ffi.Pointer<KitchenSinkTwinSyncKind>
-      cst_inflate_KitchenSinkTwinSync_Nested() {
-    return _cst_inflate_KitchenSinkTwinSync_Nested();
-  }
-
-  late final _cst_inflate_KitchenSinkTwinSync_NestedPtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<KitchenSinkTwinSyncKind> Function()>>(
-      'cst_inflate_KitchenSinkTwinSync_Nested');
-  late final _cst_inflate_KitchenSinkTwinSync_Nested =
-      _cst_inflate_KitchenSinkTwinSync_NestedPtr
-          .asFunction<ffi.Pointer<KitchenSinkTwinSyncKind> Function()>();
-
-  ffi.Pointer<KitchenSinkTwinSyncKind>
-      cst_inflate_KitchenSinkTwinSync_Optional() {
-    return _cst_inflate_KitchenSinkTwinSync_Optional();
-  }
-
-  late final _cst_inflate_KitchenSinkTwinSync_OptionalPtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<KitchenSinkTwinSyncKind> Function()>>(
-      'cst_inflate_KitchenSinkTwinSync_Optional');
-  late final _cst_inflate_KitchenSinkTwinSync_Optional =
-      _cst_inflate_KitchenSinkTwinSync_OptionalPtr
-          .asFunction<ffi.Pointer<KitchenSinkTwinSyncKind> Function()>();
-
-  ffi.Pointer<KitchenSinkTwinSyncKind>
-      cst_inflate_KitchenSinkTwinSync_Buffer() {
-    return _cst_inflate_KitchenSinkTwinSync_Buffer();
-  }
-
-  late final _cst_inflate_KitchenSinkTwinSync_BufferPtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<KitchenSinkTwinSyncKind> Function()>>(
-      'cst_inflate_KitchenSinkTwinSync_Buffer');
-  late final _cst_inflate_KitchenSinkTwinSync_Buffer =
-      _cst_inflate_KitchenSinkTwinSync_BufferPtr
-          .asFunction<ffi.Pointer<KitchenSinkTwinSyncKind> Function()>();
-
-  ffi.Pointer<KitchenSinkTwinSyncKind> cst_inflate_KitchenSinkTwinSync_Enums() {
-    return _cst_inflate_KitchenSinkTwinSync_Enums();
-  }
-
-  late final _cst_inflate_KitchenSinkTwinSync_EnumsPtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<KitchenSinkTwinSyncKind> Function()>>(
-      'cst_inflate_KitchenSinkTwinSync_Enums');
-  late final _cst_inflate_KitchenSinkTwinSync_Enums =
-      _cst_inflate_KitchenSinkTwinSync_EnumsPtr
-          .asFunction<ffi.Pointer<KitchenSinkTwinSyncKind> Function()>();
-
-  ffi.Pointer<KitchenSinkTwinSyncSseKind>
-      cst_inflate_KitchenSinkTwinSyncSse_Primitives() {
-    return _cst_inflate_KitchenSinkTwinSyncSse_Primitives();
-  }
-
-  late final _cst_inflate_KitchenSinkTwinSyncSse_PrimitivesPtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<KitchenSinkTwinSyncSseKind> Function()>>(
-      'cst_inflate_KitchenSinkTwinSyncSse_Primitives');
-  late final _cst_inflate_KitchenSinkTwinSyncSse_Primitives =
-      _cst_inflate_KitchenSinkTwinSyncSse_PrimitivesPtr
-          .asFunction<ffi.Pointer<KitchenSinkTwinSyncSseKind> Function()>();
-
-  ffi.Pointer<KitchenSinkTwinSyncSseKind>
-      cst_inflate_KitchenSinkTwinSyncSse_Nested() {
-    return _cst_inflate_KitchenSinkTwinSyncSse_Nested();
-  }
-
-  late final _cst_inflate_KitchenSinkTwinSyncSse_NestedPtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<KitchenSinkTwinSyncSseKind> Function()>>(
-      'cst_inflate_KitchenSinkTwinSyncSse_Nested');
-  late final _cst_inflate_KitchenSinkTwinSyncSse_Nested =
-      _cst_inflate_KitchenSinkTwinSyncSse_NestedPtr
-          .asFunction<ffi.Pointer<KitchenSinkTwinSyncSseKind> Function()>();
-
-  ffi.Pointer<KitchenSinkTwinSyncSseKind>
-      cst_inflate_KitchenSinkTwinSyncSse_Optional() {
-    return _cst_inflate_KitchenSinkTwinSyncSse_Optional();
-  }
-
-  late final _cst_inflate_KitchenSinkTwinSyncSse_OptionalPtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<KitchenSinkTwinSyncSseKind> Function()>>(
-      'cst_inflate_KitchenSinkTwinSyncSse_Optional');
-  late final _cst_inflate_KitchenSinkTwinSyncSse_Optional =
-      _cst_inflate_KitchenSinkTwinSyncSse_OptionalPtr
-          .asFunction<ffi.Pointer<KitchenSinkTwinSyncSseKind> Function()>();
-
-  ffi.Pointer<KitchenSinkTwinSyncSseKind>
-      cst_inflate_KitchenSinkTwinSyncSse_Buffer() {
-    return _cst_inflate_KitchenSinkTwinSyncSse_Buffer();
-  }
-
-  late final _cst_inflate_KitchenSinkTwinSyncSse_BufferPtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<KitchenSinkTwinSyncSseKind> Function()>>(
-      'cst_inflate_KitchenSinkTwinSyncSse_Buffer');
-  late final _cst_inflate_KitchenSinkTwinSyncSse_Buffer =
-      _cst_inflate_KitchenSinkTwinSyncSse_BufferPtr
-          .asFunction<ffi.Pointer<KitchenSinkTwinSyncSseKind> Function()>();
-
-  ffi.Pointer<KitchenSinkTwinSyncSseKind>
-      cst_inflate_KitchenSinkTwinSyncSse_Enums() {
-    return _cst_inflate_KitchenSinkTwinSyncSse_Enums();
-  }
-
-  late final _cst_inflate_KitchenSinkTwinSyncSse_EnumsPtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<KitchenSinkTwinSyncSseKind> Function()>>(
-      'cst_inflate_KitchenSinkTwinSyncSse_Enums');
-  late final _cst_inflate_KitchenSinkTwinSyncSse_Enums =
-      _cst_inflate_KitchenSinkTwinSyncSse_EnumsPtr
-          .asFunction<ffi.Pointer<KitchenSinkTwinSyncSseKind> Function()>();
-
-  ffi.Pointer<MeasureTwinNormalKind> cst_inflate_MeasureTwinNormal_Speed() {
-    return _cst_inflate_MeasureTwinNormal_Speed();
-  }
-
-  late final _cst_inflate_MeasureTwinNormal_SpeedPtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<MeasureTwinNormalKind> Function()>>(
-      'cst_inflate_MeasureTwinNormal_Speed');
-  late final _cst_inflate_MeasureTwinNormal_Speed =
-      _cst_inflate_MeasureTwinNormal_SpeedPtr
-          .asFunction<ffi.Pointer<MeasureTwinNormalKind> Function()>();
-
-  ffi.Pointer<MeasureTwinNormalKind> cst_inflate_MeasureTwinNormal_Distance() {
-    return _cst_inflate_MeasureTwinNormal_Distance();
-  }
-
-  late final _cst_inflate_MeasureTwinNormal_DistancePtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<MeasureTwinNormalKind> Function()>>(
-      'cst_inflate_MeasureTwinNormal_Distance');
-  late final _cst_inflate_MeasureTwinNormal_Distance =
-      _cst_inflate_MeasureTwinNormal_DistancePtr
-          .asFunction<ffi.Pointer<MeasureTwinNormalKind> Function()>();
-
-  ffi.Pointer<MeasureTwinRustAsyncKind>
-      cst_inflate_MeasureTwinRustAsync_Speed() {
-    return _cst_inflate_MeasureTwinRustAsync_Speed();
-  }
-
-  late final _cst_inflate_MeasureTwinRustAsync_SpeedPtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<MeasureTwinRustAsyncKind> Function()>>(
-      'cst_inflate_MeasureTwinRustAsync_Speed');
-  late final _cst_inflate_MeasureTwinRustAsync_Speed =
-      _cst_inflate_MeasureTwinRustAsync_SpeedPtr
-          .asFunction<ffi.Pointer<MeasureTwinRustAsyncKind> Function()>();
-
-  ffi.Pointer<MeasureTwinRustAsyncKind>
-      cst_inflate_MeasureTwinRustAsync_Distance() {
-    return _cst_inflate_MeasureTwinRustAsync_Distance();
-  }
-
-  late final _cst_inflate_MeasureTwinRustAsync_DistancePtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<MeasureTwinRustAsyncKind> Function()>>(
-      'cst_inflate_MeasureTwinRustAsync_Distance');
-  late final _cst_inflate_MeasureTwinRustAsync_Distance =
-      _cst_inflate_MeasureTwinRustAsync_DistancePtr
-          .asFunction<ffi.Pointer<MeasureTwinRustAsyncKind> Function()>();
-
-  ffi.Pointer<MeasureTwinRustAsyncSseKind>
-      cst_inflate_MeasureTwinRustAsyncSse_Speed() {
-    return _cst_inflate_MeasureTwinRustAsyncSse_Speed();
-  }
-
-  late final _cst_inflate_MeasureTwinRustAsyncSse_SpeedPtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<MeasureTwinRustAsyncSseKind> Function()>>(
-      'cst_inflate_MeasureTwinRustAsyncSse_Speed');
-  late final _cst_inflate_MeasureTwinRustAsyncSse_Speed =
-      _cst_inflate_MeasureTwinRustAsyncSse_SpeedPtr
-          .asFunction<ffi.Pointer<MeasureTwinRustAsyncSseKind> Function()>();
-
-  ffi.Pointer<MeasureTwinRustAsyncSseKind>
-      cst_inflate_MeasureTwinRustAsyncSse_Distance() {
-    return _cst_inflate_MeasureTwinRustAsyncSse_Distance();
-  }
-
-  late final _cst_inflate_MeasureTwinRustAsyncSse_DistancePtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<MeasureTwinRustAsyncSseKind> Function()>>(
-      'cst_inflate_MeasureTwinRustAsyncSse_Distance');
-  late final _cst_inflate_MeasureTwinRustAsyncSse_Distance =
-      _cst_inflate_MeasureTwinRustAsyncSse_DistancePtr
-          .asFunction<ffi.Pointer<MeasureTwinRustAsyncSseKind> Function()>();
-
-  ffi.Pointer<MeasureTwinSseKind> cst_inflate_MeasureTwinSse_Speed() {
-    return _cst_inflate_MeasureTwinSse_Speed();
-  }
-
-  late final _cst_inflate_MeasureTwinSse_SpeedPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<MeasureTwinSseKind> Function()>>(
-          'cst_inflate_MeasureTwinSse_Speed');
-  late final _cst_inflate_MeasureTwinSse_Speed =
-      _cst_inflate_MeasureTwinSse_SpeedPtr
-          .asFunction<ffi.Pointer<MeasureTwinSseKind> Function()>();
-
-  ffi.Pointer<MeasureTwinSseKind> cst_inflate_MeasureTwinSse_Distance() {
-    return _cst_inflate_MeasureTwinSse_Distance();
-  }
-
-  late final _cst_inflate_MeasureTwinSse_DistancePtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<MeasureTwinSseKind> Function()>>(
-          'cst_inflate_MeasureTwinSse_Distance');
-  late final _cst_inflate_MeasureTwinSse_Distance =
-      _cst_inflate_MeasureTwinSse_DistancePtr
-          .asFunction<ffi.Pointer<MeasureTwinSseKind> Function()>();
-
-  ffi.Pointer<MeasureTwinSyncKind> cst_inflate_MeasureTwinSync_Speed() {
-    return _cst_inflate_MeasureTwinSync_Speed();
-  }
-
-  late final _cst_inflate_MeasureTwinSync_SpeedPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<MeasureTwinSyncKind> Function()>>(
-          'cst_inflate_MeasureTwinSync_Speed');
-  late final _cst_inflate_MeasureTwinSync_Speed =
-      _cst_inflate_MeasureTwinSync_SpeedPtr
-          .asFunction<ffi.Pointer<MeasureTwinSyncKind> Function()>();
-
-  ffi.Pointer<MeasureTwinSyncKind> cst_inflate_MeasureTwinSync_Distance() {
-    return _cst_inflate_MeasureTwinSync_Distance();
-  }
-
-  late final _cst_inflate_MeasureTwinSync_DistancePtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<MeasureTwinSyncKind> Function()>>(
-          'cst_inflate_MeasureTwinSync_Distance');
-  late final _cst_inflate_MeasureTwinSync_Distance =
-      _cst_inflate_MeasureTwinSync_DistancePtr
-          .asFunction<ffi.Pointer<MeasureTwinSyncKind> Function()>();
-
-  ffi.Pointer<MeasureTwinSyncSseKind> cst_inflate_MeasureTwinSyncSse_Speed() {
-    return _cst_inflate_MeasureTwinSyncSse_Speed();
-  }
-
-  late final _cst_inflate_MeasureTwinSyncSse_SpeedPtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<MeasureTwinSyncSseKind> Function()>>(
-      'cst_inflate_MeasureTwinSyncSse_Speed');
-  late final _cst_inflate_MeasureTwinSyncSse_Speed =
-      _cst_inflate_MeasureTwinSyncSse_SpeedPtr
-          .asFunction<ffi.Pointer<MeasureTwinSyncSseKind> Function()>();
-
-  ffi.Pointer<MeasureTwinSyncSseKind>
-      cst_inflate_MeasureTwinSyncSse_Distance() {
-    return _cst_inflate_MeasureTwinSyncSse_Distance();
-  }
-
-  late final _cst_inflate_MeasureTwinSyncSse_DistancePtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<MeasureTwinSyncSseKind> Function()>>(
-      'cst_inflate_MeasureTwinSyncSse_Distance');
-  late final _cst_inflate_MeasureTwinSyncSse_Distance =
-      _cst_inflate_MeasureTwinSyncSse_DistancePtr
-          .asFunction<ffi.Pointer<MeasureTwinSyncSseKind> Function()>();
-
-  ffi.Pointer<RawStringEnumMirroredKind>
-      cst_inflate_RawStringEnumMirrored_Raw() {
-    return _cst_inflate_RawStringEnumMirrored_Raw();
-  }
-
-  late final _cst_inflate_RawStringEnumMirrored_RawPtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<RawStringEnumMirroredKind> Function()>>(
-      'cst_inflate_RawStringEnumMirrored_Raw');
-  late final _cst_inflate_RawStringEnumMirrored_Raw =
-      _cst_inflate_RawStringEnumMirrored_RawPtr
-          .asFunction<ffi.Pointer<RawStringEnumMirroredKind> Function()>();
-
-  ffi.Pointer<RawStringEnumMirroredKind>
-      cst_inflate_RawStringEnumMirrored_Nested() {
-    return _cst_inflate_RawStringEnumMirrored_Nested();
-  }
-
-  late final _cst_inflate_RawStringEnumMirrored_NestedPtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<RawStringEnumMirroredKind> Function()>>(
-      'cst_inflate_RawStringEnumMirrored_Nested');
-  late final _cst_inflate_RawStringEnumMirrored_Nested =
-      _cst_inflate_RawStringEnumMirrored_NestedPtr
-          .asFunction<ffi.Pointer<RawStringEnumMirroredKind> Function()>();
-
-  ffi.Pointer<RawStringEnumMirroredKind>
-      cst_inflate_RawStringEnumMirrored_ListOfNested() {
-    return _cst_inflate_RawStringEnumMirrored_ListOfNested();
-  }
-
-  late final _cst_inflate_RawStringEnumMirrored_ListOfNestedPtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<RawStringEnumMirroredKind> Function()>>(
-      'cst_inflate_RawStringEnumMirrored_ListOfNested');
-  late final _cst_inflate_RawStringEnumMirrored_ListOfNested =
-      _cst_inflate_RawStringEnumMirrored_ListOfNestedPtr
-          .asFunction<ffi.Pointer<RawStringEnumMirroredKind> Function()>();
-
-  ffi.Pointer<SpeedTwinNormalKind> cst_inflate_SpeedTwinNormal_GPS() {
-    return _cst_inflate_SpeedTwinNormal_GPS();
-  }
-
-  late final _cst_inflate_SpeedTwinNormal_GPSPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<SpeedTwinNormalKind> Function()>>(
-          'cst_inflate_SpeedTwinNormal_GPS');
-  late final _cst_inflate_SpeedTwinNormal_GPS =
-      _cst_inflate_SpeedTwinNormal_GPSPtr
-          .asFunction<ffi.Pointer<SpeedTwinNormalKind> Function()>();
-
-  ffi.Pointer<SpeedTwinRustAsyncKind> cst_inflate_SpeedTwinRustAsync_GPS() {
-    return _cst_inflate_SpeedTwinRustAsync_GPS();
-  }
-
-  late final _cst_inflate_SpeedTwinRustAsync_GPSPtr = _lookup<
-          ffi.NativeFunction<ffi.Pointer<SpeedTwinRustAsyncKind> Function()>>(
-      'cst_inflate_SpeedTwinRustAsync_GPS');
-  late final _cst_inflate_SpeedTwinRustAsync_GPS =
-      _cst_inflate_SpeedTwinRustAsync_GPSPtr
-          .asFunction<ffi.Pointer<SpeedTwinRustAsyncKind> Function()>();
-
-  ffi.Pointer<SpeedTwinRustAsyncSseKind>
-      cst_inflate_SpeedTwinRustAsyncSse_GPS() {
-    return _cst_inflate_SpeedTwinRustAsyncSse_GPS();
-  }
-
-  late final _cst_inflate_SpeedTwinRustAsyncSse_GPSPtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Pointer<SpeedTwinRustAsyncSseKind> Function()>>(
-      'cst_inflate_SpeedTwinRustAsyncSse_GPS');
-  late final _cst_inflate_SpeedTwinRustAsyncSse_GPS =
-      _cst_inflate_SpeedTwinRustAsyncSse_GPSPtr
-          .asFunction<ffi.Pointer<SpeedTwinRustAsyncSseKind> Function()>();
-
-  ffi.Pointer<SpeedTwinSseKind> cst_inflate_SpeedTwinSse_GPS() {
-    return _cst_inflate_SpeedTwinSse_GPS();
-  }
-
-  late final _cst_inflate_SpeedTwinSse_GPSPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<SpeedTwinSseKind> Function()>>(
-          'cst_inflate_SpeedTwinSse_GPS');
-  late final _cst_inflate_SpeedTwinSse_GPS = _cst_inflate_SpeedTwinSse_GPSPtr
-      .asFunction<ffi.Pointer<SpeedTwinSseKind> Function()>();
-
-  ffi.Pointer<SpeedTwinSyncKind> cst_inflate_SpeedTwinSync_GPS() {
-    return _cst_inflate_SpeedTwinSync_GPS();
-  }
-
-  late final _cst_inflate_SpeedTwinSync_GPSPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<SpeedTwinSyncKind> Function()>>(
-          'cst_inflate_SpeedTwinSync_GPS');
-  late final _cst_inflate_SpeedTwinSync_GPS = _cst_inflate_SpeedTwinSync_GPSPtr
-      .asFunction<ffi.Pointer<SpeedTwinSyncKind> Function()>();
-
-  ffi.Pointer<SpeedTwinSyncSseKind> cst_inflate_SpeedTwinSyncSse_GPS() {
-    return _cst_inflate_SpeedTwinSyncSse_GPS();
-  }
-
-  late final _cst_inflate_SpeedTwinSyncSse_GPSPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<SpeedTwinSyncSseKind> Function()>>(
-          'cst_inflate_SpeedTwinSyncSse_GPS');
-  late final _cst_inflate_SpeedTwinSyncSse_GPS =
-      _cst_inflate_SpeedTwinSyncSse_GPSPtr
-          .asFunction<ffi.Pointer<SpeedTwinSyncSseKind> Function()>();
-
   int dummy_method_to_enforce_bundling() {
     return _dummy_method_to_enforce_bundling();
   }
@@ -66239,16 +63054,16 @@ final class wire_cst_EnumDartOpaqueTwinNormal_Opaque extends ffi.Struct {
 }
 
 final class EnumDartOpaqueTwinNormalKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_EnumDartOpaqueTwinNormal_Primitive> Primitive;
+  external wire_cst_EnumDartOpaqueTwinNormal_Primitive Primitive;
 
-  external ffi.Pointer<wire_cst_EnumDartOpaqueTwinNormal_Opaque> Opaque;
+  external wire_cst_EnumDartOpaqueTwinNormal_Opaque Opaque;
 }
 
 final class wire_cst_enum_dart_opaque_twin_normal extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<EnumDartOpaqueTwinNormalKind> kind;
+  external EnumDartOpaqueTwinNormalKind kind;
 }
 
 final class wire_cst_dart_opaque_nested_twin_normal extends ffi.Struct {
@@ -66264,8 +63079,6 @@ final class wire_cst_list_DartOpaque extends ffi.Struct {
   external int len;
 }
 
-final class wire_cst_EnumWithItemMixedTwinNormal_A extends ffi.Opaque {}
-
 final class wire_cst_EnumWithItemMixedTwinNormal_B extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8> field0;
 }
@@ -66275,18 +63088,16 @@ final class wire_cst_EnumWithItemMixedTwinNormal_C extends ffi.Struct {
 }
 
 final class EnumWithItemMixedTwinNormalKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_EnumWithItemMixedTwinNormal_A> A;
+  external wire_cst_EnumWithItemMixedTwinNormal_B B;
 
-  external ffi.Pointer<wire_cst_EnumWithItemMixedTwinNormal_B> B;
-
-  external ffi.Pointer<wire_cst_EnumWithItemMixedTwinNormal_C> C;
+  external wire_cst_EnumWithItemMixedTwinNormal_C C;
 }
 
 final class wire_cst_enum_with_item_mixed_twin_normal extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<EnumWithItemMixedTwinNormalKind> kind;
+  external EnumWithItemMixedTwinNormalKind kind;
 }
 
 final class wire_cst_EnumWithItemStructTwinNormal_A extends ffi.Struct {
@@ -66298,16 +63109,16 @@ final class wire_cst_EnumWithItemStructTwinNormal_B extends ffi.Struct {
 }
 
 final class EnumWithItemStructTwinNormalKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_EnumWithItemStructTwinNormal_A> A;
+  external wire_cst_EnumWithItemStructTwinNormal_A A;
 
-  external ffi.Pointer<wire_cst_EnumWithItemStructTwinNormal_B> B;
+  external wire_cst_EnumWithItemStructTwinNormal_B B;
 }
 
 final class wire_cst_enum_with_item_struct_twin_normal extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<EnumWithItemStructTwinNormalKind> kind;
+  external EnumWithItemStructTwinNormalKind kind;
 }
 
 final class wire_cst_EnumWithItemTupleTwinNormal_A extends ffi.Struct {
@@ -66319,19 +63130,17 @@ final class wire_cst_EnumWithItemTupleTwinNormal_B extends ffi.Struct {
 }
 
 final class EnumWithItemTupleTwinNormalKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_EnumWithItemTupleTwinNormal_A> A;
+  external wire_cst_EnumWithItemTupleTwinNormal_A A;
 
-  external ffi.Pointer<wire_cst_EnumWithItemTupleTwinNormal_B> B;
+  external wire_cst_EnumWithItemTupleTwinNormal_B B;
 }
 
 final class wire_cst_enum_with_item_tuple_twin_normal extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<EnumWithItemTupleTwinNormalKind> kind;
+  external EnumWithItemTupleTwinNormalKind kind;
 }
-
-final class wire_cst_KitchenSinkTwinNormal_Empty extends ffi.Opaque {}
 
 final class wire_cst_KitchenSinkTwinNormal_Primitives extends ffi.Struct {
   @ffi.Int32()
@@ -66355,21 +63164,19 @@ final class wire_cst_kitchen_sink_twin_normal extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<KitchenSinkTwinNormalKind> kind;
+  external KitchenSinkTwinNormalKind kind;
 }
 
 final class KitchenSinkTwinNormalKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_KitchenSinkTwinNormal_Empty> Empty;
+  external wire_cst_KitchenSinkTwinNormal_Primitives Primitives;
 
-  external ffi.Pointer<wire_cst_KitchenSinkTwinNormal_Primitives> Primitives;
+  external wire_cst_KitchenSinkTwinNormal_Nested Nested;
 
-  external ffi.Pointer<wire_cst_KitchenSinkTwinNormal_Nested> Nested;
+  external wire_cst_KitchenSinkTwinNormal_Optional Optional;
 
-  external ffi.Pointer<wire_cst_KitchenSinkTwinNormal_Optional> Optional;
+  external wire_cst_KitchenSinkTwinNormal_Buffer Buffer;
 
-  external ffi.Pointer<wire_cst_KitchenSinkTwinNormal_Buffer> Buffer;
-
-  external ffi.Pointer<wire_cst_KitchenSinkTwinNormal_Enums> Enums;
+  external wire_cst_KitchenSinkTwinNormal_Enums Enums;
 }
 
 final class wire_cst_KitchenSinkTwinNormal_Optional extends ffi.Struct {
@@ -66387,31 +63194,25 @@ final class wire_cst_KitchenSinkTwinNormal_Enums extends ffi.Struct {
   external int field0;
 }
 
-final class wire_cst_SpeedTwinNormal_Unknown extends ffi.Opaque {}
-
 final class wire_cst_SpeedTwinNormal_GPS extends ffi.Struct {
   @ffi.Double()
   external double field0;
 }
 
 final class SpeedTwinNormalKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_SpeedTwinNormal_Unknown> Unknown;
-
-  external ffi.Pointer<wire_cst_SpeedTwinNormal_GPS> GPS;
+  external wire_cst_SpeedTwinNormal_GPS GPS;
 }
 
 final class wire_cst_speed_twin_normal extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<SpeedTwinNormalKind> kind;
+  external SpeedTwinNormalKind kind;
 }
 
 final class wire_cst_MeasureTwinNormal_Speed extends ffi.Struct {
   external ffi.Pointer<wire_cst_speed_twin_normal> field0;
 }
-
-final class wire_cst_DistanceTwinNormal_Unknown extends ffi.Opaque {}
 
 final class wire_cst_DistanceTwinNormal_Map extends ffi.Struct {
   @ffi.Double()
@@ -66419,16 +63220,14 @@ final class wire_cst_DistanceTwinNormal_Map extends ffi.Struct {
 }
 
 final class DistanceTwinNormalKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_DistanceTwinNormal_Unknown> Unknown;
-
-  external ffi.Pointer<wire_cst_DistanceTwinNormal_Map> Map;
+  external wire_cst_DistanceTwinNormal_Map Map;
 }
 
 final class wire_cst_distance_twin_normal extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<DistanceTwinNormalKind> kind;
+  external DistanceTwinNormalKind kind;
 }
 
 final class wire_cst_MeasureTwinNormal_Distance extends ffi.Struct {
@@ -66436,16 +63235,16 @@ final class wire_cst_MeasureTwinNormal_Distance extends ffi.Struct {
 }
 
 final class MeasureTwinNormalKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_MeasureTwinNormal_Speed> Speed;
+  external wire_cst_MeasureTwinNormal_Speed Speed;
 
-  external ffi.Pointer<wire_cst_MeasureTwinNormal_Distance> Distance;
+  external wire_cst_MeasureTwinNormal_Distance Distance;
 }
 
 final class wire_cst_measure_twin_normal extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<MeasureTwinNormalKind> kind;
+  external MeasureTwinNormalKind kind;
 }
 
 final class wire_cst_note_twin_normal extends ffi.Struct {
@@ -66483,16 +63282,16 @@ final class wire_cst_CustomNestedErrorInnerTwinNormal_Four extends ffi.Struct {
 }
 
 final class CustomNestedErrorInnerTwinNormalKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_CustomNestedErrorInnerTwinNormal_Three> Three;
+  external wire_cst_CustomNestedErrorInnerTwinNormal_Three Three;
 
-  external ffi.Pointer<wire_cst_CustomNestedErrorInnerTwinNormal_Four> Four;
+  external wire_cst_CustomNestedErrorInnerTwinNormal_Four Four;
 }
 
 final class wire_cst_custom_nested_error_inner_twin_normal extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<CustomNestedErrorInnerTwinNormalKind> kind;
+  external CustomNestedErrorInnerTwinNormalKind kind;
 }
 
 final class wire_cst_CustomNestedErrorOuterTwinNormal_Two extends ffi.Struct {
@@ -66500,16 +63299,16 @@ final class wire_cst_CustomNestedErrorOuterTwinNormal_Two extends ffi.Struct {
 }
 
 final class CustomNestedErrorOuterTwinNormalKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_CustomNestedErrorOuterTwinNormal_One> One;
+  external wire_cst_CustomNestedErrorOuterTwinNormal_One One;
 
-  external ffi.Pointer<wire_cst_CustomNestedErrorOuterTwinNormal_Two> Two;
+  external wire_cst_CustomNestedErrorOuterTwinNormal_Two Two;
 }
 
 final class wire_cst_custom_nested_error_outer_twin_normal extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<CustomNestedErrorOuterTwinNormalKind> kind;
+  external CustomNestedErrorOuterTwinNormalKind kind;
 }
 
 final class wire_cst_custom_struct_error_twin_normal extends ffi.Struct {
@@ -66647,20 +63446,20 @@ final class wire_cst_AbcTwinNormal_JustInt extends ffi.Struct {
 }
 
 final class AbcTwinNormalKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_AbcTwinNormal_A> A;
+  external wire_cst_AbcTwinNormal_A A;
 
-  external ffi.Pointer<wire_cst_AbcTwinNormal_B> B;
+  external wire_cst_AbcTwinNormal_B B;
 
-  external ffi.Pointer<wire_cst_AbcTwinNormal_C> C;
+  external wire_cst_AbcTwinNormal_C C;
 
-  external ffi.Pointer<wire_cst_AbcTwinNormal_JustInt> JustInt;
+  external wire_cst_AbcTwinNormal_JustInt JustInt;
 }
 
 final class wire_cst_abc_twin_normal extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<AbcTwinNormalKind> kind;
+  external AbcTwinNormalKind kind;
 }
 
 final class wire_cst_struct_with_enum_twin_normal extends ffi.Struct {
@@ -66961,17 +63760,16 @@ final class wire_cst_EnumDartOpaqueTwinRustAsync_Opaque extends ffi.Struct {
 }
 
 final class EnumDartOpaqueTwinRustAsyncKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_EnumDartOpaqueTwinRustAsync_Primitive>
-      Primitive;
+  external wire_cst_EnumDartOpaqueTwinRustAsync_Primitive Primitive;
 
-  external ffi.Pointer<wire_cst_EnumDartOpaqueTwinRustAsync_Opaque> Opaque;
+  external wire_cst_EnumDartOpaqueTwinRustAsync_Opaque Opaque;
 }
 
 final class wire_cst_enum_dart_opaque_twin_rust_async extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<EnumDartOpaqueTwinRustAsyncKind> kind;
+  external EnumDartOpaqueTwinRustAsyncKind kind;
 }
 
 final class wire_cst_dart_opaque_nested_twin_rust_async extends ffi.Struct {
@@ -66990,16 +63788,16 @@ final class wire_cst_EnumDartOpaqueTwinSync_Opaque extends ffi.Struct {
 }
 
 final class EnumDartOpaqueTwinSyncKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_EnumDartOpaqueTwinSync_Primitive> Primitive;
+  external wire_cst_EnumDartOpaqueTwinSync_Primitive Primitive;
 
-  external ffi.Pointer<wire_cst_EnumDartOpaqueTwinSync_Opaque> Opaque;
+  external wire_cst_EnumDartOpaqueTwinSync_Opaque Opaque;
 }
 
 final class wire_cst_enum_dart_opaque_twin_sync extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<EnumDartOpaqueTwinSyncKind> kind;
+  external EnumDartOpaqueTwinSyncKind kind;
 }
 
 final class wire_cst_dart_opaque_nested_twin_sync extends ffi.Struct {
@@ -67007,8 +63805,6 @@ final class wire_cst_dart_opaque_nested_twin_sync extends ffi.Struct {
 
   external ffi.Pointer<ffi.Void> second;
 }
-
-final class wire_cst_EnumWithItemMixedTwinRustAsync_A extends ffi.Opaque {}
 
 final class wire_cst_EnumWithItemMixedTwinRustAsync_B extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8> field0;
@@ -67019,18 +63815,16 @@ final class wire_cst_EnumWithItemMixedTwinRustAsync_C extends ffi.Struct {
 }
 
 final class EnumWithItemMixedTwinRustAsyncKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_EnumWithItemMixedTwinRustAsync_A> A;
+  external wire_cst_EnumWithItemMixedTwinRustAsync_B B;
 
-  external ffi.Pointer<wire_cst_EnumWithItemMixedTwinRustAsync_B> B;
-
-  external ffi.Pointer<wire_cst_EnumWithItemMixedTwinRustAsync_C> C;
+  external wire_cst_EnumWithItemMixedTwinRustAsync_C C;
 }
 
 final class wire_cst_enum_with_item_mixed_twin_rust_async extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<EnumWithItemMixedTwinRustAsyncKind> kind;
+  external EnumWithItemMixedTwinRustAsyncKind kind;
 }
 
 final class wire_cst_EnumWithItemStructTwinRustAsync_A extends ffi.Struct {
@@ -67042,16 +63836,16 @@ final class wire_cst_EnumWithItemStructTwinRustAsync_B extends ffi.Struct {
 }
 
 final class EnumWithItemStructTwinRustAsyncKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_EnumWithItemStructTwinRustAsync_A> A;
+  external wire_cst_EnumWithItemStructTwinRustAsync_A A;
 
-  external ffi.Pointer<wire_cst_EnumWithItemStructTwinRustAsync_B> B;
+  external wire_cst_EnumWithItemStructTwinRustAsync_B B;
 }
 
 final class wire_cst_enum_with_item_struct_twin_rust_async extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<EnumWithItemStructTwinRustAsyncKind> kind;
+  external EnumWithItemStructTwinRustAsyncKind kind;
 }
 
 final class wire_cst_EnumWithItemTupleTwinRustAsync_A extends ffi.Struct {
@@ -67063,19 +63857,17 @@ final class wire_cst_EnumWithItemTupleTwinRustAsync_B extends ffi.Struct {
 }
 
 final class EnumWithItemTupleTwinRustAsyncKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_EnumWithItemTupleTwinRustAsync_A> A;
+  external wire_cst_EnumWithItemTupleTwinRustAsync_A A;
 
-  external ffi.Pointer<wire_cst_EnumWithItemTupleTwinRustAsync_B> B;
+  external wire_cst_EnumWithItemTupleTwinRustAsync_B B;
 }
 
 final class wire_cst_enum_with_item_tuple_twin_rust_async extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<EnumWithItemTupleTwinRustAsyncKind> kind;
+  external EnumWithItemTupleTwinRustAsyncKind kind;
 }
-
-final class wire_cst_KitchenSinkTwinRustAsync_Empty extends ffi.Opaque {}
 
 final class wire_cst_KitchenSinkTwinRustAsync_Primitives extends ffi.Struct {
   @ffi.Int32()
@@ -67099,21 +63891,19 @@ final class wire_cst_kitchen_sink_twin_rust_async extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<KitchenSinkTwinRustAsyncKind> kind;
+  external KitchenSinkTwinRustAsyncKind kind;
 }
 
 final class KitchenSinkTwinRustAsyncKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_KitchenSinkTwinRustAsync_Empty> Empty;
+  external wire_cst_KitchenSinkTwinRustAsync_Primitives Primitives;
 
-  external ffi.Pointer<wire_cst_KitchenSinkTwinRustAsync_Primitives> Primitives;
+  external wire_cst_KitchenSinkTwinRustAsync_Nested Nested;
 
-  external ffi.Pointer<wire_cst_KitchenSinkTwinRustAsync_Nested> Nested;
+  external wire_cst_KitchenSinkTwinRustAsync_Optional Optional;
 
-  external ffi.Pointer<wire_cst_KitchenSinkTwinRustAsync_Optional> Optional;
+  external wire_cst_KitchenSinkTwinRustAsync_Buffer Buffer;
 
-  external ffi.Pointer<wire_cst_KitchenSinkTwinRustAsync_Buffer> Buffer;
-
-  external ffi.Pointer<wire_cst_KitchenSinkTwinRustAsync_Enums> Enums;
+  external wire_cst_KitchenSinkTwinRustAsync_Enums Enums;
 }
 
 final class wire_cst_KitchenSinkTwinRustAsync_Optional extends ffi.Struct {
@@ -67131,31 +63921,25 @@ final class wire_cst_KitchenSinkTwinRustAsync_Enums extends ffi.Struct {
   external int field0;
 }
 
-final class wire_cst_SpeedTwinRustAsync_Unknown extends ffi.Opaque {}
-
 final class wire_cst_SpeedTwinRustAsync_GPS extends ffi.Struct {
   @ffi.Double()
   external double field0;
 }
 
 final class SpeedTwinRustAsyncKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_SpeedTwinRustAsync_Unknown> Unknown;
-
-  external ffi.Pointer<wire_cst_SpeedTwinRustAsync_GPS> GPS;
+  external wire_cst_SpeedTwinRustAsync_GPS GPS;
 }
 
 final class wire_cst_speed_twin_rust_async extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<SpeedTwinRustAsyncKind> kind;
+  external SpeedTwinRustAsyncKind kind;
 }
 
 final class wire_cst_MeasureTwinRustAsync_Speed extends ffi.Struct {
   external ffi.Pointer<wire_cst_speed_twin_rust_async> field0;
 }
-
-final class wire_cst_DistanceTwinRustAsync_Unknown extends ffi.Opaque {}
 
 final class wire_cst_DistanceTwinRustAsync_Map extends ffi.Struct {
   @ffi.Double()
@@ -67163,16 +63947,14 @@ final class wire_cst_DistanceTwinRustAsync_Map extends ffi.Struct {
 }
 
 final class DistanceTwinRustAsyncKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_DistanceTwinRustAsync_Unknown> Unknown;
-
-  external ffi.Pointer<wire_cst_DistanceTwinRustAsync_Map> Map;
+  external wire_cst_DistanceTwinRustAsync_Map Map;
 }
 
 final class wire_cst_distance_twin_rust_async extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<DistanceTwinRustAsyncKind> kind;
+  external DistanceTwinRustAsyncKind kind;
 }
 
 final class wire_cst_MeasureTwinRustAsync_Distance extends ffi.Struct {
@@ -67180,16 +63962,16 @@ final class wire_cst_MeasureTwinRustAsync_Distance extends ffi.Struct {
 }
 
 final class MeasureTwinRustAsyncKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_MeasureTwinRustAsync_Speed> Speed;
+  external wire_cst_MeasureTwinRustAsync_Speed Speed;
 
-  external ffi.Pointer<wire_cst_MeasureTwinRustAsync_Distance> Distance;
+  external wire_cst_MeasureTwinRustAsync_Distance Distance;
 }
 
 final class wire_cst_measure_twin_rust_async extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<MeasureTwinRustAsyncKind> kind;
+  external MeasureTwinRustAsyncKind kind;
 }
 
 final class wire_cst_note_twin_rust_async extends ffi.Struct {
@@ -67197,8 +63979,6 @@ final class wire_cst_note_twin_rust_async extends ffi.Struct {
 
   external ffi.Pointer<wire_cst_list_prim_u_8> body;
 }
-
-final class wire_cst_EnumWithItemMixedTwinSync_A extends ffi.Opaque {}
 
 final class wire_cst_EnumWithItemMixedTwinSync_B extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8> field0;
@@ -67209,18 +63989,16 @@ final class wire_cst_EnumWithItemMixedTwinSync_C extends ffi.Struct {
 }
 
 final class EnumWithItemMixedTwinSyncKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_EnumWithItemMixedTwinSync_A> A;
+  external wire_cst_EnumWithItemMixedTwinSync_B B;
 
-  external ffi.Pointer<wire_cst_EnumWithItemMixedTwinSync_B> B;
-
-  external ffi.Pointer<wire_cst_EnumWithItemMixedTwinSync_C> C;
+  external wire_cst_EnumWithItemMixedTwinSync_C C;
 }
 
 final class wire_cst_enum_with_item_mixed_twin_sync extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<EnumWithItemMixedTwinSyncKind> kind;
+  external EnumWithItemMixedTwinSyncKind kind;
 }
 
 final class wire_cst_EnumWithItemStructTwinSync_A extends ffi.Struct {
@@ -67232,16 +64010,16 @@ final class wire_cst_EnumWithItemStructTwinSync_B extends ffi.Struct {
 }
 
 final class EnumWithItemStructTwinSyncKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_EnumWithItemStructTwinSync_A> A;
+  external wire_cst_EnumWithItemStructTwinSync_A A;
 
-  external ffi.Pointer<wire_cst_EnumWithItemStructTwinSync_B> B;
+  external wire_cst_EnumWithItemStructTwinSync_B B;
 }
 
 final class wire_cst_enum_with_item_struct_twin_sync extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<EnumWithItemStructTwinSyncKind> kind;
+  external EnumWithItemStructTwinSyncKind kind;
 }
 
 final class wire_cst_EnumWithItemTupleTwinSync_A extends ffi.Struct {
@@ -67253,19 +64031,17 @@ final class wire_cst_EnumWithItemTupleTwinSync_B extends ffi.Struct {
 }
 
 final class EnumWithItemTupleTwinSyncKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_EnumWithItemTupleTwinSync_A> A;
+  external wire_cst_EnumWithItemTupleTwinSync_A A;
 
-  external ffi.Pointer<wire_cst_EnumWithItemTupleTwinSync_B> B;
+  external wire_cst_EnumWithItemTupleTwinSync_B B;
 }
 
 final class wire_cst_enum_with_item_tuple_twin_sync extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<EnumWithItemTupleTwinSyncKind> kind;
+  external EnumWithItemTupleTwinSyncKind kind;
 }
-
-final class wire_cst_KitchenSinkTwinSync_Empty extends ffi.Opaque {}
 
 final class wire_cst_KitchenSinkTwinSync_Primitives extends ffi.Struct {
   @ffi.Int32()
@@ -67289,21 +64065,19 @@ final class wire_cst_kitchen_sink_twin_sync extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<KitchenSinkTwinSyncKind> kind;
+  external KitchenSinkTwinSyncKind kind;
 }
 
 final class KitchenSinkTwinSyncKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_KitchenSinkTwinSync_Empty> Empty;
+  external wire_cst_KitchenSinkTwinSync_Primitives Primitives;
 
-  external ffi.Pointer<wire_cst_KitchenSinkTwinSync_Primitives> Primitives;
+  external wire_cst_KitchenSinkTwinSync_Nested Nested;
 
-  external ffi.Pointer<wire_cst_KitchenSinkTwinSync_Nested> Nested;
+  external wire_cst_KitchenSinkTwinSync_Optional Optional;
 
-  external ffi.Pointer<wire_cst_KitchenSinkTwinSync_Optional> Optional;
+  external wire_cst_KitchenSinkTwinSync_Buffer Buffer;
 
-  external ffi.Pointer<wire_cst_KitchenSinkTwinSync_Buffer> Buffer;
-
-  external ffi.Pointer<wire_cst_KitchenSinkTwinSync_Enums> Enums;
+  external wire_cst_KitchenSinkTwinSync_Enums Enums;
 }
 
 final class wire_cst_KitchenSinkTwinSync_Optional extends ffi.Struct {
@@ -67321,31 +64095,25 @@ final class wire_cst_KitchenSinkTwinSync_Enums extends ffi.Struct {
   external int field0;
 }
 
-final class wire_cst_SpeedTwinSync_Unknown extends ffi.Opaque {}
-
 final class wire_cst_SpeedTwinSync_GPS extends ffi.Struct {
   @ffi.Double()
   external double field0;
 }
 
 final class SpeedTwinSyncKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_SpeedTwinSync_Unknown> Unknown;
-
-  external ffi.Pointer<wire_cst_SpeedTwinSync_GPS> GPS;
+  external wire_cst_SpeedTwinSync_GPS GPS;
 }
 
 final class wire_cst_speed_twin_sync extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<SpeedTwinSyncKind> kind;
+  external SpeedTwinSyncKind kind;
 }
 
 final class wire_cst_MeasureTwinSync_Speed extends ffi.Struct {
   external ffi.Pointer<wire_cst_speed_twin_sync> field0;
 }
-
-final class wire_cst_DistanceTwinSync_Unknown extends ffi.Opaque {}
 
 final class wire_cst_DistanceTwinSync_Map extends ffi.Struct {
   @ffi.Double()
@@ -67353,16 +64121,14 @@ final class wire_cst_DistanceTwinSync_Map extends ffi.Struct {
 }
 
 final class DistanceTwinSyncKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_DistanceTwinSync_Unknown> Unknown;
-
-  external ffi.Pointer<wire_cst_DistanceTwinSync_Map> Map;
+  external wire_cst_DistanceTwinSync_Map Map;
 }
 
 final class wire_cst_distance_twin_sync extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<DistanceTwinSyncKind> kind;
+  external DistanceTwinSyncKind kind;
 }
 
 final class wire_cst_MeasureTwinSync_Distance extends ffi.Struct {
@@ -67370,16 +64136,16 @@ final class wire_cst_MeasureTwinSync_Distance extends ffi.Struct {
 }
 
 final class MeasureTwinSyncKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_MeasureTwinSync_Speed> Speed;
+  external wire_cst_MeasureTwinSync_Speed Speed;
 
-  external ffi.Pointer<wire_cst_MeasureTwinSync_Distance> Distance;
+  external wire_cst_MeasureTwinSync_Distance Distance;
 }
 
 final class wire_cst_measure_twin_sync extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<MeasureTwinSyncKind> kind;
+  external MeasureTwinSyncKind kind;
 }
 
 final class wire_cst_note_twin_sync extends ffi.Struct {
@@ -67420,10 +64186,9 @@ final class wire_cst_CustomNestedErrorInnerTwinRustAsync_Four
 }
 
 final class CustomNestedErrorInnerTwinRustAsyncKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_CustomNestedErrorInnerTwinRustAsync_Three>
-      Three;
+  external wire_cst_CustomNestedErrorInnerTwinRustAsync_Three Three;
 
-  external ffi.Pointer<wire_cst_CustomNestedErrorInnerTwinRustAsync_Four> Four;
+  external wire_cst_CustomNestedErrorInnerTwinRustAsync_Four Four;
 }
 
 final class wire_cst_custom_nested_error_inner_twin_rust_async
@@ -67431,7 +64196,7 @@ final class wire_cst_custom_nested_error_inner_twin_rust_async
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<CustomNestedErrorInnerTwinRustAsyncKind> kind;
+  external CustomNestedErrorInnerTwinRustAsyncKind kind;
 }
 
 final class wire_cst_CustomNestedErrorOuterTwinRustAsync_Two
@@ -67441,9 +64206,9 @@ final class wire_cst_CustomNestedErrorOuterTwinRustAsync_Two
 }
 
 final class CustomNestedErrorOuterTwinRustAsyncKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_CustomNestedErrorOuterTwinRustAsync_One> One;
+  external wire_cst_CustomNestedErrorOuterTwinRustAsync_One One;
 
-  external ffi.Pointer<wire_cst_CustomNestedErrorOuterTwinRustAsync_Two> Two;
+  external wire_cst_CustomNestedErrorOuterTwinRustAsync_Two Two;
 }
 
 final class wire_cst_custom_nested_error_outer_twin_rust_async
@@ -67451,7 +64216,7 @@ final class wire_cst_custom_nested_error_outer_twin_rust_async
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<CustomNestedErrorOuterTwinRustAsyncKind> kind;
+  external CustomNestedErrorOuterTwinRustAsyncKind kind;
 }
 
 final class wire_cst_custom_struct_error_twin_rust_async extends ffi.Struct {
@@ -67481,16 +64246,16 @@ final class wire_cst_CustomNestedErrorInnerTwinSync_Four extends ffi.Struct {
 }
 
 final class CustomNestedErrorInnerTwinSyncKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_CustomNestedErrorInnerTwinSync_Three> Three;
+  external wire_cst_CustomNestedErrorInnerTwinSync_Three Three;
 
-  external ffi.Pointer<wire_cst_CustomNestedErrorInnerTwinSync_Four> Four;
+  external wire_cst_CustomNestedErrorInnerTwinSync_Four Four;
 }
 
 final class wire_cst_custom_nested_error_inner_twin_sync extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<CustomNestedErrorInnerTwinSyncKind> kind;
+  external CustomNestedErrorInnerTwinSyncKind kind;
 }
 
 final class wire_cst_CustomNestedErrorOuterTwinSync_Two extends ffi.Struct {
@@ -67498,16 +64263,16 @@ final class wire_cst_CustomNestedErrorOuterTwinSync_Two extends ffi.Struct {
 }
 
 final class CustomNestedErrorOuterTwinSyncKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_CustomNestedErrorOuterTwinSync_One> One;
+  external wire_cst_CustomNestedErrorOuterTwinSync_One One;
 
-  external ffi.Pointer<wire_cst_CustomNestedErrorOuterTwinSync_Two> Two;
+  external wire_cst_CustomNestedErrorOuterTwinSync_Two Two;
 }
 
 final class wire_cst_custom_nested_error_outer_twin_sync extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<CustomNestedErrorOuterTwinSyncKind> kind;
+  external CustomNestedErrorOuterTwinSyncKind kind;
 }
 
 final class wire_cst_custom_struct_error_twin_sync extends ffi.Struct {
@@ -67597,20 +64362,20 @@ final class wire_cst_AbcTwinRustAsync_JustInt extends ffi.Struct {
 }
 
 final class AbcTwinRustAsyncKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_AbcTwinRustAsync_A> A;
+  external wire_cst_AbcTwinRustAsync_A A;
 
-  external ffi.Pointer<wire_cst_AbcTwinRustAsync_B> B;
+  external wire_cst_AbcTwinRustAsync_B B;
 
-  external ffi.Pointer<wire_cst_AbcTwinRustAsync_C> C;
+  external wire_cst_AbcTwinRustAsync_C C;
 
-  external ffi.Pointer<wire_cst_AbcTwinRustAsync_JustInt> JustInt;
+  external wire_cst_AbcTwinRustAsync_JustInt JustInt;
 }
 
 final class wire_cst_abc_twin_rust_async extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<AbcTwinRustAsyncKind> kind;
+  external AbcTwinRustAsyncKind kind;
 }
 
 final class wire_cst_struct_with_enum_twin_rust_async extends ffi.Struct {
@@ -67684,20 +64449,20 @@ final class wire_cst_AbcTwinSync_JustInt extends ffi.Struct {
 }
 
 final class AbcTwinSyncKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_AbcTwinSync_A> A;
+  external wire_cst_AbcTwinSync_A A;
 
-  external ffi.Pointer<wire_cst_AbcTwinSync_B> B;
+  external wire_cst_AbcTwinSync_B B;
 
-  external ffi.Pointer<wire_cst_AbcTwinSync_C> C;
+  external wire_cst_AbcTwinSync_C C;
 
-  external ffi.Pointer<wire_cst_AbcTwinSync_JustInt> JustInt;
+  external wire_cst_AbcTwinSync_JustInt JustInt;
 }
 
 final class wire_cst_abc_twin_sync extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<AbcTwinSyncKind> kind;
+  external AbcTwinSyncKind kind;
 }
 
 final class wire_cst_struct_with_enum_twin_sync extends ffi.Struct {
@@ -67933,22 +64698,22 @@ final class wire_cst_EnumOpaqueTwinRustAsync_RwLock extends ffi.Struct {
 }
 
 final class EnumOpaqueTwinRustAsyncKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_EnumOpaqueTwinRustAsync_Struct> Struct;
+  external wire_cst_EnumOpaqueTwinRustAsync_Struct Struct;
 
-  external ffi.Pointer<wire_cst_EnumOpaqueTwinRustAsync_Primitive> Primitive;
+  external wire_cst_EnumOpaqueTwinRustAsync_Primitive Primitive;
 
-  external ffi.Pointer<wire_cst_EnumOpaqueTwinRustAsync_TraitObj> TraitObj;
+  external wire_cst_EnumOpaqueTwinRustAsync_TraitObj TraitObj;
 
-  external ffi.Pointer<wire_cst_EnumOpaqueTwinRustAsync_Mutex> Mutex;
+  external wire_cst_EnumOpaqueTwinRustAsync_Mutex Mutex;
 
-  external ffi.Pointer<wire_cst_EnumOpaqueTwinRustAsync_RwLock> RwLock;
+  external wire_cst_EnumOpaqueTwinRustAsync_RwLock RwLock;
 }
 
 final class wire_cst_enum_opaque_twin_rust_async extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<EnumOpaqueTwinRustAsyncKind> kind;
+  external EnumOpaqueTwinRustAsyncKind kind;
 }
 
 final class wire_cst_opaque_nested_twin_rust_async extends ffi.Struct {
@@ -67978,22 +64743,22 @@ final class wire_cst_EnumOpaqueTwinSync_RwLock extends ffi.Struct {
 }
 
 final class EnumOpaqueTwinSyncKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_EnumOpaqueTwinSync_Struct> Struct;
+  external wire_cst_EnumOpaqueTwinSync_Struct Struct;
 
-  external ffi.Pointer<wire_cst_EnumOpaqueTwinSync_Primitive> Primitive;
+  external wire_cst_EnumOpaqueTwinSync_Primitive Primitive;
 
-  external ffi.Pointer<wire_cst_EnumOpaqueTwinSync_TraitObj> TraitObj;
+  external wire_cst_EnumOpaqueTwinSync_TraitObj TraitObj;
 
-  external ffi.Pointer<wire_cst_EnumOpaqueTwinSync_Mutex> Mutex;
+  external wire_cst_EnumOpaqueTwinSync_Mutex Mutex;
 
-  external ffi.Pointer<wire_cst_EnumOpaqueTwinSync_RwLock> RwLock;
+  external wire_cst_EnumOpaqueTwinSync_RwLock RwLock;
 }
 
 final class wire_cst_enum_opaque_twin_sync extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<EnumOpaqueTwinSyncKind> kind;
+  external EnumOpaqueTwinSyncKind kind;
 }
 
 final class wire_cst_opaque_nested_twin_sync extends ffi.Struct {
@@ -68104,22 +64869,22 @@ final class wire_cst_EnumOpaqueTwinNormal_RwLock extends ffi.Struct {
 }
 
 final class EnumOpaqueTwinNormalKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_EnumOpaqueTwinNormal_Struct> Struct;
+  external wire_cst_EnumOpaqueTwinNormal_Struct Struct;
 
-  external ffi.Pointer<wire_cst_EnumOpaqueTwinNormal_Primitive> Primitive;
+  external wire_cst_EnumOpaqueTwinNormal_Primitive Primitive;
 
-  external ffi.Pointer<wire_cst_EnumOpaqueTwinNormal_TraitObj> TraitObj;
+  external wire_cst_EnumOpaqueTwinNormal_TraitObj TraitObj;
 
-  external ffi.Pointer<wire_cst_EnumOpaqueTwinNormal_Mutex> Mutex;
+  external wire_cst_EnumOpaqueTwinNormal_Mutex Mutex;
 
-  external ffi.Pointer<wire_cst_EnumOpaqueTwinNormal_RwLock> RwLock;
+  external wire_cst_EnumOpaqueTwinNormal_RwLock RwLock;
 }
 
 final class wire_cst_enum_opaque_twin_normal extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<EnumOpaqueTwinNormalKind> kind;
+  external EnumOpaqueTwinNormalKind kind;
 }
 
 final class wire_cst_opaque_nested_twin_normal extends ffi.Struct {
@@ -68202,20 +64967,20 @@ final class wire_cst_AbcTwinRustAsyncSse_JustInt extends ffi.Struct {
 }
 
 final class AbcTwinRustAsyncSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_AbcTwinRustAsyncSse_A> A;
+  external wire_cst_AbcTwinRustAsyncSse_A A;
 
-  external ffi.Pointer<wire_cst_AbcTwinRustAsyncSse_B> B;
+  external wire_cst_AbcTwinRustAsyncSse_B B;
 
-  external ffi.Pointer<wire_cst_AbcTwinRustAsyncSse_C> C;
+  external wire_cst_AbcTwinRustAsyncSse_C C;
 
-  external ffi.Pointer<wire_cst_AbcTwinRustAsyncSse_JustInt> JustInt;
+  external wire_cst_AbcTwinRustAsyncSse_JustInt JustInt;
 }
 
 final class wire_cst_abc_twin_rust_async_sse extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<AbcTwinRustAsyncSseKind> kind;
+  external AbcTwinRustAsyncSseKind kind;
 }
 
 final class wire_cst_AbcTwinSse_A extends ffi.Struct {
@@ -68246,20 +65011,20 @@ final class wire_cst_AbcTwinSse_JustInt extends ffi.Struct {
 }
 
 final class AbcTwinSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_AbcTwinSse_A> A;
+  external wire_cst_AbcTwinSse_A A;
 
-  external ffi.Pointer<wire_cst_AbcTwinSse_B> B;
+  external wire_cst_AbcTwinSse_B B;
 
-  external ffi.Pointer<wire_cst_AbcTwinSse_C> C;
+  external wire_cst_AbcTwinSse_C C;
 
-  external ffi.Pointer<wire_cst_AbcTwinSse_JustInt> JustInt;
+  external wire_cst_AbcTwinSse_JustInt JustInt;
 }
 
 final class wire_cst_abc_twin_sse extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<AbcTwinSseKind> kind;
+  external AbcTwinSseKind kind;
 }
 
 final class wire_cst_AbcTwinSyncSse_A extends ffi.Struct {
@@ -68290,20 +65055,20 @@ final class wire_cst_AbcTwinSyncSse_JustInt extends ffi.Struct {
 }
 
 final class AbcTwinSyncSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_AbcTwinSyncSse_A> A;
+  external wire_cst_AbcTwinSyncSse_A A;
 
-  external ffi.Pointer<wire_cst_AbcTwinSyncSse_B> B;
+  external wire_cst_AbcTwinSyncSse_B B;
 
-  external ffi.Pointer<wire_cst_AbcTwinSyncSse_C> C;
+  external wire_cst_AbcTwinSyncSse_C C;
 
-  external ffi.Pointer<wire_cst_AbcTwinSyncSse_JustInt> JustInt;
+  external wire_cst_AbcTwinSyncSse_JustInt JustInt;
 }
 
 final class wire_cst_abc_twin_sync_sse extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<AbcTwinSyncSseKind> kind;
+  external AbcTwinSyncSseKind kind;
 }
 
 final class wire_cst_attribute_twin_rust_async_sse extends ffi.Struct {
@@ -68398,11 +65163,9 @@ final class wire_cst_CustomNestedError2TwinNormal_CustomNested2Number
 }
 
 final class CustomNestedError2TwinNormalKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_CustomNestedError2TwinNormal_CustomNested2>
-      CustomNested2;
+  external wire_cst_CustomNestedError2TwinNormal_CustomNested2 CustomNested2;
 
-  external ffi
-      .Pointer<wire_cst_CustomNestedError2TwinNormal_CustomNested2Number>
+  external wire_cst_CustomNestedError2TwinNormal_CustomNested2Number
       CustomNested2Number;
 }
 
@@ -68410,7 +65173,7 @@ final class wire_cst_custom_nested_error_2_twin_normal extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<CustomNestedError2TwinNormalKind> kind;
+  external CustomNestedError2TwinNormalKind kind;
 }
 
 final class wire_cst_CustomNestedError2TwinRustAsync_CustomNested2
@@ -68425,11 +65188,9 @@ final class wire_cst_CustomNestedError2TwinRustAsync_CustomNested2Number
 }
 
 final class CustomNestedError2TwinRustAsyncKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_CustomNestedError2TwinRustAsync_CustomNested2>
-      CustomNested2;
+  external wire_cst_CustomNestedError2TwinRustAsync_CustomNested2 CustomNested2;
 
-  external ffi
-      .Pointer<wire_cst_CustomNestedError2TwinRustAsync_CustomNested2Number>
+  external wire_cst_CustomNestedError2TwinRustAsync_CustomNested2Number
       CustomNested2Number;
 }
 
@@ -68437,7 +65198,7 @@ final class wire_cst_custom_nested_error_2_twin_rust_async extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<CustomNestedError2TwinRustAsyncKind> kind;
+  external CustomNestedError2TwinRustAsyncKind kind;
 }
 
 final class wire_cst_CustomNestedError2TwinRustAsyncSse_CustomNested2
@@ -68452,12 +65213,10 @@ final class wire_cst_CustomNestedError2TwinRustAsyncSse_CustomNested2Number
 }
 
 final class CustomNestedError2TwinRustAsyncSseKind extends ffi.Union {
-  external ffi
-      .Pointer<wire_cst_CustomNestedError2TwinRustAsyncSse_CustomNested2>
+  external wire_cst_CustomNestedError2TwinRustAsyncSse_CustomNested2
       CustomNested2;
 
-  external ffi
-      .Pointer<wire_cst_CustomNestedError2TwinRustAsyncSse_CustomNested2Number>
+  external wire_cst_CustomNestedError2TwinRustAsyncSse_CustomNested2Number
       CustomNested2Number;
 }
 
@@ -68466,7 +65225,7 @@ final class wire_cst_custom_nested_error_2_twin_rust_async_sse
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<CustomNestedError2TwinRustAsyncSseKind> kind;
+  external CustomNestedError2TwinRustAsyncSseKind kind;
 }
 
 final class wire_cst_CustomNestedError2TwinSse_CustomNested2
@@ -68481,10 +65240,9 @@ final class wire_cst_CustomNestedError2TwinSse_CustomNested2Number
 }
 
 final class CustomNestedError2TwinSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_CustomNestedError2TwinSse_CustomNested2>
-      CustomNested2;
+  external wire_cst_CustomNestedError2TwinSse_CustomNested2 CustomNested2;
 
-  external ffi.Pointer<wire_cst_CustomNestedError2TwinSse_CustomNested2Number>
+  external wire_cst_CustomNestedError2TwinSse_CustomNested2Number
       CustomNested2Number;
 }
 
@@ -68492,7 +65250,7 @@ final class wire_cst_custom_nested_error_2_twin_sse extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<CustomNestedError2TwinSseKind> kind;
+  external CustomNestedError2TwinSseKind kind;
 }
 
 final class wire_cst_CustomNestedError2TwinSync_CustomNested2
@@ -68507,10 +65265,9 @@ final class wire_cst_CustomNestedError2TwinSync_CustomNested2Number
 }
 
 final class CustomNestedError2TwinSyncKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_CustomNestedError2TwinSync_CustomNested2>
-      CustomNested2;
+  external wire_cst_CustomNestedError2TwinSync_CustomNested2 CustomNested2;
 
-  external ffi.Pointer<wire_cst_CustomNestedError2TwinSync_CustomNested2Number>
+  external wire_cst_CustomNestedError2TwinSync_CustomNested2Number
       CustomNested2Number;
 }
 
@@ -68518,7 +65275,7 @@ final class wire_cst_custom_nested_error_2_twin_sync extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<CustomNestedError2TwinSyncKind> kind;
+  external CustomNestedError2TwinSyncKind kind;
 }
 
 final class wire_cst_CustomNestedError2TwinSyncSse_CustomNested2
@@ -68533,11 +65290,9 @@ final class wire_cst_CustomNestedError2TwinSyncSse_CustomNested2Number
 }
 
 final class CustomNestedError2TwinSyncSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_CustomNestedError2TwinSyncSse_CustomNested2>
-      CustomNested2;
+  external wire_cst_CustomNestedError2TwinSyncSse_CustomNested2 CustomNested2;
 
-  external ffi
-      .Pointer<wire_cst_CustomNestedError2TwinSyncSse_CustomNested2Number>
+  external wire_cst_CustomNestedError2TwinSyncSse_CustomNested2Number
       CustomNested2Number;
 }
 
@@ -68545,7 +65300,7 @@ final class wire_cst_custom_nested_error_2_twin_sync_sse extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<CustomNestedError2TwinSyncSseKind> kind;
+  external CustomNestedError2TwinSyncSseKind kind;
 }
 
 final class wire_cst_CustomNestedErrorInnerTwinRustAsyncSse_Three
@@ -68560,11 +65315,9 @@ final class wire_cst_CustomNestedErrorInnerTwinRustAsyncSse_Four
 }
 
 final class CustomNestedErrorInnerTwinRustAsyncSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_CustomNestedErrorInnerTwinRustAsyncSse_Three>
-      Three;
+  external wire_cst_CustomNestedErrorInnerTwinRustAsyncSse_Three Three;
 
-  external ffi.Pointer<wire_cst_CustomNestedErrorInnerTwinRustAsyncSse_Four>
-      Four;
+  external wire_cst_CustomNestedErrorInnerTwinRustAsyncSse_Four Four;
 }
 
 final class wire_cst_custom_nested_error_inner_twin_rust_async_sse
@@ -68572,7 +65325,7 @@ final class wire_cst_custom_nested_error_inner_twin_rust_async_sse
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<CustomNestedErrorInnerTwinRustAsyncSseKind> kind;
+  external CustomNestedErrorInnerTwinRustAsyncSseKind kind;
 }
 
 final class wire_cst_CustomNestedErrorInnerTwinSse_Three extends ffi.Struct {
@@ -68585,16 +65338,16 @@ final class wire_cst_CustomNestedErrorInnerTwinSse_Four extends ffi.Struct {
 }
 
 final class CustomNestedErrorInnerTwinSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_CustomNestedErrorInnerTwinSse_Three> Three;
+  external wire_cst_CustomNestedErrorInnerTwinSse_Three Three;
 
-  external ffi.Pointer<wire_cst_CustomNestedErrorInnerTwinSse_Four> Four;
+  external wire_cst_CustomNestedErrorInnerTwinSse_Four Four;
 }
 
 final class wire_cst_custom_nested_error_inner_twin_sse extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<CustomNestedErrorInnerTwinSseKind> kind;
+  external CustomNestedErrorInnerTwinSseKind kind;
 }
 
 final class wire_cst_CustomNestedErrorInnerTwinSyncSse_Three
@@ -68608,9 +65361,9 @@ final class wire_cst_CustomNestedErrorInnerTwinSyncSse_Four extends ffi.Struct {
 }
 
 final class CustomNestedErrorInnerTwinSyncSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_CustomNestedErrorInnerTwinSyncSse_Three> Three;
+  external wire_cst_CustomNestedErrorInnerTwinSyncSse_Three Three;
 
-  external ffi.Pointer<wire_cst_CustomNestedErrorInnerTwinSyncSse_Four> Four;
+  external wire_cst_CustomNestedErrorInnerTwinSyncSse_Four Four;
 }
 
 final class wire_cst_custom_nested_error_inner_twin_sync_sse
@@ -68618,7 +65371,7 @@ final class wire_cst_custom_nested_error_inner_twin_sync_sse
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<CustomNestedErrorInnerTwinSyncSseKind> kind;
+  external CustomNestedErrorInnerTwinSyncSseKind kind;
 }
 
 final class wire_cst_CustomNestedErrorOuterTwinRustAsyncSse_One
@@ -68633,9 +65386,9 @@ final class wire_cst_CustomNestedErrorOuterTwinRustAsyncSse_Two
 }
 
 final class CustomNestedErrorOuterTwinRustAsyncSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_CustomNestedErrorOuterTwinRustAsyncSse_One> One;
+  external wire_cst_CustomNestedErrorOuterTwinRustAsyncSse_One One;
 
-  external ffi.Pointer<wire_cst_CustomNestedErrorOuterTwinRustAsyncSse_Two> Two;
+  external wire_cst_CustomNestedErrorOuterTwinRustAsyncSse_Two Two;
 }
 
 final class wire_cst_custom_nested_error_outer_twin_rust_async_sse
@@ -68643,7 +65396,7 @@ final class wire_cst_custom_nested_error_outer_twin_rust_async_sse
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<CustomNestedErrorOuterTwinRustAsyncSseKind> kind;
+  external CustomNestedErrorOuterTwinRustAsyncSseKind kind;
 }
 
 final class wire_cst_CustomNestedErrorOuterTwinSse_One extends ffi.Struct {
@@ -68655,16 +65408,16 @@ final class wire_cst_CustomNestedErrorOuterTwinSse_Two extends ffi.Struct {
 }
 
 final class CustomNestedErrorOuterTwinSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_CustomNestedErrorOuterTwinSse_One> One;
+  external wire_cst_CustomNestedErrorOuterTwinSse_One One;
 
-  external ffi.Pointer<wire_cst_CustomNestedErrorOuterTwinSse_Two> Two;
+  external wire_cst_CustomNestedErrorOuterTwinSse_Two Two;
 }
 
 final class wire_cst_custom_nested_error_outer_twin_sse extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<CustomNestedErrorOuterTwinSseKind> kind;
+  external CustomNestedErrorOuterTwinSseKind kind;
 }
 
 final class wire_cst_CustomNestedErrorOuterTwinSyncSse_One extends ffi.Struct {
@@ -68676,9 +65429,9 @@ final class wire_cst_CustomNestedErrorOuterTwinSyncSse_Two extends ffi.Struct {
 }
 
 final class CustomNestedErrorOuterTwinSyncSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_CustomNestedErrorOuterTwinSyncSse_One> One;
+  external wire_cst_CustomNestedErrorOuterTwinSyncSse_One One;
 
-  external ffi.Pointer<wire_cst_CustomNestedErrorOuterTwinSyncSse_Two> Two;
+  external wire_cst_CustomNestedErrorOuterTwinSyncSse_Two Two;
 }
 
 final class wire_cst_custom_nested_error_outer_twin_sync_sse
@@ -68686,7 +65439,7 @@ final class wire_cst_custom_nested_error_outer_twin_sync_sse
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<CustomNestedErrorOuterTwinSyncSseKind> kind;
+  external CustomNestedErrorOuterTwinSyncSseKind kind;
 }
 
 final class wire_cst_custom_struct_error_twin_rust_async_sse
@@ -68890,17 +65643,16 @@ final class wire_cst_EnumDartOpaqueTwinRustAsyncSse_Opaque extends ffi.Struct {
 }
 
 final class EnumDartOpaqueTwinRustAsyncSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_EnumDartOpaqueTwinRustAsyncSse_Primitive>
-      Primitive;
+  external wire_cst_EnumDartOpaqueTwinRustAsyncSse_Primitive Primitive;
 
-  external ffi.Pointer<wire_cst_EnumDartOpaqueTwinRustAsyncSse_Opaque> Opaque;
+  external wire_cst_EnumDartOpaqueTwinRustAsyncSse_Opaque Opaque;
 }
 
 final class wire_cst_enum_dart_opaque_twin_rust_async_sse extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<EnumDartOpaqueTwinRustAsyncSseKind> kind;
+  external EnumDartOpaqueTwinRustAsyncSseKind kind;
 }
 
 final class wire_cst_EnumDartOpaqueTwinSse_Primitive extends ffi.Struct {
@@ -68913,16 +65665,16 @@ final class wire_cst_EnumDartOpaqueTwinSse_Opaque extends ffi.Struct {
 }
 
 final class EnumDartOpaqueTwinSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_EnumDartOpaqueTwinSse_Primitive> Primitive;
+  external wire_cst_EnumDartOpaqueTwinSse_Primitive Primitive;
 
-  external ffi.Pointer<wire_cst_EnumDartOpaqueTwinSse_Opaque> Opaque;
+  external wire_cst_EnumDartOpaqueTwinSse_Opaque Opaque;
 }
 
 final class wire_cst_enum_dart_opaque_twin_sse extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<EnumDartOpaqueTwinSseKind> kind;
+  external EnumDartOpaqueTwinSseKind kind;
 }
 
 final class wire_cst_EnumDartOpaqueTwinSyncSse_Primitive extends ffi.Struct {
@@ -68935,16 +65687,16 @@ final class wire_cst_EnumDartOpaqueTwinSyncSse_Opaque extends ffi.Struct {
 }
 
 final class EnumDartOpaqueTwinSyncSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_EnumDartOpaqueTwinSyncSse_Primitive> Primitive;
+  external wire_cst_EnumDartOpaqueTwinSyncSse_Primitive Primitive;
 
-  external ffi.Pointer<wire_cst_EnumDartOpaqueTwinSyncSse_Opaque> Opaque;
+  external wire_cst_EnumDartOpaqueTwinSyncSse_Opaque Opaque;
 }
 
 final class wire_cst_enum_dart_opaque_twin_sync_sse extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<EnumDartOpaqueTwinSyncSseKind> kind;
+  external EnumDartOpaqueTwinSyncSseKind kind;
 }
 
 final class wire_cst_EnumOpaqueTwinRustAsyncSse_Struct extends ffi.Struct {
@@ -68968,22 +65720,22 @@ final class wire_cst_EnumOpaqueTwinRustAsyncSse_RwLock extends ffi.Struct {
 }
 
 final class EnumOpaqueTwinRustAsyncSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_EnumOpaqueTwinRustAsyncSse_Struct> Struct;
+  external wire_cst_EnumOpaqueTwinRustAsyncSse_Struct Struct;
 
-  external ffi.Pointer<wire_cst_EnumOpaqueTwinRustAsyncSse_Primitive> Primitive;
+  external wire_cst_EnumOpaqueTwinRustAsyncSse_Primitive Primitive;
 
-  external ffi.Pointer<wire_cst_EnumOpaqueTwinRustAsyncSse_TraitObj> TraitObj;
+  external wire_cst_EnumOpaqueTwinRustAsyncSse_TraitObj TraitObj;
 
-  external ffi.Pointer<wire_cst_EnumOpaqueTwinRustAsyncSse_Mutex> Mutex;
+  external wire_cst_EnumOpaqueTwinRustAsyncSse_Mutex Mutex;
 
-  external ffi.Pointer<wire_cst_EnumOpaqueTwinRustAsyncSse_RwLock> RwLock;
+  external wire_cst_EnumOpaqueTwinRustAsyncSse_RwLock RwLock;
 }
 
 final class wire_cst_enum_opaque_twin_rust_async_sse extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<EnumOpaqueTwinRustAsyncSseKind> kind;
+  external EnumOpaqueTwinRustAsyncSseKind kind;
 }
 
 final class wire_cst_EnumOpaqueTwinSse_Struct extends ffi.Struct {
@@ -69007,22 +65759,22 @@ final class wire_cst_EnumOpaqueTwinSse_RwLock extends ffi.Struct {
 }
 
 final class EnumOpaqueTwinSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_EnumOpaqueTwinSse_Struct> Struct;
+  external wire_cst_EnumOpaqueTwinSse_Struct Struct;
 
-  external ffi.Pointer<wire_cst_EnumOpaqueTwinSse_Primitive> Primitive;
+  external wire_cst_EnumOpaqueTwinSse_Primitive Primitive;
 
-  external ffi.Pointer<wire_cst_EnumOpaqueTwinSse_TraitObj> TraitObj;
+  external wire_cst_EnumOpaqueTwinSse_TraitObj TraitObj;
 
-  external ffi.Pointer<wire_cst_EnumOpaqueTwinSse_Mutex> Mutex;
+  external wire_cst_EnumOpaqueTwinSse_Mutex Mutex;
 
-  external ffi.Pointer<wire_cst_EnumOpaqueTwinSse_RwLock> RwLock;
+  external wire_cst_EnumOpaqueTwinSse_RwLock RwLock;
 }
 
 final class wire_cst_enum_opaque_twin_sse extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<EnumOpaqueTwinSseKind> kind;
+  external EnumOpaqueTwinSseKind kind;
 }
 
 final class wire_cst_EnumOpaqueTwinSyncSse_Struct extends ffi.Struct {
@@ -69046,25 +65798,23 @@ final class wire_cst_EnumOpaqueTwinSyncSse_RwLock extends ffi.Struct {
 }
 
 final class EnumOpaqueTwinSyncSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_EnumOpaqueTwinSyncSse_Struct> Struct;
+  external wire_cst_EnumOpaqueTwinSyncSse_Struct Struct;
 
-  external ffi.Pointer<wire_cst_EnumOpaqueTwinSyncSse_Primitive> Primitive;
+  external wire_cst_EnumOpaqueTwinSyncSse_Primitive Primitive;
 
-  external ffi.Pointer<wire_cst_EnumOpaqueTwinSyncSse_TraitObj> TraitObj;
+  external wire_cst_EnumOpaqueTwinSyncSse_TraitObj TraitObj;
 
-  external ffi.Pointer<wire_cst_EnumOpaqueTwinSyncSse_Mutex> Mutex;
+  external wire_cst_EnumOpaqueTwinSyncSse_Mutex Mutex;
 
-  external ffi.Pointer<wire_cst_EnumOpaqueTwinSyncSse_RwLock> RwLock;
+  external wire_cst_EnumOpaqueTwinSyncSse_RwLock RwLock;
 }
 
 final class wire_cst_enum_opaque_twin_sync_sse extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<EnumOpaqueTwinSyncSseKind> kind;
+  external EnumOpaqueTwinSyncSseKind kind;
 }
-
-final class wire_cst_EnumWithItemMixedTwinRustAsyncSse_A extends ffi.Opaque {}
 
 final class wire_cst_EnumWithItemMixedTwinRustAsyncSse_B extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8> field0;
@@ -69075,11 +65825,9 @@ final class wire_cst_EnumWithItemMixedTwinRustAsyncSse_C extends ffi.Struct {
 }
 
 final class EnumWithItemMixedTwinRustAsyncSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_EnumWithItemMixedTwinRustAsyncSse_A> A;
+  external wire_cst_EnumWithItemMixedTwinRustAsyncSse_B B;
 
-  external ffi.Pointer<wire_cst_EnumWithItemMixedTwinRustAsyncSse_B> B;
-
-  external ffi.Pointer<wire_cst_EnumWithItemMixedTwinRustAsyncSse_C> C;
+  external wire_cst_EnumWithItemMixedTwinRustAsyncSse_C C;
 }
 
 final class wire_cst_enum_with_item_mixed_twin_rust_async_sse
@@ -69087,10 +65835,8 @@ final class wire_cst_enum_with_item_mixed_twin_rust_async_sse
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<EnumWithItemMixedTwinRustAsyncSseKind> kind;
+  external EnumWithItemMixedTwinRustAsyncSseKind kind;
 }
-
-final class wire_cst_EnumWithItemMixedTwinSse_A extends ffi.Opaque {}
 
 final class wire_cst_EnumWithItemMixedTwinSse_B extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8> field0;
@@ -69101,21 +65847,17 @@ final class wire_cst_EnumWithItemMixedTwinSse_C extends ffi.Struct {
 }
 
 final class EnumWithItemMixedTwinSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_EnumWithItemMixedTwinSse_A> A;
+  external wire_cst_EnumWithItemMixedTwinSse_B B;
 
-  external ffi.Pointer<wire_cst_EnumWithItemMixedTwinSse_B> B;
-
-  external ffi.Pointer<wire_cst_EnumWithItemMixedTwinSse_C> C;
+  external wire_cst_EnumWithItemMixedTwinSse_C C;
 }
 
 final class wire_cst_enum_with_item_mixed_twin_sse extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<EnumWithItemMixedTwinSseKind> kind;
+  external EnumWithItemMixedTwinSseKind kind;
 }
-
-final class wire_cst_EnumWithItemMixedTwinSyncSse_A extends ffi.Opaque {}
 
 final class wire_cst_EnumWithItemMixedTwinSyncSse_B extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8> field0;
@@ -69126,18 +65868,16 @@ final class wire_cst_EnumWithItemMixedTwinSyncSse_C extends ffi.Struct {
 }
 
 final class EnumWithItemMixedTwinSyncSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_EnumWithItemMixedTwinSyncSse_A> A;
+  external wire_cst_EnumWithItemMixedTwinSyncSse_B B;
 
-  external ffi.Pointer<wire_cst_EnumWithItemMixedTwinSyncSse_B> B;
-
-  external ffi.Pointer<wire_cst_EnumWithItemMixedTwinSyncSse_C> C;
+  external wire_cst_EnumWithItemMixedTwinSyncSse_C C;
 }
 
 final class wire_cst_enum_with_item_mixed_twin_sync_sse extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<EnumWithItemMixedTwinSyncSseKind> kind;
+  external EnumWithItemMixedTwinSyncSseKind kind;
 }
 
 final class wire_cst_EnumWithItemStructTwinRustAsyncSse_A extends ffi.Struct {
@@ -69149,9 +65889,9 @@ final class wire_cst_EnumWithItemStructTwinRustAsyncSse_B extends ffi.Struct {
 }
 
 final class EnumWithItemStructTwinRustAsyncSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_EnumWithItemStructTwinRustAsyncSse_A> A;
+  external wire_cst_EnumWithItemStructTwinRustAsyncSse_A A;
 
-  external ffi.Pointer<wire_cst_EnumWithItemStructTwinRustAsyncSse_B> B;
+  external wire_cst_EnumWithItemStructTwinRustAsyncSse_B B;
 }
 
 final class wire_cst_enum_with_item_struct_twin_rust_async_sse
@@ -69159,7 +65899,7 @@ final class wire_cst_enum_with_item_struct_twin_rust_async_sse
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<EnumWithItemStructTwinRustAsyncSseKind> kind;
+  external EnumWithItemStructTwinRustAsyncSseKind kind;
 }
 
 final class wire_cst_EnumWithItemStructTwinSse_A extends ffi.Struct {
@@ -69171,16 +65911,16 @@ final class wire_cst_EnumWithItemStructTwinSse_B extends ffi.Struct {
 }
 
 final class EnumWithItemStructTwinSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_EnumWithItemStructTwinSse_A> A;
+  external wire_cst_EnumWithItemStructTwinSse_A A;
 
-  external ffi.Pointer<wire_cst_EnumWithItemStructTwinSse_B> B;
+  external wire_cst_EnumWithItemStructTwinSse_B B;
 }
 
 final class wire_cst_enum_with_item_struct_twin_sse extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<EnumWithItemStructTwinSseKind> kind;
+  external EnumWithItemStructTwinSseKind kind;
 }
 
 final class wire_cst_EnumWithItemStructTwinSyncSse_A extends ffi.Struct {
@@ -69192,16 +65932,16 @@ final class wire_cst_EnumWithItemStructTwinSyncSse_B extends ffi.Struct {
 }
 
 final class EnumWithItemStructTwinSyncSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_EnumWithItemStructTwinSyncSse_A> A;
+  external wire_cst_EnumWithItemStructTwinSyncSse_A A;
 
-  external ffi.Pointer<wire_cst_EnumWithItemStructTwinSyncSse_B> B;
+  external wire_cst_EnumWithItemStructTwinSyncSse_B B;
 }
 
 final class wire_cst_enum_with_item_struct_twin_sync_sse extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<EnumWithItemStructTwinSyncSseKind> kind;
+  external EnumWithItemStructTwinSyncSseKind kind;
 }
 
 final class wire_cst_EnumWithItemTupleTwinRustAsyncSse_A extends ffi.Struct {
@@ -69213,9 +65953,9 @@ final class wire_cst_EnumWithItemTupleTwinRustAsyncSse_B extends ffi.Struct {
 }
 
 final class EnumWithItemTupleTwinRustAsyncSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_EnumWithItemTupleTwinRustAsyncSse_A> A;
+  external wire_cst_EnumWithItemTupleTwinRustAsyncSse_A A;
 
-  external ffi.Pointer<wire_cst_EnumWithItemTupleTwinRustAsyncSse_B> B;
+  external wire_cst_EnumWithItemTupleTwinRustAsyncSse_B B;
 }
 
 final class wire_cst_enum_with_item_tuple_twin_rust_async_sse
@@ -69223,7 +65963,7 @@ final class wire_cst_enum_with_item_tuple_twin_rust_async_sse
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<EnumWithItemTupleTwinRustAsyncSseKind> kind;
+  external EnumWithItemTupleTwinRustAsyncSseKind kind;
 }
 
 final class wire_cst_EnumWithItemTupleTwinSse_A extends ffi.Struct {
@@ -69235,16 +65975,16 @@ final class wire_cst_EnumWithItemTupleTwinSse_B extends ffi.Struct {
 }
 
 final class EnumWithItemTupleTwinSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_EnumWithItemTupleTwinSse_A> A;
+  external wire_cst_EnumWithItemTupleTwinSse_A A;
 
-  external ffi.Pointer<wire_cst_EnumWithItemTupleTwinSse_B> B;
+  external wire_cst_EnumWithItemTupleTwinSse_B B;
 }
 
 final class wire_cst_enum_with_item_tuple_twin_sse extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<EnumWithItemTupleTwinSseKind> kind;
+  external EnumWithItemTupleTwinSseKind kind;
 }
 
 final class wire_cst_EnumWithItemTupleTwinSyncSse_A extends ffi.Struct {
@@ -69256,16 +65996,16 @@ final class wire_cst_EnumWithItemTupleTwinSyncSse_B extends ffi.Struct {
 }
 
 final class EnumWithItemTupleTwinSyncSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_EnumWithItemTupleTwinSyncSse_A> A;
+  external wire_cst_EnumWithItemTupleTwinSyncSse_A A;
 
-  external ffi.Pointer<wire_cst_EnumWithItemTupleTwinSyncSse_B> B;
+  external wire_cst_EnumWithItemTupleTwinSyncSse_B B;
 }
 
 final class wire_cst_enum_with_item_tuple_twin_sync_sse extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<EnumWithItemTupleTwinSyncSseKind> kind;
+  external EnumWithItemTupleTwinSyncSseKind kind;
 }
 
 final class wire_cst_event_twin_rust_async_sse extends ffi.Struct {
@@ -69429,8 +66169,6 @@ final class wire_cst_feed_id_twin_sync_sse extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8> field0;
 }
 
-final class wire_cst_KitchenSinkTwinRustAsyncSse_Empty extends ffi.Opaque {}
-
 final class wire_cst_KitchenSinkTwinRustAsyncSse_Primitives extends ffi.Struct {
   @ffi.Int32()
   external int int32;
@@ -69453,22 +66191,19 @@ final class wire_cst_kitchen_sink_twin_rust_async_sse extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<KitchenSinkTwinRustAsyncSseKind> kind;
+  external KitchenSinkTwinRustAsyncSseKind kind;
 }
 
 final class KitchenSinkTwinRustAsyncSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_KitchenSinkTwinRustAsyncSse_Empty> Empty;
+  external wire_cst_KitchenSinkTwinRustAsyncSse_Primitives Primitives;
 
-  external ffi.Pointer<wire_cst_KitchenSinkTwinRustAsyncSse_Primitives>
-      Primitives;
+  external wire_cst_KitchenSinkTwinRustAsyncSse_Nested Nested;
 
-  external ffi.Pointer<wire_cst_KitchenSinkTwinRustAsyncSse_Nested> Nested;
+  external wire_cst_KitchenSinkTwinRustAsyncSse_Optional Optional;
 
-  external ffi.Pointer<wire_cst_KitchenSinkTwinRustAsyncSse_Optional> Optional;
+  external wire_cst_KitchenSinkTwinRustAsyncSse_Buffer Buffer;
 
-  external ffi.Pointer<wire_cst_KitchenSinkTwinRustAsyncSse_Buffer> Buffer;
-
-  external ffi.Pointer<wire_cst_KitchenSinkTwinRustAsyncSse_Enums> Enums;
+  external wire_cst_KitchenSinkTwinRustAsyncSse_Enums Enums;
 }
 
 final class wire_cst_KitchenSinkTwinRustAsyncSse_Optional extends ffi.Struct {
@@ -69485,8 +66220,6 @@ final class wire_cst_KitchenSinkTwinRustAsyncSse_Enums extends ffi.Struct {
   @ffi.Int32()
   external int field0;
 }
-
-final class wire_cst_KitchenSinkTwinSse_Empty extends ffi.Opaque {}
 
 final class wire_cst_KitchenSinkTwinSse_Primitives extends ffi.Struct {
   @ffi.Int32()
@@ -69510,21 +66243,19 @@ final class wire_cst_kitchen_sink_twin_sse extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<KitchenSinkTwinSseKind> kind;
+  external KitchenSinkTwinSseKind kind;
 }
 
 final class KitchenSinkTwinSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_KitchenSinkTwinSse_Empty> Empty;
+  external wire_cst_KitchenSinkTwinSse_Primitives Primitives;
 
-  external ffi.Pointer<wire_cst_KitchenSinkTwinSse_Primitives> Primitives;
+  external wire_cst_KitchenSinkTwinSse_Nested Nested;
 
-  external ffi.Pointer<wire_cst_KitchenSinkTwinSse_Nested> Nested;
+  external wire_cst_KitchenSinkTwinSse_Optional Optional;
 
-  external ffi.Pointer<wire_cst_KitchenSinkTwinSse_Optional> Optional;
+  external wire_cst_KitchenSinkTwinSse_Buffer Buffer;
 
-  external ffi.Pointer<wire_cst_KitchenSinkTwinSse_Buffer> Buffer;
-
-  external ffi.Pointer<wire_cst_KitchenSinkTwinSse_Enums> Enums;
+  external wire_cst_KitchenSinkTwinSse_Enums Enums;
 }
 
 final class wire_cst_KitchenSinkTwinSse_Optional extends ffi.Struct {
@@ -69541,8 +66272,6 @@ final class wire_cst_KitchenSinkTwinSse_Enums extends ffi.Struct {
   @ffi.Int32()
   external int field0;
 }
-
-final class wire_cst_KitchenSinkTwinSyncSse_Empty extends ffi.Opaque {}
 
 final class wire_cst_KitchenSinkTwinSyncSse_Primitives extends ffi.Struct {
   @ffi.Int32()
@@ -69566,21 +66295,19 @@ final class wire_cst_kitchen_sink_twin_sync_sse extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<KitchenSinkTwinSyncSseKind> kind;
+  external KitchenSinkTwinSyncSseKind kind;
 }
 
 final class KitchenSinkTwinSyncSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_KitchenSinkTwinSyncSse_Empty> Empty;
+  external wire_cst_KitchenSinkTwinSyncSse_Primitives Primitives;
 
-  external ffi.Pointer<wire_cst_KitchenSinkTwinSyncSse_Primitives> Primitives;
+  external wire_cst_KitchenSinkTwinSyncSse_Nested Nested;
 
-  external ffi.Pointer<wire_cst_KitchenSinkTwinSyncSse_Nested> Nested;
+  external wire_cst_KitchenSinkTwinSyncSse_Optional Optional;
 
-  external ffi.Pointer<wire_cst_KitchenSinkTwinSyncSse_Optional> Optional;
+  external wire_cst_KitchenSinkTwinSyncSse_Buffer Buffer;
 
-  external ffi.Pointer<wire_cst_KitchenSinkTwinSyncSse_Buffer> Buffer;
-
-  external ffi.Pointer<wire_cst_KitchenSinkTwinSyncSse_Enums> Enums;
+  external wire_cst_KitchenSinkTwinSyncSse_Enums Enums;
 }
 
 final class wire_cst_KitchenSinkTwinSyncSse_Optional extends ffi.Struct {
@@ -69617,31 +66344,25 @@ final class wire_cst_list_of_nested_raw_string_mirrored extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_nested_raw_string_mirrored> raw;
 }
 
-final class wire_cst_SpeedTwinRustAsyncSse_Unknown extends ffi.Opaque {}
-
 final class wire_cst_SpeedTwinRustAsyncSse_GPS extends ffi.Struct {
   @ffi.Double()
   external double field0;
 }
 
 final class SpeedTwinRustAsyncSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_SpeedTwinRustAsyncSse_Unknown> Unknown;
-
-  external ffi.Pointer<wire_cst_SpeedTwinRustAsyncSse_GPS> GPS;
+  external wire_cst_SpeedTwinRustAsyncSse_GPS GPS;
 }
 
 final class wire_cst_speed_twin_rust_async_sse extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<SpeedTwinRustAsyncSseKind> kind;
+  external SpeedTwinRustAsyncSseKind kind;
 }
 
 final class wire_cst_MeasureTwinRustAsyncSse_Speed extends ffi.Struct {
   external ffi.Pointer<wire_cst_speed_twin_rust_async_sse> field0;
 }
-
-final class wire_cst_DistanceTwinRustAsyncSse_Unknown extends ffi.Opaque {}
 
 final class wire_cst_DistanceTwinRustAsyncSse_Map extends ffi.Struct {
   @ffi.Double()
@@ -69649,16 +66370,14 @@ final class wire_cst_DistanceTwinRustAsyncSse_Map extends ffi.Struct {
 }
 
 final class DistanceTwinRustAsyncSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_DistanceTwinRustAsyncSse_Unknown> Unknown;
-
-  external ffi.Pointer<wire_cst_DistanceTwinRustAsyncSse_Map> Map;
+  external wire_cst_DistanceTwinRustAsyncSse_Map Map;
 }
 
 final class wire_cst_distance_twin_rust_async_sse extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<DistanceTwinRustAsyncSseKind> kind;
+  external DistanceTwinRustAsyncSseKind kind;
 }
 
 final class wire_cst_MeasureTwinRustAsyncSse_Distance extends ffi.Struct {
@@ -69666,19 +66385,17 @@ final class wire_cst_MeasureTwinRustAsyncSse_Distance extends ffi.Struct {
 }
 
 final class MeasureTwinRustAsyncSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_MeasureTwinRustAsyncSse_Speed> Speed;
+  external wire_cst_MeasureTwinRustAsyncSse_Speed Speed;
 
-  external ffi.Pointer<wire_cst_MeasureTwinRustAsyncSse_Distance> Distance;
+  external wire_cst_MeasureTwinRustAsyncSse_Distance Distance;
 }
 
 final class wire_cst_measure_twin_rust_async_sse extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<MeasureTwinRustAsyncSseKind> kind;
+  external MeasureTwinRustAsyncSseKind kind;
 }
-
-final class wire_cst_SpeedTwinSse_Unknown extends ffi.Opaque {}
 
 final class wire_cst_SpeedTwinSse_GPS extends ffi.Struct {
   @ffi.Double()
@@ -69686,23 +66403,19 @@ final class wire_cst_SpeedTwinSse_GPS extends ffi.Struct {
 }
 
 final class SpeedTwinSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_SpeedTwinSse_Unknown> Unknown;
-
-  external ffi.Pointer<wire_cst_SpeedTwinSse_GPS> GPS;
+  external wire_cst_SpeedTwinSse_GPS GPS;
 }
 
 final class wire_cst_speed_twin_sse extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<SpeedTwinSseKind> kind;
+  external SpeedTwinSseKind kind;
 }
 
 final class wire_cst_MeasureTwinSse_Speed extends ffi.Struct {
   external ffi.Pointer<wire_cst_speed_twin_sse> field0;
 }
-
-final class wire_cst_DistanceTwinSse_Unknown extends ffi.Opaque {}
 
 final class wire_cst_DistanceTwinSse_Map extends ffi.Struct {
   @ffi.Double()
@@ -69710,16 +66423,14 @@ final class wire_cst_DistanceTwinSse_Map extends ffi.Struct {
 }
 
 final class DistanceTwinSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_DistanceTwinSse_Unknown> Unknown;
-
-  external ffi.Pointer<wire_cst_DistanceTwinSse_Map> Map;
+  external wire_cst_DistanceTwinSse_Map Map;
 }
 
 final class wire_cst_distance_twin_sse extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<DistanceTwinSseKind> kind;
+  external DistanceTwinSseKind kind;
 }
 
 final class wire_cst_MeasureTwinSse_Distance extends ffi.Struct {
@@ -69727,19 +66438,17 @@ final class wire_cst_MeasureTwinSse_Distance extends ffi.Struct {
 }
 
 final class MeasureTwinSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_MeasureTwinSse_Speed> Speed;
+  external wire_cst_MeasureTwinSse_Speed Speed;
 
-  external ffi.Pointer<wire_cst_MeasureTwinSse_Distance> Distance;
+  external wire_cst_MeasureTwinSse_Distance Distance;
 }
 
 final class wire_cst_measure_twin_sse extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<MeasureTwinSseKind> kind;
+  external MeasureTwinSseKind kind;
 }
-
-final class wire_cst_SpeedTwinSyncSse_Unknown extends ffi.Opaque {}
 
 final class wire_cst_SpeedTwinSyncSse_GPS extends ffi.Struct {
   @ffi.Double()
@@ -69747,23 +66456,19 @@ final class wire_cst_SpeedTwinSyncSse_GPS extends ffi.Struct {
 }
 
 final class SpeedTwinSyncSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_SpeedTwinSyncSse_Unknown> Unknown;
-
-  external ffi.Pointer<wire_cst_SpeedTwinSyncSse_GPS> GPS;
+  external wire_cst_SpeedTwinSyncSse_GPS GPS;
 }
 
 final class wire_cst_speed_twin_sync_sse extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<SpeedTwinSyncSseKind> kind;
+  external SpeedTwinSyncSseKind kind;
 }
 
 final class wire_cst_MeasureTwinSyncSse_Speed extends ffi.Struct {
   external ffi.Pointer<wire_cst_speed_twin_sync_sse> field0;
 }
-
-final class wire_cst_DistanceTwinSyncSse_Unknown extends ffi.Opaque {}
 
 final class wire_cst_DistanceTwinSyncSse_Map extends ffi.Struct {
   @ffi.Double()
@@ -69771,16 +66476,14 @@ final class wire_cst_DistanceTwinSyncSse_Map extends ffi.Struct {
 }
 
 final class DistanceTwinSyncSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_DistanceTwinSyncSse_Unknown> Unknown;
-
-  external ffi.Pointer<wire_cst_DistanceTwinSyncSse_Map> Map;
+  external wire_cst_DistanceTwinSyncSse_Map Map;
 }
 
 final class wire_cst_distance_twin_sync_sse extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<DistanceTwinSyncSseKind> kind;
+  external DistanceTwinSyncSseKind kind;
 }
 
 final class wire_cst_MeasureTwinSyncSse_Distance extends ffi.Struct {
@@ -69788,16 +66491,16 @@ final class wire_cst_MeasureTwinSyncSse_Distance extends ffi.Struct {
 }
 
 final class MeasureTwinSyncSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_MeasureTwinSyncSse_Speed> Speed;
+  external wire_cst_MeasureTwinSyncSse_Speed Speed;
 
-  external ffi.Pointer<wire_cst_MeasureTwinSyncSse_Distance> Distance;
+  external wire_cst_MeasureTwinSyncSse_Distance Distance;
 }
 
 final class wire_cst_measure_twin_sync_sse extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<MeasureTwinSyncSseKind> kind;
+  external MeasureTwinSyncSseKind kind;
 }
 
 final class wire_cst_message_id_twin_rust_async_sse extends ffi.Struct {
@@ -70342,19 +67045,18 @@ final class wire_cst_RawStringEnumMirrored_ListOfNested extends ffi.Struct {
 }
 
 final class RawStringEnumMirroredKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_RawStringEnumMirrored_Raw> Raw;
+  external wire_cst_RawStringEnumMirrored_Raw Raw;
 
-  external ffi.Pointer<wire_cst_RawStringEnumMirrored_Nested> Nested;
+  external wire_cst_RawStringEnumMirrored_Nested Nested;
 
-  external ffi.Pointer<wire_cst_RawStringEnumMirrored_ListOfNested>
-      ListOfNested;
+  external wire_cst_RawStringEnumMirrored_ListOfNested ListOfNested;
 }
 
 final class wire_cst_raw_string_enum_mirrored extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<RawStringEnumMirroredKind> kind;
+  external RawStringEnumMirroredKind kind;
 }
 
 final class wire_cst_list_raw_string_enum_mirrored extends ffi.Struct {
@@ -70455,365 +67157,6 @@ final class wire_cst_list_weekdays_twin_sync_sse extends ffi.Struct {
   external int len;
 }
 
-final class wire_cst_ApplicationMessage_DisplayMessage extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8> field0;
-}
-
-final class wire_cst_ApplicationMessage_RenderPixel extends ffi.Struct {
-  @ffi.Int32()
-  external int x;
-
-  @ffi.Int32()
-  external int y;
-}
-
-final class wire_cst_ApplicationMessage_Exit extends ffi.Opaque {}
-
-final class ApplicationMessageKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_ApplicationMessage_DisplayMessage>
-      DisplayMessage;
-
-  external ffi.Pointer<wire_cst_ApplicationMessage_RenderPixel> RenderPixel;
-
-  external ffi.Pointer<wire_cst_ApplicationMessage_Exit> Exit;
-}
-
-final class wire_cst_CustomEnumErrorTwinNormal_One extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8> message;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
-}
-
-final class wire_cst_CustomEnumErrorTwinNormal_Two extends ffi.Struct {
-  @ffi.Uint32()
-  external int message;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
-}
-
-final class CustomEnumErrorTwinNormalKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_CustomEnumErrorTwinNormal_One> One;
-
-  external ffi.Pointer<wire_cst_CustomEnumErrorTwinNormal_Two> Two;
-}
-
-final class wire_cst_CustomEnumErrorTwinRustAsync_One extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8> message;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
-}
-
-final class wire_cst_CustomEnumErrorTwinRustAsync_Two extends ffi.Struct {
-  @ffi.Uint32()
-  external int message;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
-}
-
-final class CustomEnumErrorTwinRustAsyncKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_CustomEnumErrorTwinRustAsync_One> One;
-
-  external ffi.Pointer<wire_cst_CustomEnumErrorTwinRustAsync_Two> Two;
-}
-
-final class wire_cst_CustomEnumErrorTwinRustAsyncSse_One extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8> message;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
-}
-
-final class wire_cst_CustomEnumErrorTwinRustAsyncSse_Two extends ffi.Struct {
-  @ffi.Uint32()
-  external int message;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
-}
-
-final class CustomEnumErrorTwinRustAsyncSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_CustomEnumErrorTwinRustAsyncSse_One> One;
-
-  external ffi.Pointer<wire_cst_CustomEnumErrorTwinRustAsyncSse_Two> Two;
-}
-
-final class wire_cst_CustomEnumErrorTwinSse_One extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8> message;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
-}
-
-final class wire_cst_CustomEnumErrorTwinSse_Two extends ffi.Struct {
-  @ffi.Uint32()
-  external int message;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
-}
-
-final class CustomEnumErrorTwinSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_CustomEnumErrorTwinSse_One> One;
-
-  external ffi.Pointer<wire_cst_CustomEnumErrorTwinSse_Two> Two;
-}
-
-final class wire_cst_CustomEnumErrorTwinSync_One extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8> message;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
-}
-
-final class wire_cst_CustomEnumErrorTwinSync_Two extends ffi.Struct {
-  @ffi.Uint32()
-  external int message;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
-}
-
-final class CustomEnumErrorTwinSyncKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_CustomEnumErrorTwinSync_One> One;
-
-  external ffi.Pointer<wire_cst_CustomEnumErrorTwinSync_Two> Two;
-}
-
-final class wire_cst_CustomEnumErrorTwinSyncSse_One extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8> message;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
-}
-
-final class wire_cst_CustomEnumErrorTwinSyncSse_Two extends ffi.Struct {
-  @ffi.Uint32()
-  external int message;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
-}
-
-final class CustomEnumErrorTwinSyncSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_CustomEnumErrorTwinSyncSse_One> One;
-
-  external ffi.Pointer<wire_cst_CustomEnumErrorTwinSyncSse_Two> Two;
-}
-
-final class wire_cst_CustomErrorTwinNormal_Error0 extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8> e;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
-}
-
-final class wire_cst_CustomErrorTwinNormal_Error1 extends ffi.Struct {
-  @ffi.Uint32()
-  external int e;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
-}
-
-final class CustomErrorTwinNormalKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_CustomErrorTwinNormal_Error0> Error0;
-
-  external ffi.Pointer<wire_cst_CustomErrorTwinNormal_Error1> Error1;
-}
-
-final class wire_cst_CustomErrorTwinRustAsync_Error0 extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8> e;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
-}
-
-final class wire_cst_CustomErrorTwinRustAsync_Error1 extends ffi.Struct {
-  @ffi.Uint32()
-  external int e;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
-}
-
-final class CustomErrorTwinRustAsyncKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_CustomErrorTwinRustAsync_Error0> Error0;
-
-  external ffi.Pointer<wire_cst_CustomErrorTwinRustAsync_Error1> Error1;
-}
-
-final class wire_cst_CustomErrorTwinRustAsyncSse_Error0 extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8> e;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
-}
-
-final class wire_cst_CustomErrorTwinRustAsyncSse_Error1 extends ffi.Struct {
-  @ffi.Uint32()
-  external int e;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
-}
-
-final class CustomErrorTwinRustAsyncSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_CustomErrorTwinRustAsyncSse_Error0> Error0;
-
-  external ffi.Pointer<wire_cst_CustomErrorTwinRustAsyncSse_Error1> Error1;
-}
-
-final class wire_cst_CustomErrorTwinSse_Error0 extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8> e;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
-}
-
-final class wire_cst_CustomErrorTwinSse_Error1 extends ffi.Struct {
-  @ffi.Uint32()
-  external int e;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
-}
-
-final class CustomErrorTwinSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_CustomErrorTwinSse_Error0> Error0;
-
-  external ffi.Pointer<wire_cst_CustomErrorTwinSse_Error1> Error1;
-}
-
-final class wire_cst_CustomErrorTwinSync_Error0 extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8> e;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
-}
-
-final class wire_cst_CustomErrorTwinSync_Error1 extends ffi.Struct {
-  @ffi.Uint32()
-  external int e;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
-}
-
-final class CustomErrorTwinSyncKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_CustomErrorTwinSync_Error0> Error0;
-
-  external ffi.Pointer<wire_cst_CustomErrorTwinSync_Error1> Error1;
-}
-
-final class wire_cst_CustomErrorTwinSyncSse_Error0 extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8> e;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
-}
-
-final class wire_cst_CustomErrorTwinSyncSse_Error1 extends ffi.Struct {
-  @ffi.Uint32()
-  external int e;
-
-  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
-}
-
-final class CustomErrorTwinSyncSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_CustomErrorTwinSyncSse_Error0> Error0;
-
-  external ffi.Pointer<wire_cst_CustomErrorTwinSyncSse_Error1> Error1;
-}
-
-final class wire_cst_CustomNestedError1TwinNormal_CustomNested1
-    extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8> field0;
-}
-
-final class wire_cst_CustomNestedError1TwinNormal_ErrorNested
-    extends ffi.Struct {
-  external ffi.Pointer<wire_cst_custom_nested_error_2_twin_normal> field0;
-}
-
-final class CustomNestedError1TwinNormalKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_CustomNestedError1TwinNormal_CustomNested1>
-      CustomNested1;
-
-  external ffi.Pointer<wire_cst_CustomNestedError1TwinNormal_ErrorNested>
-      ErrorNested;
-}
-
-final class wire_cst_CustomNestedError1TwinRustAsync_CustomNested1
-    extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8> field0;
-}
-
-final class wire_cst_CustomNestedError1TwinRustAsync_ErrorNested
-    extends ffi.Struct {
-  external ffi.Pointer<wire_cst_custom_nested_error_2_twin_rust_async> field0;
-}
-
-final class CustomNestedError1TwinRustAsyncKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_CustomNestedError1TwinRustAsync_CustomNested1>
-      CustomNested1;
-
-  external ffi.Pointer<wire_cst_CustomNestedError1TwinRustAsync_ErrorNested>
-      ErrorNested;
-}
-
-final class wire_cst_CustomNestedError1TwinRustAsyncSse_CustomNested1
-    extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8> field0;
-}
-
-final class wire_cst_CustomNestedError1TwinRustAsyncSse_ErrorNested
-    extends ffi.Struct {
-  external ffi.Pointer<wire_cst_custom_nested_error_2_twin_rust_async_sse>
-      field0;
-}
-
-final class CustomNestedError1TwinRustAsyncSseKind extends ffi.Union {
-  external ffi
-      .Pointer<wire_cst_CustomNestedError1TwinRustAsyncSse_CustomNested1>
-      CustomNested1;
-
-  external ffi.Pointer<wire_cst_CustomNestedError1TwinRustAsyncSse_ErrorNested>
-      ErrorNested;
-}
-
-final class wire_cst_CustomNestedError1TwinSse_CustomNested1
-    extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8> field0;
-}
-
-final class wire_cst_CustomNestedError1TwinSse_ErrorNested extends ffi.Struct {
-  external ffi.Pointer<wire_cst_custom_nested_error_2_twin_sse> field0;
-}
-
-final class CustomNestedError1TwinSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_CustomNestedError1TwinSse_CustomNested1>
-      CustomNested1;
-
-  external ffi.Pointer<wire_cst_CustomNestedError1TwinSse_ErrorNested>
-      ErrorNested;
-}
-
-final class wire_cst_CustomNestedError1TwinSync_CustomNested1
-    extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8> field0;
-}
-
-final class wire_cst_CustomNestedError1TwinSync_ErrorNested extends ffi.Struct {
-  external ffi.Pointer<wire_cst_custom_nested_error_2_twin_sync> field0;
-}
-
-final class CustomNestedError1TwinSyncKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_CustomNestedError1TwinSync_CustomNested1>
-      CustomNested1;
-
-  external ffi.Pointer<wire_cst_CustomNestedError1TwinSync_ErrorNested>
-      ErrorNested;
-}
-
-final class wire_cst_CustomNestedError1TwinSyncSse_CustomNested1
-    extends ffi.Struct {
-  external ffi.Pointer<wire_cst_list_prim_u_8> field0;
-}
-
-final class wire_cst_CustomNestedError1TwinSyncSse_ErrorNested
-    extends ffi.Struct {
-  external ffi.Pointer<wire_cst_custom_nested_error_2_twin_sync_sse> field0;
-}
-
-final class CustomNestedError1TwinSyncSseKind extends ffi.Union {
-  external ffi.Pointer<wire_cst_CustomNestedError1TwinSyncSse_CustomNested1>
-      CustomNested1;
-
-  external ffi.Pointer<wire_cst_CustomNestedError1TwinSyncSse_ErrorNested>
-      ErrorNested;
-}
-
 final class wire_cst_another_macro_struct_twin_normal extends ffi.Struct {
   @ffi.Int32()
   external int data;
@@ -70846,11 +67189,29 @@ final class wire_cst_another_twin_sync_sse extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8> a;
 }
 
+final class wire_cst_ApplicationMessage_DisplayMessage extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8> field0;
+}
+
+final class wire_cst_ApplicationMessage_RenderPixel extends ffi.Struct {
+  @ffi.Int32()
+  external int x;
+
+  @ffi.Int32()
+  external int y;
+}
+
+final class ApplicationMessageKind extends ffi.Union {
+  external wire_cst_ApplicationMessage_DisplayMessage DisplayMessage;
+
+  external wire_cst_ApplicationMessage_RenderPixel RenderPixel;
+}
+
 final class wire_cst_application_message extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<ApplicationMessageKind> kind;
+  external ApplicationMessageKind kind;
 }
 
 final class wire_cst_big_buffers_twin_normal extends ffi.Struct {
@@ -70929,102 +67290,380 @@ final class wire_cst_contains_mirrored_sub_struct_twin_sync_sse
   external wire_cst_another_twin_sync_sse test2;
 }
 
+final class wire_cst_CustomEnumErrorTwinNormal_One extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8> message;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
+}
+
+final class wire_cst_CustomEnumErrorTwinNormal_Two extends ffi.Struct {
+  @ffi.Uint32()
+  external int message;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
+}
+
+final class CustomEnumErrorTwinNormalKind extends ffi.Union {
+  external wire_cst_CustomEnumErrorTwinNormal_One One;
+
+  external wire_cst_CustomEnumErrorTwinNormal_Two Two;
+}
+
 final class wire_cst_custom_enum_error_twin_normal extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<CustomEnumErrorTwinNormalKind> kind;
+  external CustomEnumErrorTwinNormalKind kind;
+}
+
+final class wire_cst_CustomEnumErrorTwinRustAsync_One extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8> message;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
+}
+
+final class wire_cst_CustomEnumErrorTwinRustAsync_Two extends ffi.Struct {
+  @ffi.Uint32()
+  external int message;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
+}
+
+final class CustomEnumErrorTwinRustAsyncKind extends ffi.Union {
+  external wire_cst_CustomEnumErrorTwinRustAsync_One One;
+
+  external wire_cst_CustomEnumErrorTwinRustAsync_Two Two;
 }
 
 final class wire_cst_custom_enum_error_twin_rust_async extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<CustomEnumErrorTwinRustAsyncKind> kind;
+  external CustomEnumErrorTwinRustAsyncKind kind;
+}
+
+final class wire_cst_CustomEnumErrorTwinRustAsyncSse_One extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8> message;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
+}
+
+final class wire_cst_CustomEnumErrorTwinRustAsyncSse_Two extends ffi.Struct {
+  @ffi.Uint32()
+  external int message;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
+}
+
+final class CustomEnumErrorTwinRustAsyncSseKind extends ffi.Union {
+  external wire_cst_CustomEnumErrorTwinRustAsyncSse_One One;
+
+  external wire_cst_CustomEnumErrorTwinRustAsyncSse_Two Two;
 }
 
 final class wire_cst_custom_enum_error_twin_rust_async_sse extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<CustomEnumErrorTwinRustAsyncSseKind> kind;
+  external CustomEnumErrorTwinRustAsyncSseKind kind;
+}
+
+final class wire_cst_CustomEnumErrorTwinSse_One extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8> message;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
+}
+
+final class wire_cst_CustomEnumErrorTwinSse_Two extends ffi.Struct {
+  @ffi.Uint32()
+  external int message;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
+}
+
+final class CustomEnumErrorTwinSseKind extends ffi.Union {
+  external wire_cst_CustomEnumErrorTwinSse_One One;
+
+  external wire_cst_CustomEnumErrorTwinSse_Two Two;
 }
 
 final class wire_cst_custom_enum_error_twin_sse extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<CustomEnumErrorTwinSseKind> kind;
+  external CustomEnumErrorTwinSseKind kind;
+}
+
+final class wire_cst_CustomEnumErrorTwinSync_One extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8> message;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
+}
+
+final class wire_cst_CustomEnumErrorTwinSync_Two extends ffi.Struct {
+  @ffi.Uint32()
+  external int message;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
+}
+
+final class CustomEnumErrorTwinSyncKind extends ffi.Union {
+  external wire_cst_CustomEnumErrorTwinSync_One One;
+
+  external wire_cst_CustomEnumErrorTwinSync_Two Two;
 }
 
 final class wire_cst_custom_enum_error_twin_sync extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<CustomEnumErrorTwinSyncKind> kind;
+  external CustomEnumErrorTwinSyncKind kind;
+}
+
+final class wire_cst_CustomEnumErrorTwinSyncSse_One extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8> message;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
+}
+
+final class wire_cst_CustomEnumErrorTwinSyncSse_Two extends ffi.Struct {
+  @ffi.Uint32()
+  external int message;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
+}
+
+final class CustomEnumErrorTwinSyncSseKind extends ffi.Union {
+  external wire_cst_CustomEnumErrorTwinSyncSse_One One;
+
+  external wire_cst_CustomEnumErrorTwinSyncSse_Two Two;
 }
 
 final class wire_cst_custom_enum_error_twin_sync_sse extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<CustomEnumErrorTwinSyncSseKind> kind;
+  external CustomEnumErrorTwinSyncSseKind kind;
+}
+
+final class wire_cst_CustomErrorTwinNormal_Error0 extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8> e;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
+}
+
+final class wire_cst_CustomErrorTwinNormal_Error1 extends ffi.Struct {
+  @ffi.Uint32()
+  external int e;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
+}
+
+final class CustomErrorTwinNormalKind extends ffi.Union {
+  external wire_cst_CustomErrorTwinNormal_Error0 Error0;
+
+  external wire_cst_CustomErrorTwinNormal_Error1 Error1;
 }
 
 final class wire_cst_custom_error_twin_normal extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<CustomErrorTwinNormalKind> kind;
+  external CustomErrorTwinNormalKind kind;
+}
+
+final class wire_cst_CustomErrorTwinRustAsync_Error0 extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8> e;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
+}
+
+final class wire_cst_CustomErrorTwinRustAsync_Error1 extends ffi.Struct {
+  @ffi.Uint32()
+  external int e;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
+}
+
+final class CustomErrorTwinRustAsyncKind extends ffi.Union {
+  external wire_cst_CustomErrorTwinRustAsync_Error0 Error0;
+
+  external wire_cst_CustomErrorTwinRustAsync_Error1 Error1;
 }
 
 final class wire_cst_custom_error_twin_rust_async extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<CustomErrorTwinRustAsyncKind> kind;
+  external CustomErrorTwinRustAsyncKind kind;
+}
+
+final class wire_cst_CustomErrorTwinRustAsyncSse_Error0 extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8> e;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
+}
+
+final class wire_cst_CustomErrorTwinRustAsyncSse_Error1 extends ffi.Struct {
+  @ffi.Uint32()
+  external int e;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
+}
+
+final class CustomErrorTwinRustAsyncSseKind extends ffi.Union {
+  external wire_cst_CustomErrorTwinRustAsyncSse_Error0 Error0;
+
+  external wire_cst_CustomErrorTwinRustAsyncSse_Error1 Error1;
 }
 
 final class wire_cst_custom_error_twin_rust_async_sse extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<CustomErrorTwinRustAsyncSseKind> kind;
+  external CustomErrorTwinRustAsyncSseKind kind;
+}
+
+final class wire_cst_CustomErrorTwinSse_Error0 extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8> e;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
+}
+
+final class wire_cst_CustomErrorTwinSse_Error1 extends ffi.Struct {
+  @ffi.Uint32()
+  external int e;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
+}
+
+final class CustomErrorTwinSseKind extends ffi.Union {
+  external wire_cst_CustomErrorTwinSse_Error0 Error0;
+
+  external wire_cst_CustomErrorTwinSse_Error1 Error1;
 }
 
 final class wire_cst_custom_error_twin_sse extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<CustomErrorTwinSseKind> kind;
+  external CustomErrorTwinSseKind kind;
+}
+
+final class wire_cst_CustomErrorTwinSync_Error0 extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8> e;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
+}
+
+final class wire_cst_CustomErrorTwinSync_Error1 extends ffi.Struct {
+  @ffi.Uint32()
+  external int e;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
+}
+
+final class CustomErrorTwinSyncKind extends ffi.Union {
+  external wire_cst_CustomErrorTwinSync_Error0 Error0;
+
+  external wire_cst_CustomErrorTwinSync_Error1 Error1;
 }
 
 final class wire_cst_custom_error_twin_sync extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<CustomErrorTwinSyncKind> kind;
+  external CustomErrorTwinSyncKind kind;
+}
+
+final class wire_cst_CustomErrorTwinSyncSse_Error0 extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8> e;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
+}
+
+final class wire_cst_CustomErrorTwinSyncSse_Error1 extends ffi.Struct {
+  @ffi.Uint32()
+  external int e;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8> backtrace;
+}
+
+final class CustomErrorTwinSyncSseKind extends ffi.Union {
+  external wire_cst_CustomErrorTwinSyncSse_Error0 Error0;
+
+  external wire_cst_CustomErrorTwinSyncSse_Error1 Error1;
 }
 
 final class wire_cst_custom_error_twin_sync_sse extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<CustomErrorTwinSyncSseKind> kind;
+  external CustomErrorTwinSyncSseKind kind;
+}
+
+final class wire_cst_CustomNestedError1TwinNormal_CustomNested1
+    extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8> field0;
+}
+
+final class wire_cst_CustomNestedError1TwinNormal_ErrorNested
+    extends ffi.Struct {
+  external ffi.Pointer<wire_cst_custom_nested_error_2_twin_normal> field0;
+}
+
+final class CustomNestedError1TwinNormalKind extends ffi.Union {
+  external wire_cst_CustomNestedError1TwinNormal_CustomNested1 CustomNested1;
+
+  external wire_cst_CustomNestedError1TwinNormal_ErrorNested ErrorNested;
 }
 
 final class wire_cst_custom_nested_error_1_twin_normal extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<CustomNestedError1TwinNormalKind> kind;
+  external CustomNestedError1TwinNormalKind kind;
+}
+
+final class wire_cst_CustomNestedError1TwinRustAsync_CustomNested1
+    extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8> field0;
+}
+
+final class wire_cst_CustomNestedError1TwinRustAsync_ErrorNested
+    extends ffi.Struct {
+  external ffi.Pointer<wire_cst_custom_nested_error_2_twin_rust_async> field0;
+}
+
+final class CustomNestedError1TwinRustAsyncKind extends ffi.Union {
+  external wire_cst_CustomNestedError1TwinRustAsync_CustomNested1 CustomNested1;
+
+  external wire_cst_CustomNestedError1TwinRustAsync_ErrorNested ErrorNested;
 }
 
 final class wire_cst_custom_nested_error_1_twin_rust_async extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<CustomNestedError1TwinRustAsyncKind> kind;
+  external CustomNestedError1TwinRustAsyncKind kind;
+}
+
+final class wire_cst_CustomNestedError1TwinRustAsyncSse_CustomNested1
+    extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8> field0;
+}
+
+final class wire_cst_CustomNestedError1TwinRustAsyncSse_ErrorNested
+    extends ffi.Struct {
+  external ffi.Pointer<wire_cst_custom_nested_error_2_twin_rust_async_sse>
+      field0;
+}
+
+final class CustomNestedError1TwinRustAsyncSseKind extends ffi.Union {
+  external wire_cst_CustomNestedError1TwinRustAsyncSse_CustomNested1
+      CustomNested1;
+
+  external wire_cst_CustomNestedError1TwinRustAsyncSse_ErrorNested ErrorNested;
 }
 
 final class wire_cst_custom_nested_error_1_twin_rust_async_sse
@@ -71032,28 +67671,74 @@ final class wire_cst_custom_nested_error_1_twin_rust_async_sse
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<CustomNestedError1TwinRustAsyncSseKind> kind;
+  external CustomNestedError1TwinRustAsyncSseKind kind;
+}
+
+final class wire_cst_CustomNestedError1TwinSse_CustomNested1
+    extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8> field0;
+}
+
+final class wire_cst_CustomNestedError1TwinSse_ErrorNested extends ffi.Struct {
+  external ffi.Pointer<wire_cst_custom_nested_error_2_twin_sse> field0;
+}
+
+final class CustomNestedError1TwinSseKind extends ffi.Union {
+  external wire_cst_CustomNestedError1TwinSse_CustomNested1 CustomNested1;
+
+  external wire_cst_CustomNestedError1TwinSse_ErrorNested ErrorNested;
 }
 
 final class wire_cst_custom_nested_error_1_twin_sse extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<CustomNestedError1TwinSseKind> kind;
+  external CustomNestedError1TwinSseKind kind;
+}
+
+final class wire_cst_CustomNestedError1TwinSync_CustomNested1
+    extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8> field0;
+}
+
+final class wire_cst_CustomNestedError1TwinSync_ErrorNested extends ffi.Struct {
+  external ffi.Pointer<wire_cst_custom_nested_error_2_twin_sync> field0;
+}
+
+final class CustomNestedError1TwinSyncKind extends ffi.Union {
+  external wire_cst_CustomNestedError1TwinSync_CustomNested1 CustomNested1;
+
+  external wire_cst_CustomNestedError1TwinSync_ErrorNested ErrorNested;
 }
 
 final class wire_cst_custom_nested_error_1_twin_sync extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<CustomNestedError1TwinSyncKind> kind;
+  external CustomNestedError1TwinSyncKind kind;
+}
+
+final class wire_cst_CustomNestedError1TwinSyncSse_CustomNested1
+    extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8> field0;
+}
+
+final class wire_cst_CustomNestedError1TwinSyncSse_ErrorNested
+    extends ffi.Struct {
+  external ffi.Pointer<wire_cst_custom_nested_error_2_twin_sync_sse> field0;
+}
+
+final class CustomNestedError1TwinSyncSseKind extends ffi.Union {
+  external wire_cst_CustomNestedError1TwinSyncSse_CustomNested1 CustomNested1;
+
+  external wire_cst_CustomNestedError1TwinSyncSse_ErrorNested ErrorNested;
 }
 
 final class wire_cst_custom_nested_error_1_twin_sync_sse extends ffi.Struct {
   @ffi.Int32()
   external int tag;
 
-  external ffi.Pointer<CustomNestedError1TwinSyncSseKind> kind;
+  external CustomNestedError1TwinSyncSseKind kind;
 }
 
 final class wire_cst_custom_struct_error_another_twin_normal

--- a/frb_example/pure_dart/rust/src/api/dart_opaque_sync.rs
+++ b/frb_example/pure_dart/rust/src/api/dart_opaque_sync.rs
@@ -21,7 +21,7 @@ pub fn sync_accept_dart_opaque_twin_normal(opaque: DartOpaque) -> String {
 /// [DartWrapObject] can be safely retrieved on a dart thread.
 #[frb(sync)]
 pub fn unwrap_dart_opaque_twin_normal(opaque: DartOpaque) -> String {
-    let handle = opaque.into_inner().unwrap();
+    let _handle = opaque.into_inner().unwrap();
     "Test".to_owned()
 }
 

--- a/frb_example/pure_dart/rust/src/api/pseudo_manual/dart_opaque_sync_twin_sse.rs
+++ b/frb_example/pure_dart/rust/src/api/pseudo_manual/dart_opaque_sync_twin_sse.rs
@@ -29,7 +29,7 @@ pub fn sync_accept_dart_opaque_twin_sse(opaque: DartOpaque) -> String {
 #[frb(sync)]
 #[flutter_rust_bridge::frb(serialize)]
 pub fn unwrap_dart_opaque_twin_sse(opaque: DartOpaque) -> String {
-    let handle = opaque.into_inner().unwrap();
+    let _handle = opaque.into_inner().unwrap();
     "Test".to_owned()
 }
 

--- a/frb_example/pure_dart/rust/src/frb_generated.io.rs
+++ b/frb_example/pure_dart/rust/src/frb_generated.io.rs
@@ -416,26 +416,22 @@ impl CstDecode<crate::api::pseudo_manual::misc_example_twin_sync_sse::ATwinSyncS
 impl CstDecode<crate::api::misc_example::AbcTwinNormal> for wire_cst_abc_twin_normal {
     fn cst_decode(self) -> crate::api::misc_example::AbcTwinNormal {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.A);
+            0 => {
+                let ans = unsafe { self.kind.A };
                 crate::api::misc_example::AbcTwinNormal::A(ans.field0.cst_decode())
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.B);
+            }
+            1 => {
+                let ans = unsafe { self.kind.B };
                 crate::api::misc_example::AbcTwinNormal::B(ans.field0.cst_decode())
-            },
-            2 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.C);
+            }
+            2 => {
+                let ans = unsafe { self.kind.C };
                 crate::api::misc_example::AbcTwinNormal::C(ans.field0.cst_decode())
-            },
-            3 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.JustInt);
+            }
+            3 => {
+                let ans = unsafe { self.kind.JustInt };
                 crate::api::misc_example::AbcTwinNormal::JustInt(ans.field0.cst_decode())
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -447,34 +443,30 @@ impl CstDecode<crate::api::pseudo_manual::misc_example_twin_rust_async::AbcTwinR
         self,
     ) -> crate::api::pseudo_manual::misc_example_twin_rust_async::AbcTwinRustAsync {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.A);
+            0 => {
+                let ans = unsafe { self.kind.A };
                 crate::api::pseudo_manual::misc_example_twin_rust_async::AbcTwinRustAsync::A(
                     ans.field0.cst_decode(),
                 )
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.B);
+            }
+            1 => {
+                let ans = unsafe { self.kind.B };
                 crate::api::pseudo_manual::misc_example_twin_rust_async::AbcTwinRustAsync::B(
                     ans.field0.cst_decode(),
                 )
-            },
-            2 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.C);
+            }
+            2 => {
+                let ans = unsafe { self.kind.C };
                 crate::api::pseudo_manual::misc_example_twin_rust_async::AbcTwinRustAsync::C(
                     ans.field0.cst_decode(),
                 )
-            },
-            3 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.JustInt);
+            }
+            3 => {
+                let ans = unsafe { self.kind.JustInt };
                 crate::api::pseudo_manual::misc_example_twin_rust_async::AbcTwinRustAsync::JustInt(
                     ans.field0.cst_decode(),
                 )
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -486,32 +478,28 @@ impl CstDecode<crate::api::pseudo_manual::misc_example_twin_rust_async_sse::AbcT
         self,
     ) -> crate::api::pseudo_manual::misc_example_twin_rust_async_sse::AbcTwinRustAsyncSse {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.A);
+            0 => {
+                let ans = unsafe { self.kind.A };
                 crate::api::pseudo_manual::misc_example_twin_rust_async_sse::AbcTwinRustAsyncSse::A(
                     ans.field0.cst_decode(),
                 )
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.B);
+            }
+            1 => {
+                let ans = unsafe { self.kind.B };
                 crate::api::pseudo_manual::misc_example_twin_rust_async_sse::AbcTwinRustAsyncSse::B(
                     ans.field0.cst_decode(),
                 )
-            },
-            2 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.C);
+            }
+            2 => {
+                let ans = unsafe { self.kind.C };
                 crate::api::pseudo_manual::misc_example_twin_rust_async_sse::AbcTwinRustAsyncSse::C(
                     ans.field0.cst_decode(),
                 )
-            },
-            3 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.JustInt);
+            }
+            3 => {
+                let ans = unsafe { self.kind.JustInt };
                 crate::api::pseudo_manual::misc_example_twin_rust_async_sse::AbcTwinRustAsyncSse::JustInt( ans.field0.cst_decode())
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -521,34 +509,30 @@ impl CstDecode<crate::api::pseudo_manual::misc_example_twin_sse::AbcTwinSse>
 {
     fn cst_decode(self) -> crate::api::pseudo_manual::misc_example_twin_sse::AbcTwinSse {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.A);
+            0 => {
+                let ans = unsafe { self.kind.A };
                 crate::api::pseudo_manual::misc_example_twin_sse::AbcTwinSse::A(
                     ans.field0.cst_decode(),
                 )
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.B);
+            }
+            1 => {
+                let ans = unsafe { self.kind.B };
                 crate::api::pseudo_manual::misc_example_twin_sse::AbcTwinSse::B(
                     ans.field0.cst_decode(),
                 )
-            },
-            2 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.C);
+            }
+            2 => {
+                let ans = unsafe { self.kind.C };
                 crate::api::pseudo_manual::misc_example_twin_sse::AbcTwinSse::C(
                     ans.field0.cst_decode(),
                 )
-            },
-            3 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.JustInt);
+            }
+            3 => {
+                let ans = unsafe { self.kind.JustInt };
                 crate::api::pseudo_manual::misc_example_twin_sse::AbcTwinSse::JustInt(
                     ans.field0.cst_decode(),
                 )
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -558,34 +542,30 @@ impl CstDecode<crate::api::pseudo_manual::misc_example_twin_sync::AbcTwinSync>
 {
     fn cst_decode(self) -> crate::api::pseudo_manual::misc_example_twin_sync::AbcTwinSync {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.A);
+            0 => {
+                let ans = unsafe { self.kind.A };
                 crate::api::pseudo_manual::misc_example_twin_sync::AbcTwinSync::A(
                     ans.field0.cst_decode(),
                 )
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.B);
+            }
+            1 => {
+                let ans = unsafe { self.kind.B };
                 crate::api::pseudo_manual::misc_example_twin_sync::AbcTwinSync::B(
                     ans.field0.cst_decode(),
                 )
-            },
-            2 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.C);
+            }
+            2 => {
+                let ans = unsafe { self.kind.C };
                 crate::api::pseudo_manual::misc_example_twin_sync::AbcTwinSync::C(
                     ans.field0.cst_decode(),
                 )
-            },
-            3 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.JustInt);
+            }
+            3 => {
+                let ans = unsafe { self.kind.JustInt };
                 crate::api::pseudo_manual::misc_example_twin_sync::AbcTwinSync::JustInt(
                     ans.field0.cst_decode(),
                 )
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -595,34 +575,30 @@ impl CstDecode<crate::api::pseudo_manual::misc_example_twin_sync_sse::AbcTwinSyn
 {
     fn cst_decode(self) -> crate::api::pseudo_manual::misc_example_twin_sync_sse::AbcTwinSyncSse {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.A);
+            0 => {
+                let ans = unsafe { self.kind.A };
                 crate::api::pseudo_manual::misc_example_twin_sync_sse::AbcTwinSyncSse::A(
                     ans.field0.cst_decode(),
                 )
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.B);
+            }
+            1 => {
+                let ans = unsafe { self.kind.B };
                 crate::api::pseudo_manual::misc_example_twin_sync_sse::AbcTwinSyncSse::B(
                     ans.field0.cst_decode(),
                 )
-            },
-            2 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.C);
+            }
+            2 => {
+                let ans = unsafe { self.kind.C };
                 crate::api::pseudo_manual::misc_example_twin_sync_sse::AbcTwinSyncSse::C(
                     ans.field0.cst_decode(),
                 )
-            },
-            3 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.JustInt);
+            }
+            3 => {
+                let ans = unsafe { self.kind.JustInt };
                 crate::api::pseudo_manual::misc_example_twin_sync_sse::AbcTwinSyncSse::JustInt(
                     ans.field0.cst_decode(),
                 )
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -715,21 +691,19 @@ impl CstDecode<crate::api::pseudo_manual::mirror_twin_sync_sse::ApplicationMessa
 {
     fn cst_decode(self) -> crate::api::pseudo_manual::mirror_twin_sync_sse::ApplicationMessage {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.DisplayMessage);
+            0 => {
+                let ans = unsafe { self.kind.DisplayMessage };
                 crate::api::pseudo_manual::mirror_twin_sync_sse::ApplicationMessage::DisplayMessage(
                     ans.field0.cst_decode(),
                 )
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.RenderPixel);
+            }
+            1 => {
+                let ans = unsafe { self.kind.RenderPixel };
                 crate::api::pseudo_manual::mirror_twin_sync_sse::ApplicationMessage::RenderPixel {
                     x: ans.x.cst_decode(),
                     y: ans.y.cst_decode(),
                 }
-            },
+            }
             2 => crate::api::pseudo_manual::mirror_twin_sync_sse::ApplicationMessage::Exit,
             _ => unreachable!(),
         }
@@ -4766,22 +4740,20 @@ impl CstDecode<crate::api::exception::CustomEnumErrorTwinNormal>
 {
     fn cst_decode(self) -> crate::api::exception::CustomEnumErrorTwinNormal {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.One);
+            0 => {
+                let ans = unsafe { self.kind.One };
                 crate::api::exception::CustomEnumErrorTwinNormal::One {
                     message: ans.message.cst_decode(),
                     backtrace: ans.backtrace.cst_decode(),
                 }
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Two);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Two };
                 crate::api::exception::CustomEnumErrorTwinNormal::Two {
                     message: ans.message.cst_decode(),
                     backtrace: ans.backtrace.cst_decode(),
                 }
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -4793,16 +4765,14 @@ impl CstDecode<crate::api::pseudo_manual::exception_twin_rust_async::CustomEnumE
         self,
     ) -> crate::api::pseudo_manual::exception_twin_rust_async::CustomEnumErrorTwinRustAsync {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.One);
+            0 => {
+                let ans = unsafe { self.kind.One };
                 crate::api::pseudo_manual::exception_twin_rust_async::CustomEnumErrorTwinRustAsync::One{message:  ans.message.cst_decode(),backtrace:  ans.backtrace.cst_decode()}
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Two);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Two };
                 crate::api::pseudo_manual::exception_twin_rust_async::CustomEnumErrorTwinRustAsync::Two{message:  ans.message.cst_decode(),backtrace:  ans.backtrace.cst_decode()}
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -4817,16 +4787,14 @@ impl
     ) -> crate::api::pseudo_manual::exception_twin_rust_async_sse::CustomEnumErrorTwinRustAsyncSse
     {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.One);
+            0 => {
+                let ans = unsafe { self.kind.One };
                 crate::api::pseudo_manual::exception_twin_rust_async_sse::CustomEnumErrorTwinRustAsyncSse::One{message:  ans.message.cst_decode(),backtrace:  ans.backtrace.cst_decode()}
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Two);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Two };
                 crate::api::pseudo_manual::exception_twin_rust_async_sse::CustomEnumErrorTwinRustAsyncSse::Two{message:  ans.message.cst_decode(),backtrace:  ans.backtrace.cst_decode()}
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -4836,22 +4804,20 @@ impl CstDecode<crate::api::pseudo_manual::exception_twin_sse::CustomEnumErrorTwi
 {
     fn cst_decode(self) -> crate::api::pseudo_manual::exception_twin_sse::CustomEnumErrorTwinSse {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.One);
+            0 => {
+                let ans = unsafe { self.kind.One };
                 crate::api::pseudo_manual::exception_twin_sse::CustomEnumErrorTwinSse::One {
                     message: ans.message.cst_decode(),
                     backtrace: ans.backtrace.cst_decode(),
                 }
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Two);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Two };
                 crate::api::pseudo_manual::exception_twin_sse::CustomEnumErrorTwinSse::Two {
                     message: ans.message.cst_decode(),
                     backtrace: ans.backtrace.cst_decode(),
                 }
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -4861,22 +4827,20 @@ impl CstDecode<crate::api::pseudo_manual::exception_twin_sync::CustomEnumErrorTw
 {
     fn cst_decode(self) -> crate::api::pseudo_manual::exception_twin_sync::CustomEnumErrorTwinSync {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.One);
+            0 => {
+                let ans = unsafe { self.kind.One };
                 crate::api::pseudo_manual::exception_twin_sync::CustomEnumErrorTwinSync::One {
                     message: ans.message.cst_decode(),
                     backtrace: ans.backtrace.cst_decode(),
                 }
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Two);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Two };
                 crate::api::pseudo_manual::exception_twin_sync::CustomEnumErrorTwinSync::Two {
                     message: ans.message.cst_decode(),
                     backtrace: ans.backtrace.cst_decode(),
                 }
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -4888,16 +4852,14 @@ impl CstDecode<crate::api::pseudo_manual::exception_twin_sync_sse::CustomEnumErr
         self,
     ) -> crate::api::pseudo_manual::exception_twin_sync_sse::CustomEnumErrorTwinSyncSse {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.One);
+            0 => {
+                let ans = unsafe { self.kind.One };
                 crate::api::pseudo_manual::exception_twin_sync_sse::CustomEnumErrorTwinSyncSse::One{message:  ans.message.cst_decode(),backtrace:  ans.backtrace.cst_decode()}
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Two);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Two };
                 crate::api::pseudo_manual::exception_twin_sync_sse::CustomEnumErrorTwinSyncSse::Two{message:  ans.message.cst_decode(),backtrace:  ans.backtrace.cst_decode()}
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -4905,22 +4867,20 @@ impl CstDecode<crate::api::pseudo_manual::exception_twin_sync_sse::CustomEnumErr
 impl CstDecode<crate::api::exception::CustomErrorTwinNormal> for wire_cst_custom_error_twin_normal {
     fn cst_decode(self) -> crate::api::exception::CustomErrorTwinNormal {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Error0);
+            0 => {
+                let ans = unsafe { self.kind.Error0 };
                 crate::api::exception::CustomErrorTwinNormal::Error0 {
                     e: ans.e.cst_decode(),
                     backtrace: ans.backtrace.cst_decode(),
                 }
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Error1);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Error1 };
                 crate::api::exception::CustomErrorTwinNormal::Error1 {
                     e: ans.e.cst_decode(),
                     backtrace: ans.backtrace.cst_decode(),
                 }
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -4932,16 +4892,14 @@ impl CstDecode<crate::api::pseudo_manual::exception_twin_rust_async::CustomError
         self,
     ) -> crate::api::pseudo_manual::exception_twin_rust_async::CustomErrorTwinRustAsync {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Error0);
+            0 => {
+                let ans = unsafe { self.kind.Error0 };
                 crate::api::pseudo_manual::exception_twin_rust_async::CustomErrorTwinRustAsync::Error0{e:  ans.e.cst_decode(),backtrace:  ans.backtrace.cst_decode()}
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Error1);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Error1 };
                 crate::api::pseudo_manual::exception_twin_rust_async::CustomErrorTwinRustAsync::Error1{e:  ans.e.cst_decode(),backtrace:  ans.backtrace.cst_decode()}
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -4954,16 +4912,14 @@ impl
         self,
     ) -> crate::api::pseudo_manual::exception_twin_rust_async_sse::CustomErrorTwinRustAsyncSse {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Error0);
+            0 => {
+                let ans = unsafe { self.kind.Error0 };
                 crate::api::pseudo_manual::exception_twin_rust_async_sse::CustomErrorTwinRustAsyncSse::Error0{e:  ans.e.cst_decode(),backtrace:  ans.backtrace.cst_decode()}
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Error1);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Error1 };
                 crate::api::pseudo_manual::exception_twin_rust_async_sse::CustomErrorTwinRustAsyncSse::Error1{e:  ans.e.cst_decode(),backtrace:  ans.backtrace.cst_decode()}
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -4973,22 +4929,20 @@ impl CstDecode<crate::api::pseudo_manual::exception_twin_sse::CustomErrorTwinSse
 {
     fn cst_decode(self) -> crate::api::pseudo_manual::exception_twin_sse::CustomErrorTwinSse {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Error0);
+            0 => {
+                let ans = unsafe { self.kind.Error0 };
                 crate::api::pseudo_manual::exception_twin_sse::CustomErrorTwinSse::Error0 {
                     e: ans.e.cst_decode(),
                     backtrace: ans.backtrace.cst_decode(),
                 }
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Error1);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Error1 };
                 crate::api::pseudo_manual::exception_twin_sse::CustomErrorTwinSse::Error1 {
                     e: ans.e.cst_decode(),
                     backtrace: ans.backtrace.cst_decode(),
                 }
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -4998,22 +4952,20 @@ impl CstDecode<crate::api::pseudo_manual::exception_twin_sync::CustomErrorTwinSy
 {
     fn cst_decode(self) -> crate::api::pseudo_manual::exception_twin_sync::CustomErrorTwinSync {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Error0);
+            0 => {
+                let ans = unsafe { self.kind.Error0 };
                 crate::api::pseudo_manual::exception_twin_sync::CustomErrorTwinSync::Error0 {
                     e: ans.e.cst_decode(),
                     backtrace: ans.backtrace.cst_decode(),
                 }
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Error1);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Error1 };
                 crate::api::pseudo_manual::exception_twin_sync::CustomErrorTwinSync::Error1 {
                     e: ans.e.cst_decode(),
                     backtrace: ans.backtrace.cst_decode(),
                 }
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -5025,22 +4977,20 @@ impl CstDecode<crate::api::pseudo_manual::exception_twin_sync_sse::CustomErrorTw
         self,
     ) -> crate::api::pseudo_manual::exception_twin_sync_sse::CustomErrorTwinSyncSse {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Error0);
+            0 => {
+                let ans = unsafe { self.kind.Error0 };
                 crate::api::pseudo_manual::exception_twin_sync_sse::CustomErrorTwinSyncSse::Error0 {
                     e: ans.e.cst_decode(),
                     backtrace: ans.backtrace.cst_decode(),
                 }
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Error1);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Error1 };
                 crate::api::pseudo_manual::exception_twin_sync_sse::CustomErrorTwinSyncSse::Error1 {
                     e: ans.e.cst_decode(),
                     backtrace: ans.backtrace.cst_decode(),
                 }
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -5050,20 +5000,18 @@ impl CstDecode<crate::api::exception::CustomNestedError1TwinNormal>
 {
     fn cst_decode(self) -> crate::api::exception::CustomNestedError1TwinNormal {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.CustomNested1);
+            0 => {
+                let ans = unsafe { self.kind.CustomNested1 };
                 crate::api::exception::CustomNestedError1TwinNormal::CustomNested1(
                     ans.field0.cst_decode(),
                 )
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.ErrorNested);
+            }
+            1 => {
+                let ans = unsafe { self.kind.ErrorNested };
                 crate::api::exception::CustomNestedError1TwinNormal::ErrorNested(
                     ans.field0.cst_decode(),
                 )
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -5076,16 +5024,14 @@ impl
         self,
     ) -> crate::api::pseudo_manual::exception_twin_rust_async::CustomNestedError1TwinRustAsync {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.CustomNested1);
+            0 => {
+                let ans = unsafe { self.kind.CustomNested1 };
                 crate::api::pseudo_manual::exception_twin_rust_async::CustomNestedError1TwinRustAsync::CustomNested1( ans.field0.cst_decode())
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.ErrorNested);
+            }
+            1 => {
+                let ans = unsafe { self.kind.ErrorNested };
                 crate::api::pseudo_manual::exception_twin_rust_async::CustomNestedError1TwinRustAsync::ErrorNested( ans.field0.cst_decode())
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -5093,14 +5039,12 @@ impl
 impl CstDecode<crate::api::pseudo_manual::exception_twin_rust_async_sse::CustomNestedError1TwinRustAsyncSse> for wire_cst_custom_nested_error_1_twin_rust_async_sse {
             fn cst_decode(self) -> crate::api::pseudo_manual::exception_twin_rust_async_sse::CustomNestedError1TwinRustAsyncSse {
                 match self.tag {
-                    0 => unsafe {
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.CustomNested1);
+                    0 => {
+                        let ans = unsafe { self.kind.CustomNested1 };
                         crate::api::pseudo_manual::exception_twin_rust_async_sse::CustomNestedError1TwinRustAsyncSse::CustomNested1( ans.field0.cst_decode())
                     }
-1 => unsafe {
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.ErrorNested);
+1 => {
+                        let ans = unsafe { self.kind.ErrorNested };
                         crate::api::pseudo_manual::exception_twin_rust_async_sse::CustomNestedError1TwinRustAsyncSse::ErrorNested( ans.field0.cst_decode())
                     }
                     _ => unreachable!(),
@@ -5114,16 +5058,14 @@ impl CstDecode<crate::api::pseudo_manual::exception_twin_sse::CustomNestedError1
         self,
     ) -> crate::api::pseudo_manual::exception_twin_sse::CustomNestedError1TwinSse {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.CustomNested1);
+            0 => {
+                let ans = unsafe { self.kind.CustomNested1 };
                 crate::api::pseudo_manual::exception_twin_sse::CustomNestedError1TwinSse::CustomNested1( ans.field0.cst_decode())
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.ErrorNested);
+            }
+            1 => {
+                let ans = unsafe { self.kind.ErrorNested };
                 crate::api::pseudo_manual::exception_twin_sse::CustomNestedError1TwinSse::ErrorNested( ans.field0.cst_decode())
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -5135,16 +5077,14 @@ impl CstDecode<crate::api::pseudo_manual::exception_twin_sync::CustomNestedError
         self,
     ) -> crate::api::pseudo_manual::exception_twin_sync::CustomNestedError1TwinSync {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.CustomNested1);
+            0 => {
+                let ans = unsafe { self.kind.CustomNested1 };
                 crate::api::pseudo_manual::exception_twin_sync::CustomNestedError1TwinSync::CustomNested1( ans.field0.cst_decode())
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.ErrorNested);
+            }
+            1 => {
+                let ans = unsafe { self.kind.ErrorNested };
                 crate::api::pseudo_manual::exception_twin_sync::CustomNestedError1TwinSync::ErrorNested( ans.field0.cst_decode())
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -5156,16 +5096,14 @@ impl CstDecode<crate::api::pseudo_manual::exception_twin_sync_sse::CustomNestedE
         self,
     ) -> crate::api::pseudo_manual::exception_twin_sync_sse::CustomNestedError1TwinSyncSse {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.CustomNested1);
+            0 => {
+                let ans = unsafe { self.kind.CustomNested1 };
                 crate::api::pseudo_manual::exception_twin_sync_sse::CustomNestedError1TwinSyncSse::CustomNested1( ans.field0.cst_decode())
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.ErrorNested);
+            }
+            1 => {
+                let ans = unsafe { self.kind.ErrorNested };
                 crate::api::pseudo_manual::exception_twin_sync_sse::CustomNestedError1TwinSyncSse::ErrorNested( ans.field0.cst_decode())
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -5175,21 +5113,18 @@ impl CstDecode<crate::api::exception::CustomNestedError2TwinNormal>
 {
     fn cst_decode(self) -> crate::api::exception::CustomNestedError2TwinNormal {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.CustomNested2);
+            0 => {
+                let ans = unsafe { self.kind.CustomNested2 };
                 crate::api::exception::CustomNestedError2TwinNormal::CustomNested2(
                     ans.field0.cst_decode(),
                 )
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans =
-                    flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.CustomNested2Number);
+            }
+            1 => {
+                let ans = unsafe { self.kind.CustomNested2Number };
                 crate::api::exception::CustomNestedError2TwinNormal::CustomNested2Number(
                     ans.field0.cst_decode(),
                 )
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -5202,17 +5137,14 @@ impl
         self,
     ) -> crate::api::pseudo_manual::exception_twin_rust_async::CustomNestedError2TwinRustAsync {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.CustomNested2);
+            0 => {
+                let ans = unsafe { self.kind.CustomNested2 };
                 crate::api::pseudo_manual::exception_twin_rust_async::CustomNestedError2TwinRustAsync::CustomNested2( ans.field0.cst_decode())
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans =
-                    flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.CustomNested2Number);
+            }
+            1 => {
+                let ans = unsafe { self.kind.CustomNested2Number };
                 crate::api::pseudo_manual::exception_twin_rust_async::CustomNestedError2TwinRustAsync::CustomNested2Number( ans.field0.cst_decode())
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -5220,14 +5152,12 @@ impl
 impl CstDecode<crate::api::pseudo_manual::exception_twin_rust_async_sse::CustomNestedError2TwinRustAsyncSse> for wire_cst_custom_nested_error_2_twin_rust_async_sse {
             fn cst_decode(self) -> crate::api::pseudo_manual::exception_twin_rust_async_sse::CustomNestedError2TwinRustAsyncSse {
                 match self.tag {
-                    0 => unsafe {
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.CustomNested2);
+                    0 => {
+                        let ans = unsafe { self.kind.CustomNested2 };
                         crate::api::pseudo_manual::exception_twin_rust_async_sse::CustomNestedError2TwinRustAsyncSse::CustomNested2( ans.field0.cst_decode())
                     }
-1 => unsafe {
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.CustomNested2Number);
+1 => {
+                        let ans = unsafe { self.kind.CustomNested2Number };
                         crate::api::pseudo_manual::exception_twin_rust_async_sse::CustomNestedError2TwinRustAsyncSse::CustomNested2Number( ans.field0.cst_decode())
                     }
                     _ => unreachable!(),
@@ -5241,17 +5171,14 @@ impl CstDecode<crate::api::pseudo_manual::exception_twin_sse::CustomNestedError2
         self,
     ) -> crate::api::pseudo_manual::exception_twin_sse::CustomNestedError2TwinSse {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.CustomNested2);
+            0 => {
+                let ans = unsafe { self.kind.CustomNested2 };
                 crate::api::pseudo_manual::exception_twin_sse::CustomNestedError2TwinSse::CustomNested2( ans.field0.cst_decode())
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans =
-                    flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.CustomNested2Number);
+            }
+            1 => {
+                let ans = unsafe { self.kind.CustomNested2Number };
                 crate::api::pseudo_manual::exception_twin_sse::CustomNestedError2TwinSse::CustomNested2Number( ans.field0.cst_decode())
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -5263,17 +5190,14 @@ impl CstDecode<crate::api::pseudo_manual::exception_twin_sync::CustomNestedError
         self,
     ) -> crate::api::pseudo_manual::exception_twin_sync::CustomNestedError2TwinSync {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.CustomNested2);
+            0 => {
+                let ans = unsafe { self.kind.CustomNested2 };
                 crate::api::pseudo_manual::exception_twin_sync::CustomNestedError2TwinSync::CustomNested2( ans.field0.cst_decode())
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans =
-                    flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.CustomNested2Number);
+            }
+            1 => {
+                let ans = unsafe { self.kind.CustomNested2Number };
                 crate::api::pseudo_manual::exception_twin_sync::CustomNestedError2TwinSync::CustomNested2Number( ans.field0.cst_decode())
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -5285,17 +5209,14 @@ impl CstDecode<crate::api::pseudo_manual::exception_twin_sync_sse::CustomNestedE
         self,
     ) -> crate::api::pseudo_manual::exception_twin_sync_sse::CustomNestedError2TwinSyncSse {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.CustomNested2);
+            0 => {
+                let ans = unsafe { self.kind.CustomNested2 };
                 crate::api::pseudo_manual::exception_twin_sync_sse::CustomNestedError2TwinSyncSse::CustomNested2( ans.field0.cst_decode())
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans =
-                    flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.CustomNested2Number);
+            }
+            1 => {
+                let ans = unsafe { self.kind.CustomNested2Number };
                 crate::api::pseudo_manual::exception_twin_sync_sse::CustomNestedError2TwinSyncSse::CustomNested2Number( ans.field0.cst_decode())
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -5305,20 +5226,18 @@ impl CstDecode<crate::api::exception::CustomNestedErrorInnerTwinNormal>
 {
     fn cst_decode(self) -> crate::api::exception::CustomNestedErrorInnerTwinNormal {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Three);
+            0 => {
+                let ans = unsafe { self.kind.Three };
                 crate::api::exception::CustomNestedErrorInnerTwinNormal::Three(
                     ans.field0.cst_decode(),
                 )
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Four);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Four };
                 crate::api::exception::CustomNestedErrorInnerTwinNormal::Four(
                     ans.field0.cst_decode(),
                 )
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -5333,16 +5252,14 @@ impl
     ) -> crate::api::pseudo_manual::exception_twin_rust_async::CustomNestedErrorInnerTwinRustAsync
     {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Three);
+            0 => {
+                let ans = unsafe { self.kind.Three };
                 crate::api::pseudo_manual::exception_twin_rust_async::CustomNestedErrorInnerTwinRustAsync::Three( ans.field0.cst_decode())
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Four);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Four };
                 crate::api::pseudo_manual::exception_twin_rust_async::CustomNestedErrorInnerTwinRustAsync::Four( ans.field0.cst_decode())
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -5350,14 +5267,12 @@ impl
 impl CstDecode<crate::api::pseudo_manual::exception_twin_rust_async_sse::CustomNestedErrorInnerTwinRustAsyncSse> for wire_cst_custom_nested_error_inner_twin_rust_async_sse {
             fn cst_decode(self) -> crate::api::pseudo_manual::exception_twin_rust_async_sse::CustomNestedErrorInnerTwinRustAsyncSse {
                 match self.tag {
-                    0 => unsafe {
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Three);
+                    0 => {
+                        let ans = unsafe { self.kind.Three };
                         crate::api::pseudo_manual::exception_twin_rust_async_sse::CustomNestedErrorInnerTwinRustAsyncSse::Three( ans.field0.cst_decode())
                     }
-1 => unsafe {
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Four);
+1 => {
+                        let ans = unsafe { self.kind.Four };
                         crate::api::pseudo_manual::exception_twin_rust_async_sse::CustomNestedErrorInnerTwinRustAsyncSse::Four( ans.field0.cst_decode())
                     }
                     _ => unreachable!(),
@@ -5371,20 +5286,18 @@ impl CstDecode<crate::api::pseudo_manual::exception_twin_sse::CustomNestedErrorI
         self,
     ) -> crate::api::pseudo_manual::exception_twin_sse::CustomNestedErrorInnerTwinSse {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Three);
+            0 => {
+                let ans = unsafe { self.kind.Three };
                 crate::api::pseudo_manual::exception_twin_sse::CustomNestedErrorInnerTwinSse::Three(
                     ans.field0.cst_decode(),
                 )
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Four);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Four };
                 crate::api::pseudo_manual::exception_twin_sse::CustomNestedErrorInnerTwinSse::Four(
                     ans.field0.cst_decode(),
                 )
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -5396,18 +5309,16 @@ impl CstDecode<crate::api::pseudo_manual::exception_twin_sync::CustomNestedError
         self,
     ) -> crate::api::pseudo_manual::exception_twin_sync::CustomNestedErrorInnerTwinSync {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Three);
+            0 => {
+                let ans = unsafe { self.kind.Three };
                 crate::api::pseudo_manual::exception_twin_sync::CustomNestedErrorInnerTwinSync::Three( ans.field0.cst_decode())
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Four);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Four };
                 crate::api::pseudo_manual::exception_twin_sync::CustomNestedErrorInnerTwinSync::Four(
                     ans.field0.cst_decode(),
                 )
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -5420,16 +5331,14 @@ impl
         self,
     ) -> crate::api::pseudo_manual::exception_twin_sync_sse::CustomNestedErrorInnerTwinSyncSse {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Three);
+            0 => {
+                let ans = unsafe { self.kind.Three };
                 crate::api::pseudo_manual::exception_twin_sync_sse::CustomNestedErrorInnerTwinSyncSse::Three( ans.field0.cst_decode())
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Four);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Four };
                 crate::api::pseudo_manual::exception_twin_sync_sse::CustomNestedErrorInnerTwinSyncSse::Four( ans.field0.cst_decode())
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -5439,20 +5348,18 @@ impl CstDecode<crate::api::exception::CustomNestedErrorOuterTwinNormal>
 {
     fn cst_decode(self) -> crate::api::exception::CustomNestedErrorOuterTwinNormal {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.One);
+            0 => {
+                let ans = unsafe { self.kind.One };
                 crate::api::exception::CustomNestedErrorOuterTwinNormal::One(
                     ans.field0.cst_decode(),
                 )
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Two);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Two };
                 crate::api::exception::CustomNestedErrorOuterTwinNormal::Two(
                     ans.field0.cst_decode(),
                 )
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -5467,16 +5374,14 @@ impl
     ) -> crate::api::pseudo_manual::exception_twin_rust_async::CustomNestedErrorOuterTwinRustAsync
     {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.One);
+            0 => {
+                let ans = unsafe { self.kind.One };
                 crate::api::pseudo_manual::exception_twin_rust_async::CustomNestedErrorOuterTwinRustAsync::One( ans.field0.cst_decode())
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Two);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Two };
                 crate::api::pseudo_manual::exception_twin_rust_async::CustomNestedErrorOuterTwinRustAsync::Two( ans.field0.cst_decode())
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -5484,14 +5389,12 @@ impl
 impl CstDecode<crate::api::pseudo_manual::exception_twin_rust_async_sse::CustomNestedErrorOuterTwinRustAsyncSse> for wire_cst_custom_nested_error_outer_twin_rust_async_sse {
             fn cst_decode(self) -> crate::api::pseudo_manual::exception_twin_rust_async_sse::CustomNestedErrorOuterTwinRustAsyncSse {
                 match self.tag {
-                    0 => unsafe {
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.One);
+                    0 => {
+                        let ans = unsafe { self.kind.One };
                         crate::api::pseudo_manual::exception_twin_rust_async_sse::CustomNestedErrorOuterTwinRustAsyncSse::One( ans.field0.cst_decode())
                     }
-1 => unsafe {
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Two);
+1 => {
+                        let ans = unsafe { self.kind.Two };
                         crate::api::pseudo_manual::exception_twin_rust_async_sse::CustomNestedErrorOuterTwinRustAsyncSse::Two( ans.field0.cst_decode())
                     }
                     _ => unreachable!(),
@@ -5505,20 +5408,18 @@ impl CstDecode<crate::api::pseudo_manual::exception_twin_sse::CustomNestedErrorO
         self,
     ) -> crate::api::pseudo_manual::exception_twin_sse::CustomNestedErrorOuterTwinSse {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.One);
+            0 => {
+                let ans = unsafe { self.kind.One };
                 crate::api::pseudo_manual::exception_twin_sse::CustomNestedErrorOuterTwinSse::One(
                     ans.field0.cst_decode(),
                 )
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Two);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Two };
                 crate::api::pseudo_manual::exception_twin_sse::CustomNestedErrorOuterTwinSse::Two(
                     ans.field0.cst_decode(),
                 )
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -5530,20 +5431,18 @@ impl CstDecode<crate::api::pseudo_manual::exception_twin_sync::CustomNestedError
         self,
     ) -> crate::api::pseudo_manual::exception_twin_sync::CustomNestedErrorOuterTwinSync {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.One);
+            0 => {
+                let ans = unsafe { self.kind.One };
                 crate::api::pseudo_manual::exception_twin_sync::CustomNestedErrorOuterTwinSync::One(
                     ans.field0.cst_decode(),
                 )
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Two);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Two };
                 crate::api::pseudo_manual::exception_twin_sync::CustomNestedErrorOuterTwinSync::Two(
                     ans.field0.cst_decode(),
                 )
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -5556,16 +5455,14 @@ impl
         self,
     ) -> crate::api::pseudo_manual::exception_twin_sync_sse::CustomNestedErrorOuterTwinSyncSse {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.One);
+            0 => {
+                let ans = unsafe { self.kind.One };
                 crate::api::pseudo_manual::exception_twin_sync_sse::CustomNestedErrorOuterTwinSyncSse::One( ans.field0.cst_decode())
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Two);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Two };
                 crate::api::pseudo_manual::exception_twin_sync_sse::CustomNestedErrorOuterTwinSyncSse::Two( ans.field0.cst_decode())
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -5929,11 +5826,10 @@ impl CstDecode<crate::api::enumeration::DistanceTwinNormal> for wire_cst_distanc
     fn cst_decode(self) -> crate::api::enumeration::DistanceTwinNormal {
         match self.tag {
             0 => crate::api::enumeration::DistanceTwinNormal::Unknown,
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Map);
+            1 => {
+                let ans = unsafe { self.kind.Map };
                 crate::api::enumeration::DistanceTwinNormal::Map(ans.field0.cst_decode())
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -5946,9 +5842,8 @@ impl CstDecode<crate::api::pseudo_manual::enumeration_twin_rust_async::DistanceT
     ) -> crate::api::pseudo_manual::enumeration_twin_rust_async::DistanceTwinRustAsync {
         match self.tag {
                     0 => crate::api::pseudo_manual::enumeration_twin_rust_async::DistanceTwinRustAsync::Unknown,
-1 => unsafe {
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Map);
+1 => {
+                        let ans = unsafe { self.kind.Map };
                         crate::api::pseudo_manual::enumeration_twin_rust_async::DistanceTwinRustAsync::Map( ans.field0.cst_decode())
                     }
                     _ => unreachable!(),
@@ -5963,9 +5858,8 @@ impl CstDecode<crate::api::pseudo_manual::enumeration_twin_rust_async_sse::Dista
     ) -> crate::api::pseudo_manual::enumeration_twin_rust_async_sse::DistanceTwinRustAsyncSse {
         match self.tag {
                     0 => crate::api::pseudo_manual::enumeration_twin_rust_async_sse::DistanceTwinRustAsyncSse::Unknown,
-1 => unsafe {
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Map);
+1 => {
+                        let ans = unsafe { self.kind.Map };
                         crate::api::pseudo_manual::enumeration_twin_rust_async_sse::DistanceTwinRustAsyncSse::Map( ans.field0.cst_decode())
                     }
                     _ => unreachable!(),
@@ -5978,13 +5872,12 @@ impl CstDecode<crate::api::pseudo_manual::enumeration_twin_sse::DistanceTwinSse>
     fn cst_decode(self) -> crate::api::pseudo_manual::enumeration_twin_sse::DistanceTwinSse {
         match self.tag {
             0 => crate::api::pseudo_manual::enumeration_twin_sse::DistanceTwinSse::Unknown,
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Map);
+            1 => {
+                let ans = unsafe { self.kind.Map };
                 crate::api::pseudo_manual::enumeration_twin_sse::DistanceTwinSse::Map(
                     ans.field0.cst_decode(),
                 )
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -5995,13 +5888,12 @@ impl CstDecode<crate::api::pseudo_manual::enumeration_twin_sync::DistanceTwinSyn
     fn cst_decode(self) -> crate::api::pseudo_manual::enumeration_twin_sync::DistanceTwinSync {
         match self.tag {
             0 => crate::api::pseudo_manual::enumeration_twin_sync::DistanceTwinSync::Unknown,
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Map);
+            1 => {
+                let ans = unsafe { self.kind.Map };
                 crate::api::pseudo_manual::enumeration_twin_sync::DistanceTwinSync::Map(
                     ans.field0.cst_decode(),
                 )
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -6014,13 +5906,12 @@ impl CstDecode<crate::api::pseudo_manual::enumeration_twin_sync_sse::DistanceTwi
     ) -> crate::api::pseudo_manual::enumeration_twin_sync_sse::DistanceTwinSyncSse {
         match self.tag {
             0 => crate::api::pseudo_manual::enumeration_twin_sync_sse::DistanceTwinSyncSse::Unknown,
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Map);
+            1 => {
+                let ans = unsafe { self.kind.Map };
                 crate::api::pseudo_manual::enumeration_twin_sync_sse::DistanceTwinSyncSse::Map(
                     ans.field0.cst_decode(),
                 )
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -6148,18 +6039,16 @@ impl CstDecode<crate::api::dart_opaque::EnumDartOpaqueTwinNormal>
 {
     fn cst_decode(self) -> crate::api::dart_opaque::EnumDartOpaqueTwinNormal {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Primitive);
+            0 => {
+                let ans = unsafe { self.kind.Primitive };
                 crate::api::dart_opaque::EnumDartOpaqueTwinNormal::Primitive(
                     ans.field0.cst_decode(),
                 )
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Opaque);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Opaque };
                 crate::api::dart_opaque::EnumDartOpaqueTwinNormal::Opaque(ans.field0.cst_decode())
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -6171,16 +6060,14 @@ impl CstDecode<crate::api::pseudo_manual::dart_opaque_twin_rust_async::EnumDartO
         self,
     ) -> crate::api::pseudo_manual::dart_opaque_twin_rust_async::EnumDartOpaqueTwinRustAsync {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Primitive);
+            0 => {
+                let ans = unsafe { self.kind.Primitive };
                 crate::api::pseudo_manual::dart_opaque_twin_rust_async::EnumDartOpaqueTwinRustAsync::Primitive( ans.field0.cst_decode())
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Opaque);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Opaque };
                 crate::api::pseudo_manual::dart_opaque_twin_rust_async::EnumDartOpaqueTwinRustAsync::Opaque( ans.field0.cst_decode())
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -6195,16 +6082,14 @@ impl
     ) -> crate::api::pseudo_manual::dart_opaque_twin_rust_async_sse::EnumDartOpaqueTwinRustAsyncSse
     {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Primitive);
+            0 => {
+                let ans = unsafe { self.kind.Primitive };
                 crate::api::pseudo_manual::dart_opaque_twin_rust_async_sse::EnumDartOpaqueTwinRustAsyncSse::Primitive( ans.field0.cst_decode())
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Opaque);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Opaque };
                 crate::api::pseudo_manual::dart_opaque_twin_rust_async_sse::EnumDartOpaqueTwinRustAsyncSse::Opaque( ans.field0.cst_decode())
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -6214,20 +6099,18 @@ impl CstDecode<crate::api::pseudo_manual::dart_opaque_twin_sse::EnumDartOpaqueTw
 {
     fn cst_decode(self) -> crate::api::pseudo_manual::dart_opaque_twin_sse::EnumDartOpaqueTwinSse {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Primitive);
+            0 => {
+                let ans = unsafe { self.kind.Primitive };
                 crate::api::pseudo_manual::dart_opaque_twin_sse::EnumDartOpaqueTwinSse::Primitive(
                     ans.field0.cst_decode(),
                 )
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Opaque);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Opaque };
                 crate::api::pseudo_manual::dart_opaque_twin_sse::EnumDartOpaqueTwinSse::Opaque(
                     ans.field0.cst_decode(),
                 )
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -6239,20 +6122,18 @@ impl CstDecode<crate::api::pseudo_manual::dart_opaque_twin_sync::EnumDartOpaqueT
         self,
     ) -> crate::api::pseudo_manual::dart_opaque_twin_sync::EnumDartOpaqueTwinSync {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Primitive);
+            0 => {
+                let ans = unsafe { self.kind.Primitive };
                 crate::api::pseudo_manual::dart_opaque_twin_sync::EnumDartOpaqueTwinSync::Primitive(
                     ans.field0.cst_decode(),
                 )
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Opaque);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Opaque };
                 crate::api::pseudo_manual::dart_opaque_twin_sync::EnumDartOpaqueTwinSync::Opaque(
                     ans.field0.cst_decode(),
                 )
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -6264,16 +6145,14 @@ impl CstDecode<crate::api::pseudo_manual::dart_opaque_twin_sync_sse::EnumDartOpa
         self,
     ) -> crate::api::pseudo_manual::dart_opaque_twin_sync_sse::EnumDartOpaqueTwinSyncSse {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Primitive);
+            0 => {
+                let ans = unsafe { self.kind.Primitive };
                 crate::api::pseudo_manual::dart_opaque_twin_sync_sse::EnumDartOpaqueTwinSyncSse::Primitive( ans.field0.cst_decode())
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Opaque);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Opaque };
                 crate::api::pseudo_manual::dart_opaque_twin_sync_sse::EnumDartOpaqueTwinSyncSse::Opaque( ans.field0.cst_decode())
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -6281,31 +6160,26 @@ impl CstDecode<crate::api::pseudo_manual::dart_opaque_twin_sync_sse::EnumDartOpa
 impl CstDecode<crate::api::rust_opaque::EnumOpaqueTwinNormal> for wire_cst_enum_opaque_twin_normal {
     fn cst_decode(self) -> crate::api::rust_opaque::EnumOpaqueTwinNormal {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Struct);
+            0 => {
+                let ans = unsafe { self.kind.Struct };
                 crate::api::rust_opaque::EnumOpaqueTwinNormal::Struct(ans.field0.cst_decode())
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Primitive);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Primitive };
                 crate::api::rust_opaque::EnumOpaqueTwinNormal::Primitive(ans.field0.cst_decode())
-            },
-            2 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.TraitObj);
+            }
+            2 => {
+                let ans = unsafe { self.kind.TraitObj };
                 crate::api::rust_opaque::EnumOpaqueTwinNormal::TraitObj(ans.field0.cst_decode())
-            },
-            3 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Mutex);
+            }
+            3 => {
+                let ans = unsafe { self.kind.Mutex };
                 crate::api::rust_opaque::EnumOpaqueTwinNormal::Mutex(ans.field0.cst_decode())
-            },
-            4 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.RwLock);
+            }
+            4 => {
+                let ans = unsafe { self.kind.RwLock };
                 crate::api::rust_opaque::EnumOpaqueTwinNormal::RwLock(ans.field0.cst_decode())
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -6325,31 +6199,26 @@ impl CstDecode<crate::api::pseudo_manual::rust_opaque_twin_rust_async::EnumOpaqu
         self,
     ) -> crate::api::pseudo_manual::rust_opaque_twin_rust_async::EnumOpaqueTwinRustAsync {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Struct);
+            0 => {
+                let ans = unsafe { self.kind.Struct };
                 crate::api::pseudo_manual::rust_opaque_twin_rust_async::EnumOpaqueTwinRustAsync::Struct( ans.field0.cst_decode())
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Primitive);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Primitive };
                 crate::api::pseudo_manual::rust_opaque_twin_rust_async::EnumOpaqueTwinRustAsync::Primitive( ans.field0.cst_decode())
-            },
-            2 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.TraitObj);
+            }
+            2 => {
+                let ans = unsafe { self.kind.TraitObj };
                 crate::api::pseudo_manual::rust_opaque_twin_rust_async::EnumOpaqueTwinRustAsync::TraitObj( ans.field0.cst_decode())
-            },
-            3 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Mutex);
+            }
+            3 => {
+                let ans = unsafe { self.kind.Mutex };
                 crate::api::pseudo_manual::rust_opaque_twin_rust_async::EnumOpaqueTwinRustAsync::Mutex( ans.field0.cst_decode())
-            },
-            4 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.RwLock);
+            }
+            4 => {
+                let ans = unsafe { self.kind.RwLock };
                 crate::api::pseudo_manual::rust_opaque_twin_rust_async::EnumOpaqueTwinRustAsync::RwLock( ans.field0.cst_decode())
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -6376,31 +6245,26 @@ impl
     ) -> crate::api::pseudo_manual::rust_opaque_twin_rust_async_sse::EnumOpaqueTwinRustAsyncSse
     {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Struct);
+            0 => {
+                let ans = unsafe { self.kind.Struct };
                 crate::api::pseudo_manual::rust_opaque_twin_rust_async_sse::EnumOpaqueTwinRustAsyncSse::Struct( ans.field0.cst_decode())
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Primitive);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Primitive };
                 crate::api::pseudo_manual::rust_opaque_twin_rust_async_sse::EnumOpaqueTwinRustAsyncSse::Primitive( ans.field0.cst_decode())
-            },
-            2 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.TraitObj);
+            }
+            2 => {
+                let ans = unsafe { self.kind.TraitObj };
                 crate::api::pseudo_manual::rust_opaque_twin_rust_async_sse::EnumOpaqueTwinRustAsyncSse::TraitObj( ans.field0.cst_decode())
-            },
-            3 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Mutex);
+            }
+            3 => {
+                let ans = unsafe { self.kind.Mutex };
                 crate::api::pseudo_manual::rust_opaque_twin_rust_async_sse::EnumOpaqueTwinRustAsyncSse::Mutex( ans.field0.cst_decode())
-            },
-            4 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.RwLock);
+            }
+            4 => {
+                let ans = unsafe { self.kind.RwLock };
                 crate::api::pseudo_manual::rust_opaque_twin_rust_async_sse::EnumOpaqueTwinRustAsyncSse::RwLock( ans.field0.cst_decode())
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -6425,41 +6289,36 @@ impl CstDecode<crate::api::pseudo_manual::rust_opaque_twin_sse::EnumOpaqueTwinSs
 {
     fn cst_decode(self) -> crate::api::pseudo_manual::rust_opaque_twin_sse::EnumOpaqueTwinSse {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Struct);
+            0 => {
+                let ans = unsafe { self.kind.Struct };
                 crate::api::pseudo_manual::rust_opaque_twin_sse::EnumOpaqueTwinSse::Struct(
                     ans.field0.cst_decode(),
                 )
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Primitive);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Primitive };
                 crate::api::pseudo_manual::rust_opaque_twin_sse::EnumOpaqueTwinSse::Primitive(
                     ans.field0.cst_decode(),
                 )
-            },
-            2 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.TraitObj);
+            }
+            2 => {
+                let ans = unsafe { self.kind.TraitObj };
                 crate::api::pseudo_manual::rust_opaque_twin_sse::EnumOpaqueTwinSse::TraitObj(
                     ans.field0.cst_decode(),
                 )
-            },
-            3 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Mutex);
+            }
+            3 => {
+                let ans = unsafe { self.kind.Mutex };
                 crate::api::pseudo_manual::rust_opaque_twin_sse::EnumOpaqueTwinSse::Mutex(
                     ans.field0.cst_decode(),
                 )
-            },
-            4 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.RwLock);
+            }
+            4 => {
+                let ans = unsafe { self.kind.RwLock };
                 crate::api::pseudo_manual::rust_opaque_twin_sse::EnumOpaqueTwinSse::RwLock(
                     ans.field0.cst_decode(),
                 )
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -6478,41 +6337,36 @@ impl CstDecode<crate::api::pseudo_manual::rust_opaque_twin_sync::EnumOpaqueTwinS
 {
     fn cst_decode(self) -> crate::api::pseudo_manual::rust_opaque_twin_sync::EnumOpaqueTwinSync {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Struct);
+            0 => {
+                let ans = unsafe { self.kind.Struct };
                 crate::api::pseudo_manual::rust_opaque_twin_sync::EnumOpaqueTwinSync::Struct(
                     ans.field0.cst_decode(),
                 )
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Primitive);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Primitive };
                 crate::api::pseudo_manual::rust_opaque_twin_sync::EnumOpaqueTwinSync::Primitive(
                     ans.field0.cst_decode(),
                 )
-            },
-            2 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.TraitObj);
+            }
+            2 => {
+                let ans = unsafe { self.kind.TraitObj };
                 crate::api::pseudo_manual::rust_opaque_twin_sync::EnumOpaqueTwinSync::TraitObj(
                     ans.field0.cst_decode(),
                 )
-            },
-            3 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Mutex);
+            }
+            3 => {
+                let ans = unsafe { self.kind.Mutex };
                 crate::api::pseudo_manual::rust_opaque_twin_sync::EnumOpaqueTwinSync::Mutex(
                     ans.field0.cst_decode(),
                 )
-            },
-            4 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.RwLock);
+            }
+            4 => {
+                let ans = unsafe { self.kind.RwLock };
                 crate::api::pseudo_manual::rust_opaque_twin_sync::EnumOpaqueTwinSync::RwLock(
                     ans.field0.cst_decode(),
                 )
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -6535,37 +6389,32 @@ impl CstDecode<crate::api::pseudo_manual::rust_opaque_twin_sync_sse::EnumOpaqueT
         self,
     ) -> crate::api::pseudo_manual::rust_opaque_twin_sync_sse::EnumOpaqueTwinSyncSse {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Struct);
+            0 => {
+                let ans = unsafe { self.kind.Struct };
                 crate::api::pseudo_manual::rust_opaque_twin_sync_sse::EnumOpaqueTwinSyncSse::Struct(
                     ans.field0.cst_decode(),
                 )
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Primitive);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Primitive };
                 crate::api::pseudo_manual::rust_opaque_twin_sync_sse::EnumOpaqueTwinSyncSse::Primitive( ans.field0.cst_decode())
-            },
-            2 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.TraitObj);
+            }
+            2 => {
+                let ans = unsafe { self.kind.TraitObj };
                 crate::api::pseudo_manual::rust_opaque_twin_sync_sse::EnumOpaqueTwinSyncSse::TraitObj( ans.field0.cst_decode())
-            },
-            3 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Mutex);
+            }
+            3 => {
+                let ans = unsafe { self.kind.Mutex };
                 crate::api::pseudo_manual::rust_opaque_twin_sync_sse::EnumOpaqueTwinSyncSse::Mutex(
                     ans.field0.cst_decode(),
                 )
-            },
-            4 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.RwLock);
+            }
+            4 => {
+                let ans = unsafe { self.kind.RwLock };
                 crate::api::pseudo_manual::rust_opaque_twin_sync_sse::EnumOpaqueTwinSyncSse::RwLock(
                     ans.field0.cst_decode(),
                 )
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -6587,18 +6436,16 @@ impl CstDecode<crate::api::enumeration::EnumWithItemMixedTwinNormal>
     fn cst_decode(self) -> crate::api::enumeration::EnumWithItemMixedTwinNormal {
         match self.tag {
             0 => crate::api::enumeration::EnumWithItemMixedTwinNormal::A,
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.B);
+            1 => {
+                let ans = unsafe { self.kind.B };
                 crate::api::enumeration::EnumWithItemMixedTwinNormal::B(ans.field0.cst_decode())
-            },
-            2 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.C);
+            }
+            2 => {
+                let ans = unsafe { self.kind.C };
                 crate::api::enumeration::EnumWithItemMixedTwinNormal::C {
                     c_field: ans.c_field.cst_decode(),
                 }
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -6614,14 +6461,12 @@ impl
     {
         match self.tag {
                     0 => crate::api::pseudo_manual::enumeration_twin_rust_async::EnumWithItemMixedTwinRustAsync::A,
-1 => unsafe {
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.B);
+1 => {
+                        let ans = unsafe { self.kind.B };
                         crate::api::pseudo_manual::enumeration_twin_rust_async::EnumWithItemMixedTwinRustAsync::B( ans.field0.cst_decode())
                     }
-2 => unsafe {
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.C);
+2 => {
+                        let ans = unsafe { self.kind.C };
                         crate::api::pseudo_manual::enumeration_twin_rust_async::EnumWithItemMixedTwinRustAsync::C{c_field:  ans.c_field.cst_decode()}
                     }
                     _ => unreachable!(),
@@ -6632,14 +6477,12 @@ impl CstDecode<crate::api::pseudo_manual::enumeration_twin_rust_async_sse::EnumW
             fn cst_decode(self) -> crate::api::pseudo_manual::enumeration_twin_rust_async_sse::EnumWithItemMixedTwinRustAsyncSse {
                 match self.tag {
                     0 => crate::api::pseudo_manual::enumeration_twin_rust_async_sse::EnumWithItemMixedTwinRustAsyncSse::A,
-1 => unsafe {
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.B);
+1 => {
+                        let ans = unsafe { self.kind.B };
                         crate::api::pseudo_manual::enumeration_twin_rust_async_sse::EnumWithItemMixedTwinRustAsyncSse::B( ans.field0.cst_decode())
                     }
-2 => unsafe {
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.C);
+2 => {
+                        let ans = unsafe { self.kind.C };
                         crate::api::pseudo_manual::enumeration_twin_rust_async_sse::EnumWithItemMixedTwinRustAsyncSse::C{c_field:  ans.c_field.cst_decode()}
                     }
                     _ => unreachable!(),
@@ -6654,20 +6497,18 @@ impl CstDecode<crate::api::pseudo_manual::enumeration_twin_sse::EnumWithItemMixe
     ) -> crate::api::pseudo_manual::enumeration_twin_sse::EnumWithItemMixedTwinSse {
         match self.tag {
             0 => crate::api::pseudo_manual::enumeration_twin_sse::EnumWithItemMixedTwinSse::A,
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.B);
+            1 => {
+                let ans = unsafe { self.kind.B };
                 crate::api::pseudo_manual::enumeration_twin_sse::EnumWithItemMixedTwinSse::B(
                     ans.field0.cst_decode(),
                 )
-            },
-            2 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.C);
+            }
+            2 => {
+                let ans = unsafe { self.kind.C };
                 crate::api::pseudo_manual::enumeration_twin_sse::EnumWithItemMixedTwinSse::C {
                     c_field: ans.c_field.cst_decode(),
                 }
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -6680,20 +6521,18 @@ impl CstDecode<crate::api::pseudo_manual::enumeration_twin_sync::EnumWithItemMix
     ) -> crate::api::pseudo_manual::enumeration_twin_sync::EnumWithItemMixedTwinSync {
         match self.tag {
             0 => crate::api::pseudo_manual::enumeration_twin_sync::EnumWithItemMixedTwinSync::A,
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.B);
+            1 => {
+                let ans = unsafe { self.kind.B };
                 crate::api::pseudo_manual::enumeration_twin_sync::EnumWithItemMixedTwinSync::B(
                     ans.field0.cst_decode(),
                 )
-            },
-            2 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.C);
+            }
+            2 => {
+                let ans = unsafe { self.kind.C };
                 crate::api::pseudo_manual::enumeration_twin_sync::EnumWithItemMixedTwinSync::C {
                     c_field: ans.c_field.cst_decode(),
                 }
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -6706,14 +6545,12 @@ impl CstDecode<crate::api::pseudo_manual::enumeration_twin_sync_sse::EnumWithIte
     ) -> crate::api::pseudo_manual::enumeration_twin_sync_sse::EnumWithItemMixedTwinSyncSse {
         match self.tag {
                     0 => crate::api::pseudo_manual::enumeration_twin_sync_sse::EnumWithItemMixedTwinSyncSse::A,
-1 => unsafe {
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.B);
+1 => {
+                        let ans = unsafe { self.kind.B };
                         crate::api::pseudo_manual::enumeration_twin_sync_sse::EnumWithItemMixedTwinSyncSse::B( ans.field0.cst_decode())
                     }
-2 => unsafe {
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.C);
+2 => {
+                        let ans = unsafe { self.kind.C };
                         crate::api::pseudo_manual::enumeration_twin_sync_sse::EnumWithItemMixedTwinSyncSse::C{c_field:  ans.c_field.cst_decode()}
                     }
                     _ => unreachable!(),
@@ -6725,20 +6562,18 @@ impl CstDecode<crate::api::enumeration::EnumWithItemStructTwinNormal>
 {
     fn cst_decode(self) -> crate::api::enumeration::EnumWithItemStructTwinNormal {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.A);
+            0 => {
+                let ans = unsafe { self.kind.A };
                 crate::api::enumeration::EnumWithItemStructTwinNormal::A {
                     a_field: ans.a_field.cst_decode(),
                 }
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.B);
+            }
+            1 => {
+                let ans = unsafe { self.kind.B };
                 crate::api::enumeration::EnumWithItemStructTwinNormal::B {
                     b_field: ans.b_field.cst_decode(),
                 }
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -6753,16 +6588,14 @@ impl
     ) -> crate::api::pseudo_manual::enumeration_twin_rust_async::EnumWithItemStructTwinRustAsync
     {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.A);
+            0 => {
+                let ans = unsafe { self.kind.A };
                 crate::api::pseudo_manual::enumeration_twin_rust_async::EnumWithItemStructTwinRustAsync::A{a_field:  ans.a_field.cst_decode()}
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.B);
+            }
+            1 => {
+                let ans = unsafe { self.kind.B };
                 crate::api::pseudo_manual::enumeration_twin_rust_async::EnumWithItemStructTwinRustAsync::B{b_field:  ans.b_field.cst_decode()}
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -6770,14 +6603,12 @@ impl
 impl CstDecode<crate::api::pseudo_manual::enumeration_twin_rust_async_sse::EnumWithItemStructTwinRustAsyncSse> for wire_cst_enum_with_item_struct_twin_rust_async_sse {
             fn cst_decode(self) -> crate::api::pseudo_manual::enumeration_twin_rust_async_sse::EnumWithItemStructTwinRustAsyncSse {
                 match self.tag {
-                    0 => unsafe {
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.A);
+                    0 => {
+                        let ans = unsafe { self.kind.A };
                         crate::api::pseudo_manual::enumeration_twin_rust_async_sse::EnumWithItemStructTwinRustAsyncSse::A{a_field:  ans.a_field.cst_decode()}
                     }
-1 => unsafe {
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.B);
+1 => {
+                        let ans = unsafe { self.kind.B };
                         crate::api::pseudo_manual::enumeration_twin_rust_async_sse::EnumWithItemStructTwinRustAsyncSse::B{b_field:  ans.b_field.cst_decode()}
                     }
                     _ => unreachable!(),
@@ -6791,20 +6622,18 @@ impl CstDecode<crate::api::pseudo_manual::enumeration_twin_sse::EnumWithItemStru
         self,
     ) -> crate::api::pseudo_manual::enumeration_twin_sse::EnumWithItemStructTwinSse {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.A);
+            0 => {
+                let ans = unsafe { self.kind.A };
                 crate::api::pseudo_manual::enumeration_twin_sse::EnumWithItemStructTwinSse::A {
                     a_field: ans.a_field.cst_decode(),
                 }
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.B);
+            }
+            1 => {
+                let ans = unsafe { self.kind.B };
                 crate::api::pseudo_manual::enumeration_twin_sse::EnumWithItemStructTwinSse::B {
                     b_field: ans.b_field.cst_decode(),
                 }
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -6816,20 +6645,18 @@ impl CstDecode<crate::api::pseudo_manual::enumeration_twin_sync::EnumWithItemStr
         self,
     ) -> crate::api::pseudo_manual::enumeration_twin_sync::EnumWithItemStructTwinSync {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.A);
+            0 => {
+                let ans = unsafe { self.kind.A };
                 crate::api::pseudo_manual::enumeration_twin_sync::EnumWithItemStructTwinSync::A {
                     a_field: ans.a_field.cst_decode(),
                 }
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.B);
+            }
+            1 => {
+                let ans = unsafe { self.kind.B };
                 crate::api::pseudo_manual::enumeration_twin_sync::EnumWithItemStructTwinSync::B {
                     b_field: ans.b_field.cst_decode(),
                 }
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -6841,16 +6668,14 @@ impl CstDecode<crate::api::pseudo_manual::enumeration_twin_sync_sse::EnumWithIte
         self,
     ) -> crate::api::pseudo_manual::enumeration_twin_sync_sse::EnumWithItemStructTwinSyncSse {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.A);
+            0 => {
+                let ans = unsafe { self.kind.A };
                 crate::api::pseudo_manual::enumeration_twin_sync_sse::EnumWithItemStructTwinSyncSse::A{a_field:  ans.a_field.cst_decode()}
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.B);
+            }
+            1 => {
+                let ans = unsafe { self.kind.B };
                 crate::api::pseudo_manual::enumeration_twin_sync_sse::EnumWithItemStructTwinSyncSse::B{b_field:  ans.b_field.cst_decode()}
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -6860,16 +6685,14 @@ impl CstDecode<crate::api::enumeration::EnumWithItemTupleTwinNormal>
 {
     fn cst_decode(self) -> crate::api::enumeration::EnumWithItemTupleTwinNormal {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.A);
+            0 => {
+                let ans = unsafe { self.kind.A };
                 crate::api::enumeration::EnumWithItemTupleTwinNormal::A(ans.field0.cst_decode())
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.B);
+            }
+            1 => {
+                let ans = unsafe { self.kind.B };
                 crate::api::enumeration::EnumWithItemTupleTwinNormal::B(ans.field0.cst_decode())
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -6884,16 +6707,14 @@ impl
     ) -> crate::api::pseudo_manual::enumeration_twin_rust_async::EnumWithItemTupleTwinRustAsync
     {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.A);
+            0 => {
+                let ans = unsafe { self.kind.A };
                 crate::api::pseudo_manual::enumeration_twin_rust_async::EnumWithItemTupleTwinRustAsync::A( ans.field0.cst_decode())
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.B);
+            }
+            1 => {
+                let ans = unsafe { self.kind.B };
                 crate::api::pseudo_manual::enumeration_twin_rust_async::EnumWithItemTupleTwinRustAsync::B( ans.field0.cst_decode())
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -6901,14 +6722,12 @@ impl
 impl CstDecode<crate::api::pseudo_manual::enumeration_twin_rust_async_sse::EnumWithItemTupleTwinRustAsyncSse> for wire_cst_enum_with_item_tuple_twin_rust_async_sse {
             fn cst_decode(self) -> crate::api::pseudo_manual::enumeration_twin_rust_async_sse::EnumWithItemTupleTwinRustAsyncSse {
                 match self.tag {
-                    0 => unsafe {
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.A);
+                    0 => {
+                        let ans = unsafe { self.kind.A };
                         crate::api::pseudo_manual::enumeration_twin_rust_async_sse::EnumWithItemTupleTwinRustAsyncSse::A( ans.field0.cst_decode())
                     }
-1 => unsafe {
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.B);
+1 => {
+                        let ans = unsafe { self.kind.B };
                         crate::api::pseudo_manual::enumeration_twin_rust_async_sse::EnumWithItemTupleTwinRustAsyncSse::B( ans.field0.cst_decode())
                     }
                     _ => unreachable!(),
@@ -6922,20 +6741,18 @@ impl CstDecode<crate::api::pseudo_manual::enumeration_twin_sse::EnumWithItemTupl
         self,
     ) -> crate::api::pseudo_manual::enumeration_twin_sse::EnumWithItemTupleTwinSse {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.A);
+            0 => {
+                let ans = unsafe { self.kind.A };
                 crate::api::pseudo_manual::enumeration_twin_sse::EnumWithItemTupleTwinSse::A(
                     ans.field0.cst_decode(),
                 )
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.B);
+            }
+            1 => {
+                let ans = unsafe { self.kind.B };
                 crate::api::pseudo_manual::enumeration_twin_sse::EnumWithItemTupleTwinSse::B(
                     ans.field0.cst_decode(),
                 )
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -6947,20 +6764,18 @@ impl CstDecode<crate::api::pseudo_manual::enumeration_twin_sync::EnumWithItemTup
         self,
     ) -> crate::api::pseudo_manual::enumeration_twin_sync::EnumWithItemTupleTwinSync {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.A);
+            0 => {
+                let ans = unsafe { self.kind.A };
                 crate::api::pseudo_manual::enumeration_twin_sync::EnumWithItemTupleTwinSync::A(
                     ans.field0.cst_decode(),
                 )
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.B);
+            }
+            1 => {
+                let ans = unsafe { self.kind.B };
                 crate::api::pseudo_manual::enumeration_twin_sync::EnumWithItemTupleTwinSync::B(
                     ans.field0.cst_decode(),
                 )
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -6972,16 +6787,14 @@ impl CstDecode<crate::api::pseudo_manual::enumeration_twin_sync_sse::EnumWithIte
         self,
     ) -> crate::api::pseudo_manual::enumeration_twin_sync_sse::EnumWithItemTupleTwinSyncSse {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.A);
+            0 => {
+                let ans = unsafe { self.kind.A };
                 crate::api::pseudo_manual::enumeration_twin_sync_sse::EnumWithItemTupleTwinSyncSse::A( ans.field0.cst_decode())
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.B);
+            }
+            1 => {
+                let ans = unsafe { self.kind.B };
                 crate::api::pseudo_manual::enumeration_twin_sync_sse::EnumWithItemTupleTwinSyncSse::B( ans.field0.cst_decode())
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -7298,41 +7111,36 @@ impl CstDecode<crate::api::enumeration::KitchenSinkTwinNormal>
     fn cst_decode(self) -> crate::api::enumeration::KitchenSinkTwinNormal {
         match self.tag {
             0 => crate::api::enumeration::KitchenSinkTwinNormal::Empty,
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Primitives);
+            1 => {
+                let ans = unsafe { self.kind.Primitives };
                 crate::api::enumeration::KitchenSinkTwinNormal::Primitives {
                     int32: ans.int32.cst_decode(),
                     float64: ans.float64.cst_decode(),
                     boolean: ans.boolean.cst_decode(),
                 }
-            },
-            2 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Nested);
+            }
+            2 => {
+                let ans = unsafe { self.kind.Nested };
                 crate::api::enumeration::KitchenSinkTwinNormal::Nested(
                     ans.field0.cst_decode(),
                     ans.field1.cst_decode(),
                 )
-            },
-            3 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Optional);
+            }
+            3 => {
+                let ans = unsafe { self.kind.Optional };
                 crate::api::enumeration::KitchenSinkTwinNormal::Optional(
                     ans.field0.cst_decode(),
                     ans.field1.cst_decode(),
                 )
-            },
-            4 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Buffer);
+            }
+            4 => {
+                let ans = unsafe { self.kind.Buffer };
                 crate::api::enumeration::KitchenSinkTwinNormal::Buffer(ans.field0.cst_decode())
-            },
-            5 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Enums);
+            }
+            5 => {
+                let ans = unsafe { self.kind.Enums };
                 crate::api::enumeration::KitchenSinkTwinNormal::Enums(ans.field0.cst_decode())
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -7345,29 +7153,24 @@ impl CstDecode<crate::api::pseudo_manual::enumeration_twin_rust_async::KitchenSi
     ) -> crate::api::pseudo_manual::enumeration_twin_rust_async::KitchenSinkTwinRustAsync {
         match self.tag {
                     0 => crate::api::pseudo_manual::enumeration_twin_rust_async::KitchenSinkTwinRustAsync::Empty,
-1 => unsafe {
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Primitives);
+1 => {
+                        let ans = unsafe { self.kind.Primitives };
                         crate::api::pseudo_manual::enumeration_twin_rust_async::KitchenSinkTwinRustAsync::Primitives{int32:  ans.int32.cst_decode(),float64:  ans.float64.cst_decode(),boolean:  ans.boolean.cst_decode()}
                     }
-2 => unsafe {
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Nested);
+2 => {
+                        let ans = unsafe { self.kind.Nested };
                         crate::api::pseudo_manual::enumeration_twin_rust_async::KitchenSinkTwinRustAsync::Nested( ans.field0.cst_decode(), ans.field1.cst_decode())
                     }
-3 => unsafe {
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Optional);
+3 => {
+                        let ans = unsafe { self.kind.Optional };
                         crate::api::pseudo_manual::enumeration_twin_rust_async::KitchenSinkTwinRustAsync::Optional( ans.field0.cst_decode(), ans.field1.cst_decode())
                     }
-4 => unsafe {
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Buffer);
+4 => {
+                        let ans = unsafe { self.kind.Buffer };
                         crate::api::pseudo_manual::enumeration_twin_rust_async::KitchenSinkTwinRustAsync::Buffer( ans.field0.cst_decode())
                     }
-5 => unsafe {
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Enums);
+5 => {
+                        let ans = unsafe { self.kind.Enums };
                         crate::api::pseudo_manual::enumeration_twin_rust_async::KitchenSinkTwinRustAsync::Enums( ans.field0.cst_decode())
                     }
                     _ => unreachable!(),
@@ -7385,29 +7188,24 @@ impl
     {
         match self.tag {
                     0 => crate::api::pseudo_manual::enumeration_twin_rust_async_sse::KitchenSinkTwinRustAsyncSse::Empty,
-1 => unsafe {
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Primitives);
+1 => {
+                        let ans = unsafe { self.kind.Primitives };
                         crate::api::pseudo_manual::enumeration_twin_rust_async_sse::KitchenSinkTwinRustAsyncSse::Primitives{int32:  ans.int32.cst_decode(),float64:  ans.float64.cst_decode(),boolean:  ans.boolean.cst_decode()}
                     }
-2 => unsafe {
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Nested);
+2 => {
+                        let ans = unsafe { self.kind.Nested };
                         crate::api::pseudo_manual::enumeration_twin_rust_async_sse::KitchenSinkTwinRustAsyncSse::Nested( ans.field0.cst_decode(), ans.field1.cst_decode())
                     }
-3 => unsafe {
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Optional);
+3 => {
+                        let ans = unsafe { self.kind.Optional };
                         crate::api::pseudo_manual::enumeration_twin_rust_async_sse::KitchenSinkTwinRustAsyncSse::Optional( ans.field0.cst_decode(), ans.field1.cst_decode())
                     }
-4 => unsafe {
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Buffer);
+4 => {
+                        let ans = unsafe { self.kind.Buffer };
                         crate::api::pseudo_manual::enumeration_twin_rust_async_sse::KitchenSinkTwinRustAsyncSse::Buffer( ans.field0.cst_decode())
                     }
-5 => unsafe {
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Enums);
+5 => {
+                        let ans = unsafe { self.kind.Enums };
                         crate::api::pseudo_manual::enumeration_twin_rust_async_sse::KitchenSinkTwinRustAsyncSse::Enums( ans.field0.cst_decode())
                     }
                     _ => unreachable!(),
@@ -7420,45 +7218,40 @@ impl CstDecode<crate::api::pseudo_manual::enumeration_twin_sse::KitchenSinkTwinS
     fn cst_decode(self) -> crate::api::pseudo_manual::enumeration_twin_sse::KitchenSinkTwinSse {
         match self.tag {
             0 => crate::api::pseudo_manual::enumeration_twin_sse::KitchenSinkTwinSse::Empty,
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Primitives);
+            1 => {
+                let ans = unsafe { self.kind.Primitives };
                 crate::api::pseudo_manual::enumeration_twin_sse::KitchenSinkTwinSse::Primitives {
                     int32: ans.int32.cst_decode(),
                     float64: ans.float64.cst_decode(),
                     boolean: ans.boolean.cst_decode(),
                 }
-            },
-            2 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Nested);
+            }
+            2 => {
+                let ans = unsafe { self.kind.Nested };
                 crate::api::pseudo_manual::enumeration_twin_sse::KitchenSinkTwinSse::Nested(
                     ans.field0.cst_decode(),
                     ans.field1.cst_decode(),
                 )
-            },
-            3 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Optional);
+            }
+            3 => {
+                let ans = unsafe { self.kind.Optional };
                 crate::api::pseudo_manual::enumeration_twin_sse::KitchenSinkTwinSse::Optional(
                     ans.field0.cst_decode(),
                     ans.field1.cst_decode(),
                 )
-            },
-            4 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Buffer);
+            }
+            4 => {
+                let ans = unsafe { self.kind.Buffer };
                 crate::api::pseudo_manual::enumeration_twin_sse::KitchenSinkTwinSse::Buffer(
                     ans.field0.cst_decode(),
                 )
-            },
-            5 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Enums);
+            }
+            5 => {
+                let ans = unsafe { self.kind.Enums };
                 crate::api::pseudo_manual::enumeration_twin_sse::KitchenSinkTwinSse::Enums(
                     ans.field0.cst_decode(),
                 )
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -7469,45 +7262,40 @@ impl CstDecode<crate::api::pseudo_manual::enumeration_twin_sync::KitchenSinkTwin
     fn cst_decode(self) -> crate::api::pseudo_manual::enumeration_twin_sync::KitchenSinkTwinSync {
         match self.tag {
             0 => crate::api::pseudo_manual::enumeration_twin_sync::KitchenSinkTwinSync::Empty,
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Primitives);
+            1 => {
+                let ans = unsafe { self.kind.Primitives };
                 crate::api::pseudo_manual::enumeration_twin_sync::KitchenSinkTwinSync::Primitives {
                     int32: ans.int32.cst_decode(),
                     float64: ans.float64.cst_decode(),
                     boolean: ans.boolean.cst_decode(),
                 }
-            },
-            2 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Nested);
+            }
+            2 => {
+                let ans = unsafe { self.kind.Nested };
                 crate::api::pseudo_manual::enumeration_twin_sync::KitchenSinkTwinSync::Nested(
                     ans.field0.cst_decode(),
                     ans.field1.cst_decode(),
                 )
-            },
-            3 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Optional);
+            }
+            3 => {
+                let ans = unsafe { self.kind.Optional };
                 crate::api::pseudo_manual::enumeration_twin_sync::KitchenSinkTwinSync::Optional(
                     ans.field0.cst_decode(),
                     ans.field1.cst_decode(),
                 )
-            },
-            4 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Buffer);
+            }
+            4 => {
+                let ans = unsafe { self.kind.Buffer };
                 crate::api::pseudo_manual::enumeration_twin_sync::KitchenSinkTwinSync::Buffer(
                     ans.field0.cst_decode(),
                 )
-            },
-            5 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Enums);
+            }
+            5 => {
+                let ans = unsafe { self.kind.Enums };
                 crate::api::pseudo_manual::enumeration_twin_sync::KitchenSinkTwinSync::Enums(
                     ans.field0.cst_decode(),
                 )
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -7522,38 +7310,33 @@ impl CstDecode<crate::api::pseudo_manual::enumeration_twin_sync_sse::KitchenSink
             0 => {
                 crate::api::pseudo_manual::enumeration_twin_sync_sse::KitchenSinkTwinSyncSse::Empty
             }
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Primitives);
+            1 => {
+                let ans = unsafe { self.kind.Primitives };
                 crate::api::pseudo_manual::enumeration_twin_sync_sse::KitchenSinkTwinSyncSse::Primitives{int32:  ans.int32.cst_decode(),float64:  ans.float64.cst_decode(),boolean:  ans.boolean.cst_decode()}
-            },
-            2 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Nested);
+            }
+            2 => {
+                let ans = unsafe { self.kind.Nested };
                 crate::api::pseudo_manual::enumeration_twin_sync_sse::KitchenSinkTwinSyncSse::Nested(
                     ans.field0.cst_decode(),
                     ans.field1.cst_decode(),
                 )
-            },
-            3 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Optional);
+            }
+            3 => {
+                let ans = unsafe { self.kind.Optional };
                 crate::api::pseudo_manual::enumeration_twin_sync_sse::KitchenSinkTwinSyncSse::Optional( ans.field0.cst_decode(), ans.field1.cst_decode())
-            },
-            4 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Buffer);
+            }
+            4 => {
+                let ans = unsafe { self.kind.Buffer };
                 crate::api::pseudo_manual::enumeration_twin_sync_sse::KitchenSinkTwinSyncSse::Buffer(
                     ans.field0.cst_decode(),
                 )
-            },
-            5 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Enums);
+            }
+            5 => {
+                let ans = unsafe { self.kind.Enums };
                 crate::api::pseudo_manual::enumeration_twin_sync_sse::KitchenSinkTwinSyncSse::Enums(
                     ans.field0.cst_decode(),
                 )
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -8698,16 +8481,14 @@ impl CstDecode<crate::api::inside_macro::MacroStruct> for wire_cst_macro_struct 
 impl CstDecode<crate::api::enumeration::MeasureTwinNormal> for wire_cst_measure_twin_normal {
     fn cst_decode(self) -> crate::api::enumeration::MeasureTwinNormal {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Speed);
+            0 => {
+                let ans = unsafe { self.kind.Speed };
                 crate::api::enumeration::MeasureTwinNormal::Speed(ans.field0.cst_decode())
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Distance);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Distance };
                 crate::api::enumeration::MeasureTwinNormal::Distance(ans.field0.cst_decode())
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -8719,18 +8500,16 @@ impl CstDecode<crate::api::pseudo_manual::enumeration_twin_rust_async::MeasureTw
         self,
     ) -> crate::api::pseudo_manual::enumeration_twin_rust_async::MeasureTwinRustAsync {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Speed);
+            0 => {
+                let ans = unsafe { self.kind.Speed };
                 crate::api::pseudo_manual::enumeration_twin_rust_async::MeasureTwinRustAsync::Speed(
                     ans.field0.cst_decode(),
                 )
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Distance);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Distance };
                 crate::api::pseudo_manual::enumeration_twin_rust_async::MeasureTwinRustAsync::Distance( ans.field0.cst_decode())
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -8742,16 +8521,14 @@ impl CstDecode<crate::api::pseudo_manual::enumeration_twin_rust_async_sse::Measu
         self,
     ) -> crate::api::pseudo_manual::enumeration_twin_rust_async_sse::MeasureTwinRustAsyncSse {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Speed);
+            0 => {
+                let ans = unsafe { self.kind.Speed };
                 crate::api::pseudo_manual::enumeration_twin_rust_async_sse::MeasureTwinRustAsyncSse::Speed( ans.field0.cst_decode())
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Distance);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Distance };
                 crate::api::pseudo_manual::enumeration_twin_rust_async_sse::MeasureTwinRustAsyncSse::Distance( ans.field0.cst_decode())
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -8761,20 +8538,18 @@ impl CstDecode<crate::api::pseudo_manual::enumeration_twin_sse::MeasureTwinSse>
 {
     fn cst_decode(self) -> crate::api::pseudo_manual::enumeration_twin_sse::MeasureTwinSse {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Speed);
+            0 => {
+                let ans = unsafe { self.kind.Speed };
                 crate::api::pseudo_manual::enumeration_twin_sse::MeasureTwinSse::Speed(
                     ans.field0.cst_decode(),
                 )
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Distance);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Distance };
                 crate::api::pseudo_manual::enumeration_twin_sse::MeasureTwinSse::Distance(
                     ans.field0.cst_decode(),
                 )
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -8784,20 +8559,18 @@ impl CstDecode<crate::api::pseudo_manual::enumeration_twin_sync::MeasureTwinSync
 {
     fn cst_decode(self) -> crate::api::pseudo_manual::enumeration_twin_sync::MeasureTwinSync {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Speed);
+            0 => {
+                let ans = unsafe { self.kind.Speed };
                 crate::api::pseudo_manual::enumeration_twin_sync::MeasureTwinSync::Speed(
                     ans.field0.cst_decode(),
                 )
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Distance);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Distance };
                 crate::api::pseudo_manual::enumeration_twin_sync::MeasureTwinSync::Distance(
                     ans.field0.cst_decode(),
                 )
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -8809,20 +8582,18 @@ impl CstDecode<crate::api::pseudo_manual::enumeration_twin_sync_sse::MeasureTwin
         self,
     ) -> crate::api::pseudo_manual::enumeration_twin_sync_sse::MeasureTwinSyncSse {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Speed);
+            0 => {
+                let ans = unsafe { self.kind.Speed };
                 crate::api::pseudo_manual::enumeration_twin_sync_sse::MeasureTwinSyncSse::Speed(
                     ans.field0.cst_decode(),
                 )
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Distance);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Distance };
                 crate::api::pseudo_manual::enumeration_twin_sync_sse::MeasureTwinSyncSse::Distance(
                     ans.field0.cst_decode(),
                 )
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -9636,27 +9407,24 @@ impl CstDecode<crate::api::pseudo_manual::mirror_twin_sync_sse::RawStringEnumMir
 {
     fn cst_decode(self) -> crate::api::pseudo_manual::mirror_twin_sync_sse::RawStringEnumMirrored {
         match self.tag {
-            0 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Raw);
+            0 => {
+                let ans = unsafe { self.kind.Raw };
                 crate::api::pseudo_manual::mirror_twin_sync_sse::RawStringEnumMirrored::Raw(
                     ans.field0.cst_decode(),
                 )
-            },
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.Nested);
+            }
+            1 => {
+                let ans = unsafe { self.kind.Nested };
                 crate::api::pseudo_manual::mirror_twin_sync_sse::RawStringEnumMirrored::Nested(
                     ans.field0.cst_decode(),
                 )
-            },
-            2 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.ListOfNested);
+            }
+            2 => {
+                let ans = unsafe { self.kind.ListOfNested };
                 crate::api::pseudo_manual::mirror_twin_sync_sse::RawStringEnumMirrored::ListOfNested(
                     ans.field0.cst_decode(),
                 )
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -9818,11 +9586,10 @@ impl CstDecode<crate::api::enumeration::SpeedTwinNormal> for wire_cst_speed_twin
     fn cst_decode(self) -> crate::api::enumeration::SpeedTwinNormal {
         match self.tag {
             0 => crate::api::enumeration::SpeedTwinNormal::Unknown,
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.GPS);
+            1 => {
+                let ans = unsafe { self.kind.GPS };
                 crate::api::enumeration::SpeedTwinNormal::GPS(ans.field0.cst_decode())
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -9837,13 +9604,12 @@ impl CstDecode<crate::api::pseudo_manual::enumeration_twin_rust_async::SpeedTwin
             0 => {
                 crate::api::pseudo_manual::enumeration_twin_rust_async::SpeedTwinRustAsync::Unknown
             }
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.GPS);
+            1 => {
+                let ans = unsafe { self.kind.GPS };
                 crate::api::pseudo_manual::enumeration_twin_rust_async::SpeedTwinRustAsync::GPS(
                     ans.field0.cst_decode(),
                 )
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -9856,9 +9622,8 @@ impl CstDecode<crate::api::pseudo_manual::enumeration_twin_rust_async_sse::Speed
     ) -> crate::api::pseudo_manual::enumeration_twin_rust_async_sse::SpeedTwinRustAsyncSse {
         match self.tag {
                     0 => crate::api::pseudo_manual::enumeration_twin_rust_async_sse::SpeedTwinRustAsyncSse::Unknown,
-1 => unsafe {
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                        let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.GPS);
+1 => {
+                        let ans = unsafe { self.kind.GPS };
                         crate::api::pseudo_manual::enumeration_twin_rust_async_sse::SpeedTwinRustAsyncSse::GPS( ans.field0.cst_decode())
                     }
                     _ => unreachable!(),
@@ -9871,13 +9636,12 @@ impl CstDecode<crate::api::pseudo_manual::enumeration_twin_sse::SpeedTwinSse>
     fn cst_decode(self) -> crate::api::pseudo_manual::enumeration_twin_sse::SpeedTwinSse {
         match self.tag {
             0 => crate::api::pseudo_manual::enumeration_twin_sse::SpeedTwinSse::Unknown,
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.GPS);
+            1 => {
+                let ans = unsafe { self.kind.GPS };
                 crate::api::pseudo_manual::enumeration_twin_sse::SpeedTwinSse::GPS(
                     ans.field0.cst_decode(),
                 )
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -9888,13 +9652,12 @@ impl CstDecode<crate::api::pseudo_manual::enumeration_twin_sync::SpeedTwinSync>
     fn cst_decode(self) -> crate::api::pseudo_manual::enumeration_twin_sync::SpeedTwinSync {
         match self.tag {
             0 => crate::api::pseudo_manual::enumeration_twin_sync::SpeedTwinSync::Unknown,
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.GPS);
+            1 => {
+                let ans = unsafe { self.kind.GPS };
                 crate::api::pseudo_manual::enumeration_twin_sync::SpeedTwinSync::GPS(
                     ans.field0.cst_decode(),
                 )
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -9905,13 +9668,12 @@ impl CstDecode<crate::api::pseudo_manual::enumeration_twin_sync_sse::SpeedTwinSy
     fn cst_decode(self) -> crate::api::pseudo_manual::enumeration_twin_sync_sse::SpeedTwinSyncSse {
         match self.tag {
             0 => crate::api::pseudo_manual::enumeration_twin_sync_sse::SpeedTwinSyncSse::Unknown,
-            1 => unsafe {
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(self.kind);
-                let ans = flutter_rust_bridge::for_generated::box_from_leak_ptr(ans.GPS);
+            1 => {
+                let ans = unsafe { self.kind.GPS };
                 crate::api::pseudo_manual::enumeration_twin_sync_sse::SpeedTwinSyncSse::GPS(
                     ans.field0.cst_decode(),
                 )
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -10983,7 +10745,7 @@ impl NewWithNullPtr for wire_cst_abc_twin_normal {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: AbcTwinNormalKind { nil__: () },
         }
     }
 }
@@ -10996,7 +10758,7 @@ impl NewWithNullPtr for wire_cst_abc_twin_rust_async {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: AbcTwinRustAsyncKind { nil__: () },
         }
     }
 }
@@ -11009,7 +10771,7 @@ impl NewWithNullPtr for wire_cst_abc_twin_rust_async_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: AbcTwinRustAsyncSseKind { nil__: () },
         }
     }
 }
@@ -11022,7 +10784,7 @@ impl NewWithNullPtr for wire_cst_abc_twin_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: AbcTwinSseKind { nil__: () },
         }
     }
 }
@@ -11035,7 +10797,7 @@ impl NewWithNullPtr for wire_cst_abc_twin_sync {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: AbcTwinSyncKind { nil__: () },
         }
     }
 }
@@ -11048,7 +10810,7 @@ impl NewWithNullPtr for wire_cst_abc_twin_sync_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: AbcTwinSyncSseKind { nil__: () },
         }
     }
 }
@@ -11171,7 +10933,7 @@ impl NewWithNullPtr for wire_cst_application_message {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: ApplicationMessageKind { nil__: () },
         }
     }
 }
@@ -11890,7 +11652,7 @@ impl NewWithNullPtr for wire_cst_custom_enum_error_twin_normal {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: CustomEnumErrorTwinNormalKind { nil__: () },
         }
     }
 }
@@ -11903,7 +11665,7 @@ impl NewWithNullPtr for wire_cst_custom_enum_error_twin_rust_async {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: CustomEnumErrorTwinRustAsyncKind { nil__: () },
         }
     }
 }
@@ -11916,7 +11678,7 @@ impl NewWithNullPtr for wire_cst_custom_enum_error_twin_rust_async_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: CustomEnumErrorTwinRustAsyncSseKind { nil__: () },
         }
     }
 }
@@ -11929,7 +11691,7 @@ impl NewWithNullPtr for wire_cst_custom_enum_error_twin_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: CustomEnumErrorTwinSseKind { nil__: () },
         }
     }
 }
@@ -11942,7 +11704,7 @@ impl NewWithNullPtr for wire_cst_custom_enum_error_twin_sync {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: CustomEnumErrorTwinSyncKind { nil__: () },
         }
     }
 }
@@ -11955,7 +11717,7 @@ impl NewWithNullPtr for wire_cst_custom_enum_error_twin_sync_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: CustomEnumErrorTwinSyncSseKind { nil__: () },
         }
     }
 }
@@ -11968,7 +11730,7 @@ impl NewWithNullPtr for wire_cst_custom_error_twin_normal {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: CustomErrorTwinNormalKind { nil__: () },
         }
     }
 }
@@ -11981,7 +11743,7 @@ impl NewWithNullPtr for wire_cst_custom_error_twin_rust_async {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: CustomErrorTwinRustAsyncKind { nil__: () },
         }
     }
 }
@@ -11994,7 +11756,7 @@ impl NewWithNullPtr for wire_cst_custom_error_twin_rust_async_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: CustomErrorTwinRustAsyncSseKind { nil__: () },
         }
     }
 }
@@ -12007,7 +11769,7 @@ impl NewWithNullPtr for wire_cst_custom_error_twin_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: CustomErrorTwinSseKind { nil__: () },
         }
     }
 }
@@ -12020,7 +11782,7 @@ impl NewWithNullPtr for wire_cst_custom_error_twin_sync {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: CustomErrorTwinSyncKind { nil__: () },
         }
     }
 }
@@ -12033,7 +11795,7 @@ impl NewWithNullPtr for wire_cst_custom_error_twin_sync_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: CustomErrorTwinSyncSseKind { nil__: () },
         }
     }
 }
@@ -12046,7 +11808,7 @@ impl NewWithNullPtr for wire_cst_custom_nested_error_1_twin_normal {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: CustomNestedError1TwinNormalKind { nil__: () },
         }
     }
 }
@@ -12059,7 +11821,7 @@ impl NewWithNullPtr for wire_cst_custom_nested_error_1_twin_rust_async {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: CustomNestedError1TwinRustAsyncKind { nil__: () },
         }
     }
 }
@@ -12072,7 +11834,7 @@ impl NewWithNullPtr for wire_cst_custom_nested_error_1_twin_rust_async_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: CustomNestedError1TwinRustAsyncSseKind { nil__: () },
         }
     }
 }
@@ -12085,7 +11847,7 @@ impl NewWithNullPtr for wire_cst_custom_nested_error_1_twin_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: CustomNestedError1TwinSseKind { nil__: () },
         }
     }
 }
@@ -12098,7 +11860,7 @@ impl NewWithNullPtr for wire_cst_custom_nested_error_1_twin_sync {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: CustomNestedError1TwinSyncKind { nil__: () },
         }
     }
 }
@@ -12111,7 +11873,7 @@ impl NewWithNullPtr for wire_cst_custom_nested_error_1_twin_sync_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: CustomNestedError1TwinSyncSseKind { nil__: () },
         }
     }
 }
@@ -12124,7 +11886,7 @@ impl NewWithNullPtr for wire_cst_custom_nested_error_2_twin_normal {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: CustomNestedError2TwinNormalKind { nil__: () },
         }
     }
 }
@@ -12137,7 +11899,7 @@ impl NewWithNullPtr for wire_cst_custom_nested_error_2_twin_rust_async {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: CustomNestedError2TwinRustAsyncKind { nil__: () },
         }
     }
 }
@@ -12150,7 +11912,7 @@ impl NewWithNullPtr for wire_cst_custom_nested_error_2_twin_rust_async_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: CustomNestedError2TwinRustAsyncSseKind { nil__: () },
         }
     }
 }
@@ -12163,7 +11925,7 @@ impl NewWithNullPtr for wire_cst_custom_nested_error_2_twin_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: CustomNestedError2TwinSseKind { nil__: () },
         }
     }
 }
@@ -12176,7 +11938,7 @@ impl NewWithNullPtr for wire_cst_custom_nested_error_2_twin_sync {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: CustomNestedError2TwinSyncKind { nil__: () },
         }
     }
 }
@@ -12189,7 +11951,7 @@ impl NewWithNullPtr for wire_cst_custom_nested_error_2_twin_sync_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: CustomNestedError2TwinSyncSseKind { nil__: () },
         }
     }
 }
@@ -12202,7 +11964,7 @@ impl NewWithNullPtr for wire_cst_custom_nested_error_inner_twin_normal {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: CustomNestedErrorInnerTwinNormalKind { nil__: () },
         }
     }
 }
@@ -12215,7 +11977,7 @@ impl NewWithNullPtr for wire_cst_custom_nested_error_inner_twin_rust_async {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: CustomNestedErrorInnerTwinRustAsyncKind { nil__: () },
         }
     }
 }
@@ -12228,7 +11990,7 @@ impl NewWithNullPtr for wire_cst_custom_nested_error_inner_twin_rust_async_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: CustomNestedErrorInnerTwinRustAsyncSseKind { nil__: () },
         }
     }
 }
@@ -12241,7 +12003,7 @@ impl NewWithNullPtr for wire_cst_custom_nested_error_inner_twin_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: CustomNestedErrorInnerTwinSseKind { nil__: () },
         }
     }
 }
@@ -12254,7 +12016,7 @@ impl NewWithNullPtr for wire_cst_custom_nested_error_inner_twin_sync {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: CustomNestedErrorInnerTwinSyncKind { nil__: () },
         }
     }
 }
@@ -12267,7 +12029,7 @@ impl NewWithNullPtr for wire_cst_custom_nested_error_inner_twin_sync_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: CustomNestedErrorInnerTwinSyncSseKind { nil__: () },
         }
     }
 }
@@ -12280,7 +12042,7 @@ impl NewWithNullPtr for wire_cst_custom_nested_error_outer_twin_normal {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: CustomNestedErrorOuterTwinNormalKind { nil__: () },
         }
     }
 }
@@ -12293,7 +12055,7 @@ impl NewWithNullPtr for wire_cst_custom_nested_error_outer_twin_rust_async {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: CustomNestedErrorOuterTwinRustAsyncKind { nil__: () },
         }
     }
 }
@@ -12306,7 +12068,7 @@ impl NewWithNullPtr for wire_cst_custom_nested_error_outer_twin_rust_async_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: CustomNestedErrorOuterTwinRustAsyncSseKind { nil__: () },
         }
     }
 }
@@ -12319,7 +12081,7 @@ impl NewWithNullPtr for wire_cst_custom_nested_error_outer_twin_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: CustomNestedErrorOuterTwinSseKind { nil__: () },
         }
     }
 }
@@ -12332,7 +12094,7 @@ impl NewWithNullPtr for wire_cst_custom_nested_error_outer_twin_sync {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: CustomNestedErrorOuterTwinSyncKind { nil__: () },
         }
     }
 }
@@ -12345,7 +12107,7 @@ impl NewWithNullPtr for wire_cst_custom_nested_error_outer_twin_sync_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: CustomNestedErrorOuterTwinSyncSseKind { nil__: () },
         }
     }
 }
@@ -12778,7 +12540,7 @@ impl NewWithNullPtr for wire_cst_distance_twin_normal {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: DistanceTwinNormalKind { nil__: () },
         }
     }
 }
@@ -12791,7 +12553,7 @@ impl NewWithNullPtr for wire_cst_distance_twin_rust_async {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: DistanceTwinRustAsyncKind { nil__: () },
         }
     }
 }
@@ -12804,7 +12566,7 @@ impl NewWithNullPtr for wire_cst_distance_twin_rust_async_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: DistanceTwinRustAsyncSseKind { nil__: () },
         }
     }
 }
@@ -12817,7 +12579,7 @@ impl NewWithNullPtr for wire_cst_distance_twin_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: DistanceTwinSseKind { nil__: () },
         }
     }
 }
@@ -12830,7 +12592,7 @@ impl NewWithNullPtr for wire_cst_distance_twin_sync {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: DistanceTwinSyncKind { nil__: () },
         }
     }
 }
@@ -12843,7 +12605,7 @@ impl NewWithNullPtr for wire_cst_distance_twin_sync_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: DistanceTwinSyncSseKind { nil__: () },
         }
     }
 }
@@ -13006,7 +12768,7 @@ impl NewWithNullPtr for wire_cst_enum_dart_opaque_twin_normal {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: EnumDartOpaqueTwinNormalKind { nil__: () },
         }
     }
 }
@@ -13019,7 +12781,7 @@ impl NewWithNullPtr for wire_cst_enum_dart_opaque_twin_rust_async {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: EnumDartOpaqueTwinRustAsyncKind { nil__: () },
         }
     }
 }
@@ -13032,7 +12794,7 @@ impl NewWithNullPtr for wire_cst_enum_dart_opaque_twin_rust_async_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: EnumDartOpaqueTwinRustAsyncSseKind { nil__: () },
         }
     }
 }
@@ -13045,7 +12807,7 @@ impl NewWithNullPtr for wire_cst_enum_dart_opaque_twin_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: EnumDartOpaqueTwinSseKind { nil__: () },
         }
     }
 }
@@ -13058,7 +12820,7 @@ impl NewWithNullPtr for wire_cst_enum_dart_opaque_twin_sync {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: EnumDartOpaqueTwinSyncKind { nil__: () },
         }
     }
 }
@@ -13071,7 +12833,7 @@ impl NewWithNullPtr for wire_cst_enum_dart_opaque_twin_sync_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: EnumDartOpaqueTwinSyncSseKind { nil__: () },
         }
     }
 }
@@ -13084,7 +12846,7 @@ impl NewWithNullPtr for wire_cst_enum_opaque_twin_normal {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: EnumOpaqueTwinNormalKind { nil__: () },
         }
     }
 }
@@ -13097,7 +12859,7 @@ impl NewWithNullPtr for wire_cst_enum_opaque_twin_rust_async {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: EnumOpaqueTwinRustAsyncKind { nil__: () },
         }
     }
 }
@@ -13110,7 +12872,7 @@ impl NewWithNullPtr for wire_cst_enum_opaque_twin_rust_async_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: EnumOpaqueTwinRustAsyncSseKind { nil__: () },
         }
     }
 }
@@ -13123,7 +12885,7 @@ impl NewWithNullPtr for wire_cst_enum_opaque_twin_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: EnumOpaqueTwinSseKind { nil__: () },
         }
     }
 }
@@ -13136,7 +12898,7 @@ impl NewWithNullPtr for wire_cst_enum_opaque_twin_sync {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: EnumOpaqueTwinSyncKind { nil__: () },
         }
     }
 }
@@ -13149,7 +12911,7 @@ impl NewWithNullPtr for wire_cst_enum_opaque_twin_sync_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: EnumOpaqueTwinSyncSseKind { nil__: () },
         }
     }
 }
@@ -13162,7 +12924,7 @@ impl NewWithNullPtr for wire_cst_enum_with_item_mixed_twin_normal {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: EnumWithItemMixedTwinNormalKind { nil__: () },
         }
     }
 }
@@ -13175,7 +12937,7 @@ impl NewWithNullPtr for wire_cst_enum_with_item_mixed_twin_rust_async {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: EnumWithItemMixedTwinRustAsyncKind { nil__: () },
         }
     }
 }
@@ -13188,7 +12950,7 @@ impl NewWithNullPtr for wire_cst_enum_with_item_mixed_twin_rust_async_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: EnumWithItemMixedTwinRustAsyncSseKind { nil__: () },
         }
     }
 }
@@ -13201,7 +12963,7 @@ impl NewWithNullPtr for wire_cst_enum_with_item_mixed_twin_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: EnumWithItemMixedTwinSseKind { nil__: () },
         }
     }
 }
@@ -13214,7 +12976,7 @@ impl NewWithNullPtr for wire_cst_enum_with_item_mixed_twin_sync {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: EnumWithItemMixedTwinSyncKind { nil__: () },
         }
     }
 }
@@ -13227,7 +12989,7 @@ impl NewWithNullPtr for wire_cst_enum_with_item_mixed_twin_sync_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: EnumWithItemMixedTwinSyncSseKind { nil__: () },
         }
     }
 }
@@ -13240,7 +13002,7 @@ impl NewWithNullPtr for wire_cst_enum_with_item_struct_twin_normal {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: EnumWithItemStructTwinNormalKind { nil__: () },
         }
     }
 }
@@ -13253,7 +13015,7 @@ impl NewWithNullPtr for wire_cst_enum_with_item_struct_twin_rust_async {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: EnumWithItemStructTwinRustAsyncKind { nil__: () },
         }
     }
 }
@@ -13266,7 +13028,7 @@ impl NewWithNullPtr for wire_cst_enum_with_item_struct_twin_rust_async_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: EnumWithItemStructTwinRustAsyncSseKind { nil__: () },
         }
     }
 }
@@ -13279,7 +13041,7 @@ impl NewWithNullPtr for wire_cst_enum_with_item_struct_twin_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: EnumWithItemStructTwinSseKind { nil__: () },
         }
     }
 }
@@ -13292,7 +13054,7 @@ impl NewWithNullPtr for wire_cst_enum_with_item_struct_twin_sync {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: EnumWithItemStructTwinSyncKind { nil__: () },
         }
     }
 }
@@ -13305,7 +13067,7 @@ impl NewWithNullPtr for wire_cst_enum_with_item_struct_twin_sync_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: EnumWithItemStructTwinSyncSseKind { nil__: () },
         }
     }
 }
@@ -13318,7 +13080,7 @@ impl NewWithNullPtr for wire_cst_enum_with_item_tuple_twin_normal {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: EnumWithItemTupleTwinNormalKind { nil__: () },
         }
     }
 }
@@ -13331,7 +13093,7 @@ impl NewWithNullPtr for wire_cst_enum_with_item_tuple_twin_rust_async {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: EnumWithItemTupleTwinRustAsyncKind { nil__: () },
         }
     }
 }
@@ -13344,7 +13106,7 @@ impl NewWithNullPtr for wire_cst_enum_with_item_tuple_twin_rust_async_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: EnumWithItemTupleTwinRustAsyncSseKind { nil__: () },
         }
     }
 }
@@ -13357,7 +13119,7 @@ impl NewWithNullPtr for wire_cst_enum_with_item_tuple_twin_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: EnumWithItemTupleTwinSseKind { nil__: () },
         }
     }
 }
@@ -13370,7 +13132,7 @@ impl NewWithNullPtr for wire_cst_enum_with_item_tuple_twin_sync {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: EnumWithItemTupleTwinSyncKind { nil__: () },
         }
     }
 }
@@ -13383,7 +13145,7 @@ impl NewWithNullPtr for wire_cst_enum_with_item_tuple_twin_sync_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: EnumWithItemTupleTwinSyncSseKind { nil__: () },
         }
     }
 }
@@ -13751,7 +13513,7 @@ impl NewWithNullPtr for wire_cst_kitchen_sink_twin_normal {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: KitchenSinkTwinNormalKind { nil__: () },
         }
     }
 }
@@ -13764,7 +13526,7 @@ impl NewWithNullPtr for wire_cst_kitchen_sink_twin_rust_async {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: KitchenSinkTwinRustAsyncKind { nil__: () },
         }
     }
 }
@@ -13777,7 +13539,7 @@ impl NewWithNullPtr for wire_cst_kitchen_sink_twin_rust_async_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: KitchenSinkTwinRustAsyncSseKind { nil__: () },
         }
     }
 }
@@ -13790,7 +13552,7 @@ impl NewWithNullPtr for wire_cst_kitchen_sink_twin_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: KitchenSinkTwinSseKind { nil__: () },
         }
     }
 }
@@ -13803,7 +13565,7 @@ impl NewWithNullPtr for wire_cst_kitchen_sink_twin_sync {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: KitchenSinkTwinSyncKind { nil__: () },
         }
     }
 }
@@ -13816,7 +13578,7 @@ impl NewWithNullPtr for wire_cst_kitchen_sink_twin_sync_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: KitchenSinkTwinSyncSseKind { nil__: () },
         }
     }
 }
@@ -13983,7 +13745,7 @@ impl NewWithNullPtr for wire_cst_measure_twin_normal {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: MeasureTwinNormalKind { nil__: () },
         }
     }
 }
@@ -13996,7 +13758,7 @@ impl NewWithNullPtr for wire_cst_measure_twin_rust_async {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: MeasureTwinRustAsyncKind { nil__: () },
         }
     }
 }
@@ -14009,7 +13771,7 @@ impl NewWithNullPtr for wire_cst_measure_twin_rust_async_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: MeasureTwinRustAsyncSseKind { nil__: () },
         }
     }
 }
@@ -14022,7 +13784,7 @@ impl NewWithNullPtr for wire_cst_measure_twin_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: MeasureTwinSseKind { nil__: () },
         }
     }
 }
@@ -14035,7 +13797,7 @@ impl NewWithNullPtr for wire_cst_measure_twin_sync {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: MeasureTwinSyncKind { nil__: () },
         }
     }
 }
@@ -14048,7 +13810,7 @@ impl NewWithNullPtr for wire_cst_measure_twin_sync_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: MeasureTwinSyncSseKind { nil__: () },
         }
     }
 }
@@ -14998,7 +14760,7 @@ impl NewWithNullPtr for wire_cst_raw_string_enum_mirrored {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: RawStringEnumMirroredKind { nil__: () },
         }
     }
 }
@@ -15205,7 +14967,7 @@ impl NewWithNullPtr for wire_cst_speed_twin_normal {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: SpeedTwinNormalKind { nil__: () },
         }
     }
 }
@@ -15218,7 +14980,7 @@ impl NewWithNullPtr for wire_cst_speed_twin_rust_async {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: SpeedTwinRustAsyncKind { nil__: () },
         }
     }
 }
@@ -15231,7 +14993,7 @@ impl NewWithNullPtr for wire_cst_speed_twin_rust_async_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: SpeedTwinRustAsyncSseKind { nil__: () },
         }
     }
 }
@@ -15244,7 +15006,7 @@ impl NewWithNullPtr for wire_cst_speed_twin_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: SpeedTwinSseKind { nil__: () },
         }
     }
 }
@@ -15257,7 +15019,7 @@ impl NewWithNullPtr for wire_cst_speed_twin_sync {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: SpeedTwinSyncKind { nil__: () },
         }
     }
 }
@@ -15270,7 +15032,7 @@ impl NewWithNullPtr for wire_cst_speed_twin_sync_sse {
     fn new_with_null_ptr() -> Self {
         Self {
             tag: -1,
-            kind: core::ptr::null_mut(),
+            kind: SpeedTwinSyncSseKind { nil__: () },
         }
     }
 }
@@ -33694,2996 +33456,319 @@ pub extern "C" fn cst_new_list_weekdays_twin_sync_sse(
     flutter_rust_bridge::for_generated::new_leak_box_ptr(wrap)
 }
 
-#[no_mangle]
-pub extern "C" fn cst_inflate_AbcTwinNormal_A() -> *mut AbcTwinNormalKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(AbcTwinNormalKind {
-        A: flutter_rust_bridge::for_generated::new_leak_box_ptr(wire_cst_AbcTwinNormal_A {
-            field0: core::ptr::null_mut(),
-        }),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_AbcTwinNormal_B() -> *mut AbcTwinNormalKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(AbcTwinNormalKind {
-        B: flutter_rust_bridge::for_generated::new_leak_box_ptr(wire_cst_AbcTwinNormal_B {
-            field0: core::ptr::null_mut(),
-        }),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_AbcTwinNormal_C() -> *mut AbcTwinNormalKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(AbcTwinNormalKind {
-        C: flutter_rust_bridge::for_generated::new_leak_box_ptr(wire_cst_AbcTwinNormal_C {
-            field0: core::ptr::null_mut(),
-        }),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_AbcTwinNormal_JustInt() -> *mut AbcTwinNormalKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(AbcTwinNormalKind {
-        JustInt: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_AbcTwinNormal_JustInt {
-                field0: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_AbcTwinRustAsync_A() -> *mut AbcTwinRustAsyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(AbcTwinRustAsyncKind {
-        A: flutter_rust_bridge::for_generated::new_leak_box_ptr(wire_cst_AbcTwinRustAsync_A {
-            field0: core::ptr::null_mut(),
-        }),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_AbcTwinRustAsync_B() -> *mut AbcTwinRustAsyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(AbcTwinRustAsyncKind {
-        B: flutter_rust_bridge::for_generated::new_leak_box_ptr(wire_cst_AbcTwinRustAsync_B {
-            field0: core::ptr::null_mut(),
-        }),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_AbcTwinRustAsync_C() -> *mut AbcTwinRustAsyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(AbcTwinRustAsyncKind {
-        C: flutter_rust_bridge::for_generated::new_leak_box_ptr(wire_cst_AbcTwinRustAsync_C {
-            field0: core::ptr::null_mut(),
-        }),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_AbcTwinRustAsync_JustInt() -> *mut AbcTwinRustAsyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(AbcTwinRustAsyncKind {
-        JustInt: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_AbcTwinRustAsync_JustInt {
-                field0: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_AbcTwinRustAsyncSse_A() -> *mut AbcTwinRustAsyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(AbcTwinRustAsyncSseKind {
-        A: flutter_rust_bridge::for_generated::new_leak_box_ptr(wire_cst_AbcTwinRustAsyncSse_A {
-            field0: core::ptr::null_mut(),
-        }),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_AbcTwinRustAsyncSse_B() -> *mut AbcTwinRustAsyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(AbcTwinRustAsyncSseKind {
-        B: flutter_rust_bridge::for_generated::new_leak_box_ptr(wire_cst_AbcTwinRustAsyncSse_B {
-            field0: core::ptr::null_mut(),
-        }),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_AbcTwinRustAsyncSse_C() -> *mut AbcTwinRustAsyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(AbcTwinRustAsyncSseKind {
-        C: flutter_rust_bridge::for_generated::new_leak_box_ptr(wire_cst_AbcTwinRustAsyncSse_C {
-            field0: core::ptr::null_mut(),
-        }),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_AbcTwinRustAsyncSse_JustInt() -> *mut AbcTwinRustAsyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(AbcTwinRustAsyncSseKind {
-        JustInt: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_AbcTwinRustAsyncSse_JustInt {
-                field0: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_AbcTwinSse_A() -> *mut AbcTwinSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(AbcTwinSseKind {
-        A: flutter_rust_bridge::for_generated::new_leak_box_ptr(wire_cst_AbcTwinSse_A {
-            field0: core::ptr::null_mut(),
-        }),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_AbcTwinSse_B() -> *mut AbcTwinSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(AbcTwinSseKind {
-        B: flutter_rust_bridge::for_generated::new_leak_box_ptr(wire_cst_AbcTwinSse_B {
-            field0: core::ptr::null_mut(),
-        }),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_AbcTwinSse_C() -> *mut AbcTwinSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(AbcTwinSseKind {
-        C: flutter_rust_bridge::for_generated::new_leak_box_ptr(wire_cst_AbcTwinSse_C {
-            field0: core::ptr::null_mut(),
-        }),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_AbcTwinSse_JustInt() -> *mut AbcTwinSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(AbcTwinSseKind {
-        JustInt: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_AbcTwinSse_JustInt {
-                field0: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_AbcTwinSync_A() -> *mut AbcTwinSyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(AbcTwinSyncKind {
-        A: flutter_rust_bridge::for_generated::new_leak_box_ptr(wire_cst_AbcTwinSync_A {
-            field0: core::ptr::null_mut(),
-        }),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_AbcTwinSync_B() -> *mut AbcTwinSyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(AbcTwinSyncKind {
-        B: flutter_rust_bridge::for_generated::new_leak_box_ptr(wire_cst_AbcTwinSync_B {
-            field0: core::ptr::null_mut(),
-        }),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_AbcTwinSync_C() -> *mut AbcTwinSyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(AbcTwinSyncKind {
-        C: flutter_rust_bridge::for_generated::new_leak_box_ptr(wire_cst_AbcTwinSync_C {
-            field0: core::ptr::null_mut(),
-        }),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_AbcTwinSync_JustInt() -> *mut AbcTwinSyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(AbcTwinSyncKind {
-        JustInt: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_AbcTwinSync_JustInt {
-                field0: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_AbcTwinSyncSse_A() -> *mut AbcTwinSyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(AbcTwinSyncSseKind {
-        A: flutter_rust_bridge::for_generated::new_leak_box_ptr(wire_cst_AbcTwinSyncSse_A {
-            field0: core::ptr::null_mut(),
-        }),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_AbcTwinSyncSse_B() -> *mut AbcTwinSyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(AbcTwinSyncSseKind {
-        B: flutter_rust_bridge::for_generated::new_leak_box_ptr(wire_cst_AbcTwinSyncSse_B {
-            field0: core::ptr::null_mut(),
-        }),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_AbcTwinSyncSse_C() -> *mut AbcTwinSyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(AbcTwinSyncSseKind {
-        C: flutter_rust_bridge::for_generated::new_leak_box_ptr(wire_cst_AbcTwinSyncSse_C {
-            field0: core::ptr::null_mut(),
-        }),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_AbcTwinSyncSse_JustInt() -> *mut AbcTwinSyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(AbcTwinSyncSseKind {
-        JustInt: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_AbcTwinSyncSse_JustInt {
-                field0: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_ApplicationMessage_DisplayMessage() -> *mut ApplicationMessageKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(ApplicationMessageKind {
-        DisplayMessage: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_ApplicationMessage_DisplayMessage {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_ApplicationMessage_RenderPixel() -> *mut ApplicationMessageKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(ApplicationMessageKind {
-        RenderPixel: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_ApplicationMessage_RenderPixel {
-                x: Default::default(),
-                y: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomEnumErrorTwinNormal_One() -> *mut CustomEnumErrorTwinNormalKind
-{
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomEnumErrorTwinNormalKind {
-        One: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomEnumErrorTwinNormal_One {
-                message: core::ptr::null_mut(),
-                backtrace: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomEnumErrorTwinNormal_Two() -> *mut CustomEnumErrorTwinNormalKind
-{
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomEnumErrorTwinNormalKind {
-        Two: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomEnumErrorTwinNormal_Two {
-                message: Default::default(),
-                backtrace: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomEnumErrorTwinRustAsync_One(
-) -> *mut CustomEnumErrorTwinRustAsyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomEnumErrorTwinRustAsyncKind {
-        One: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomEnumErrorTwinRustAsync_One {
-                message: core::ptr::null_mut(),
-                backtrace: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomEnumErrorTwinRustAsync_Two(
-) -> *mut CustomEnumErrorTwinRustAsyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomEnumErrorTwinRustAsyncKind {
-        Two: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomEnumErrorTwinRustAsync_Two {
-                message: Default::default(),
-                backtrace: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomEnumErrorTwinRustAsyncSse_One(
-) -> *mut CustomEnumErrorTwinRustAsyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomEnumErrorTwinRustAsyncSseKind {
-        One: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomEnumErrorTwinRustAsyncSse_One {
-                message: core::ptr::null_mut(),
-                backtrace: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomEnumErrorTwinRustAsyncSse_Two(
-) -> *mut CustomEnumErrorTwinRustAsyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomEnumErrorTwinRustAsyncSseKind {
-        Two: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomEnumErrorTwinRustAsyncSse_Two {
-                message: Default::default(),
-                backtrace: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomEnumErrorTwinSse_One() -> *mut CustomEnumErrorTwinSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomEnumErrorTwinSseKind {
-        One: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomEnumErrorTwinSse_One {
-                message: core::ptr::null_mut(),
-                backtrace: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomEnumErrorTwinSse_Two() -> *mut CustomEnumErrorTwinSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomEnumErrorTwinSseKind {
-        Two: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomEnumErrorTwinSse_Two {
-                message: Default::default(),
-                backtrace: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomEnumErrorTwinSync_One() -> *mut CustomEnumErrorTwinSyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomEnumErrorTwinSyncKind {
-        One: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomEnumErrorTwinSync_One {
-                message: core::ptr::null_mut(),
-                backtrace: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomEnumErrorTwinSync_Two() -> *mut CustomEnumErrorTwinSyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomEnumErrorTwinSyncKind {
-        Two: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomEnumErrorTwinSync_Two {
-                message: Default::default(),
-                backtrace: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomEnumErrorTwinSyncSse_One() -> *mut CustomEnumErrorTwinSyncSseKind
-{
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomEnumErrorTwinSyncSseKind {
-        One: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomEnumErrorTwinSyncSse_One {
-                message: core::ptr::null_mut(),
-                backtrace: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomEnumErrorTwinSyncSse_Two() -> *mut CustomEnumErrorTwinSyncSseKind
-{
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomEnumErrorTwinSyncSseKind {
-        Two: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomEnumErrorTwinSyncSse_Two {
-                message: Default::default(),
-                backtrace: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomErrorTwinNormal_Error0() -> *mut CustomErrorTwinNormalKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomErrorTwinNormalKind {
-        Error0: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomErrorTwinNormal_Error0 {
-                e: core::ptr::null_mut(),
-                backtrace: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomErrorTwinNormal_Error1() -> *mut CustomErrorTwinNormalKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomErrorTwinNormalKind {
-        Error1: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomErrorTwinNormal_Error1 {
-                e: Default::default(),
-                backtrace: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomErrorTwinRustAsync_Error0() -> *mut CustomErrorTwinRustAsyncKind
-{
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomErrorTwinRustAsyncKind {
-        Error0: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomErrorTwinRustAsync_Error0 {
-                e: core::ptr::null_mut(),
-                backtrace: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomErrorTwinRustAsync_Error1() -> *mut CustomErrorTwinRustAsyncKind
-{
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomErrorTwinRustAsyncKind {
-        Error1: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomErrorTwinRustAsync_Error1 {
-                e: Default::default(),
-                backtrace: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomErrorTwinRustAsyncSse_Error0(
-) -> *mut CustomErrorTwinRustAsyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomErrorTwinRustAsyncSseKind {
-        Error0: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomErrorTwinRustAsyncSse_Error0 {
-                e: core::ptr::null_mut(),
-                backtrace: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomErrorTwinRustAsyncSse_Error1(
-) -> *mut CustomErrorTwinRustAsyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomErrorTwinRustAsyncSseKind {
-        Error1: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomErrorTwinRustAsyncSse_Error1 {
-                e: Default::default(),
-                backtrace: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomErrorTwinSse_Error0() -> *mut CustomErrorTwinSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomErrorTwinSseKind {
-        Error0: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomErrorTwinSse_Error0 {
-                e: core::ptr::null_mut(),
-                backtrace: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomErrorTwinSse_Error1() -> *mut CustomErrorTwinSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomErrorTwinSseKind {
-        Error1: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomErrorTwinSse_Error1 {
-                e: Default::default(),
-                backtrace: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomErrorTwinSync_Error0() -> *mut CustomErrorTwinSyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomErrorTwinSyncKind {
-        Error0: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomErrorTwinSync_Error0 {
-                e: core::ptr::null_mut(),
-                backtrace: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomErrorTwinSync_Error1() -> *mut CustomErrorTwinSyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomErrorTwinSyncKind {
-        Error1: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomErrorTwinSync_Error1 {
-                e: Default::default(),
-                backtrace: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomErrorTwinSyncSse_Error0() -> *mut CustomErrorTwinSyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomErrorTwinSyncSseKind {
-        Error0: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomErrorTwinSyncSse_Error0 {
-                e: core::ptr::null_mut(),
-                backtrace: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomErrorTwinSyncSse_Error1() -> *mut CustomErrorTwinSyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomErrorTwinSyncSseKind {
-        Error1: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomErrorTwinSyncSse_Error1 {
-                e: Default::default(),
-                backtrace: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedError1TwinNormal_CustomNested1(
-) -> *mut CustomNestedError1TwinNormalKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedError1TwinNormalKind {
-        CustomNested1: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedError1TwinNormal_CustomNested1 {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedError1TwinNormal_ErrorNested(
-) -> *mut CustomNestedError1TwinNormalKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedError1TwinNormalKind {
-        ErrorNested: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedError1TwinNormal_ErrorNested {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedError1TwinRustAsync_CustomNested1(
-) -> *mut CustomNestedError1TwinRustAsyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedError1TwinRustAsyncKind {
-        CustomNested1: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedError1TwinRustAsync_CustomNested1 {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedError1TwinRustAsync_ErrorNested(
-) -> *mut CustomNestedError1TwinRustAsyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedError1TwinRustAsyncKind {
-        ErrorNested: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedError1TwinRustAsync_ErrorNested {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedError1TwinRustAsyncSse_CustomNested1(
-) -> *mut CustomNestedError1TwinRustAsyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedError1TwinRustAsyncSseKind {
-        CustomNested1: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedError1TwinRustAsyncSse_CustomNested1 {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedError1TwinRustAsyncSse_ErrorNested(
-) -> *mut CustomNestedError1TwinRustAsyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedError1TwinRustAsyncSseKind {
-        ErrorNested: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedError1TwinRustAsyncSse_ErrorNested {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedError1TwinSse_CustomNested1(
-) -> *mut CustomNestedError1TwinSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedError1TwinSseKind {
-        CustomNested1: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedError1TwinSse_CustomNested1 {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedError1TwinSse_ErrorNested(
-) -> *mut CustomNestedError1TwinSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedError1TwinSseKind {
-        ErrorNested: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedError1TwinSse_ErrorNested {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedError1TwinSync_CustomNested1(
-) -> *mut CustomNestedError1TwinSyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedError1TwinSyncKind {
-        CustomNested1: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedError1TwinSync_CustomNested1 {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedError1TwinSync_ErrorNested(
-) -> *mut CustomNestedError1TwinSyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedError1TwinSyncKind {
-        ErrorNested: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedError1TwinSync_ErrorNested {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedError1TwinSyncSse_CustomNested1(
-) -> *mut CustomNestedError1TwinSyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedError1TwinSyncSseKind {
-        CustomNested1: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedError1TwinSyncSse_CustomNested1 {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedError1TwinSyncSse_ErrorNested(
-) -> *mut CustomNestedError1TwinSyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedError1TwinSyncSseKind {
-        ErrorNested: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedError1TwinSyncSse_ErrorNested {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedError2TwinNormal_CustomNested2(
-) -> *mut CustomNestedError2TwinNormalKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedError2TwinNormalKind {
-        CustomNested2: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedError2TwinNormal_CustomNested2 {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedError2TwinNormal_CustomNested2Number(
-) -> *mut CustomNestedError2TwinNormalKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedError2TwinNormalKind {
-        CustomNested2Number: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedError2TwinNormal_CustomNested2Number {
-                field0: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedError2TwinRustAsync_CustomNested2(
-) -> *mut CustomNestedError2TwinRustAsyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedError2TwinRustAsyncKind {
-        CustomNested2: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedError2TwinRustAsync_CustomNested2 {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedError2TwinRustAsync_CustomNested2Number(
-) -> *mut CustomNestedError2TwinRustAsyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedError2TwinRustAsyncKind {
-        CustomNested2Number: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedError2TwinRustAsync_CustomNested2Number {
-                field0: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedError2TwinRustAsyncSse_CustomNested2(
-) -> *mut CustomNestedError2TwinRustAsyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedError2TwinRustAsyncSseKind {
-        CustomNested2: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedError2TwinRustAsyncSse_CustomNested2 {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedError2TwinRustAsyncSse_CustomNested2Number(
-) -> *mut CustomNestedError2TwinRustAsyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedError2TwinRustAsyncSseKind {
-        CustomNested2Number: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedError2TwinRustAsyncSse_CustomNested2Number {
-                field0: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedError2TwinSse_CustomNested2(
-) -> *mut CustomNestedError2TwinSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedError2TwinSseKind {
-        CustomNested2: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedError2TwinSse_CustomNested2 {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedError2TwinSse_CustomNested2Number(
-) -> *mut CustomNestedError2TwinSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedError2TwinSseKind {
-        CustomNested2Number: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedError2TwinSse_CustomNested2Number {
-                field0: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedError2TwinSync_CustomNested2(
-) -> *mut CustomNestedError2TwinSyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedError2TwinSyncKind {
-        CustomNested2: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedError2TwinSync_CustomNested2 {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedError2TwinSync_CustomNested2Number(
-) -> *mut CustomNestedError2TwinSyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedError2TwinSyncKind {
-        CustomNested2Number: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedError2TwinSync_CustomNested2Number {
-                field0: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedError2TwinSyncSse_CustomNested2(
-) -> *mut CustomNestedError2TwinSyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedError2TwinSyncSseKind {
-        CustomNested2: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedError2TwinSyncSse_CustomNested2 {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedError2TwinSyncSse_CustomNested2Number(
-) -> *mut CustomNestedError2TwinSyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedError2TwinSyncSseKind {
-        CustomNested2Number: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedError2TwinSyncSse_CustomNested2Number {
-                field0: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedErrorInnerTwinNormal_Three(
-) -> *mut CustomNestedErrorInnerTwinNormalKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedErrorInnerTwinNormalKind {
-        Three: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedErrorInnerTwinNormal_Three {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedErrorInnerTwinNormal_Four(
-) -> *mut CustomNestedErrorInnerTwinNormalKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedErrorInnerTwinNormalKind {
-        Four: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedErrorInnerTwinNormal_Four {
-                field0: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedErrorInnerTwinRustAsync_Three(
-) -> *mut CustomNestedErrorInnerTwinRustAsyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedErrorInnerTwinRustAsyncKind {
-        Three: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedErrorInnerTwinRustAsync_Three {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedErrorInnerTwinRustAsync_Four(
-) -> *mut CustomNestedErrorInnerTwinRustAsyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedErrorInnerTwinRustAsyncKind {
-        Four: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedErrorInnerTwinRustAsync_Four {
-                field0: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedErrorInnerTwinRustAsyncSse_Three(
-) -> *mut CustomNestedErrorInnerTwinRustAsyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(
-        CustomNestedErrorInnerTwinRustAsyncSseKind {
-            Three: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-                wire_cst_CustomNestedErrorInnerTwinRustAsyncSse_Three {
-                    field0: core::ptr::null_mut(),
-                },
-            ),
-        },
-    )
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedErrorInnerTwinRustAsyncSse_Four(
-) -> *mut CustomNestedErrorInnerTwinRustAsyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(
-        CustomNestedErrorInnerTwinRustAsyncSseKind {
-            Four: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-                wire_cst_CustomNestedErrorInnerTwinRustAsyncSse_Four {
-                    field0: Default::default(),
-                },
-            ),
-        },
-    )
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedErrorInnerTwinSse_Three(
-) -> *mut CustomNestedErrorInnerTwinSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedErrorInnerTwinSseKind {
-        Three: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedErrorInnerTwinSse_Three {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedErrorInnerTwinSse_Four(
-) -> *mut CustomNestedErrorInnerTwinSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedErrorInnerTwinSseKind {
-        Four: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedErrorInnerTwinSse_Four {
-                field0: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedErrorInnerTwinSync_Three(
-) -> *mut CustomNestedErrorInnerTwinSyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedErrorInnerTwinSyncKind {
-        Three: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedErrorInnerTwinSync_Three {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedErrorInnerTwinSync_Four(
-) -> *mut CustomNestedErrorInnerTwinSyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedErrorInnerTwinSyncKind {
-        Four: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedErrorInnerTwinSync_Four {
-                field0: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedErrorInnerTwinSyncSse_Three(
-) -> *mut CustomNestedErrorInnerTwinSyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedErrorInnerTwinSyncSseKind {
-        Three: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedErrorInnerTwinSyncSse_Three {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedErrorInnerTwinSyncSse_Four(
-) -> *mut CustomNestedErrorInnerTwinSyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedErrorInnerTwinSyncSseKind {
-        Four: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedErrorInnerTwinSyncSse_Four {
-                field0: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedErrorOuterTwinNormal_One(
-) -> *mut CustomNestedErrorOuterTwinNormalKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedErrorOuterTwinNormalKind {
-        One: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedErrorOuterTwinNormal_One {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedErrorOuterTwinNormal_Two(
-) -> *mut CustomNestedErrorOuterTwinNormalKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedErrorOuterTwinNormalKind {
-        Two: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedErrorOuterTwinNormal_Two {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedErrorOuterTwinRustAsync_One(
-) -> *mut CustomNestedErrorOuterTwinRustAsyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedErrorOuterTwinRustAsyncKind {
-        One: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedErrorOuterTwinRustAsync_One {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedErrorOuterTwinRustAsync_Two(
-) -> *mut CustomNestedErrorOuterTwinRustAsyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedErrorOuterTwinRustAsyncKind {
-        Two: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedErrorOuterTwinRustAsync_Two {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedErrorOuterTwinRustAsyncSse_One(
-) -> *mut CustomNestedErrorOuterTwinRustAsyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(
-        CustomNestedErrorOuterTwinRustAsyncSseKind {
-            One: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-                wire_cst_CustomNestedErrorOuterTwinRustAsyncSse_One {
-                    field0: core::ptr::null_mut(),
-                },
-            ),
-        },
-    )
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedErrorOuterTwinRustAsyncSse_Two(
-) -> *mut CustomNestedErrorOuterTwinRustAsyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(
-        CustomNestedErrorOuterTwinRustAsyncSseKind {
-            Two: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-                wire_cst_CustomNestedErrorOuterTwinRustAsyncSse_Two {
-                    field0: core::ptr::null_mut(),
-                },
-            ),
-        },
-    )
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedErrorOuterTwinSse_One(
-) -> *mut CustomNestedErrorOuterTwinSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedErrorOuterTwinSseKind {
-        One: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedErrorOuterTwinSse_One {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedErrorOuterTwinSse_Two(
-) -> *mut CustomNestedErrorOuterTwinSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedErrorOuterTwinSseKind {
-        Two: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedErrorOuterTwinSse_Two {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedErrorOuterTwinSync_One(
-) -> *mut CustomNestedErrorOuterTwinSyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedErrorOuterTwinSyncKind {
-        One: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedErrorOuterTwinSync_One {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedErrorOuterTwinSync_Two(
-) -> *mut CustomNestedErrorOuterTwinSyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedErrorOuterTwinSyncKind {
-        Two: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedErrorOuterTwinSync_Two {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedErrorOuterTwinSyncSse_One(
-) -> *mut CustomNestedErrorOuterTwinSyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedErrorOuterTwinSyncSseKind {
-        One: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedErrorOuterTwinSyncSse_One {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_CustomNestedErrorOuterTwinSyncSse_Two(
-) -> *mut CustomNestedErrorOuterTwinSyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(CustomNestedErrorOuterTwinSyncSseKind {
-        Two: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_CustomNestedErrorOuterTwinSyncSse_Two {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_DistanceTwinNormal_Map() -> *mut DistanceTwinNormalKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(DistanceTwinNormalKind {
-        Map: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_DistanceTwinNormal_Map {
-                field0: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_DistanceTwinRustAsync_Map() -> *mut DistanceTwinRustAsyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(DistanceTwinRustAsyncKind {
-        Map: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_DistanceTwinRustAsync_Map {
-                field0: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_DistanceTwinRustAsyncSse_Map() -> *mut DistanceTwinRustAsyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(DistanceTwinRustAsyncSseKind {
-        Map: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_DistanceTwinRustAsyncSse_Map {
-                field0: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_DistanceTwinSse_Map() -> *mut DistanceTwinSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(DistanceTwinSseKind {
-        Map: flutter_rust_bridge::for_generated::new_leak_box_ptr(wire_cst_DistanceTwinSse_Map {
-            field0: Default::default(),
-        }),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_DistanceTwinSync_Map() -> *mut DistanceTwinSyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(DistanceTwinSyncKind {
-        Map: flutter_rust_bridge::for_generated::new_leak_box_ptr(wire_cst_DistanceTwinSync_Map {
-            field0: Default::default(),
-        }),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_DistanceTwinSyncSse_Map() -> *mut DistanceTwinSyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(DistanceTwinSyncSseKind {
-        Map: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_DistanceTwinSyncSse_Map {
-                field0: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumDartOpaqueTwinNormal_Primitive(
-) -> *mut EnumDartOpaqueTwinNormalKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumDartOpaqueTwinNormalKind {
-        Primitive: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumDartOpaqueTwinNormal_Primitive {
-                field0: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumDartOpaqueTwinNormal_Opaque() -> *mut EnumDartOpaqueTwinNormalKind
-{
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumDartOpaqueTwinNormalKind {
-        Opaque: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumDartOpaqueTwinNormal_Opaque {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumDartOpaqueTwinRustAsync_Primitive(
-) -> *mut EnumDartOpaqueTwinRustAsyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumDartOpaqueTwinRustAsyncKind {
-        Primitive: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumDartOpaqueTwinRustAsync_Primitive {
-                field0: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumDartOpaqueTwinRustAsync_Opaque(
-) -> *mut EnumDartOpaqueTwinRustAsyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumDartOpaqueTwinRustAsyncKind {
-        Opaque: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumDartOpaqueTwinRustAsync_Opaque {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumDartOpaqueTwinRustAsyncSse_Primitive(
-) -> *mut EnumDartOpaqueTwinRustAsyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumDartOpaqueTwinRustAsyncSseKind {
-        Primitive: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumDartOpaqueTwinRustAsyncSse_Primitive {
-                field0: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumDartOpaqueTwinRustAsyncSse_Opaque(
-) -> *mut EnumDartOpaqueTwinRustAsyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumDartOpaqueTwinRustAsyncSseKind {
-        Opaque: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumDartOpaqueTwinRustAsyncSse_Opaque {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumDartOpaqueTwinSse_Primitive() -> *mut EnumDartOpaqueTwinSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumDartOpaqueTwinSseKind {
-        Primitive: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumDartOpaqueTwinSse_Primitive {
-                field0: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumDartOpaqueTwinSse_Opaque() -> *mut EnumDartOpaqueTwinSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumDartOpaqueTwinSseKind {
-        Opaque: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumDartOpaqueTwinSse_Opaque {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumDartOpaqueTwinSync_Primitive() -> *mut EnumDartOpaqueTwinSyncKind
-{
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumDartOpaqueTwinSyncKind {
-        Primitive: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumDartOpaqueTwinSync_Primitive {
-                field0: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumDartOpaqueTwinSync_Opaque() -> *mut EnumDartOpaqueTwinSyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumDartOpaqueTwinSyncKind {
-        Opaque: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumDartOpaqueTwinSync_Opaque {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumDartOpaqueTwinSyncSse_Primitive(
-) -> *mut EnumDartOpaqueTwinSyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumDartOpaqueTwinSyncSseKind {
-        Primitive: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumDartOpaqueTwinSyncSse_Primitive {
-                field0: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumDartOpaqueTwinSyncSse_Opaque(
-) -> *mut EnumDartOpaqueTwinSyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumDartOpaqueTwinSyncSseKind {
-        Opaque: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumDartOpaqueTwinSyncSse_Opaque {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumOpaqueTwinNormal_Struct() -> *mut EnumOpaqueTwinNormalKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumOpaqueTwinNormalKind {
-        Struct: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumOpaqueTwinNormal_Struct {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumOpaqueTwinNormal_Primitive() -> *mut EnumOpaqueTwinNormalKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumOpaqueTwinNormalKind {
-        Primitive: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumOpaqueTwinNormal_Primitive {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumOpaqueTwinNormal_TraitObj() -> *mut EnumOpaqueTwinNormalKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumOpaqueTwinNormalKind {
-        TraitObj: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumOpaqueTwinNormal_TraitObj {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumOpaqueTwinNormal_Mutex() -> *mut EnumOpaqueTwinNormalKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumOpaqueTwinNormalKind {
-        Mutex: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumOpaqueTwinNormal_Mutex {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumOpaqueTwinNormal_RwLock() -> *mut EnumOpaqueTwinNormalKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumOpaqueTwinNormalKind {
-        RwLock: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumOpaqueTwinNormal_RwLock {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumOpaqueTwinRustAsync_Struct() -> *mut EnumOpaqueTwinRustAsyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumOpaqueTwinRustAsyncKind {
-        Struct: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumOpaqueTwinRustAsync_Struct {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumOpaqueTwinRustAsync_Primitive() -> *mut EnumOpaqueTwinRustAsyncKind
-{
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumOpaqueTwinRustAsyncKind {
-        Primitive: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumOpaqueTwinRustAsync_Primitive {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumOpaqueTwinRustAsync_TraitObj() -> *mut EnumOpaqueTwinRustAsyncKind
-{
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumOpaqueTwinRustAsyncKind {
-        TraitObj: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumOpaqueTwinRustAsync_TraitObj {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumOpaqueTwinRustAsync_Mutex() -> *mut EnumOpaqueTwinRustAsyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumOpaqueTwinRustAsyncKind {
-        Mutex: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumOpaqueTwinRustAsync_Mutex {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumOpaqueTwinRustAsync_RwLock() -> *mut EnumOpaqueTwinRustAsyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumOpaqueTwinRustAsyncKind {
-        RwLock: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumOpaqueTwinRustAsync_RwLock {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumOpaqueTwinRustAsyncSse_Struct(
-) -> *mut EnumOpaqueTwinRustAsyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumOpaqueTwinRustAsyncSseKind {
-        Struct: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumOpaqueTwinRustAsyncSse_Struct {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumOpaqueTwinRustAsyncSse_Primitive(
-) -> *mut EnumOpaqueTwinRustAsyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumOpaqueTwinRustAsyncSseKind {
-        Primitive: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumOpaqueTwinRustAsyncSse_Primitive {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumOpaqueTwinRustAsyncSse_TraitObj(
-) -> *mut EnumOpaqueTwinRustAsyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumOpaqueTwinRustAsyncSseKind {
-        TraitObj: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumOpaqueTwinRustAsyncSse_TraitObj {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumOpaqueTwinRustAsyncSse_Mutex(
-) -> *mut EnumOpaqueTwinRustAsyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumOpaqueTwinRustAsyncSseKind {
-        Mutex: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumOpaqueTwinRustAsyncSse_Mutex {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumOpaqueTwinRustAsyncSse_RwLock(
-) -> *mut EnumOpaqueTwinRustAsyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumOpaqueTwinRustAsyncSseKind {
-        RwLock: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumOpaqueTwinRustAsyncSse_RwLock {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumOpaqueTwinSse_Struct() -> *mut EnumOpaqueTwinSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumOpaqueTwinSseKind {
-        Struct: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumOpaqueTwinSse_Struct {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumOpaqueTwinSse_Primitive() -> *mut EnumOpaqueTwinSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumOpaqueTwinSseKind {
-        Primitive: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumOpaqueTwinSse_Primitive {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumOpaqueTwinSse_TraitObj() -> *mut EnumOpaqueTwinSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumOpaqueTwinSseKind {
-        TraitObj: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumOpaqueTwinSse_TraitObj {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumOpaqueTwinSse_Mutex() -> *mut EnumOpaqueTwinSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumOpaqueTwinSseKind {
-        Mutex: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumOpaqueTwinSse_Mutex {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumOpaqueTwinSse_RwLock() -> *mut EnumOpaqueTwinSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumOpaqueTwinSseKind {
-        RwLock: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumOpaqueTwinSse_RwLock {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumOpaqueTwinSync_Struct() -> *mut EnumOpaqueTwinSyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumOpaqueTwinSyncKind {
-        Struct: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumOpaqueTwinSync_Struct {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumOpaqueTwinSync_Primitive() -> *mut EnumOpaqueTwinSyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumOpaqueTwinSyncKind {
-        Primitive: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumOpaqueTwinSync_Primitive {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumOpaqueTwinSync_TraitObj() -> *mut EnumOpaqueTwinSyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumOpaqueTwinSyncKind {
-        TraitObj: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumOpaqueTwinSync_TraitObj {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumOpaqueTwinSync_Mutex() -> *mut EnumOpaqueTwinSyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumOpaqueTwinSyncKind {
-        Mutex: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumOpaqueTwinSync_Mutex {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumOpaqueTwinSync_RwLock() -> *mut EnumOpaqueTwinSyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumOpaqueTwinSyncKind {
-        RwLock: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumOpaqueTwinSync_RwLock {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumOpaqueTwinSyncSse_Struct() -> *mut EnumOpaqueTwinSyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumOpaqueTwinSyncSseKind {
-        Struct: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumOpaqueTwinSyncSse_Struct {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumOpaqueTwinSyncSse_Primitive() -> *mut EnumOpaqueTwinSyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumOpaqueTwinSyncSseKind {
-        Primitive: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumOpaqueTwinSyncSse_Primitive {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumOpaqueTwinSyncSse_TraitObj() -> *mut EnumOpaqueTwinSyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumOpaqueTwinSyncSseKind {
-        TraitObj: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumOpaqueTwinSyncSse_TraitObj {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumOpaqueTwinSyncSse_Mutex() -> *mut EnumOpaqueTwinSyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumOpaqueTwinSyncSseKind {
-        Mutex: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumOpaqueTwinSyncSse_Mutex {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumOpaqueTwinSyncSse_RwLock() -> *mut EnumOpaqueTwinSyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumOpaqueTwinSyncSseKind {
-        RwLock: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumOpaqueTwinSyncSse_RwLock {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumWithItemMixedTwinNormal_B() -> *mut EnumWithItemMixedTwinNormalKind
-{
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumWithItemMixedTwinNormalKind {
-        B: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumWithItemMixedTwinNormal_B {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumWithItemMixedTwinNormal_C() -> *mut EnumWithItemMixedTwinNormalKind
-{
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumWithItemMixedTwinNormalKind {
-        C: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumWithItemMixedTwinNormal_C {
-                c_field: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumWithItemMixedTwinRustAsync_B(
-) -> *mut EnumWithItemMixedTwinRustAsyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumWithItemMixedTwinRustAsyncKind {
-        B: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumWithItemMixedTwinRustAsync_B {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumWithItemMixedTwinRustAsync_C(
-) -> *mut EnumWithItemMixedTwinRustAsyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumWithItemMixedTwinRustAsyncKind {
-        C: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumWithItemMixedTwinRustAsync_C {
-                c_field: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumWithItemMixedTwinRustAsyncSse_B(
-) -> *mut EnumWithItemMixedTwinRustAsyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumWithItemMixedTwinRustAsyncSseKind {
-        B: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumWithItemMixedTwinRustAsyncSse_B {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumWithItemMixedTwinRustAsyncSse_C(
-) -> *mut EnumWithItemMixedTwinRustAsyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumWithItemMixedTwinRustAsyncSseKind {
-        C: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumWithItemMixedTwinRustAsyncSse_C {
-                c_field: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumWithItemMixedTwinSse_B() -> *mut EnumWithItemMixedTwinSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumWithItemMixedTwinSseKind {
-        B: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumWithItemMixedTwinSse_B {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumWithItemMixedTwinSse_C() -> *mut EnumWithItemMixedTwinSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumWithItemMixedTwinSseKind {
-        C: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumWithItemMixedTwinSse_C {
-                c_field: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumWithItemMixedTwinSync_B() -> *mut EnumWithItemMixedTwinSyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumWithItemMixedTwinSyncKind {
-        B: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumWithItemMixedTwinSync_B {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumWithItemMixedTwinSync_C() -> *mut EnumWithItemMixedTwinSyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumWithItemMixedTwinSyncKind {
-        C: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumWithItemMixedTwinSync_C {
-                c_field: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumWithItemMixedTwinSyncSse_B(
-) -> *mut EnumWithItemMixedTwinSyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumWithItemMixedTwinSyncSseKind {
-        B: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumWithItemMixedTwinSyncSse_B {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumWithItemMixedTwinSyncSse_C(
-) -> *mut EnumWithItemMixedTwinSyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumWithItemMixedTwinSyncSseKind {
-        C: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumWithItemMixedTwinSyncSse_C {
-                c_field: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumWithItemStructTwinNormal_A(
-) -> *mut EnumWithItemStructTwinNormalKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumWithItemStructTwinNormalKind {
-        A: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumWithItemStructTwinNormal_A {
-                a_field: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumWithItemStructTwinNormal_B(
-) -> *mut EnumWithItemStructTwinNormalKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumWithItemStructTwinNormalKind {
-        B: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumWithItemStructTwinNormal_B {
-                b_field: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumWithItemStructTwinRustAsync_A(
-) -> *mut EnumWithItemStructTwinRustAsyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumWithItemStructTwinRustAsyncKind {
-        A: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumWithItemStructTwinRustAsync_A {
-                a_field: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumWithItemStructTwinRustAsync_B(
-) -> *mut EnumWithItemStructTwinRustAsyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumWithItemStructTwinRustAsyncKind {
-        B: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumWithItemStructTwinRustAsync_B {
-                b_field: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumWithItemStructTwinRustAsyncSse_A(
-) -> *mut EnumWithItemStructTwinRustAsyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumWithItemStructTwinRustAsyncSseKind {
-        A: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumWithItemStructTwinRustAsyncSse_A {
-                a_field: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumWithItemStructTwinRustAsyncSse_B(
-) -> *mut EnumWithItemStructTwinRustAsyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumWithItemStructTwinRustAsyncSseKind {
-        B: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumWithItemStructTwinRustAsyncSse_B {
-                b_field: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumWithItemStructTwinSse_A() -> *mut EnumWithItemStructTwinSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumWithItemStructTwinSseKind {
-        A: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumWithItemStructTwinSse_A {
-                a_field: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumWithItemStructTwinSse_B() -> *mut EnumWithItemStructTwinSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumWithItemStructTwinSseKind {
-        B: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumWithItemStructTwinSse_B {
-                b_field: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumWithItemStructTwinSync_A() -> *mut EnumWithItemStructTwinSyncKind
-{
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumWithItemStructTwinSyncKind {
-        A: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumWithItemStructTwinSync_A {
-                a_field: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumWithItemStructTwinSync_B() -> *mut EnumWithItemStructTwinSyncKind
-{
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumWithItemStructTwinSyncKind {
-        B: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumWithItemStructTwinSync_B {
-                b_field: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumWithItemStructTwinSyncSse_A(
-) -> *mut EnumWithItemStructTwinSyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumWithItemStructTwinSyncSseKind {
-        A: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumWithItemStructTwinSyncSse_A {
-                a_field: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumWithItemStructTwinSyncSse_B(
-) -> *mut EnumWithItemStructTwinSyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumWithItemStructTwinSyncSseKind {
-        B: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumWithItemStructTwinSyncSse_B {
-                b_field: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumWithItemTupleTwinNormal_A() -> *mut EnumWithItemTupleTwinNormalKind
-{
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumWithItemTupleTwinNormalKind {
-        A: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumWithItemTupleTwinNormal_A {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumWithItemTupleTwinNormal_B() -> *mut EnumWithItemTupleTwinNormalKind
-{
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumWithItemTupleTwinNormalKind {
-        B: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumWithItemTupleTwinNormal_B {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumWithItemTupleTwinRustAsync_A(
-) -> *mut EnumWithItemTupleTwinRustAsyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumWithItemTupleTwinRustAsyncKind {
-        A: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumWithItemTupleTwinRustAsync_A {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumWithItemTupleTwinRustAsync_B(
-) -> *mut EnumWithItemTupleTwinRustAsyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumWithItemTupleTwinRustAsyncKind {
-        B: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumWithItemTupleTwinRustAsync_B {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumWithItemTupleTwinRustAsyncSse_A(
-) -> *mut EnumWithItemTupleTwinRustAsyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumWithItemTupleTwinRustAsyncSseKind {
-        A: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumWithItemTupleTwinRustAsyncSse_A {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumWithItemTupleTwinRustAsyncSse_B(
-) -> *mut EnumWithItemTupleTwinRustAsyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumWithItemTupleTwinRustAsyncSseKind {
-        B: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumWithItemTupleTwinRustAsyncSse_B {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumWithItemTupleTwinSse_A() -> *mut EnumWithItemTupleTwinSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumWithItemTupleTwinSseKind {
-        A: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumWithItemTupleTwinSse_A {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumWithItemTupleTwinSse_B() -> *mut EnumWithItemTupleTwinSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumWithItemTupleTwinSseKind {
-        B: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumWithItemTupleTwinSse_B {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumWithItemTupleTwinSync_A() -> *mut EnumWithItemTupleTwinSyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumWithItemTupleTwinSyncKind {
-        A: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumWithItemTupleTwinSync_A {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumWithItemTupleTwinSync_B() -> *mut EnumWithItemTupleTwinSyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumWithItemTupleTwinSyncKind {
-        B: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumWithItemTupleTwinSync_B {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumWithItemTupleTwinSyncSse_A(
-) -> *mut EnumWithItemTupleTwinSyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumWithItemTupleTwinSyncSseKind {
-        A: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumWithItemTupleTwinSyncSse_A {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_EnumWithItemTupleTwinSyncSse_B(
-) -> *mut EnumWithItemTupleTwinSyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(EnumWithItemTupleTwinSyncSseKind {
-        B: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_EnumWithItemTupleTwinSyncSse_B {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_KitchenSinkTwinNormal_Primitives() -> *mut KitchenSinkTwinNormalKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(KitchenSinkTwinNormalKind {
-        Primitives: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_KitchenSinkTwinNormal_Primitives {
-                int32: Default::default(),
-                float64: Default::default(),
-                boolean: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_KitchenSinkTwinNormal_Nested() -> *mut KitchenSinkTwinNormalKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(KitchenSinkTwinNormalKind {
-        Nested: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_KitchenSinkTwinNormal_Nested {
-                field0: Default::default(),
-                field1: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_KitchenSinkTwinNormal_Optional() -> *mut KitchenSinkTwinNormalKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(KitchenSinkTwinNormalKind {
-        Optional: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_KitchenSinkTwinNormal_Optional {
-                field0: core::ptr::null_mut(),
-                field1: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_KitchenSinkTwinNormal_Buffer() -> *mut KitchenSinkTwinNormalKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(KitchenSinkTwinNormalKind {
-        Buffer: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_KitchenSinkTwinNormal_Buffer {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_KitchenSinkTwinNormal_Enums() -> *mut KitchenSinkTwinNormalKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(KitchenSinkTwinNormalKind {
-        Enums: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_KitchenSinkTwinNormal_Enums {
-                field0: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_KitchenSinkTwinRustAsync_Primitives(
-) -> *mut KitchenSinkTwinRustAsyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(KitchenSinkTwinRustAsyncKind {
-        Primitives: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_KitchenSinkTwinRustAsync_Primitives {
-                int32: Default::default(),
-                float64: Default::default(),
-                boolean: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_KitchenSinkTwinRustAsync_Nested() -> *mut KitchenSinkTwinRustAsyncKind
-{
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(KitchenSinkTwinRustAsyncKind {
-        Nested: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_KitchenSinkTwinRustAsync_Nested {
-                field0: Default::default(),
-                field1: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_KitchenSinkTwinRustAsync_Optional(
-) -> *mut KitchenSinkTwinRustAsyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(KitchenSinkTwinRustAsyncKind {
-        Optional: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_KitchenSinkTwinRustAsync_Optional {
-                field0: core::ptr::null_mut(),
-                field1: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_KitchenSinkTwinRustAsync_Buffer() -> *mut KitchenSinkTwinRustAsyncKind
-{
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(KitchenSinkTwinRustAsyncKind {
-        Buffer: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_KitchenSinkTwinRustAsync_Buffer {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_KitchenSinkTwinRustAsync_Enums() -> *mut KitchenSinkTwinRustAsyncKind
-{
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(KitchenSinkTwinRustAsyncKind {
-        Enums: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_KitchenSinkTwinRustAsync_Enums {
-                field0: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_KitchenSinkTwinRustAsyncSse_Primitives(
-) -> *mut KitchenSinkTwinRustAsyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(KitchenSinkTwinRustAsyncSseKind {
-        Primitives: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_KitchenSinkTwinRustAsyncSse_Primitives {
-                int32: Default::default(),
-                float64: Default::default(),
-                boolean: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_KitchenSinkTwinRustAsyncSse_Nested(
-) -> *mut KitchenSinkTwinRustAsyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(KitchenSinkTwinRustAsyncSseKind {
-        Nested: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_KitchenSinkTwinRustAsyncSse_Nested {
-                field0: Default::default(),
-                field1: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_KitchenSinkTwinRustAsyncSse_Optional(
-) -> *mut KitchenSinkTwinRustAsyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(KitchenSinkTwinRustAsyncSseKind {
-        Optional: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_KitchenSinkTwinRustAsyncSse_Optional {
-                field0: core::ptr::null_mut(),
-                field1: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_KitchenSinkTwinRustAsyncSse_Buffer(
-) -> *mut KitchenSinkTwinRustAsyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(KitchenSinkTwinRustAsyncSseKind {
-        Buffer: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_KitchenSinkTwinRustAsyncSse_Buffer {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_KitchenSinkTwinRustAsyncSse_Enums(
-) -> *mut KitchenSinkTwinRustAsyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(KitchenSinkTwinRustAsyncSseKind {
-        Enums: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_KitchenSinkTwinRustAsyncSse_Enums {
-                field0: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_KitchenSinkTwinSse_Primitives() -> *mut KitchenSinkTwinSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(KitchenSinkTwinSseKind {
-        Primitives: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_KitchenSinkTwinSse_Primitives {
-                int32: Default::default(),
-                float64: Default::default(),
-                boolean: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_KitchenSinkTwinSse_Nested() -> *mut KitchenSinkTwinSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(KitchenSinkTwinSseKind {
-        Nested: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_KitchenSinkTwinSse_Nested {
-                field0: Default::default(),
-                field1: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_KitchenSinkTwinSse_Optional() -> *mut KitchenSinkTwinSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(KitchenSinkTwinSseKind {
-        Optional: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_KitchenSinkTwinSse_Optional {
-                field0: core::ptr::null_mut(),
-                field1: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_KitchenSinkTwinSse_Buffer() -> *mut KitchenSinkTwinSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(KitchenSinkTwinSseKind {
-        Buffer: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_KitchenSinkTwinSse_Buffer {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_KitchenSinkTwinSse_Enums() -> *mut KitchenSinkTwinSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(KitchenSinkTwinSseKind {
-        Enums: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_KitchenSinkTwinSse_Enums {
-                field0: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_KitchenSinkTwinSync_Primitives() -> *mut KitchenSinkTwinSyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(KitchenSinkTwinSyncKind {
-        Primitives: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_KitchenSinkTwinSync_Primitives {
-                int32: Default::default(),
-                float64: Default::default(),
-                boolean: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_KitchenSinkTwinSync_Nested() -> *mut KitchenSinkTwinSyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(KitchenSinkTwinSyncKind {
-        Nested: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_KitchenSinkTwinSync_Nested {
-                field0: Default::default(),
-                field1: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_KitchenSinkTwinSync_Optional() -> *mut KitchenSinkTwinSyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(KitchenSinkTwinSyncKind {
-        Optional: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_KitchenSinkTwinSync_Optional {
-                field0: core::ptr::null_mut(),
-                field1: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_KitchenSinkTwinSync_Buffer() -> *mut KitchenSinkTwinSyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(KitchenSinkTwinSyncKind {
-        Buffer: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_KitchenSinkTwinSync_Buffer {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_KitchenSinkTwinSync_Enums() -> *mut KitchenSinkTwinSyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(KitchenSinkTwinSyncKind {
-        Enums: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_KitchenSinkTwinSync_Enums {
-                field0: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_KitchenSinkTwinSyncSse_Primitives() -> *mut KitchenSinkTwinSyncSseKind
-{
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(KitchenSinkTwinSyncSseKind {
-        Primitives: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_KitchenSinkTwinSyncSse_Primitives {
-                int32: Default::default(),
-                float64: Default::default(),
-                boolean: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_KitchenSinkTwinSyncSse_Nested() -> *mut KitchenSinkTwinSyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(KitchenSinkTwinSyncSseKind {
-        Nested: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_KitchenSinkTwinSyncSse_Nested {
-                field0: Default::default(),
-                field1: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_KitchenSinkTwinSyncSse_Optional() -> *mut KitchenSinkTwinSyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(KitchenSinkTwinSyncSseKind {
-        Optional: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_KitchenSinkTwinSyncSse_Optional {
-                field0: core::ptr::null_mut(),
-                field1: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_KitchenSinkTwinSyncSse_Buffer() -> *mut KitchenSinkTwinSyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(KitchenSinkTwinSyncSseKind {
-        Buffer: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_KitchenSinkTwinSyncSse_Buffer {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_KitchenSinkTwinSyncSse_Enums() -> *mut KitchenSinkTwinSyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(KitchenSinkTwinSyncSseKind {
-        Enums: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_KitchenSinkTwinSyncSse_Enums {
-                field0: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_MeasureTwinNormal_Speed() -> *mut MeasureTwinNormalKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(MeasureTwinNormalKind {
-        Speed: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_MeasureTwinNormal_Speed {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_MeasureTwinNormal_Distance() -> *mut MeasureTwinNormalKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(MeasureTwinNormalKind {
-        Distance: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_MeasureTwinNormal_Distance {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_MeasureTwinRustAsync_Speed() -> *mut MeasureTwinRustAsyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(MeasureTwinRustAsyncKind {
-        Speed: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_MeasureTwinRustAsync_Speed {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_MeasureTwinRustAsync_Distance() -> *mut MeasureTwinRustAsyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(MeasureTwinRustAsyncKind {
-        Distance: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_MeasureTwinRustAsync_Distance {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_MeasureTwinRustAsyncSse_Speed() -> *mut MeasureTwinRustAsyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(MeasureTwinRustAsyncSseKind {
-        Speed: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_MeasureTwinRustAsyncSse_Speed {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_MeasureTwinRustAsyncSse_Distance() -> *mut MeasureTwinRustAsyncSseKind
-{
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(MeasureTwinRustAsyncSseKind {
-        Distance: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_MeasureTwinRustAsyncSse_Distance {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_MeasureTwinSse_Speed() -> *mut MeasureTwinSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(MeasureTwinSseKind {
-        Speed: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_MeasureTwinSse_Speed {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_MeasureTwinSse_Distance() -> *mut MeasureTwinSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(MeasureTwinSseKind {
-        Distance: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_MeasureTwinSse_Distance {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_MeasureTwinSync_Speed() -> *mut MeasureTwinSyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(MeasureTwinSyncKind {
-        Speed: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_MeasureTwinSync_Speed {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_MeasureTwinSync_Distance() -> *mut MeasureTwinSyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(MeasureTwinSyncKind {
-        Distance: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_MeasureTwinSync_Distance {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_MeasureTwinSyncSse_Speed() -> *mut MeasureTwinSyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(MeasureTwinSyncSseKind {
-        Speed: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_MeasureTwinSyncSse_Speed {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_MeasureTwinSyncSse_Distance() -> *mut MeasureTwinSyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(MeasureTwinSyncSseKind {
-        Distance: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_MeasureTwinSyncSse_Distance {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_RawStringEnumMirrored_Raw() -> *mut RawStringEnumMirroredKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(RawStringEnumMirroredKind {
-        Raw: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_RawStringEnumMirrored_Raw {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_RawStringEnumMirrored_Nested() -> *mut RawStringEnumMirroredKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(RawStringEnumMirroredKind {
-        Nested: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_RawStringEnumMirrored_Nested {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_RawStringEnumMirrored_ListOfNested() -> *mut RawStringEnumMirroredKind
-{
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(RawStringEnumMirroredKind {
-        ListOfNested: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_RawStringEnumMirrored_ListOfNested {
-                field0: core::ptr::null_mut(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_SpeedTwinNormal_GPS() -> *mut SpeedTwinNormalKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(SpeedTwinNormalKind {
-        GPS: flutter_rust_bridge::for_generated::new_leak_box_ptr(wire_cst_SpeedTwinNormal_GPS {
-            field0: Default::default(),
-        }),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_SpeedTwinRustAsync_GPS() -> *mut SpeedTwinRustAsyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(SpeedTwinRustAsyncKind {
-        GPS: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_SpeedTwinRustAsync_GPS {
-                field0: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_SpeedTwinRustAsyncSse_GPS() -> *mut SpeedTwinRustAsyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(SpeedTwinRustAsyncSseKind {
-        GPS: flutter_rust_bridge::for_generated::new_leak_box_ptr(
-            wire_cst_SpeedTwinRustAsyncSse_GPS {
-                field0: Default::default(),
-            },
-        ),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_SpeedTwinSse_GPS() -> *mut SpeedTwinSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(SpeedTwinSseKind {
-        GPS: flutter_rust_bridge::for_generated::new_leak_box_ptr(wire_cst_SpeedTwinSse_GPS {
-            field0: Default::default(),
-        }),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_SpeedTwinSync_GPS() -> *mut SpeedTwinSyncKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(SpeedTwinSyncKind {
-        GPS: flutter_rust_bridge::for_generated::new_leak_box_ptr(wire_cst_SpeedTwinSync_GPS {
-            field0: Default::default(),
-        }),
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn cst_inflate_SpeedTwinSyncSse_GPS() -> *mut SpeedTwinSyncSseKind {
-    flutter_rust_bridge::for_generated::new_leak_box_ptr(SpeedTwinSyncSseKind {
-        GPS: flutter_rust_bridge::for_generated::new_leak_box_ptr(wire_cst_SpeedTwinSyncSse_GPS {
-            field0: Default::default(),
-        }),
-    })
-}
-
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_a_twin_normal {
     a: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_a_twin_rust_async {
     a: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_a_twin_rust_async_sse {
     a: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_a_twin_sse {
     a: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_a_twin_sync {
     a: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_a_twin_sync_sse {
     a: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_abc_twin_normal {
     tag: i32,
-    kind: *mut AbcTwinNormalKind,
+    kind: AbcTwinNormalKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union AbcTwinNormalKind {
-    A: *mut wire_cst_AbcTwinNormal_A,
-    B: *mut wire_cst_AbcTwinNormal_B,
-    C: *mut wire_cst_AbcTwinNormal_C,
-    JustInt: *mut wire_cst_AbcTwinNormal_JustInt,
+    A: wire_cst_AbcTwinNormal_A,
+    B: wire_cst_AbcTwinNormal_B,
+    C: wire_cst_AbcTwinNormal_C,
+    JustInt: wire_cst_AbcTwinNormal_JustInt,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_AbcTwinNormal_A {
     field0: *mut wire_cst_a_twin_normal,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_AbcTwinNormal_B {
     field0: *mut wire_cst_b_twin_normal,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_AbcTwinNormal_C {
     field0: *mut wire_cst_c_twin_normal,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_AbcTwinNormal_JustInt {
     field0: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_abc_twin_rust_async {
     tag: i32,
-    kind: *mut AbcTwinRustAsyncKind,
+    kind: AbcTwinRustAsyncKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union AbcTwinRustAsyncKind {
-    A: *mut wire_cst_AbcTwinRustAsync_A,
-    B: *mut wire_cst_AbcTwinRustAsync_B,
-    C: *mut wire_cst_AbcTwinRustAsync_C,
-    JustInt: *mut wire_cst_AbcTwinRustAsync_JustInt,
+    A: wire_cst_AbcTwinRustAsync_A,
+    B: wire_cst_AbcTwinRustAsync_B,
+    C: wire_cst_AbcTwinRustAsync_C,
+    JustInt: wire_cst_AbcTwinRustAsync_JustInt,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_AbcTwinRustAsync_A {
     field0: *mut wire_cst_a_twin_rust_async,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_AbcTwinRustAsync_B {
     field0: *mut wire_cst_b_twin_rust_async,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_AbcTwinRustAsync_C {
     field0: *mut wire_cst_c_twin_rust_async,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_AbcTwinRustAsync_JustInt {
     field0: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_abc_twin_rust_async_sse {
     tag: i32,
-    kind: *mut AbcTwinRustAsyncSseKind,
+    kind: AbcTwinRustAsyncSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union AbcTwinRustAsyncSseKind {
-    A: *mut wire_cst_AbcTwinRustAsyncSse_A,
-    B: *mut wire_cst_AbcTwinRustAsyncSse_B,
-    C: *mut wire_cst_AbcTwinRustAsyncSse_C,
-    JustInt: *mut wire_cst_AbcTwinRustAsyncSse_JustInt,
+    A: wire_cst_AbcTwinRustAsyncSse_A,
+    B: wire_cst_AbcTwinRustAsyncSse_B,
+    C: wire_cst_AbcTwinRustAsyncSse_C,
+    JustInt: wire_cst_AbcTwinRustAsyncSse_JustInt,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_AbcTwinRustAsyncSse_A {
     field0: *mut wire_cst_a_twin_rust_async_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_AbcTwinRustAsyncSse_B {
     field0: *mut wire_cst_b_twin_rust_async_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_AbcTwinRustAsyncSse_C {
     field0: *mut wire_cst_c_twin_rust_async_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_AbcTwinRustAsyncSse_JustInt {
     field0: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_abc_twin_sse {
     tag: i32,
-    kind: *mut AbcTwinSseKind,
+    kind: AbcTwinSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union AbcTwinSseKind {
-    A: *mut wire_cst_AbcTwinSse_A,
-    B: *mut wire_cst_AbcTwinSse_B,
-    C: *mut wire_cst_AbcTwinSse_C,
-    JustInt: *mut wire_cst_AbcTwinSse_JustInt,
+    A: wire_cst_AbcTwinSse_A,
+    B: wire_cst_AbcTwinSse_B,
+    C: wire_cst_AbcTwinSse_C,
+    JustInt: wire_cst_AbcTwinSse_JustInt,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_AbcTwinSse_A {
     field0: *mut wire_cst_a_twin_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_AbcTwinSse_B {
     field0: *mut wire_cst_b_twin_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_AbcTwinSse_C {
     field0: *mut wire_cst_c_twin_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_AbcTwinSse_JustInt {
     field0: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_abc_twin_sync {
     tag: i32,
-    kind: *mut AbcTwinSyncKind,
+    kind: AbcTwinSyncKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union AbcTwinSyncKind {
-    A: *mut wire_cst_AbcTwinSync_A,
-    B: *mut wire_cst_AbcTwinSync_B,
-    C: *mut wire_cst_AbcTwinSync_C,
-    JustInt: *mut wire_cst_AbcTwinSync_JustInt,
+    A: wire_cst_AbcTwinSync_A,
+    B: wire_cst_AbcTwinSync_B,
+    C: wire_cst_AbcTwinSync_C,
+    JustInt: wire_cst_AbcTwinSync_JustInt,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_AbcTwinSync_A {
     field0: *mut wire_cst_a_twin_sync,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_AbcTwinSync_B {
     field0: *mut wire_cst_b_twin_sync,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_AbcTwinSync_C {
     field0: *mut wire_cst_c_twin_sync,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_AbcTwinSync_JustInt {
     field0: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_abc_twin_sync_sse {
     tag: i32,
-    kind: *mut AbcTwinSyncSseKind,
+    kind: AbcTwinSyncSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union AbcTwinSyncSseKind {
-    A: *mut wire_cst_AbcTwinSyncSse_A,
-    B: *mut wire_cst_AbcTwinSyncSse_B,
-    C: *mut wire_cst_AbcTwinSyncSse_C,
-    JustInt: *mut wire_cst_AbcTwinSyncSse_JustInt,
+    A: wire_cst_AbcTwinSyncSse_A,
+    B: wire_cst_AbcTwinSyncSse_B,
+    C: wire_cst_AbcTwinSyncSse_C,
+    JustInt: wire_cst_AbcTwinSyncSse_JustInt,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_AbcTwinSyncSse_A {
     field0: *mut wire_cst_a_twin_sync_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_AbcTwinSyncSse_B {
     field0: *mut wire_cst_b_twin_sync_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_AbcTwinSyncSse_C {
     field0: *mut wire_cst_c_twin_sync_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_AbcTwinSyncSse_JustInt {
     field0: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_another_macro_struct_twin_normal {
     data: i32,
     non_final_data: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_another_twin_normal {
     a: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_another_twin_rust_async {
     a: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_another_twin_rust_async_sse {
     a: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_another_twin_sse {
     a: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_another_twin_sync {
     a: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_another_twin_sync_sse {
     a: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_application_env {
     vars: *mut wire_cst_list_application_env_var,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_application_env_var {
     field0: *mut wire_cst_list_prim_u_8,
     field1: bool,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_application_message {
     tag: i32,
-    kind: *mut ApplicationMessageKind,
+    kind: ApplicationMessageKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union ApplicationMessageKind {
-    DisplayMessage: *mut wire_cst_ApplicationMessage_DisplayMessage,
-    RenderPixel: *mut wire_cst_ApplicationMessage_RenderPixel,
-    Exit: *mut wire_cst_ApplicationMessage_Exit,
+    DisplayMessage: wire_cst_ApplicationMessage_DisplayMessage,
+    RenderPixel: wire_cst_ApplicationMessage_RenderPixel,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_ApplicationMessage_DisplayMessage {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_ApplicationMessage_RenderPixel {
     x: i32,
     y: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
-pub struct wire_cst_ApplicationMessage_Exit {}
-#[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_application_settings {
     name: *mut wire_cst_list_prim_u_8,
     version: *mut wire_cst_list_prim_u_8,
@@ -36692,1395 +33777,1455 @@ pub struct wire_cst_application_settings {
     env_optional: *mut wire_cst_application_env,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_attribute_twin_normal {
     key: *mut wire_cst_list_prim_u_8,
     value: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_attribute_twin_rust_async {
     key: *mut wire_cst_list_prim_u_8,
     value: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_attribute_twin_rust_async_sse {
     key: *mut wire_cst_list_prim_u_8,
     value: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_attribute_twin_sse {
     key: *mut wire_cst_list_prim_u_8,
     value: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_attribute_twin_sync {
     key: *mut wire_cst_list_prim_u_8,
     value: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_attribute_twin_sync_sse {
     key: *mut wire_cst_list_prim_u_8,
     value: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_b_twin_normal {
     b: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_b_twin_rust_async {
     b: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_b_twin_rust_async_sse {
     b: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_b_twin_sse {
     b: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_b_twin_sync {
     b: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_b_twin_sync_sse {
     b: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_benchmark_binary_tree_twin_normal {
     name: *mut wire_cst_list_prim_u_8,
     left: *mut wire_cst_benchmark_binary_tree_twin_normal,
     right: *mut wire_cst_benchmark_binary_tree_twin_normal,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_benchmark_binary_tree_twin_rust_async {
     name: *mut wire_cst_list_prim_u_8,
     left: *mut wire_cst_benchmark_binary_tree_twin_rust_async,
     right: *mut wire_cst_benchmark_binary_tree_twin_rust_async,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_benchmark_binary_tree_twin_rust_async_sse {
     name: *mut wire_cst_list_prim_u_8,
     left: *mut wire_cst_benchmark_binary_tree_twin_rust_async_sse,
     right: *mut wire_cst_benchmark_binary_tree_twin_rust_async_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_benchmark_binary_tree_twin_sse {
     name: *mut wire_cst_list_prim_u_8,
     left: *mut wire_cst_benchmark_binary_tree_twin_sse,
     right: *mut wire_cst_benchmark_binary_tree_twin_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_benchmark_binary_tree_twin_sync {
     name: *mut wire_cst_list_prim_u_8,
     left: *mut wire_cst_benchmark_binary_tree_twin_sync,
     right: *mut wire_cst_benchmark_binary_tree_twin_sync,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_benchmark_binary_tree_twin_sync_sse {
     name: *mut wire_cst_list_prim_u_8,
     left: *mut wire_cst_benchmark_binary_tree_twin_sync_sse,
     right: *mut wire_cst_benchmark_binary_tree_twin_sync_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_benchmark_blob_twin_normal {
     first: *mut wire_cst_list_prim_u_8,
     second: *mut wire_cst_list_prim_u_8,
     third: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_benchmark_blob_twin_rust_async {
     first: *mut wire_cst_list_prim_u_8,
     second: *mut wire_cst_list_prim_u_8,
     third: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_benchmark_blob_twin_rust_async_sse {
     first: *mut wire_cst_list_prim_u_8,
     second: *mut wire_cst_list_prim_u_8,
     third: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_benchmark_blob_twin_sse {
     first: *mut wire_cst_list_prim_u_8,
     second: *mut wire_cst_list_prim_u_8,
     third: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_benchmark_blob_twin_sync {
     first: *mut wire_cst_list_prim_u_8,
     second: *mut wire_cst_list_prim_u_8,
     third: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_benchmark_blob_twin_sync_sse {
     first: *mut wire_cst_list_prim_u_8,
     second: *mut wire_cst_list_prim_u_8,
     third: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_big_buffers_twin_normal {
     int64: *mut wire_cst_list_prim_i_64,
     uint64: *mut wire_cst_list_prim_u_64,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_big_buffers_twin_rust_async {
     int64: *mut wire_cst_list_prim_i_64,
     uint64: *mut wire_cst_list_prim_u_64,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_big_buffers_twin_rust_async_sse {
     int64: *mut wire_cst_list_prim_i_64,
     uint64: *mut wire_cst_list_prim_u_64,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_big_buffers_twin_sse {
     int64: *mut wire_cst_list_prim_i_64,
     uint64: *mut wire_cst_list_prim_u_64,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_big_buffers_twin_sync {
     int64: *mut wire_cst_list_prim_i_64,
     uint64: *mut wire_cst_list_prim_u_64,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_big_buffers_twin_sync_sse {
     int64: *mut wire_cst_list_prim_i_64,
     uint64: *mut wire_cst_list_prim_u_64,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_blob_twin_normal {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_blob_twin_rust_async {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_blob_twin_rust_async_sse {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_blob_twin_sse {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_blob_twin_sync {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_blob_twin_sync_sse {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_c_twin_normal {
     c: bool,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_c_twin_rust_async {
     c: bool,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_c_twin_rust_async_sse {
     c: bool,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_c_twin_sse {
     c: bool,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_c_twin_sync {
     c: bool,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_c_twin_sync_sse {
     c: bool,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_concatenate_with_twin_normal {
     a: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_concatenate_with_twin_rust_async {
     a: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_concatenate_with_twin_rust_async_sse {
     a: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_concatenate_with_twin_sse {
     a: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_concatenate_with_twin_sync {
     a: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_concatenate_with_twin_sync_sse {
     a: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_contains_mirrored_sub_struct_twin_normal {
     test: wire_cst_raw_string_mirrored,
     test2: wire_cst_another_twin_normal,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_contains_mirrored_sub_struct_twin_rust_async {
     test: wire_cst_raw_string_mirrored,
     test2: wire_cst_another_twin_rust_async,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_contains_mirrored_sub_struct_twin_rust_async_sse {
     test: wire_cst_raw_string_mirrored,
     test2: wire_cst_another_twin_rust_async_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_contains_mirrored_sub_struct_twin_sse {
     test: wire_cst_raw_string_mirrored,
     test2: wire_cst_another_twin_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_contains_mirrored_sub_struct_twin_sync {
     test: wire_cst_raw_string_mirrored,
     test2: wire_cst_another_twin_sync,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_contains_mirrored_sub_struct_twin_sync_sse {
     test: wire_cst_raw_string_mirrored,
     test2: wire_cst_another_twin_sync_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_enum_error_twin_normal {
     tag: i32,
-    kind: *mut CustomEnumErrorTwinNormalKind,
+    kind: CustomEnumErrorTwinNormalKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union CustomEnumErrorTwinNormalKind {
-    One: *mut wire_cst_CustomEnumErrorTwinNormal_One,
-    Two: *mut wire_cst_CustomEnumErrorTwinNormal_Two,
+    One: wire_cst_CustomEnumErrorTwinNormal_One,
+    Two: wire_cst_CustomEnumErrorTwinNormal_Two,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomEnumErrorTwinNormal_One {
     message: *mut wire_cst_list_prim_u_8,
     backtrace: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomEnumErrorTwinNormal_Two {
     message: u32,
     backtrace: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_enum_error_twin_rust_async {
     tag: i32,
-    kind: *mut CustomEnumErrorTwinRustAsyncKind,
+    kind: CustomEnumErrorTwinRustAsyncKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union CustomEnumErrorTwinRustAsyncKind {
-    One: *mut wire_cst_CustomEnumErrorTwinRustAsync_One,
-    Two: *mut wire_cst_CustomEnumErrorTwinRustAsync_Two,
+    One: wire_cst_CustomEnumErrorTwinRustAsync_One,
+    Two: wire_cst_CustomEnumErrorTwinRustAsync_Two,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomEnumErrorTwinRustAsync_One {
     message: *mut wire_cst_list_prim_u_8,
     backtrace: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomEnumErrorTwinRustAsync_Two {
     message: u32,
     backtrace: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_enum_error_twin_rust_async_sse {
     tag: i32,
-    kind: *mut CustomEnumErrorTwinRustAsyncSseKind,
+    kind: CustomEnumErrorTwinRustAsyncSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union CustomEnumErrorTwinRustAsyncSseKind {
-    One: *mut wire_cst_CustomEnumErrorTwinRustAsyncSse_One,
-    Two: *mut wire_cst_CustomEnumErrorTwinRustAsyncSse_Two,
+    One: wire_cst_CustomEnumErrorTwinRustAsyncSse_One,
+    Two: wire_cst_CustomEnumErrorTwinRustAsyncSse_Two,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomEnumErrorTwinRustAsyncSse_One {
     message: *mut wire_cst_list_prim_u_8,
     backtrace: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomEnumErrorTwinRustAsyncSse_Two {
     message: u32,
     backtrace: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_enum_error_twin_sse {
     tag: i32,
-    kind: *mut CustomEnumErrorTwinSseKind,
+    kind: CustomEnumErrorTwinSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union CustomEnumErrorTwinSseKind {
-    One: *mut wire_cst_CustomEnumErrorTwinSse_One,
-    Two: *mut wire_cst_CustomEnumErrorTwinSse_Two,
+    One: wire_cst_CustomEnumErrorTwinSse_One,
+    Two: wire_cst_CustomEnumErrorTwinSse_Two,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomEnumErrorTwinSse_One {
     message: *mut wire_cst_list_prim_u_8,
     backtrace: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomEnumErrorTwinSse_Two {
     message: u32,
     backtrace: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_enum_error_twin_sync {
     tag: i32,
-    kind: *mut CustomEnumErrorTwinSyncKind,
+    kind: CustomEnumErrorTwinSyncKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union CustomEnumErrorTwinSyncKind {
-    One: *mut wire_cst_CustomEnumErrorTwinSync_One,
-    Two: *mut wire_cst_CustomEnumErrorTwinSync_Two,
+    One: wire_cst_CustomEnumErrorTwinSync_One,
+    Two: wire_cst_CustomEnumErrorTwinSync_Two,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomEnumErrorTwinSync_One {
     message: *mut wire_cst_list_prim_u_8,
     backtrace: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomEnumErrorTwinSync_Two {
     message: u32,
     backtrace: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_enum_error_twin_sync_sse {
     tag: i32,
-    kind: *mut CustomEnumErrorTwinSyncSseKind,
+    kind: CustomEnumErrorTwinSyncSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union CustomEnumErrorTwinSyncSseKind {
-    One: *mut wire_cst_CustomEnumErrorTwinSyncSse_One,
-    Two: *mut wire_cst_CustomEnumErrorTwinSyncSse_Two,
+    One: wire_cst_CustomEnumErrorTwinSyncSse_One,
+    Two: wire_cst_CustomEnumErrorTwinSyncSse_Two,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomEnumErrorTwinSyncSse_One {
     message: *mut wire_cst_list_prim_u_8,
     backtrace: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomEnumErrorTwinSyncSse_Two {
     message: u32,
     backtrace: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_error_twin_normal {
     tag: i32,
-    kind: *mut CustomErrorTwinNormalKind,
+    kind: CustomErrorTwinNormalKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union CustomErrorTwinNormalKind {
-    Error0: *mut wire_cst_CustomErrorTwinNormal_Error0,
-    Error1: *mut wire_cst_CustomErrorTwinNormal_Error1,
+    Error0: wire_cst_CustomErrorTwinNormal_Error0,
+    Error1: wire_cst_CustomErrorTwinNormal_Error1,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomErrorTwinNormal_Error0 {
     e: *mut wire_cst_list_prim_u_8,
     backtrace: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomErrorTwinNormal_Error1 {
     e: u32,
     backtrace: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_error_twin_rust_async {
     tag: i32,
-    kind: *mut CustomErrorTwinRustAsyncKind,
+    kind: CustomErrorTwinRustAsyncKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union CustomErrorTwinRustAsyncKind {
-    Error0: *mut wire_cst_CustomErrorTwinRustAsync_Error0,
-    Error1: *mut wire_cst_CustomErrorTwinRustAsync_Error1,
+    Error0: wire_cst_CustomErrorTwinRustAsync_Error0,
+    Error1: wire_cst_CustomErrorTwinRustAsync_Error1,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomErrorTwinRustAsync_Error0 {
     e: *mut wire_cst_list_prim_u_8,
     backtrace: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomErrorTwinRustAsync_Error1 {
     e: u32,
     backtrace: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_error_twin_rust_async_sse {
     tag: i32,
-    kind: *mut CustomErrorTwinRustAsyncSseKind,
+    kind: CustomErrorTwinRustAsyncSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union CustomErrorTwinRustAsyncSseKind {
-    Error0: *mut wire_cst_CustomErrorTwinRustAsyncSse_Error0,
-    Error1: *mut wire_cst_CustomErrorTwinRustAsyncSse_Error1,
+    Error0: wire_cst_CustomErrorTwinRustAsyncSse_Error0,
+    Error1: wire_cst_CustomErrorTwinRustAsyncSse_Error1,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomErrorTwinRustAsyncSse_Error0 {
     e: *mut wire_cst_list_prim_u_8,
     backtrace: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomErrorTwinRustAsyncSse_Error1 {
     e: u32,
     backtrace: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_error_twin_sse {
     tag: i32,
-    kind: *mut CustomErrorTwinSseKind,
+    kind: CustomErrorTwinSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union CustomErrorTwinSseKind {
-    Error0: *mut wire_cst_CustomErrorTwinSse_Error0,
-    Error1: *mut wire_cst_CustomErrorTwinSse_Error1,
+    Error0: wire_cst_CustomErrorTwinSse_Error0,
+    Error1: wire_cst_CustomErrorTwinSse_Error1,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomErrorTwinSse_Error0 {
     e: *mut wire_cst_list_prim_u_8,
     backtrace: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomErrorTwinSse_Error1 {
     e: u32,
     backtrace: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_error_twin_sync {
     tag: i32,
-    kind: *mut CustomErrorTwinSyncKind,
+    kind: CustomErrorTwinSyncKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union CustomErrorTwinSyncKind {
-    Error0: *mut wire_cst_CustomErrorTwinSync_Error0,
-    Error1: *mut wire_cst_CustomErrorTwinSync_Error1,
+    Error0: wire_cst_CustomErrorTwinSync_Error0,
+    Error1: wire_cst_CustomErrorTwinSync_Error1,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomErrorTwinSync_Error0 {
     e: *mut wire_cst_list_prim_u_8,
     backtrace: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomErrorTwinSync_Error1 {
     e: u32,
     backtrace: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_error_twin_sync_sse {
     tag: i32,
-    kind: *mut CustomErrorTwinSyncSseKind,
+    kind: CustomErrorTwinSyncSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union CustomErrorTwinSyncSseKind {
-    Error0: *mut wire_cst_CustomErrorTwinSyncSse_Error0,
-    Error1: *mut wire_cst_CustomErrorTwinSyncSse_Error1,
+    Error0: wire_cst_CustomErrorTwinSyncSse_Error0,
+    Error1: wire_cst_CustomErrorTwinSyncSse_Error1,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomErrorTwinSyncSse_Error0 {
     e: *mut wire_cst_list_prim_u_8,
     backtrace: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomErrorTwinSyncSse_Error1 {
     e: u32,
     backtrace: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_nested_error_1_twin_normal {
     tag: i32,
-    kind: *mut CustomNestedError1TwinNormalKind,
+    kind: CustomNestedError1TwinNormalKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union CustomNestedError1TwinNormalKind {
-    CustomNested1: *mut wire_cst_CustomNestedError1TwinNormal_CustomNested1,
-    ErrorNested: *mut wire_cst_CustomNestedError1TwinNormal_ErrorNested,
+    CustomNested1: wire_cst_CustomNestedError1TwinNormal_CustomNested1,
+    ErrorNested: wire_cst_CustomNestedError1TwinNormal_ErrorNested,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedError1TwinNormal_CustomNested1 {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedError1TwinNormal_ErrorNested {
     field0: *mut wire_cst_custom_nested_error_2_twin_normal,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_nested_error_1_twin_rust_async {
     tag: i32,
-    kind: *mut CustomNestedError1TwinRustAsyncKind,
+    kind: CustomNestedError1TwinRustAsyncKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union CustomNestedError1TwinRustAsyncKind {
-    CustomNested1: *mut wire_cst_CustomNestedError1TwinRustAsync_CustomNested1,
-    ErrorNested: *mut wire_cst_CustomNestedError1TwinRustAsync_ErrorNested,
+    CustomNested1: wire_cst_CustomNestedError1TwinRustAsync_CustomNested1,
+    ErrorNested: wire_cst_CustomNestedError1TwinRustAsync_ErrorNested,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedError1TwinRustAsync_CustomNested1 {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedError1TwinRustAsync_ErrorNested {
     field0: *mut wire_cst_custom_nested_error_2_twin_rust_async,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_nested_error_1_twin_rust_async_sse {
     tag: i32,
-    kind: *mut CustomNestedError1TwinRustAsyncSseKind,
+    kind: CustomNestedError1TwinRustAsyncSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union CustomNestedError1TwinRustAsyncSseKind {
-    CustomNested1: *mut wire_cst_CustomNestedError1TwinRustAsyncSse_CustomNested1,
-    ErrorNested: *mut wire_cst_CustomNestedError1TwinRustAsyncSse_ErrorNested,
+    CustomNested1: wire_cst_CustomNestedError1TwinRustAsyncSse_CustomNested1,
+    ErrorNested: wire_cst_CustomNestedError1TwinRustAsyncSse_ErrorNested,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedError1TwinRustAsyncSse_CustomNested1 {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedError1TwinRustAsyncSse_ErrorNested {
     field0: *mut wire_cst_custom_nested_error_2_twin_rust_async_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_nested_error_1_twin_sse {
     tag: i32,
-    kind: *mut CustomNestedError1TwinSseKind,
+    kind: CustomNestedError1TwinSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union CustomNestedError1TwinSseKind {
-    CustomNested1: *mut wire_cst_CustomNestedError1TwinSse_CustomNested1,
-    ErrorNested: *mut wire_cst_CustomNestedError1TwinSse_ErrorNested,
+    CustomNested1: wire_cst_CustomNestedError1TwinSse_CustomNested1,
+    ErrorNested: wire_cst_CustomNestedError1TwinSse_ErrorNested,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedError1TwinSse_CustomNested1 {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedError1TwinSse_ErrorNested {
     field0: *mut wire_cst_custom_nested_error_2_twin_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_nested_error_1_twin_sync {
     tag: i32,
-    kind: *mut CustomNestedError1TwinSyncKind,
+    kind: CustomNestedError1TwinSyncKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union CustomNestedError1TwinSyncKind {
-    CustomNested1: *mut wire_cst_CustomNestedError1TwinSync_CustomNested1,
-    ErrorNested: *mut wire_cst_CustomNestedError1TwinSync_ErrorNested,
+    CustomNested1: wire_cst_CustomNestedError1TwinSync_CustomNested1,
+    ErrorNested: wire_cst_CustomNestedError1TwinSync_ErrorNested,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedError1TwinSync_CustomNested1 {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedError1TwinSync_ErrorNested {
     field0: *mut wire_cst_custom_nested_error_2_twin_sync,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_nested_error_1_twin_sync_sse {
     tag: i32,
-    kind: *mut CustomNestedError1TwinSyncSseKind,
+    kind: CustomNestedError1TwinSyncSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union CustomNestedError1TwinSyncSseKind {
-    CustomNested1: *mut wire_cst_CustomNestedError1TwinSyncSse_CustomNested1,
-    ErrorNested: *mut wire_cst_CustomNestedError1TwinSyncSse_ErrorNested,
+    CustomNested1: wire_cst_CustomNestedError1TwinSyncSse_CustomNested1,
+    ErrorNested: wire_cst_CustomNestedError1TwinSyncSse_ErrorNested,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedError1TwinSyncSse_CustomNested1 {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedError1TwinSyncSse_ErrorNested {
     field0: *mut wire_cst_custom_nested_error_2_twin_sync_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_nested_error_2_twin_normal {
     tag: i32,
-    kind: *mut CustomNestedError2TwinNormalKind,
+    kind: CustomNestedError2TwinNormalKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union CustomNestedError2TwinNormalKind {
-    CustomNested2: *mut wire_cst_CustomNestedError2TwinNormal_CustomNested2,
-    CustomNested2Number: *mut wire_cst_CustomNestedError2TwinNormal_CustomNested2Number,
+    CustomNested2: wire_cst_CustomNestedError2TwinNormal_CustomNested2,
+    CustomNested2Number: wire_cst_CustomNestedError2TwinNormal_CustomNested2Number,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedError2TwinNormal_CustomNested2 {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedError2TwinNormal_CustomNested2Number {
     field0: u32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_nested_error_2_twin_rust_async {
     tag: i32,
-    kind: *mut CustomNestedError2TwinRustAsyncKind,
+    kind: CustomNestedError2TwinRustAsyncKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union CustomNestedError2TwinRustAsyncKind {
-    CustomNested2: *mut wire_cst_CustomNestedError2TwinRustAsync_CustomNested2,
-    CustomNested2Number: *mut wire_cst_CustomNestedError2TwinRustAsync_CustomNested2Number,
+    CustomNested2: wire_cst_CustomNestedError2TwinRustAsync_CustomNested2,
+    CustomNested2Number: wire_cst_CustomNestedError2TwinRustAsync_CustomNested2Number,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedError2TwinRustAsync_CustomNested2 {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedError2TwinRustAsync_CustomNested2Number {
     field0: u32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_nested_error_2_twin_rust_async_sse {
     tag: i32,
-    kind: *mut CustomNestedError2TwinRustAsyncSseKind,
+    kind: CustomNestedError2TwinRustAsyncSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union CustomNestedError2TwinRustAsyncSseKind {
-    CustomNested2: *mut wire_cst_CustomNestedError2TwinRustAsyncSse_CustomNested2,
-    CustomNested2Number: *mut wire_cst_CustomNestedError2TwinRustAsyncSse_CustomNested2Number,
+    CustomNested2: wire_cst_CustomNestedError2TwinRustAsyncSse_CustomNested2,
+    CustomNested2Number: wire_cst_CustomNestedError2TwinRustAsyncSse_CustomNested2Number,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedError2TwinRustAsyncSse_CustomNested2 {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedError2TwinRustAsyncSse_CustomNested2Number {
     field0: u32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_nested_error_2_twin_sse {
     tag: i32,
-    kind: *mut CustomNestedError2TwinSseKind,
+    kind: CustomNestedError2TwinSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union CustomNestedError2TwinSseKind {
-    CustomNested2: *mut wire_cst_CustomNestedError2TwinSse_CustomNested2,
-    CustomNested2Number: *mut wire_cst_CustomNestedError2TwinSse_CustomNested2Number,
+    CustomNested2: wire_cst_CustomNestedError2TwinSse_CustomNested2,
+    CustomNested2Number: wire_cst_CustomNestedError2TwinSse_CustomNested2Number,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedError2TwinSse_CustomNested2 {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedError2TwinSse_CustomNested2Number {
     field0: u32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_nested_error_2_twin_sync {
     tag: i32,
-    kind: *mut CustomNestedError2TwinSyncKind,
+    kind: CustomNestedError2TwinSyncKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union CustomNestedError2TwinSyncKind {
-    CustomNested2: *mut wire_cst_CustomNestedError2TwinSync_CustomNested2,
-    CustomNested2Number: *mut wire_cst_CustomNestedError2TwinSync_CustomNested2Number,
+    CustomNested2: wire_cst_CustomNestedError2TwinSync_CustomNested2,
+    CustomNested2Number: wire_cst_CustomNestedError2TwinSync_CustomNested2Number,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedError2TwinSync_CustomNested2 {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedError2TwinSync_CustomNested2Number {
     field0: u32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_nested_error_2_twin_sync_sse {
     tag: i32,
-    kind: *mut CustomNestedError2TwinSyncSseKind,
+    kind: CustomNestedError2TwinSyncSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union CustomNestedError2TwinSyncSseKind {
-    CustomNested2: *mut wire_cst_CustomNestedError2TwinSyncSse_CustomNested2,
-    CustomNested2Number: *mut wire_cst_CustomNestedError2TwinSyncSse_CustomNested2Number,
+    CustomNested2: wire_cst_CustomNestedError2TwinSyncSse_CustomNested2,
+    CustomNested2Number: wire_cst_CustomNestedError2TwinSyncSse_CustomNested2Number,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedError2TwinSyncSse_CustomNested2 {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedError2TwinSyncSse_CustomNested2Number {
     field0: u32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_nested_error_inner_twin_normal {
     tag: i32,
-    kind: *mut CustomNestedErrorInnerTwinNormalKind,
+    kind: CustomNestedErrorInnerTwinNormalKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union CustomNestedErrorInnerTwinNormalKind {
-    Three: *mut wire_cst_CustomNestedErrorInnerTwinNormal_Three,
-    Four: *mut wire_cst_CustomNestedErrorInnerTwinNormal_Four,
+    Three: wire_cst_CustomNestedErrorInnerTwinNormal_Three,
+    Four: wire_cst_CustomNestedErrorInnerTwinNormal_Four,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedErrorInnerTwinNormal_Three {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedErrorInnerTwinNormal_Four {
     field0: u32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_nested_error_inner_twin_rust_async {
     tag: i32,
-    kind: *mut CustomNestedErrorInnerTwinRustAsyncKind,
+    kind: CustomNestedErrorInnerTwinRustAsyncKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union CustomNestedErrorInnerTwinRustAsyncKind {
-    Three: *mut wire_cst_CustomNestedErrorInnerTwinRustAsync_Three,
-    Four: *mut wire_cst_CustomNestedErrorInnerTwinRustAsync_Four,
+    Three: wire_cst_CustomNestedErrorInnerTwinRustAsync_Three,
+    Four: wire_cst_CustomNestedErrorInnerTwinRustAsync_Four,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedErrorInnerTwinRustAsync_Three {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedErrorInnerTwinRustAsync_Four {
     field0: u32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_nested_error_inner_twin_rust_async_sse {
     tag: i32,
-    kind: *mut CustomNestedErrorInnerTwinRustAsyncSseKind,
+    kind: CustomNestedErrorInnerTwinRustAsyncSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union CustomNestedErrorInnerTwinRustAsyncSseKind {
-    Three: *mut wire_cst_CustomNestedErrorInnerTwinRustAsyncSse_Three,
-    Four: *mut wire_cst_CustomNestedErrorInnerTwinRustAsyncSse_Four,
+    Three: wire_cst_CustomNestedErrorInnerTwinRustAsyncSse_Three,
+    Four: wire_cst_CustomNestedErrorInnerTwinRustAsyncSse_Four,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedErrorInnerTwinRustAsyncSse_Three {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedErrorInnerTwinRustAsyncSse_Four {
     field0: u32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_nested_error_inner_twin_sse {
     tag: i32,
-    kind: *mut CustomNestedErrorInnerTwinSseKind,
+    kind: CustomNestedErrorInnerTwinSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union CustomNestedErrorInnerTwinSseKind {
-    Three: *mut wire_cst_CustomNestedErrorInnerTwinSse_Three,
-    Four: *mut wire_cst_CustomNestedErrorInnerTwinSse_Four,
+    Three: wire_cst_CustomNestedErrorInnerTwinSse_Three,
+    Four: wire_cst_CustomNestedErrorInnerTwinSse_Four,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedErrorInnerTwinSse_Three {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedErrorInnerTwinSse_Four {
     field0: u32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_nested_error_inner_twin_sync {
     tag: i32,
-    kind: *mut CustomNestedErrorInnerTwinSyncKind,
+    kind: CustomNestedErrorInnerTwinSyncKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union CustomNestedErrorInnerTwinSyncKind {
-    Three: *mut wire_cst_CustomNestedErrorInnerTwinSync_Three,
-    Four: *mut wire_cst_CustomNestedErrorInnerTwinSync_Four,
+    Three: wire_cst_CustomNestedErrorInnerTwinSync_Three,
+    Four: wire_cst_CustomNestedErrorInnerTwinSync_Four,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedErrorInnerTwinSync_Three {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedErrorInnerTwinSync_Four {
     field0: u32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_nested_error_inner_twin_sync_sse {
     tag: i32,
-    kind: *mut CustomNestedErrorInnerTwinSyncSseKind,
+    kind: CustomNestedErrorInnerTwinSyncSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union CustomNestedErrorInnerTwinSyncSseKind {
-    Three: *mut wire_cst_CustomNestedErrorInnerTwinSyncSse_Three,
-    Four: *mut wire_cst_CustomNestedErrorInnerTwinSyncSse_Four,
+    Three: wire_cst_CustomNestedErrorInnerTwinSyncSse_Three,
+    Four: wire_cst_CustomNestedErrorInnerTwinSyncSse_Four,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedErrorInnerTwinSyncSse_Three {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedErrorInnerTwinSyncSse_Four {
     field0: u32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_nested_error_outer_twin_normal {
     tag: i32,
-    kind: *mut CustomNestedErrorOuterTwinNormalKind,
+    kind: CustomNestedErrorOuterTwinNormalKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union CustomNestedErrorOuterTwinNormalKind {
-    One: *mut wire_cst_CustomNestedErrorOuterTwinNormal_One,
-    Two: *mut wire_cst_CustomNestedErrorOuterTwinNormal_Two,
+    One: wire_cst_CustomNestedErrorOuterTwinNormal_One,
+    Two: wire_cst_CustomNestedErrorOuterTwinNormal_Two,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedErrorOuterTwinNormal_One {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedErrorOuterTwinNormal_Two {
     field0: *mut wire_cst_custom_nested_error_inner_twin_normal,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_nested_error_outer_twin_rust_async {
     tag: i32,
-    kind: *mut CustomNestedErrorOuterTwinRustAsyncKind,
+    kind: CustomNestedErrorOuterTwinRustAsyncKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union CustomNestedErrorOuterTwinRustAsyncKind {
-    One: *mut wire_cst_CustomNestedErrorOuterTwinRustAsync_One,
-    Two: *mut wire_cst_CustomNestedErrorOuterTwinRustAsync_Two,
+    One: wire_cst_CustomNestedErrorOuterTwinRustAsync_One,
+    Two: wire_cst_CustomNestedErrorOuterTwinRustAsync_Two,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedErrorOuterTwinRustAsync_One {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedErrorOuterTwinRustAsync_Two {
     field0: *mut wire_cst_custom_nested_error_inner_twin_rust_async,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_nested_error_outer_twin_rust_async_sse {
     tag: i32,
-    kind: *mut CustomNestedErrorOuterTwinRustAsyncSseKind,
+    kind: CustomNestedErrorOuterTwinRustAsyncSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union CustomNestedErrorOuterTwinRustAsyncSseKind {
-    One: *mut wire_cst_CustomNestedErrorOuterTwinRustAsyncSse_One,
-    Two: *mut wire_cst_CustomNestedErrorOuterTwinRustAsyncSse_Two,
+    One: wire_cst_CustomNestedErrorOuterTwinRustAsyncSse_One,
+    Two: wire_cst_CustomNestedErrorOuterTwinRustAsyncSse_Two,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedErrorOuterTwinRustAsyncSse_One {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedErrorOuterTwinRustAsyncSse_Two {
     field0: *mut wire_cst_custom_nested_error_inner_twin_rust_async_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_nested_error_outer_twin_sse {
     tag: i32,
-    kind: *mut CustomNestedErrorOuterTwinSseKind,
+    kind: CustomNestedErrorOuterTwinSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union CustomNestedErrorOuterTwinSseKind {
-    One: *mut wire_cst_CustomNestedErrorOuterTwinSse_One,
-    Two: *mut wire_cst_CustomNestedErrorOuterTwinSse_Two,
+    One: wire_cst_CustomNestedErrorOuterTwinSse_One,
+    Two: wire_cst_CustomNestedErrorOuterTwinSse_Two,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedErrorOuterTwinSse_One {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedErrorOuterTwinSse_Two {
     field0: *mut wire_cst_custom_nested_error_inner_twin_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_nested_error_outer_twin_sync {
     tag: i32,
-    kind: *mut CustomNestedErrorOuterTwinSyncKind,
+    kind: CustomNestedErrorOuterTwinSyncKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union CustomNestedErrorOuterTwinSyncKind {
-    One: *mut wire_cst_CustomNestedErrorOuterTwinSync_One,
-    Two: *mut wire_cst_CustomNestedErrorOuterTwinSync_Two,
+    One: wire_cst_CustomNestedErrorOuterTwinSync_One,
+    Two: wire_cst_CustomNestedErrorOuterTwinSync_Two,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedErrorOuterTwinSync_One {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedErrorOuterTwinSync_Two {
     field0: *mut wire_cst_custom_nested_error_inner_twin_sync,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_nested_error_outer_twin_sync_sse {
     tag: i32,
-    kind: *mut CustomNestedErrorOuterTwinSyncSseKind,
+    kind: CustomNestedErrorOuterTwinSyncSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union CustomNestedErrorOuterTwinSyncSseKind {
-    One: *mut wire_cst_CustomNestedErrorOuterTwinSyncSse_One,
-    Two: *mut wire_cst_CustomNestedErrorOuterTwinSyncSse_Two,
+    One: wire_cst_CustomNestedErrorOuterTwinSyncSse_One,
+    Two: wire_cst_CustomNestedErrorOuterTwinSyncSse_Two,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedErrorOuterTwinSyncSse_One {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_CustomNestedErrorOuterTwinSyncSse_Two {
     field0: *mut wire_cst_custom_nested_error_inner_twin_sync_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_struct_error_another_twin_normal {
     message: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_struct_error_another_twin_rust_async {
     message: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_struct_error_another_twin_rust_async_sse {
     message: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_struct_error_another_twin_sse {
     message: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_struct_error_another_twin_sync {
     message: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_struct_error_another_twin_sync_sse {
     message: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_struct_error_twin_normal {
     a: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_struct_error_twin_rust_async {
     a: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_struct_error_twin_rust_async_sse {
     a: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_struct_error_twin_sse {
     a: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_struct_error_twin_sync {
     a: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_struct_error_twin_sync_sse {
     a: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_struct_twin_normal {
     message: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_struct_twin_rust_async {
     message: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_struct_twin_rust_async_sse {
     message: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_struct_twin_sse {
     message: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_struct_twin_sync {
     message: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_custom_struct_twin_sync_sse {
     message: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_customized_twin_normal {
     final_field: *mut wire_cst_list_prim_u_8,
     non_final_field: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_customized_twin_rust_async {
     final_field: *mut wire_cst_list_prim_u_8,
     non_final_field: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_customized_twin_rust_async_sse {
     final_field: *mut wire_cst_list_prim_u_8,
     non_final_field: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_customized_twin_sse {
     final_field: *mut wire_cst_list_prim_u_8,
     non_final_field: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_customized_twin_sync {
     final_field: *mut wire_cst_list_prim_u_8,
     non_final_field: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_customized_twin_sync_sse {
     final_field: *mut wire_cst_list_prim_u_8,
     non_final_field: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_dart_opaque_nested_twin_normal {
     first: *const std::ffi::c_void,
     second: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_dart_opaque_nested_twin_rust_async {
     first: *const std::ffi::c_void,
     second: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_dart_opaque_nested_twin_rust_async_sse {
     first: *const std::ffi::c_void,
     second: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_dart_opaque_nested_twin_sse {
     first: *const std::ffi::c_void,
     second: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_dart_opaque_nested_twin_sync {
     first: *const std::ffi::c_void,
     second: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_dart_opaque_nested_twin_sync_sse {
     first: *const std::ffi::c_void,
     second: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_demo_struct_for_rust_call_dart_twin_normal {
     name: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_demo_struct_for_rust_call_dart_twin_rust_async {
     name: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_demo_struct_for_rust_call_dart_twin_rust_async_sse {
     name: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_demo_struct_for_rust_call_dart_twin_sse {
     name: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_distance_twin_normal {
     tag: i32,
-    kind: *mut DistanceTwinNormalKind,
+    kind: DistanceTwinNormalKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union DistanceTwinNormalKind {
-    Unknown: *mut wire_cst_DistanceTwinNormal_Unknown,
-    Map: *mut wire_cst_DistanceTwinNormal_Map,
+    Map: wire_cst_DistanceTwinNormal_Map,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
-pub struct wire_cst_DistanceTwinNormal_Unknown {}
-#[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_DistanceTwinNormal_Map {
     field0: f64,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_distance_twin_rust_async {
     tag: i32,
-    kind: *mut DistanceTwinRustAsyncKind,
+    kind: DistanceTwinRustAsyncKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union DistanceTwinRustAsyncKind {
-    Unknown: *mut wire_cst_DistanceTwinRustAsync_Unknown,
-    Map: *mut wire_cst_DistanceTwinRustAsync_Map,
+    Map: wire_cst_DistanceTwinRustAsync_Map,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
-pub struct wire_cst_DistanceTwinRustAsync_Unknown {}
-#[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_DistanceTwinRustAsync_Map {
     field0: f64,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_distance_twin_rust_async_sse {
     tag: i32,
-    kind: *mut DistanceTwinRustAsyncSseKind,
+    kind: DistanceTwinRustAsyncSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union DistanceTwinRustAsyncSseKind {
-    Unknown: *mut wire_cst_DistanceTwinRustAsyncSse_Unknown,
-    Map: *mut wire_cst_DistanceTwinRustAsyncSse_Map,
+    Map: wire_cst_DistanceTwinRustAsyncSse_Map,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
-pub struct wire_cst_DistanceTwinRustAsyncSse_Unknown {}
-#[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_DistanceTwinRustAsyncSse_Map {
     field0: f64,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_distance_twin_sse {
     tag: i32,
-    kind: *mut DistanceTwinSseKind,
+    kind: DistanceTwinSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union DistanceTwinSseKind {
-    Unknown: *mut wire_cst_DistanceTwinSse_Unknown,
-    Map: *mut wire_cst_DistanceTwinSse_Map,
+    Map: wire_cst_DistanceTwinSse_Map,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
-pub struct wire_cst_DistanceTwinSse_Unknown {}
-#[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_DistanceTwinSse_Map {
     field0: f64,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_distance_twin_sync {
     tag: i32,
-    kind: *mut DistanceTwinSyncKind,
+    kind: DistanceTwinSyncKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union DistanceTwinSyncKind {
-    Unknown: *mut wire_cst_DistanceTwinSync_Unknown,
-    Map: *mut wire_cst_DistanceTwinSync_Map,
+    Map: wire_cst_DistanceTwinSync_Map,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
-pub struct wire_cst_DistanceTwinSync_Unknown {}
-#[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_DistanceTwinSync_Map {
     field0: f64,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_distance_twin_sync_sse {
     tag: i32,
-    kind: *mut DistanceTwinSyncSseKind,
+    kind: DistanceTwinSyncSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union DistanceTwinSyncSseKind {
-    Unknown: *mut wire_cst_DistanceTwinSyncSse_Unknown,
-    Map: *mut wire_cst_DistanceTwinSyncSse_Map,
+    Map: wire_cst_DistanceTwinSyncSse_Map,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
-pub struct wire_cst_DistanceTwinSyncSse_Unknown {}
-#[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_DistanceTwinSyncSse_Map {
     field0: f64,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_element_twin_normal {
     tag: *mut wire_cst_list_prim_u_8,
     text: *mut wire_cst_list_prim_u_8,
@@ -38088,7 +35233,7 @@ pub struct wire_cst_element_twin_normal {
     children: *mut wire_cst_list_element_twin_normal,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_element_twin_rust_async {
     tag: *mut wire_cst_list_prim_u_8,
     text: *mut wire_cst_list_prim_u_8,
@@ -38096,7 +35241,7 @@ pub struct wire_cst_element_twin_rust_async {
     children: *mut wire_cst_list_element_twin_rust_async,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_element_twin_rust_async_sse {
     tag: *mut wire_cst_list_prim_u_8,
     text: *mut wire_cst_list_prim_u_8,
@@ -38104,7 +35249,7 @@ pub struct wire_cst_element_twin_rust_async_sse {
     children: *mut wire_cst_list_element_twin_rust_async_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_element_twin_sse {
     tag: *mut wire_cst_list_prim_u_8,
     text: *mut wire_cst_list_prim_u_8,
@@ -38112,7 +35257,7 @@ pub struct wire_cst_element_twin_sse {
     children: *mut wire_cst_list_element_twin_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_element_twin_sync {
     tag: *mut wire_cst_list_prim_u_8,
     text: *mut wire_cst_list_prim_u_8,
@@ -38120,7 +35265,7 @@ pub struct wire_cst_element_twin_sync {
     children: *mut wire_cst_list_element_twin_sync,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_element_twin_sync_sse {
     tag: *mut wire_cst_list_prim_u_8,
     text: *mut wire_cst_list_prim_u_8,
@@ -38128,811 +35273,847 @@ pub struct wire_cst_element_twin_sync_sse {
     children: *mut wire_cst_list_element_twin_sync_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_empty_twin_normal {}
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_empty_twin_rust_async {}
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_empty_twin_rust_async_sse {}
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_empty_twin_sse {}
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_empty_twin_sync {}
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_empty_twin_sync_sse {}
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_enum_dart_opaque_twin_normal {
     tag: i32,
-    kind: *mut EnumDartOpaqueTwinNormalKind,
+    kind: EnumDartOpaqueTwinNormalKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union EnumDartOpaqueTwinNormalKind {
-    Primitive: *mut wire_cst_EnumDartOpaqueTwinNormal_Primitive,
-    Opaque: *mut wire_cst_EnumDartOpaqueTwinNormal_Opaque,
+    Primitive: wire_cst_EnumDartOpaqueTwinNormal_Primitive,
+    Opaque: wire_cst_EnumDartOpaqueTwinNormal_Opaque,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumDartOpaqueTwinNormal_Primitive {
     field0: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumDartOpaqueTwinNormal_Opaque {
     field0: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_enum_dart_opaque_twin_rust_async {
     tag: i32,
-    kind: *mut EnumDartOpaqueTwinRustAsyncKind,
+    kind: EnumDartOpaqueTwinRustAsyncKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union EnumDartOpaqueTwinRustAsyncKind {
-    Primitive: *mut wire_cst_EnumDartOpaqueTwinRustAsync_Primitive,
-    Opaque: *mut wire_cst_EnumDartOpaqueTwinRustAsync_Opaque,
+    Primitive: wire_cst_EnumDartOpaqueTwinRustAsync_Primitive,
+    Opaque: wire_cst_EnumDartOpaqueTwinRustAsync_Opaque,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumDartOpaqueTwinRustAsync_Primitive {
     field0: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumDartOpaqueTwinRustAsync_Opaque {
     field0: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_enum_dart_opaque_twin_rust_async_sse {
     tag: i32,
-    kind: *mut EnumDartOpaqueTwinRustAsyncSseKind,
+    kind: EnumDartOpaqueTwinRustAsyncSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union EnumDartOpaqueTwinRustAsyncSseKind {
-    Primitive: *mut wire_cst_EnumDartOpaqueTwinRustAsyncSse_Primitive,
-    Opaque: *mut wire_cst_EnumDartOpaqueTwinRustAsyncSse_Opaque,
+    Primitive: wire_cst_EnumDartOpaqueTwinRustAsyncSse_Primitive,
+    Opaque: wire_cst_EnumDartOpaqueTwinRustAsyncSse_Opaque,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumDartOpaqueTwinRustAsyncSse_Primitive {
     field0: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumDartOpaqueTwinRustAsyncSse_Opaque {
     field0: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_enum_dart_opaque_twin_sse {
     tag: i32,
-    kind: *mut EnumDartOpaqueTwinSseKind,
+    kind: EnumDartOpaqueTwinSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union EnumDartOpaqueTwinSseKind {
-    Primitive: *mut wire_cst_EnumDartOpaqueTwinSse_Primitive,
-    Opaque: *mut wire_cst_EnumDartOpaqueTwinSse_Opaque,
+    Primitive: wire_cst_EnumDartOpaqueTwinSse_Primitive,
+    Opaque: wire_cst_EnumDartOpaqueTwinSse_Opaque,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumDartOpaqueTwinSse_Primitive {
     field0: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumDartOpaqueTwinSse_Opaque {
     field0: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_enum_dart_opaque_twin_sync {
     tag: i32,
-    kind: *mut EnumDartOpaqueTwinSyncKind,
+    kind: EnumDartOpaqueTwinSyncKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union EnumDartOpaqueTwinSyncKind {
-    Primitive: *mut wire_cst_EnumDartOpaqueTwinSync_Primitive,
-    Opaque: *mut wire_cst_EnumDartOpaqueTwinSync_Opaque,
+    Primitive: wire_cst_EnumDartOpaqueTwinSync_Primitive,
+    Opaque: wire_cst_EnumDartOpaqueTwinSync_Opaque,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumDartOpaqueTwinSync_Primitive {
     field0: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumDartOpaqueTwinSync_Opaque {
     field0: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_enum_dart_opaque_twin_sync_sse {
     tag: i32,
-    kind: *mut EnumDartOpaqueTwinSyncSseKind,
+    kind: EnumDartOpaqueTwinSyncSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union EnumDartOpaqueTwinSyncSseKind {
-    Primitive: *mut wire_cst_EnumDartOpaqueTwinSyncSse_Primitive,
-    Opaque: *mut wire_cst_EnumDartOpaqueTwinSyncSse_Opaque,
+    Primitive: wire_cst_EnumDartOpaqueTwinSyncSse_Primitive,
+    Opaque: wire_cst_EnumDartOpaqueTwinSyncSse_Opaque,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumDartOpaqueTwinSyncSse_Primitive {
     field0: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumDartOpaqueTwinSyncSse_Opaque {
     field0: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_enum_opaque_twin_normal {
     tag: i32,
-    kind: *mut EnumOpaqueTwinNormalKind,
+    kind: EnumOpaqueTwinNormalKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union EnumOpaqueTwinNormalKind {
-    Struct: *mut wire_cst_EnumOpaqueTwinNormal_Struct,
-    Primitive: *mut wire_cst_EnumOpaqueTwinNormal_Primitive,
-    TraitObj: *mut wire_cst_EnumOpaqueTwinNormal_TraitObj,
-    Mutex: *mut wire_cst_EnumOpaqueTwinNormal_Mutex,
-    RwLock: *mut wire_cst_EnumOpaqueTwinNormal_RwLock,
+    Struct: wire_cst_EnumOpaqueTwinNormal_Struct,
+    Primitive: wire_cst_EnumOpaqueTwinNormal_Primitive,
+    TraitObj: wire_cst_EnumOpaqueTwinNormal_TraitObj,
+    Mutex: wire_cst_EnumOpaqueTwinNormal_Mutex,
+    RwLock: wire_cst_EnumOpaqueTwinNormal_RwLock,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumOpaqueTwinNormal_Struct {
     field0: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumOpaqueTwinNormal_Primitive {
     field0: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumOpaqueTwinNormal_TraitObj {
     field0: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumOpaqueTwinNormal_Mutex {
     field0: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumOpaqueTwinNormal_RwLock {
     field0: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_enum_opaque_twin_rust_async {
     tag: i32,
-    kind: *mut EnumOpaqueTwinRustAsyncKind,
+    kind: EnumOpaqueTwinRustAsyncKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union EnumOpaqueTwinRustAsyncKind {
-    Struct: *mut wire_cst_EnumOpaqueTwinRustAsync_Struct,
-    Primitive: *mut wire_cst_EnumOpaqueTwinRustAsync_Primitive,
-    TraitObj: *mut wire_cst_EnumOpaqueTwinRustAsync_TraitObj,
-    Mutex: *mut wire_cst_EnumOpaqueTwinRustAsync_Mutex,
-    RwLock: *mut wire_cst_EnumOpaqueTwinRustAsync_RwLock,
+    Struct: wire_cst_EnumOpaqueTwinRustAsync_Struct,
+    Primitive: wire_cst_EnumOpaqueTwinRustAsync_Primitive,
+    TraitObj: wire_cst_EnumOpaqueTwinRustAsync_TraitObj,
+    Mutex: wire_cst_EnumOpaqueTwinRustAsync_Mutex,
+    RwLock: wire_cst_EnumOpaqueTwinRustAsync_RwLock,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumOpaqueTwinRustAsync_Struct {
     field0: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumOpaqueTwinRustAsync_Primitive {
     field0: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumOpaqueTwinRustAsync_TraitObj {
     field0: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumOpaqueTwinRustAsync_Mutex {
     field0: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumOpaqueTwinRustAsync_RwLock {
     field0: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_enum_opaque_twin_rust_async_sse {
     tag: i32,
-    kind: *mut EnumOpaqueTwinRustAsyncSseKind,
+    kind: EnumOpaqueTwinRustAsyncSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union EnumOpaqueTwinRustAsyncSseKind {
-    Struct: *mut wire_cst_EnumOpaqueTwinRustAsyncSse_Struct,
-    Primitive: *mut wire_cst_EnumOpaqueTwinRustAsyncSse_Primitive,
-    TraitObj: *mut wire_cst_EnumOpaqueTwinRustAsyncSse_TraitObj,
-    Mutex: *mut wire_cst_EnumOpaqueTwinRustAsyncSse_Mutex,
-    RwLock: *mut wire_cst_EnumOpaqueTwinRustAsyncSse_RwLock,
+    Struct: wire_cst_EnumOpaqueTwinRustAsyncSse_Struct,
+    Primitive: wire_cst_EnumOpaqueTwinRustAsyncSse_Primitive,
+    TraitObj: wire_cst_EnumOpaqueTwinRustAsyncSse_TraitObj,
+    Mutex: wire_cst_EnumOpaqueTwinRustAsyncSse_Mutex,
+    RwLock: wire_cst_EnumOpaqueTwinRustAsyncSse_RwLock,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumOpaqueTwinRustAsyncSse_Struct {
     field0: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumOpaqueTwinRustAsyncSse_Primitive {
     field0: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumOpaqueTwinRustAsyncSse_TraitObj {
     field0: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumOpaqueTwinRustAsyncSse_Mutex {
     field0: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumOpaqueTwinRustAsyncSse_RwLock {
     field0: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_enum_opaque_twin_sse {
     tag: i32,
-    kind: *mut EnumOpaqueTwinSseKind,
+    kind: EnumOpaqueTwinSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union EnumOpaqueTwinSseKind {
-    Struct: *mut wire_cst_EnumOpaqueTwinSse_Struct,
-    Primitive: *mut wire_cst_EnumOpaqueTwinSse_Primitive,
-    TraitObj: *mut wire_cst_EnumOpaqueTwinSse_TraitObj,
-    Mutex: *mut wire_cst_EnumOpaqueTwinSse_Mutex,
-    RwLock: *mut wire_cst_EnumOpaqueTwinSse_RwLock,
+    Struct: wire_cst_EnumOpaqueTwinSse_Struct,
+    Primitive: wire_cst_EnumOpaqueTwinSse_Primitive,
+    TraitObj: wire_cst_EnumOpaqueTwinSse_TraitObj,
+    Mutex: wire_cst_EnumOpaqueTwinSse_Mutex,
+    RwLock: wire_cst_EnumOpaqueTwinSse_RwLock,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumOpaqueTwinSse_Struct {
     field0: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumOpaqueTwinSse_Primitive {
     field0: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumOpaqueTwinSse_TraitObj {
     field0: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumOpaqueTwinSse_Mutex {
     field0: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumOpaqueTwinSse_RwLock {
     field0: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_enum_opaque_twin_sync {
     tag: i32,
-    kind: *mut EnumOpaqueTwinSyncKind,
+    kind: EnumOpaqueTwinSyncKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union EnumOpaqueTwinSyncKind {
-    Struct: *mut wire_cst_EnumOpaqueTwinSync_Struct,
-    Primitive: *mut wire_cst_EnumOpaqueTwinSync_Primitive,
-    TraitObj: *mut wire_cst_EnumOpaqueTwinSync_TraitObj,
-    Mutex: *mut wire_cst_EnumOpaqueTwinSync_Mutex,
-    RwLock: *mut wire_cst_EnumOpaqueTwinSync_RwLock,
+    Struct: wire_cst_EnumOpaqueTwinSync_Struct,
+    Primitive: wire_cst_EnumOpaqueTwinSync_Primitive,
+    TraitObj: wire_cst_EnumOpaqueTwinSync_TraitObj,
+    Mutex: wire_cst_EnumOpaqueTwinSync_Mutex,
+    RwLock: wire_cst_EnumOpaqueTwinSync_RwLock,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumOpaqueTwinSync_Struct {
     field0: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumOpaqueTwinSync_Primitive {
     field0: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumOpaqueTwinSync_TraitObj {
     field0: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumOpaqueTwinSync_Mutex {
     field0: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumOpaqueTwinSync_RwLock {
     field0: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_enum_opaque_twin_sync_sse {
     tag: i32,
-    kind: *mut EnumOpaqueTwinSyncSseKind,
+    kind: EnumOpaqueTwinSyncSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union EnumOpaqueTwinSyncSseKind {
-    Struct: *mut wire_cst_EnumOpaqueTwinSyncSse_Struct,
-    Primitive: *mut wire_cst_EnumOpaqueTwinSyncSse_Primitive,
-    TraitObj: *mut wire_cst_EnumOpaqueTwinSyncSse_TraitObj,
-    Mutex: *mut wire_cst_EnumOpaqueTwinSyncSse_Mutex,
-    RwLock: *mut wire_cst_EnumOpaqueTwinSyncSse_RwLock,
+    Struct: wire_cst_EnumOpaqueTwinSyncSse_Struct,
+    Primitive: wire_cst_EnumOpaqueTwinSyncSse_Primitive,
+    TraitObj: wire_cst_EnumOpaqueTwinSyncSse_TraitObj,
+    Mutex: wire_cst_EnumOpaqueTwinSyncSse_Mutex,
+    RwLock: wire_cst_EnumOpaqueTwinSyncSse_RwLock,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumOpaqueTwinSyncSse_Struct {
     field0: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumOpaqueTwinSyncSse_Primitive {
     field0: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumOpaqueTwinSyncSse_TraitObj {
     field0: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumOpaqueTwinSyncSse_Mutex {
     field0: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumOpaqueTwinSyncSse_RwLock {
     field0: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_enum_with_item_mixed_twin_normal {
     tag: i32,
-    kind: *mut EnumWithItemMixedTwinNormalKind,
+    kind: EnumWithItemMixedTwinNormalKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union EnumWithItemMixedTwinNormalKind {
-    A: *mut wire_cst_EnumWithItemMixedTwinNormal_A,
-    B: *mut wire_cst_EnumWithItemMixedTwinNormal_B,
-    C: *mut wire_cst_EnumWithItemMixedTwinNormal_C,
+    B: wire_cst_EnumWithItemMixedTwinNormal_B,
+    C: wire_cst_EnumWithItemMixedTwinNormal_C,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
-pub struct wire_cst_EnumWithItemMixedTwinNormal_A {}
-#[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumWithItemMixedTwinNormal_B {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumWithItemMixedTwinNormal_C {
     c_field: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_enum_with_item_mixed_twin_rust_async {
     tag: i32,
-    kind: *mut EnumWithItemMixedTwinRustAsyncKind,
+    kind: EnumWithItemMixedTwinRustAsyncKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union EnumWithItemMixedTwinRustAsyncKind {
-    A: *mut wire_cst_EnumWithItemMixedTwinRustAsync_A,
-    B: *mut wire_cst_EnumWithItemMixedTwinRustAsync_B,
-    C: *mut wire_cst_EnumWithItemMixedTwinRustAsync_C,
+    B: wire_cst_EnumWithItemMixedTwinRustAsync_B,
+    C: wire_cst_EnumWithItemMixedTwinRustAsync_C,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
-pub struct wire_cst_EnumWithItemMixedTwinRustAsync_A {}
-#[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumWithItemMixedTwinRustAsync_B {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumWithItemMixedTwinRustAsync_C {
     c_field: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_enum_with_item_mixed_twin_rust_async_sse {
     tag: i32,
-    kind: *mut EnumWithItemMixedTwinRustAsyncSseKind,
+    kind: EnumWithItemMixedTwinRustAsyncSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union EnumWithItemMixedTwinRustAsyncSseKind {
-    A: *mut wire_cst_EnumWithItemMixedTwinRustAsyncSse_A,
-    B: *mut wire_cst_EnumWithItemMixedTwinRustAsyncSse_B,
-    C: *mut wire_cst_EnumWithItemMixedTwinRustAsyncSse_C,
+    B: wire_cst_EnumWithItemMixedTwinRustAsyncSse_B,
+    C: wire_cst_EnumWithItemMixedTwinRustAsyncSse_C,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
-pub struct wire_cst_EnumWithItemMixedTwinRustAsyncSse_A {}
-#[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumWithItemMixedTwinRustAsyncSse_B {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumWithItemMixedTwinRustAsyncSse_C {
     c_field: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_enum_with_item_mixed_twin_sse {
     tag: i32,
-    kind: *mut EnumWithItemMixedTwinSseKind,
+    kind: EnumWithItemMixedTwinSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union EnumWithItemMixedTwinSseKind {
-    A: *mut wire_cst_EnumWithItemMixedTwinSse_A,
-    B: *mut wire_cst_EnumWithItemMixedTwinSse_B,
-    C: *mut wire_cst_EnumWithItemMixedTwinSse_C,
+    B: wire_cst_EnumWithItemMixedTwinSse_B,
+    C: wire_cst_EnumWithItemMixedTwinSse_C,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
-pub struct wire_cst_EnumWithItemMixedTwinSse_A {}
-#[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumWithItemMixedTwinSse_B {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumWithItemMixedTwinSse_C {
     c_field: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_enum_with_item_mixed_twin_sync {
     tag: i32,
-    kind: *mut EnumWithItemMixedTwinSyncKind,
+    kind: EnumWithItemMixedTwinSyncKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union EnumWithItemMixedTwinSyncKind {
-    A: *mut wire_cst_EnumWithItemMixedTwinSync_A,
-    B: *mut wire_cst_EnumWithItemMixedTwinSync_B,
-    C: *mut wire_cst_EnumWithItemMixedTwinSync_C,
+    B: wire_cst_EnumWithItemMixedTwinSync_B,
+    C: wire_cst_EnumWithItemMixedTwinSync_C,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
-pub struct wire_cst_EnumWithItemMixedTwinSync_A {}
-#[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumWithItemMixedTwinSync_B {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumWithItemMixedTwinSync_C {
     c_field: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_enum_with_item_mixed_twin_sync_sse {
     tag: i32,
-    kind: *mut EnumWithItemMixedTwinSyncSseKind,
+    kind: EnumWithItemMixedTwinSyncSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union EnumWithItemMixedTwinSyncSseKind {
-    A: *mut wire_cst_EnumWithItemMixedTwinSyncSse_A,
-    B: *mut wire_cst_EnumWithItemMixedTwinSyncSse_B,
-    C: *mut wire_cst_EnumWithItemMixedTwinSyncSse_C,
+    B: wire_cst_EnumWithItemMixedTwinSyncSse_B,
+    C: wire_cst_EnumWithItemMixedTwinSyncSse_C,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
-pub struct wire_cst_EnumWithItemMixedTwinSyncSse_A {}
-#[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumWithItemMixedTwinSyncSse_B {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumWithItemMixedTwinSyncSse_C {
     c_field: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_enum_with_item_struct_twin_normal {
     tag: i32,
-    kind: *mut EnumWithItemStructTwinNormalKind,
+    kind: EnumWithItemStructTwinNormalKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union EnumWithItemStructTwinNormalKind {
-    A: *mut wire_cst_EnumWithItemStructTwinNormal_A,
-    B: *mut wire_cst_EnumWithItemStructTwinNormal_B,
+    A: wire_cst_EnumWithItemStructTwinNormal_A,
+    B: wire_cst_EnumWithItemStructTwinNormal_B,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumWithItemStructTwinNormal_A {
     a_field: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumWithItemStructTwinNormal_B {
     b_field: *mut wire_cst_list_prim_i_32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_enum_with_item_struct_twin_rust_async {
     tag: i32,
-    kind: *mut EnumWithItemStructTwinRustAsyncKind,
+    kind: EnumWithItemStructTwinRustAsyncKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union EnumWithItemStructTwinRustAsyncKind {
-    A: *mut wire_cst_EnumWithItemStructTwinRustAsync_A,
-    B: *mut wire_cst_EnumWithItemStructTwinRustAsync_B,
+    A: wire_cst_EnumWithItemStructTwinRustAsync_A,
+    B: wire_cst_EnumWithItemStructTwinRustAsync_B,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumWithItemStructTwinRustAsync_A {
     a_field: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumWithItemStructTwinRustAsync_B {
     b_field: *mut wire_cst_list_prim_i_32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_enum_with_item_struct_twin_rust_async_sse {
     tag: i32,
-    kind: *mut EnumWithItemStructTwinRustAsyncSseKind,
+    kind: EnumWithItemStructTwinRustAsyncSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union EnumWithItemStructTwinRustAsyncSseKind {
-    A: *mut wire_cst_EnumWithItemStructTwinRustAsyncSse_A,
-    B: *mut wire_cst_EnumWithItemStructTwinRustAsyncSse_B,
+    A: wire_cst_EnumWithItemStructTwinRustAsyncSse_A,
+    B: wire_cst_EnumWithItemStructTwinRustAsyncSse_B,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumWithItemStructTwinRustAsyncSse_A {
     a_field: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumWithItemStructTwinRustAsyncSse_B {
     b_field: *mut wire_cst_list_prim_i_32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_enum_with_item_struct_twin_sse {
     tag: i32,
-    kind: *mut EnumWithItemStructTwinSseKind,
+    kind: EnumWithItemStructTwinSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union EnumWithItemStructTwinSseKind {
-    A: *mut wire_cst_EnumWithItemStructTwinSse_A,
-    B: *mut wire_cst_EnumWithItemStructTwinSse_B,
+    A: wire_cst_EnumWithItemStructTwinSse_A,
+    B: wire_cst_EnumWithItemStructTwinSse_B,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumWithItemStructTwinSse_A {
     a_field: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumWithItemStructTwinSse_B {
     b_field: *mut wire_cst_list_prim_i_32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_enum_with_item_struct_twin_sync {
     tag: i32,
-    kind: *mut EnumWithItemStructTwinSyncKind,
+    kind: EnumWithItemStructTwinSyncKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union EnumWithItemStructTwinSyncKind {
-    A: *mut wire_cst_EnumWithItemStructTwinSync_A,
-    B: *mut wire_cst_EnumWithItemStructTwinSync_B,
+    A: wire_cst_EnumWithItemStructTwinSync_A,
+    B: wire_cst_EnumWithItemStructTwinSync_B,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumWithItemStructTwinSync_A {
     a_field: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumWithItemStructTwinSync_B {
     b_field: *mut wire_cst_list_prim_i_32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_enum_with_item_struct_twin_sync_sse {
     tag: i32,
-    kind: *mut EnumWithItemStructTwinSyncSseKind,
+    kind: EnumWithItemStructTwinSyncSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union EnumWithItemStructTwinSyncSseKind {
-    A: *mut wire_cst_EnumWithItemStructTwinSyncSse_A,
-    B: *mut wire_cst_EnumWithItemStructTwinSyncSse_B,
+    A: wire_cst_EnumWithItemStructTwinSyncSse_A,
+    B: wire_cst_EnumWithItemStructTwinSyncSse_B,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumWithItemStructTwinSyncSse_A {
     a_field: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumWithItemStructTwinSyncSse_B {
     b_field: *mut wire_cst_list_prim_i_32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_enum_with_item_tuple_twin_normal {
     tag: i32,
-    kind: *mut EnumWithItemTupleTwinNormalKind,
+    kind: EnumWithItemTupleTwinNormalKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union EnumWithItemTupleTwinNormalKind {
-    A: *mut wire_cst_EnumWithItemTupleTwinNormal_A,
-    B: *mut wire_cst_EnumWithItemTupleTwinNormal_B,
+    A: wire_cst_EnumWithItemTupleTwinNormal_A,
+    B: wire_cst_EnumWithItemTupleTwinNormal_B,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumWithItemTupleTwinNormal_A {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumWithItemTupleTwinNormal_B {
     field0: *mut wire_cst_list_prim_i_32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_enum_with_item_tuple_twin_rust_async {
     tag: i32,
-    kind: *mut EnumWithItemTupleTwinRustAsyncKind,
+    kind: EnumWithItemTupleTwinRustAsyncKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union EnumWithItemTupleTwinRustAsyncKind {
-    A: *mut wire_cst_EnumWithItemTupleTwinRustAsync_A,
-    B: *mut wire_cst_EnumWithItemTupleTwinRustAsync_B,
+    A: wire_cst_EnumWithItemTupleTwinRustAsync_A,
+    B: wire_cst_EnumWithItemTupleTwinRustAsync_B,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumWithItemTupleTwinRustAsync_A {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumWithItemTupleTwinRustAsync_B {
     field0: *mut wire_cst_list_prim_i_32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_enum_with_item_tuple_twin_rust_async_sse {
     tag: i32,
-    kind: *mut EnumWithItemTupleTwinRustAsyncSseKind,
+    kind: EnumWithItemTupleTwinRustAsyncSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union EnumWithItemTupleTwinRustAsyncSseKind {
-    A: *mut wire_cst_EnumWithItemTupleTwinRustAsyncSse_A,
-    B: *mut wire_cst_EnumWithItemTupleTwinRustAsyncSse_B,
+    A: wire_cst_EnumWithItemTupleTwinRustAsyncSse_A,
+    B: wire_cst_EnumWithItemTupleTwinRustAsyncSse_B,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumWithItemTupleTwinRustAsyncSse_A {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumWithItemTupleTwinRustAsyncSse_B {
     field0: *mut wire_cst_list_prim_i_32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_enum_with_item_tuple_twin_sse {
     tag: i32,
-    kind: *mut EnumWithItemTupleTwinSseKind,
+    kind: EnumWithItemTupleTwinSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union EnumWithItemTupleTwinSseKind {
-    A: *mut wire_cst_EnumWithItemTupleTwinSse_A,
-    B: *mut wire_cst_EnumWithItemTupleTwinSse_B,
+    A: wire_cst_EnumWithItemTupleTwinSse_A,
+    B: wire_cst_EnumWithItemTupleTwinSse_B,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumWithItemTupleTwinSse_A {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumWithItemTupleTwinSse_B {
     field0: *mut wire_cst_list_prim_i_32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_enum_with_item_tuple_twin_sync {
     tag: i32,
-    kind: *mut EnumWithItemTupleTwinSyncKind,
+    kind: EnumWithItemTupleTwinSyncKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union EnumWithItemTupleTwinSyncKind {
-    A: *mut wire_cst_EnumWithItemTupleTwinSync_A,
-    B: *mut wire_cst_EnumWithItemTupleTwinSync_B,
+    A: wire_cst_EnumWithItemTupleTwinSync_A,
+    B: wire_cst_EnumWithItemTupleTwinSync_B,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumWithItemTupleTwinSync_A {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumWithItemTupleTwinSync_B {
     field0: *mut wire_cst_list_prim_i_32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_enum_with_item_tuple_twin_sync_sse {
     tag: i32,
-    kind: *mut EnumWithItemTupleTwinSyncSseKind,
+    kind: EnumWithItemTupleTwinSyncSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union EnumWithItemTupleTwinSyncSseKind {
-    A: *mut wire_cst_EnumWithItemTupleTwinSyncSse_A,
-    B: *mut wire_cst_EnumWithItemTupleTwinSyncSse_B,
+    A: wire_cst_EnumWithItemTupleTwinSyncSse_A,
+    B: wire_cst_EnumWithItemTupleTwinSyncSse_B,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumWithItemTupleTwinSyncSse_A {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_EnumWithItemTupleTwinSyncSse_B {
     field0: *mut wire_cst_list_prim_i_32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_event_twin_normal {
     address: *mut wire_cst_list_prim_u_8,
     payload: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_event_twin_rust_async {
     address: *mut wire_cst_list_prim_u_8,
     payload: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_event_twin_rust_async_sse {
     address: *mut wire_cst_list_prim_u_8,
     payload: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_event_twin_sse {
     address: *mut wire_cst_list_prim_u_8,
     payload: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_exotic_optionals_twin_normal {
     int32: *mut i32,
     int64: *mut i64,
@@ -38950,7 +36131,7 @@ pub struct wire_cst_exotic_optionals_twin_normal {
     newtypeint: *mut wire_cst_new_type_int_twin_normal,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_exotic_optionals_twin_rust_async {
     int32: *mut i32,
     int64: *mut i64,
@@ -38968,7 +36149,7 @@ pub struct wire_cst_exotic_optionals_twin_rust_async {
     newtypeint: *mut wire_cst_new_type_int_twin_rust_async,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_exotic_optionals_twin_rust_async_sse {
     int32: *mut i32,
     int64: *mut i64,
@@ -38986,7 +36167,7 @@ pub struct wire_cst_exotic_optionals_twin_rust_async_sse {
     newtypeint: *mut wire_cst_new_type_int_twin_rust_async_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_exotic_optionals_twin_sse {
     int32: *mut i32,
     int64: *mut i64,
@@ -39004,7 +36185,7 @@ pub struct wire_cst_exotic_optionals_twin_sse {
     newtypeint: *mut wire_cst_new_type_int_twin_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_exotic_optionals_twin_sync {
     int32: *mut i32,
     int64: *mut i64,
@@ -39022,7 +36203,7 @@ pub struct wire_cst_exotic_optionals_twin_sync {
     newtypeint: *mut wire_cst_new_type_int_twin_sync,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_exotic_optionals_twin_sync_sse {
     int32: *mut i32,
     int64: *mut i64,
@@ -39040,7 +36221,7 @@ pub struct wire_cst_exotic_optionals_twin_sync_sse {
     newtypeint: *mut wire_cst_new_type_int_twin_sync_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_feature_chrono_twin_normal {
     utc: i64,
     local: i64,
@@ -39048,7 +36229,7 @@ pub struct wire_cst_feature_chrono_twin_normal {
     naive: i64,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_feature_chrono_twin_rust_async {
     utc: i64,
     local: i64,
@@ -39056,7 +36237,7 @@ pub struct wire_cst_feature_chrono_twin_rust_async {
     naive: i64,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_feature_chrono_twin_sync {
     utc: i64,
     local: i64,
@@ -39064,1088 +36245,1088 @@ pub struct wire_cst_feature_chrono_twin_sync {
     naive: i64,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_feature_uuid_twin_normal {
     one: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_feature_uuid_twin_rust_async {
     one: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_feature_uuid_twin_sync {
     one: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_feed_id_twin_normal {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_feed_id_twin_rust_async {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_feed_id_twin_rust_async_sse {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_feed_id_twin_sse {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_feed_id_twin_sync {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_feed_id_twin_sync_sse {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_kitchen_sink_twin_normal {
     tag: i32,
-    kind: *mut KitchenSinkTwinNormalKind,
+    kind: KitchenSinkTwinNormalKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union KitchenSinkTwinNormalKind {
-    Empty: *mut wire_cst_KitchenSinkTwinNormal_Empty,
-    Primitives: *mut wire_cst_KitchenSinkTwinNormal_Primitives,
-    Nested: *mut wire_cst_KitchenSinkTwinNormal_Nested,
-    Optional: *mut wire_cst_KitchenSinkTwinNormal_Optional,
-    Buffer: *mut wire_cst_KitchenSinkTwinNormal_Buffer,
-    Enums: *mut wire_cst_KitchenSinkTwinNormal_Enums,
+    Primitives: wire_cst_KitchenSinkTwinNormal_Primitives,
+    Nested: wire_cst_KitchenSinkTwinNormal_Nested,
+    Optional: wire_cst_KitchenSinkTwinNormal_Optional,
+    Buffer: wire_cst_KitchenSinkTwinNormal_Buffer,
+    Enums: wire_cst_KitchenSinkTwinNormal_Enums,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
-pub struct wire_cst_KitchenSinkTwinNormal_Empty {}
-#[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_KitchenSinkTwinNormal_Primitives {
     int32: i32,
     float64: f64,
     boolean: bool,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_KitchenSinkTwinNormal_Nested {
     field0: i32,
     field1: *mut wire_cst_kitchen_sink_twin_normal,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_KitchenSinkTwinNormal_Optional {
     field0: *mut i32,
     field1: *mut i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_KitchenSinkTwinNormal_Buffer {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_KitchenSinkTwinNormal_Enums {
     field0: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_kitchen_sink_twin_rust_async {
     tag: i32,
-    kind: *mut KitchenSinkTwinRustAsyncKind,
+    kind: KitchenSinkTwinRustAsyncKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union KitchenSinkTwinRustAsyncKind {
-    Empty: *mut wire_cst_KitchenSinkTwinRustAsync_Empty,
-    Primitives: *mut wire_cst_KitchenSinkTwinRustAsync_Primitives,
-    Nested: *mut wire_cst_KitchenSinkTwinRustAsync_Nested,
-    Optional: *mut wire_cst_KitchenSinkTwinRustAsync_Optional,
-    Buffer: *mut wire_cst_KitchenSinkTwinRustAsync_Buffer,
-    Enums: *mut wire_cst_KitchenSinkTwinRustAsync_Enums,
+    Primitives: wire_cst_KitchenSinkTwinRustAsync_Primitives,
+    Nested: wire_cst_KitchenSinkTwinRustAsync_Nested,
+    Optional: wire_cst_KitchenSinkTwinRustAsync_Optional,
+    Buffer: wire_cst_KitchenSinkTwinRustAsync_Buffer,
+    Enums: wire_cst_KitchenSinkTwinRustAsync_Enums,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
-pub struct wire_cst_KitchenSinkTwinRustAsync_Empty {}
-#[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_KitchenSinkTwinRustAsync_Primitives {
     int32: i32,
     float64: f64,
     boolean: bool,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_KitchenSinkTwinRustAsync_Nested {
     field0: i32,
     field1: *mut wire_cst_kitchen_sink_twin_rust_async,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_KitchenSinkTwinRustAsync_Optional {
     field0: *mut i32,
     field1: *mut i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_KitchenSinkTwinRustAsync_Buffer {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_KitchenSinkTwinRustAsync_Enums {
     field0: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_kitchen_sink_twin_rust_async_sse {
     tag: i32,
-    kind: *mut KitchenSinkTwinRustAsyncSseKind,
+    kind: KitchenSinkTwinRustAsyncSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union KitchenSinkTwinRustAsyncSseKind {
-    Empty: *mut wire_cst_KitchenSinkTwinRustAsyncSse_Empty,
-    Primitives: *mut wire_cst_KitchenSinkTwinRustAsyncSse_Primitives,
-    Nested: *mut wire_cst_KitchenSinkTwinRustAsyncSse_Nested,
-    Optional: *mut wire_cst_KitchenSinkTwinRustAsyncSse_Optional,
-    Buffer: *mut wire_cst_KitchenSinkTwinRustAsyncSse_Buffer,
-    Enums: *mut wire_cst_KitchenSinkTwinRustAsyncSse_Enums,
+    Primitives: wire_cst_KitchenSinkTwinRustAsyncSse_Primitives,
+    Nested: wire_cst_KitchenSinkTwinRustAsyncSse_Nested,
+    Optional: wire_cst_KitchenSinkTwinRustAsyncSse_Optional,
+    Buffer: wire_cst_KitchenSinkTwinRustAsyncSse_Buffer,
+    Enums: wire_cst_KitchenSinkTwinRustAsyncSse_Enums,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
-pub struct wire_cst_KitchenSinkTwinRustAsyncSse_Empty {}
-#[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_KitchenSinkTwinRustAsyncSse_Primitives {
     int32: i32,
     float64: f64,
     boolean: bool,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_KitchenSinkTwinRustAsyncSse_Nested {
     field0: i32,
     field1: *mut wire_cst_kitchen_sink_twin_rust_async_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_KitchenSinkTwinRustAsyncSse_Optional {
     field0: *mut i32,
     field1: *mut i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_KitchenSinkTwinRustAsyncSse_Buffer {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_KitchenSinkTwinRustAsyncSse_Enums {
     field0: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_kitchen_sink_twin_sse {
     tag: i32,
-    kind: *mut KitchenSinkTwinSseKind,
+    kind: KitchenSinkTwinSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union KitchenSinkTwinSseKind {
-    Empty: *mut wire_cst_KitchenSinkTwinSse_Empty,
-    Primitives: *mut wire_cst_KitchenSinkTwinSse_Primitives,
-    Nested: *mut wire_cst_KitchenSinkTwinSse_Nested,
-    Optional: *mut wire_cst_KitchenSinkTwinSse_Optional,
-    Buffer: *mut wire_cst_KitchenSinkTwinSse_Buffer,
-    Enums: *mut wire_cst_KitchenSinkTwinSse_Enums,
+    Primitives: wire_cst_KitchenSinkTwinSse_Primitives,
+    Nested: wire_cst_KitchenSinkTwinSse_Nested,
+    Optional: wire_cst_KitchenSinkTwinSse_Optional,
+    Buffer: wire_cst_KitchenSinkTwinSse_Buffer,
+    Enums: wire_cst_KitchenSinkTwinSse_Enums,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
-pub struct wire_cst_KitchenSinkTwinSse_Empty {}
-#[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_KitchenSinkTwinSse_Primitives {
     int32: i32,
     float64: f64,
     boolean: bool,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_KitchenSinkTwinSse_Nested {
     field0: i32,
     field1: *mut wire_cst_kitchen_sink_twin_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_KitchenSinkTwinSse_Optional {
     field0: *mut i32,
     field1: *mut i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_KitchenSinkTwinSse_Buffer {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_KitchenSinkTwinSse_Enums {
     field0: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_kitchen_sink_twin_sync {
     tag: i32,
-    kind: *mut KitchenSinkTwinSyncKind,
+    kind: KitchenSinkTwinSyncKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union KitchenSinkTwinSyncKind {
-    Empty: *mut wire_cst_KitchenSinkTwinSync_Empty,
-    Primitives: *mut wire_cst_KitchenSinkTwinSync_Primitives,
-    Nested: *mut wire_cst_KitchenSinkTwinSync_Nested,
-    Optional: *mut wire_cst_KitchenSinkTwinSync_Optional,
-    Buffer: *mut wire_cst_KitchenSinkTwinSync_Buffer,
-    Enums: *mut wire_cst_KitchenSinkTwinSync_Enums,
+    Primitives: wire_cst_KitchenSinkTwinSync_Primitives,
+    Nested: wire_cst_KitchenSinkTwinSync_Nested,
+    Optional: wire_cst_KitchenSinkTwinSync_Optional,
+    Buffer: wire_cst_KitchenSinkTwinSync_Buffer,
+    Enums: wire_cst_KitchenSinkTwinSync_Enums,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
-pub struct wire_cst_KitchenSinkTwinSync_Empty {}
-#[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_KitchenSinkTwinSync_Primitives {
     int32: i32,
     float64: f64,
     boolean: bool,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_KitchenSinkTwinSync_Nested {
     field0: i32,
     field1: *mut wire_cst_kitchen_sink_twin_sync,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_KitchenSinkTwinSync_Optional {
     field0: *mut i32,
     field1: *mut i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_KitchenSinkTwinSync_Buffer {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_KitchenSinkTwinSync_Enums {
     field0: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_kitchen_sink_twin_sync_sse {
     tag: i32,
-    kind: *mut KitchenSinkTwinSyncSseKind,
+    kind: KitchenSinkTwinSyncSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union KitchenSinkTwinSyncSseKind {
-    Empty: *mut wire_cst_KitchenSinkTwinSyncSse_Empty,
-    Primitives: *mut wire_cst_KitchenSinkTwinSyncSse_Primitives,
-    Nested: *mut wire_cst_KitchenSinkTwinSyncSse_Nested,
-    Optional: *mut wire_cst_KitchenSinkTwinSyncSse_Optional,
-    Buffer: *mut wire_cst_KitchenSinkTwinSyncSse_Buffer,
-    Enums: *mut wire_cst_KitchenSinkTwinSyncSse_Enums,
+    Primitives: wire_cst_KitchenSinkTwinSyncSse_Primitives,
+    Nested: wire_cst_KitchenSinkTwinSyncSse_Nested,
+    Optional: wire_cst_KitchenSinkTwinSyncSse_Optional,
+    Buffer: wire_cst_KitchenSinkTwinSyncSse_Buffer,
+    Enums: wire_cst_KitchenSinkTwinSyncSse_Enums,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
-pub struct wire_cst_KitchenSinkTwinSyncSse_Empty {}
-#[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_KitchenSinkTwinSyncSse_Primitives {
     int32: i32,
     float64: f64,
     boolean: bool,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_KitchenSinkTwinSyncSse_Nested {
     field0: i32,
     field1: *mut wire_cst_kitchen_sink_twin_sync_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_KitchenSinkTwinSyncSse_Optional {
     field0: *mut i32,
     field1: *mut i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_KitchenSinkTwinSyncSse_Buffer {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_KitchenSinkTwinSyncSse_Enums {
     field0: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_Chrono_Duration {
     ptr: *mut i64,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_Chrono_Local {
     ptr: *mut i64,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_Chrono_Naive {
     ptr: *mut i64,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_DartOpaque {
     ptr: *mut *const std::ffi::c_void,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_RustOpaque_hide_data {
     ptr: *mut *const std::ffi::c_void,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_String {
     ptr: *mut *mut wire_cst_list_prim_u_8,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_application_env_var {
     ptr: *mut wire_cst_application_env_var,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_application_settings {
     ptr: *mut wire_cst_application_settings,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_attribute_twin_normal {
     ptr: *mut wire_cst_attribute_twin_normal,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_attribute_twin_rust_async {
     ptr: *mut wire_cst_attribute_twin_rust_async,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_attribute_twin_rust_async_sse {
     ptr: *mut wire_cst_attribute_twin_rust_async_sse,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_attribute_twin_sse {
     ptr: *mut wire_cst_attribute_twin_sse,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_attribute_twin_sync {
     ptr: *mut wire_cst_attribute_twin_sync,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_attribute_twin_sync_sse {
     ptr: *mut wire_cst_attribute_twin_sync_sse,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_bool {
     ptr: *mut bool,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_element_twin_normal {
     ptr: *mut wire_cst_element_twin_normal,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_element_twin_rust_async {
     ptr: *mut wire_cst_element_twin_rust_async,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_element_twin_rust_async_sse {
     ptr: *mut wire_cst_element_twin_rust_async_sse,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_element_twin_sse {
     ptr: *mut wire_cst_element_twin_sse,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_element_twin_sync {
     ptr: *mut wire_cst_element_twin_sync,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_element_twin_sync_sse {
     ptr: *mut wire_cst_element_twin_sync_sse,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_enum_opaque_twin_normal {
     ptr: *mut wire_cst_enum_opaque_twin_normal,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_enum_opaque_twin_rust_async {
     ptr: *mut wire_cst_enum_opaque_twin_rust_async,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_enum_opaque_twin_rust_async_sse {
     ptr: *mut wire_cst_enum_opaque_twin_rust_async_sse,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_enum_opaque_twin_sse {
     ptr: *mut wire_cst_enum_opaque_twin_sse,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_enum_opaque_twin_sync {
     ptr: *mut wire_cst_enum_opaque_twin_sync,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_enum_opaque_twin_sync_sse {
     ptr: *mut wire_cst_enum_opaque_twin_sync_sse,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_my_enum {
     ptr: *mut i32,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_my_size {
     ptr: *mut wire_cst_my_size,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_my_tree_node_twin_normal {
     ptr: *mut wire_cst_my_tree_node_twin_normal,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_my_tree_node_twin_rust_async {
     ptr: *mut wire_cst_my_tree_node_twin_rust_async,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_my_tree_node_twin_rust_async_sse {
     ptr: *mut wire_cst_my_tree_node_twin_rust_async_sse,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_my_tree_node_twin_sse {
     ptr: *mut wire_cst_my_tree_node_twin_sse,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_my_tree_node_twin_sync {
     ptr: *mut wire_cst_my_tree_node_twin_sync,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_my_tree_node_twin_sync_sse {
     ptr: *mut wire_cst_my_tree_node_twin_sync_sse,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_nested_raw_string_mirrored {
     ptr: *mut wire_cst_nested_raw_string_mirrored,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_of_nested_raw_string_mirrored {
     raw: *mut wire_cst_list_nested_raw_string_mirrored,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_opt_String {
     ptr: *mut *mut wire_cst_list_prim_u_8,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_opt_box_autoadd_attribute_twin_normal {
     ptr: *mut *mut wire_cst_attribute_twin_normal,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_opt_box_autoadd_attribute_twin_rust_async {
     ptr: *mut *mut wire_cst_attribute_twin_rust_async,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_opt_box_autoadd_attribute_twin_rust_async_sse {
     ptr: *mut *mut wire_cst_attribute_twin_rust_async_sse,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_opt_box_autoadd_attribute_twin_sse {
     ptr: *mut *mut wire_cst_attribute_twin_sse,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_opt_box_autoadd_attribute_twin_sync {
     ptr: *mut *mut wire_cst_attribute_twin_sync,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_opt_box_autoadd_attribute_twin_sync_sse {
     ptr: *mut *mut wire_cst_attribute_twin_sync_sse,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_opt_box_autoadd_i_32 {
     ptr: *mut *mut i32,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_opt_box_autoadd_weekdays_twin_normal {
     ptr: *mut *mut i32,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_opt_box_autoadd_weekdays_twin_rust_async {
     ptr: *mut *mut i32,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_opt_box_autoadd_weekdays_twin_rust_async_sse {
     ptr: *mut *mut i32,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_opt_box_autoadd_weekdays_twin_sse {
     ptr: *mut *mut i32,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_opt_box_autoadd_weekdays_twin_sync {
     ptr: *mut *mut i32,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_opt_box_autoadd_weekdays_twin_sync_sse {
     ptr: *mut *mut i32,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_opt_list_prim_i_32 {
     ptr: *mut *mut wire_cst_list_prim_i_32,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_point_twin_normal {
     ptr: *mut wire_cst_point_twin_normal,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_point_twin_rust_async {
     ptr: *mut wire_cst_point_twin_rust_async,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_point_twin_rust_async_sse {
     ptr: *mut wire_cst_point_twin_rust_async_sse,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_point_twin_sse {
     ptr: *mut wire_cst_point_twin_sse,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_point_twin_sync {
     ptr: *mut wire_cst_point_twin_sync,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_point_twin_sync_sse {
     ptr: *mut wire_cst_point_twin_sync_sse,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_prim_f_32 {
     ptr: *mut f32,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_prim_f_64 {
     ptr: *mut f64,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_prim_i_16 {
     ptr: *mut i16,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_prim_i_32 {
     ptr: *mut i32,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_prim_i_64 {
     ptr: *mut i64,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_prim_i_8 {
     ptr: *mut i8,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_prim_u_16 {
     ptr: *mut u16,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_prim_u_32 {
     ptr: *mut u32,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_prim_u_64 {
     ptr: *mut u64,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_prim_u_8 {
     ptr: *mut u8,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_raw_string_enum_mirrored {
     ptr: *mut wire_cst_raw_string_enum_mirrored,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_raw_string_mirrored {
     ptr: *mut wire_cst_raw_string_mirrored,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_record_string_i_32 {
     ptr: *mut wire_cst_record_string_i_32,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_sum_with_twin_normal {
     ptr: *mut wire_cst_sum_with_twin_normal,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_sum_with_twin_rust_async {
     ptr: *mut wire_cst_sum_with_twin_rust_async,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_sum_with_twin_rust_async_sse {
     ptr: *mut wire_cst_sum_with_twin_rust_async_sse,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_sum_with_twin_sse {
     ptr: *mut wire_cst_sum_with_twin_sse,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_sum_with_twin_sync {
     ptr: *mut wire_cst_sum_with_twin_sync,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_sum_with_twin_sync_sse {
     ptr: *mut wire_cst_sum_with_twin_sync_sse,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_test_id_twin_normal {
     ptr: *mut wire_cst_test_id_twin_normal,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_test_id_twin_rust_async {
     ptr: *mut wire_cst_test_id_twin_rust_async,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_test_id_twin_rust_async_sse {
     ptr: *mut wire_cst_test_id_twin_rust_async_sse,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_test_id_twin_sse {
     ptr: *mut wire_cst_test_id_twin_sse,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_test_id_twin_sync {
     ptr: *mut wire_cst_test_id_twin_sync,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_test_id_twin_sync_sse {
     ptr: *mut wire_cst_test_id_twin_sync_sse,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_weekdays_twin_normal {
     ptr: *mut i32,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_weekdays_twin_rust_async {
     ptr: *mut i32,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_weekdays_twin_rust_async_sse {
     ptr: *mut i32,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_weekdays_twin_sse {
     ptr: *mut i32,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_weekdays_twin_sync {
     ptr: *mut i32,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_list_weekdays_twin_sync_sse {
     ptr: *mut i32,
     len: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_log_2_twin_normal {
     key: u32,
     value: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_log_2_twin_rust_async {
     key: u32,
     value: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_log_2_twin_rust_async_sse {
     key: u32,
     value: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_log_2_twin_sse {
     key: u32,
     value: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_log_2_twin_sync {
     key: u32,
     value: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_log_2_twin_sync_sse {
     key: u32,
     value: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_log_twin_normal {
     key: u32,
     value: u32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_log_twin_rust_async {
     key: u32,
     value: u32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_log_twin_rust_async_sse {
     key: u32,
     value: u32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_log_twin_sse {
     key: u32,
     value: u32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_macro_struct {
     data: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_measure_twin_normal {
     tag: i32,
-    kind: *mut MeasureTwinNormalKind,
+    kind: MeasureTwinNormalKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union MeasureTwinNormalKind {
-    Speed: *mut wire_cst_MeasureTwinNormal_Speed,
-    Distance: *mut wire_cst_MeasureTwinNormal_Distance,
+    Speed: wire_cst_MeasureTwinNormal_Speed,
+    Distance: wire_cst_MeasureTwinNormal_Distance,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_MeasureTwinNormal_Speed {
     field0: *mut wire_cst_speed_twin_normal,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_MeasureTwinNormal_Distance {
     field0: *mut wire_cst_distance_twin_normal,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_measure_twin_rust_async {
     tag: i32,
-    kind: *mut MeasureTwinRustAsyncKind,
+    kind: MeasureTwinRustAsyncKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union MeasureTwinRustAsyncKind {
-    Speed: *mut wire_cst_MeasureTwinRustAsync_Speed,
-    Distance: *mut wire_cst_MeasureTwinRustAsync_Distance,
+    Speed: wire_cst_MeasureTwinRustAsync_Speed,
+    Distance: wire_cst_MeasureTwinRustAsync_Distance,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_MeasureTwinRustAsync_Speed {
     field0: *mut wire_cst_speed_twin_rust_async,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_MeasureTwinRustAsync_Distance {
     field0: *mut wire_cst_distance_twin_rust_async,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_measure_twin_rust_async_sse {
     tag: i32,
-    kind: *mut MeasureTwinRustAsyncSseKind,
+    kind: MeasureTwinRustAsyncSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union MeasureTwinRustAsyncSseKind {
-    Speed: *mut wire_cst_MeasureTwinRustAsyncSse_Speed,
-    Distance: *mut wire_cst_MeasureTwinRustAsyncSse_Distance,
+    Speed: wire_cst_MeasureTwinRustAsyncSse_Speed,
+    Distance: wire_cst_MeasureTwinRustAsyncSse_Distance,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_MeasureTwinRustAsyncSse_Speed {
     field0: *mut wire_cst_speed_twin_rust_async_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_MeasureTwinRustAsyncSse_Distance {
     field0: *mut wire_cst_distance_twin_rust_async_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_measure_twin_sse {
     tag: i32,
-    kind: *mut MeasureTwinSseKind,
+    kind: MeasureTwinSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union MeasureTwinSseKind {
-    Speed: *mut wire_cst_MeasureTwinSse_Speed,
-    Distance: *mut wire_cst_MeasureTwinSse_Distance,
+    Speed: wire_cst_MeasureTwinSse_Speed,
+    Distance: wire_cst_MeasureTwinSse_Distance,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_MeasureTwinSse_Speed {
     field0: *mut wire_cst_speed_twin_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_MeasureTwinSse_Distance {
     field0: *mut wire_cst_distance_twin_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_measure_twin_sync {
     tag: i32,
-    kind: *mut MeasureTwinSyncKind,
+    kind: MeasureTwinSyncKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union MeasureTwinSyncKind {
-    Speed: *mut wire_cst_MeasureTwinSync_Speed,
-    Distance: *mut wire_cst_MeasureTwinSync_Distance,
+    Speed: wire_cst_MeasureTwinSync_Speed,
+    Distance: wire_cst_MeasureTwinSync_Distance,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_MeasureTwinSync_Speed {
     field0: *mut wire_cst_speed_twin_sync,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_MeasureTwinSync_Distance {
     field0: *mut wire_cst_distance_twin_sync,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_measure_twin_sync_sse {
     tag: i32,
-    kind: *mut MeasureTwinSyncSseKind,
+    kind: MeasureTwinSyncSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union MeasureTwinSyncSseKind {
-    Speed: *mut wire_cst_MeasureTwinSyncSse_Speed,
-    Distance: *mut wire_cst_MeasureTwinSyncSse_Distance,
+    Speed: wire_cst_MeasureTwinSyncSse_Speed,
+    Distance: wire_cst_MeasureTwinSyncSse_Distance,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_MeasureTwinSyncSse_Speed {
     field0: *mut wire_cst_speed_twin_sync_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_MeasureTwinSyncSse_Distance {
     field0: *mut wire_cst_distance_twin_sync_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_message_id_twin_normal {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_message_id_twin_rust_async {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_message_id_twin_rust_async_sse {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_message_id_twin_sse {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_message_id_twin_sync {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_message_id_twin_sync_sse {
     field0: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_mirror_struct_twin_normal {
     a: wire_cst_application_settings,
     b: wire_cst_my_struct,
@@ -40153,7 +37334,7 @@ pub struct wire_cst_mirror_struct_twin_normal {
     d: *mut wire_cst_list_application_settings,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_mirror_struct_twin_rust_async {
     a: wire_cst_application_settings,
     b: wire_cst_my_struct,
@@ -40161,7 +37342,7 @@ pub struct wire_cst_mirror_struct_twin_rust_async {
     d: *mut wire_cst_list_application_settings,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_mirror_struct_twin_rust_async_sse {
     a: wire_cst_application_settings,
     b: wire_cst_my_struct,
@@ -40169,7 +37350,7 @@ pub struct wire_cst_mirror_struct_twin_rust_async_sse {
     d: *mut wire_cst_list_application_settings,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_mirror_struct_twin_sse {
     a: wire_cst_application_settings,
     b: wire_cst_my_struct,
@@ -40177,7 +37358,7 @@ pub struct wire_cst_mirror_struct_twin_sse {
     d: *mut wire_cst_list_application_settings,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_mirror_struct_twin_sync {
     a: wire_cst_application_settings,
     b: wire_cst_my_struct,
@@ -40185,7 +37366,7 @@ pub struct wire_cst_mirror_struct_twin_sync {
     d: *mut wire_cst_list_application_settings,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_mirror_struct_twin_sync_sse {
     a: wire_cst_application_settings,
     b: wire_cst_my_struct,
@@ -40193,7 +37374,7 @@ pub struct wire_cst_mirror_struct_twin_sync_sse {
     d: *mut wire_cst_list_application_settings,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_more_than_just_one_raw_string_struct_twin_normal {
     regular: *mut wire_cst_list_prim_u_8,
     r#type: *mut wire_cst_list_prim_u_8,
@@ -40201,7 +37382,7 @@ pub struct wire_cst_more_than_just_one_raw_string_struct_twin_normal {
     another: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_more_than_just_one_raw_string_struct_twin_rust_async {
     regular: *mut wire_cst_list_prim_u_8,
     r#type: *mut wire_cst_list_prim_u_8,
@@ -40209,7 +37390,7 @@ pub struct wire_cst_more_than_just_one_raw_string_struct_twin_rust_async {
     another: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_more_than_just_one_raw_string_struct_twin_rust_async_sse {
     regular: *mut wire_cst_list_prim_u_8,
     r#type: *mut wire_cst_list_prim_u_8,
@@ -40217,7 +37398,7 @@ pub struct wire_cst_more_than_just_one_raw_string_struct_twin_rust_async_sse {
     another: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_more_than_just_one_raw_string_struct_twin_sse {
     regular: *mut wire_cst_list_prim_u_8,
     r#type: *mut wire_cst_list_prim_u_8,
@@ -40225,7 +37406,7 @@ pub struct wire_cst_more_than_just_one_raw_string_struct_twin_sse {
     another: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_more_than_just_one_raw_string_struct_twin_sync {
     regular: *mut wire_cst_list_prim_u_8,
     r#type: *mut wire_cst_list_prim_u_8,
@@ -40233,7 +37414,7 @@ pub struct wire_cst_more_than_just_one_raw_string_struct_twin_sync {
     another: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_more_than_just_one_raw_string_struct_twin_sync_sse {
     regular: *mut wire_cst_list_prim_u_8,
     r#type: *mut wire_cst_list_prim_u_8,
@@ -40241,74 +37422,74 @@ pub struct wire_cst_more_than_just_one_raw_string_struct_twin_sync_sse {
     another: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_my_nested_struct_twin_normal {
     tree_node: wire_cst_my_tree_node_twin_normal,
     weekday: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_my_nested_struct_twin_rust_async {
     tree_node: wire_cst_my_tree_node_twin_rust_async,
     weekday: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_my_nested_struct_twin_rust_async_sse {
     tree_node: wire_cst_my_tree_node_twin_rust_async_sse,
     weekday: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_my_nested_struct_twin_sse {
     tree_node: wire_cst_my_tree_node_twin_sse,
     weekday: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_my_nested_struct_twin_sync {
     tree_node: wire_cst_my_tree_node_twin_sync,
     weekday: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_my_nested_struct_twin_sync_sse {
     tree_node: wire_cst_my_tree_node_twin_sync_sse,
     weekday: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_my_size {
     width: i32,
     height: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_my_stream_entry_twin_normal {
     hello: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_my_stream_entry_twin_rust_async {
     hello: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_my_stream_entry_twin_rust_async_sse {
     hello: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_my_stream_entry_twin_sse {
     hello: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_my_struct {
     content: bool,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_my_tree_node_twin_normal {
     value_i32: i32,
     value_vec_u8: *mut wire_cst_list_prim_u_8,
@@ -40316,7 +37497,7 @@ pub struct wire_cst_my_tree_node_twin_normal {
     children: *mut wire_cst_list_my_tree_node_twin_normal,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_my_tree_node_twin_rust_async {
     value_i32: i32,
     value_vec_u8: *mut wire_cst_list_prim_u_8,
@@ -40324,7 +37505,7 @@ pub struct wire_cst_my_tree_node_twin_rust_async {
     children: *mut wire_cst_list_my_tree_node_twin_rust_async,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_my_tree_node_twin_rust_async_sse {
     value_i32: i32,
     value_vec_u8: *mut wire_cst_list_prim_u_8,
@@ -40332,7 +37513,7 @@ pub struct wire_cst_my_tree_node_twin_rust_async_sse {
     children: *mut wire_cst_list_my_tree_node_twin_rust_async_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_my_tree_node_twin_sse {
     value_i32: i32,
     value_vec_u8: *mut wire_cst_list_prim_u_8,
@@ -40340,7 +37521,7 @@ pub struct wire_cst_my_tree_node_twin_sse {
     children: *mut wire_cst_list_my_tree_node_twin_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_my_tree_node_twin_sync {
     value_i32: i32,
     value_vec_u8: *mut wire_cst_list_prim_u_8,
@@ -40348,7 +37529,7 @@ pub struct wire_cst_my_tree_node_twin_sync {
     children: *mut wire_cst_list_my_tree_node_twin_sync,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_my_tree_node_twin_sync_sse {
     value_i32: i32,
     value_vec_u8: *mut wire_cst_list_prim_u_8,
@@ -40356,129 +37537,129 @@ pub struct wire_cst_my_tree_node_twin_sync_sse {
     children: *mut wire_cst_list_my_tree_node_twin_sync_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_nested_raw_string_mirrored {
     raw: wire_cst_raw_string_mirrored,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_new_simple_struct {
     field: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_new_type_int_twin_normal {
     field0: i64,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_new_type_int_twin_rust_async {
     field0: i64,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_new_type_int_twin_rust_async_sse {
     field0: i64,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_new_type_int_twin_sse {
     field0: i64,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_new_type_int_twin_sync {
     field0: i64,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_new_type_int_twin_sync_sse {
     field0: i64,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_note_twin_normal {
     day: *mut i32,
     body: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_note_twin_rust_async {
     day: *mut i32,
     body: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_note_twin_rust_async_sse {
     day: *mut i32,
     body: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_note_twin_sse {
     day: *mut i32,
     body: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_note_twin_sync {
     day: *mut i32,
     body: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_note_twin_sync_sse {
     day: *mut i32,
     body: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_numbers {
     field0: *mut wire_cst_list_prim_i_32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_old_simple_struct {
     field: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_opaque_nested_twin_normal {
     first: *const std::ffi::c_void,
     second: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_opaque_nested_twin_rust_async {
     first: *const std::ffi::c_void,
     second: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_opaque_nested_twin_rust_async_sse {
     first: *const std::ffi::c_void,
     second: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_opaque_nested_twin_sse {
     first: *const std::ffi::c_void,
     second: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_opaque_nested_twin_sync {
     first: *const std::ffi::c_void,
     second: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_opaque_nested_twin_sync_sse {
     first: *const std::ffi::c_void,
     second: *const std::ffi::c_void,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_opt_vecs_twin_normal {
     i32: *mut wire_cst_list_opt_box_autoadd_i_32,
     enums: *mut wire_cst_list_opt_box_autoadd_weekdays_twin_normal,
@@ -40486,7 +37667,7 @@ pub struct wire_cst_opt_vecs_twin_normal {
     buffers: *mut wire_cst_list_opt_list_prim_i_32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_opt_vecs_twin_rust_async {
     i32: *mut wire_cst_list_opt_box_autoadd_i_32,
     enums: *mut wire_cst_list_opt_box_autoadd_weekdays_twin_rust_async,
@@ -40494,7 +37675,7 @@ pub struct wire_cst_opt_vecs_twin_rust_async {
     buffers: *mut wire_cst_list_opt_list_prim_i_32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_opt_vecs_twin_rust_async_sse {
     i32: *mut wire_cst_list_opt_box_autoadd_i_32,
     enums: *mut wire_cst_list_opt_box_autoadd_weekdays_twin_rust_async_sse,
@@ -40502,7 +37683,7 @@ pub struct wire_cst_opt_vecs_twin_rust_async_sse {
     buffers: *mut wire_cst_list_opt_list_prim_i_32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_opt_vecs_twin_sse {
     i32: *mut wire_cst_list_opt_box_autoadd_i_32,
     enums: *mut wire_cst_list_opt_box_autoadd_weekdays_twin_sse,
@@ -40510,7 +37691,7 @@ pub struct wire_cst_opt_vecs_twin_sse {
     buffers: *mut wire_cst_list_opt_list_prim_i_32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_opt_vecs_twin_sync {
     i32: *mut wire_cst_list_opt_box_autoadd_i_32,
     enums: *mut wire_cst_list_opt_box_autoadd_weekdays_twin_sync,
@@ -40518,7 +37699,7 @@ pub struct wire_cst_opt_vecs_twin_sync {
     buffers: *mut wire_cst_list_opt_list_prim_i_32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_opt_vecs_twin_sync_sse {
     i32: *mut wire_cst_list_opt_box_autoadd_i_32,
     enums: *mut wire_cst_list_opt_box_autoadd_weekdays_twin_sync_sse,
@@ -40526,497 +37707,487 @@ pub struct wire_cst_opt_vecs_twin_sync_sse {
     buffers: *mut wire_cst_list_opt_list_prim_i_32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_point_twin_normal {
     x: f32,
     y: f32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_point_twin_rust_async {
     x: f32,
     y: f32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_point_twin_rust_async_sse {
     x: f32,
     y: f32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_point_twin_sse {
     x: f32,
     y: f32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_point_twin_sync {
     x: f32,
     y: f32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_point_twin_sync_sse {
     x: f32,
     y: f32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_raw_string_enum_mirrored {
     tag: i32,
-    kind: *mut RawStringEnumMirroredKind,
+    kind: RawStringEnumMirroredKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union RawStringEnumMirroredKind {
-    Raw: *mut wire_cst_RawStringEnumMirrored_Raw,
-    Nested: *mut wire_cst_RawStringEnumMirrored_Nested,
-    ListOfNested: *mut wire_cst_RawStringEnumMirrored_ListOfNested,
+    Raw: wire_cst_RawStringEnumMirrored_Raw,
+    Nested: wire_cst_RawStringEnumMirrored_Nested,
+    ListOfNested: wire_cst_RawStringEnumMirrored_ListOfNested,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_RawStringEnumMirrored_Raw {
     field0: *mut wire_cst_raw_string_mirrored,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_RawStringEnumMirrored_Nested {
     field0: *mut wire_cst_nested_raw_string_mirrored,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_RawStringEnumMirrored_ListOfNested {
     field0: *mut wire_cst_list_of_nested_raw_string_mirrored,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_raw_string_item_struct_twin_normal {
     r#type: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_raw_string_item_struct_twin_rust_async {
     r#type: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_raw_string_item_struct_twin_rust_async_sse {
     r#type: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_raw_string_item_struct_twin_sse {
     r#type: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_raw_string_item_struct_twin_sync {
     r#type: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_raw_string_item_struct_twin_sync_sse {
     r#type: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_raw_string_mirrored {
     value: *mut wire_cst_list_prim_u_8,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_record_application_settings_raw_string_enum_mirrored {
     field0: wire_cst_application_settings,
     field1: wire_cst_raw_string_enum_mirrored,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_record_string_i_32 {
     field0: *mut wire_cst_list_prim_u_8,
     field1: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_sequences {
     field0: *mut wire_cst_list_prim_i_32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_some_struct_twin_normal {
     value: u32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_some_struct_twin_rust_async {
     value: u32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_some_struct_twin_rust_async_sse {
     value: u32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_some_struct_twin_sse {
     value: u32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_some_struct_twin_sync {
     value: u32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_some_struct_twin_sync_sse {
     value: u32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_speed_twin_normal {
     tag: i32,
-    kind: *mut SpeedTwinNormalKind,
+    kind: SpeedTwinNormalKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union SpeedTwinNormalKind {
-    Unknown: *mut wire_cst_SpeedTwinNormal_Unknown,
-    GPS: *mut wire_cst_SpeedTwinNormal_GPS,
+    GPS: wire_cst_SpeedTwinNormal_GPS,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
-pub struct wire_cst_SpeedTwinNormal_Unknown {}
-#[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_SpeedTwinNormal_GPS {
     field0: f64,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_speed_twin_rust_async {
     tag: i32,
-    kind: *mut SpeedTwinRustAsyncKind,
+    kind: SpeedTwinRustAsyncKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union SpeedTwinRustAsyncKind {
-    Unknown: *mut wire_cst_SpeedTwinRustAsync_Unknown,
-    GPS: *mut wire_cst_SpeedTwinRustAsync_GPS,
+    GPS: wire_cst_SpeedTwinRustAsync_GPS,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
-pub struct wire_cst_SpeedTwinRustAsync_Unknown {}
-#[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_SpeedTwinRustAsync_GPS {
     field0: f64,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_speed_twin_rust_async_sse {
     tag: i32,
-    kind: *mut SpeedTwinRustAsyncSseKind,
+    kind: SpeedTwinRustAsyncSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union SpeedTwinRustAsyncSseKind {
-    Unknown: *mut wire_cst_SpeedTwinRustAsyncSse_Unknown,
-    GPS: *mut wire_cst_SpeedTwinRustAsyncSse_GPS,
+    GPS: wire_cst_SpeedTwinRustAsyncSse_GPS,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
-pub struct wire_cst_SpeedTwinRustAsyncSse_Unknown {}
-#[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_SpeedTwinRustAsyncSse_GPS {
     field0: f64,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_speed_twin_sse {
     tag: i32,
-    kind: *mut SpeedTwinSseKind,
+    kind: SpeedTwinSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union SpeedTwinSseKind {
-    Unknown: *mut wire_cst_SpeedTwinSse_Unknown,
-    GPS: *mut wire_cst_SpeedTwinSse_GPS,
+    GPS: wire_cst_SpeedTwinSse_GPS,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
-pub struct wire_cst_SpeedTwinSse_Unknown {}
-#[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_SpeedTwinSse_GPS {
     field0: f64,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_speed_twin_sync {
     tag: i32,
-    kind: *mut SpeedTwinSyncKind,
+    kind: SpeedTwinSyncKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union SpeedTwinSyncKind {
-    Unknown: *mut wire_cst_SpeedTwinSync_Unknown,
-    GPS: *mut wire_cst_SpeedTwinSync_GPS,
+    GPS: wire_cst_SpeedTwinSync_GPS,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
-pub struct wire_cst_SpeedTwinSync_Unknown {}
-#[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_SpeedTwinSync_GPS {
     field0: f64,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_speed_twin_sync_sse {
     tag: i32,
-    kind: *mut SpeedTwinSyncSseKind,
+    kind: SpeedTwinSyncSseKind,
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub union SpeedTwinSyncSseKind {
-    Unknown: *mut wire_cst_SpeedTwinSyncSse_Unknown,
-    GPS: *mut wire_cst_SpeedTwinSyncSse_GPS,
+    GPS: wire_cst_SpeedTwinSyncSse_GPS,
+    nil__: (),
 }
 #[repr(C)]
-#[derive(Clone)]
-pub struct wire_cst_SpeedTwinSyncSse_Unknown {}
-#[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_SpeedTwinSyncSse_GPS {
     field0: f64,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_struct_with_comments_twin_normal {
     field_with_comments: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_struct_with_comments_twin_rust_async {
     field_with_comments: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_struct_with_comments_twin_rust_async_sse {
     field_with_comments: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_struct_with_comments_twin_sse {
     field_with_comments: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_struct_with_comments_twin_sync {
     field_with_comments: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_struct_with_comments_twin_sync_sse {
     field_with_comments: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_struct_with_enum_twin_normal {
     abc1: wire_cst_abc_twin_normal,
     abc2: wire_cst_abc_twin_normal,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_struct_with_enum_twin_rust_async {
     abc1: wire_cst_abc_twin_rust_async,
     abc2: wire_cst_abc_twin_rust_async,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_struct_with_enum_twin_rust_async_sse {
     abc1: wire_cst_abc_twin_rust_async_sse,
     abc2: wire_cst_abc_twin_rust_async_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_struct_with_enum_twin_sse {
     abc1: wire_cst_abc_twin_sse,
     abc2: wire_cst_abc_twin_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_struct_with_enum_twin_sync {
     abc1: wire_cst_abc_twin_sync,
     abc2: wire_cst_abc_twin_sync,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_struct_with_enum_twin_sync_sse {
     abc1: wire_cst_abc_twin_sync_sse,
     abc2: wire_cst_abc_twin_sync_sse,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_struct_with_one_field_twin_normal {
     a: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_struct_with_one_field_twin_rust_async {
     a: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_struct_with_one_field_twin_rust_async_sse {
     a: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_struct_with_one_field_twin_sse {
     a: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_struct_with_one_field_twin_sync {
     a: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_struct_with_one_field_twin_sync_sse {
     a: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_struct_with_two_field_twin_normal {
     a: i32,
     b: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_struct_with_two_field_twin_rust_async {
     a: i32,
     b: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_struct_with_two_field_twin_rust_async_sse {
     a: i32,
     b: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_struct_with_two_field_twin_sse {
     a: i32,
     b: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_struct_with_two_field_twin_sync {
     a: i32,
     b: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_struct_with_two_field_twin_sync_sse {
     a: i32,
     b: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_struct_with_zero_field_twin_normal {}
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_struct_with_zero_field_twin_rust_async {}
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_struct_with_zero_field_twin_rust_async_sse {}
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_struct_with_zero_field_twin_sse {}
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_struct_with_zero_field_twin_sync {}
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_struct_with_zero_field_twin_sync_sse {}
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_sum_with_twin_normal {
     x: u32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_sum_with_twin_rust_async {
     x: u32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_sum_with_twin_rust_async_sse {
     x: u32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_sum_with_twin_sse {
     x: u32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_sum_with_twin_sync {
     x: u32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_sum_with_twin_sync_sse {
     x: u32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_test_chrono_twin_normal {
     dt: *mut i64,
     dt2: *mut i64,
     du: *mut i64,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_test_chrono_twin_rust_async {
     dt: *mut i64,
     dt2: *mut i64,
     du: *mut i64,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_test_chrono_twin_sync {
     dt: *mut i64,
     dt2: *mut i64,
     du: *mut i64,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_test_id_twin_normal {
     field0: *mut wire_cst_list_prim_i_32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_test_id_twin_rust_async {
     field0: *mut wire_cst_list_prim_i_32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_test_id_twin_rust_async_sse {
     field0: *mut wire_cst_list_prim_i_32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_test_id_twin_sse {
     field0: *mut wire_cst_list_prim_i_32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_test_id_twin_sync {
     field0: *mut wire_cst_list_prim_i_32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_test_id_twin_sync_sse {
     field0: *mut wire_cst_list_prim_i_32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_test_model_twin_normal {
     id: u64,
     name: *mut wire_cst_list_prim_u_8,
@@ -41024,7 +38195,7 @@ pub struct wire_cst_test_model_twin_normal {
     alias_struct: wire_cst_my_struct,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_test_model_twin_rust_async {
     id: u64,
     name: *mut wire_cst_list_prim_u_8,
@@ -41032,7 +38203,7 @@ pub struct wire_cst_test_model_twin_rust_async {
     alias_struct: wire_cst_my_struct,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_test_model_twin_rust_async_sse {
     id: u64,
     name: *mut wire_cst_list_prim_u_8,
@@ -41040,7 +38211,7 @@ pub struct wire_cst_test_model_twin_rust_async_sse {
     alias_struct: wire_cst_my_struct,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_test_model_twin_sse {
     id: u64,
     name: *mut wire_cst_list_prim_u_8,
@@ -41048,7 +38219,7 @@ pub struct wire_cst_test_model_twin_sse {
     alias_struct: wire_cst_my_struct,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_test_model_twin_sync {
     id: u64,
     name: *mut wire_cst_list_prim_u_8,
@@ -41056,7 +38227,7 @@ pub struct wire_cst_test_model_twin_sync {
     alias_struct: wire_cst_my_struct,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_test_model_twin_sync_sse {
     id: u64,
     name: *mut wire_cst_list_prim_u_8,
@@ -41064,103 +38235,103 @@ pub struct wire_cst_test_model_twin_sync_sse {
     alias_struct: wire_cst_my_struct,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_tuple_struct_with_one_field_twin_normal {
     field0: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_tuple_struct_with_one_field_twin_rust_async {
     field0: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_tuple_struct_with_one_field_twin_rust_async_sse {
     field0: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_tuple_struct_with_one_field_twin_sse {
     field0: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_tuple_struct_with_one_field_twin_sync {
     field0: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_tuple_struct_with_one_field_twin_sync_sse {
     field0: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_tuple_struct_with_two_field_twin_normal {
     field0: i32,
     field1: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_tuple_struct_with_two_field_twin_rust_async {
     field0: i32,
     field1: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_tuple_struct_with_two_field_twin_rust_async_sse {
     field0: i32,
     field1: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_tuple_struct_with_two_field_twin_sse {
     field0: i32,
     field1: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_tuple_struct_with_two_field_twin_sync {
     field0: i32,
     field1: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_tuple_struct_with_two_field_twin_sync_sse {
     field0: i32,
     field1: i32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_user_id_twin_normal {
     value: u32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_user_id_twin_rust_async {
     value: u32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_user_id_twin_rust_async_sse {
     value: u32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_user_id_twin_sse {
     value: u32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_user_id_twin_sync {
     value: u32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_user_id_twin_sync_sse {
     value: u32,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_vec_of_primitive_pack_twin_normal {
     int8list: *mut wire_cst_list_prim_i_8,
     uint8list: *mut wire_cst_list_prim_u_8,
@@ -41175,7 +38346,7 @@ pub struct wire_cst_vec_of_primitive_pack_twin_normal {
     bool_list: *mut wire_cst_list_bool,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_vec_of_primitive_pack_twin_rust_async {
     int8list: *mut wire_cst_list_prim_i_8,
     uint8list: *mut wire_cst_list_prim_u_8,
@@ -41190,7 +38361,7 @@ pub struct wire_cst_vec_of_primitive_pack_twin_rust_async {
     bool_list: *mut wire_cst_list_bool,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_vec_of_primitive_pack_twin_rust_async_sse {
     int8list: *mut wire_cst_list_prim_i_8,
     uint8list: *mut wire_cst_list_prim_u_8,
@@ -41205,7 +38376,7 @@ pub struct wire_cst_vec_of_primitive_pack_twin_rust_async_sse {
     bool_list: *mut wire_cst_list_bool,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_vec_of_primitive_pack_twin_sse {
     int8list: *mut wire_cst_list_prim_i_8,
     uint8list: *mut wire_cst_list_prim_u_8,
@@ -41220,7 +38391,7 @@ pub struct wire_cst_vec_of_primitive_pack_twin_sse {
     bool_list: *mut wire_cst_list_bool,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_vec_of_primitive_pack_twin_sync {
     int8list: *mut wire_cst_list_prim_i_8,
     uint8list: *mut wire_cst_list_prim_u_8,
@@ -41235,7 +38406,7 @@ pub struct wire_cst_vec_of_primitive_pack_twin_sync {
     bool_list: *mut wire_cst_list_bool,
 }
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct wire_cst_vec_of_primitive_pack_twin_sync_sse {
     int8list: *mut wire_cst_list_prim_i_8,
     uint8list: *mut wire_cst_list_prim_u_8,


### PR DESCRIPTION
## Changes

(CST) Remove `*mut Enum_Variant` and inflate functions in favor of `MaybeUninit`. This reduces 1-2 allocations per enum instantiation and should reduce binary size somewhat.

## Checklist

- [ ] An issue to be fixed by this PR is listed above.
- [ ] New tests are added to ensure new features are working. Please refer to [this page](https://cjycode.com/flutter_rust_bridge/guides/contributing/tip) to see how to add a test.
- [x] `./frb_internal precommit --mode slow` (or `fast`) is run (it internal runs code generator, does auto formatting, etc).
- [ ] If this PR adds/changes features, documentations (in the `./website` folder) are updated.
- [x] CI is passing. Please refer to [this page](https://cjycode.com/flutter_rust_bridge/guides/contributing/tip) to see how to solve a failed CI.

## Remark for PR creator

- `./frb_internal --help` shows utilities for development.
- If fzyzcjy does not reply for a few days, maybe he just did not see it, so please ping him.
