### PR TITLE
Allow `#[frb(one, two)]` (originally only allow `#[frb(one)] #[frb(two)]`)

### DIFF
--- a/frb_codegen/src/library/codegen/parser/attribute_parser.rs
+++ b/frb_codegen/src/library/codegen/parser/attribute_parser.rs
@@ -399,6 +399,20 @@ mod tests {
     use syn::ItemFn;
 
     #[test]
+    fn test_multiple_via_comma() -> anyhow::Result<()> {
+        let parsed = parse("#[frb(sync, non_final)]")?;
+        assert_eq!(parsed.0, vec![FrbAttribute::Sync, FrbAttribute::NonFinal]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_multiple_via_hash() -> anyhow::Result<()> {
+        let parsed = parse("#[frb(sync)]\n#[frb(non_final)]")?;
+        assert_eq!(parsed.0, vec![FrbAttribute::Sync, FrbAttribute::NonFinal]);
+        Ok(())
+    }
+
+    #[test]
     fn test_empty() -> anyhow::Result<()> {
         let parsed = parse("#[frb]")?;
         assert_eq!(parsed.0, vec![]);

--- a/frb_codegen/src/library/codegen/parser/attribute_parser.rs
+++ b/frb_codegen/src/library/codegen/parser/attribute_parser.rs
@@ -135,7 +135,7 @@ struct FrbAttributesInner(Vec<FrbAttribute>);
 impl Parse for FrbAttributesInner {
     fn parse(input: ParseStream) -> Result<Self> {
         Ok(Self(
-            Punctuated::<FrbAttribute, Token![,]>::parse_terminated(&input)?
+            Punctuated::<FrbAttribute, Token![,]>::parse_terminated(input)?
                 .into_iter()
                 .collect(),
         ))


### PR DESCRIPTION
## Changes

_Please list issues fixed by this PR here, using format "Fixes #the-issue-number"._

## Checklist

- [ ] An issue to be fixed by this PR is listed above.
- [ ] New tests are added to ensure new features are working. Please refer to [this page](https://cjycode.com/flutter_rust_bridge/guides/contributing/tip) to see how to add a test.
- [ ] `./frb_internal precommit --mode slow` (or `fast`) is run (it internal runs code generator, does auto formatting, etc).
- [ ] If this PR adds/changes features, documentations (in the `./website` folder) are updated.
- [ ] CI is passing. Please refer to [this page](https://cjycode.com/flutter_rust_bridge/guides/contributing/tip) to see how to solve a failed CI.

## Remark for PR creator

- `./frb_internal --help` shows utilities for development.
- If fzyzcjy does not reply for a few days, maybe he just did not see it, so please ping him.
