### PR TITLE
Fix warning of CMake `No project() command is present` for Android build when using the library template in doc

### DIFF
--- a/website/docs/manual/integrate/07-library/03-platform-setup/03-android.md
+++ b/website/docs/manual/integrate/07-library/03-platform-setup/03-android.md
@@ -20,6 +20,7 @@ Instead, its sole purpose is to download & extract our Android binaries
 in a cross-platform friendly way. Here is our android `CMakeLists.txt`:
 ```cmake
 set(LibraryVersion "library_name-v0.0.0") # generated; do not edit
+set(PROJECT_NAME "project_name")
 
 # Unlike the Windows & Linux CMakeLists.txt, this Android equivalent is just here
 # to download the Android binaries into src/main/jniLibs/ and does not build anything.
@@ -30,6 +31,8 @@ set(LibraryVersion "library_name-v0.0.0") # generated; do not edit
 # installed. You should not increase this version, as doing so will cause
 # the plugin to fail to compile for some customers of the plugin.
 cmake_minimum_required(VERSION 3.10)
+
+project(PROJECT_NAME)
 
 # Download the binaries if they are not already present.
 set(LibRoot "${CMAKE_CURRENT_SOURCE_DIR}/src/main/jniLibs")

--- a/website/v1_mdbook/src/library/platform_setup/android.md
+++ b/website/v1_mdbook/src/library/platform_setup/android.md
@@ -20,6 +20,7 @@ Instead, its sole purpose is to download & extract our Android binaries
 in a cross-platform friendly way. Here is our android `CMakeLists.txt`:
 ```cmake
 set(LibraryVersion "library_name-v0.0.0") # generated; do not edit
+set(PROJECT_NAME "project_name")
 
 # Unlike the Windows & Linux CMakeLists.txt, this Android equivalent is just here
 # to download the Android binaries into src/main/jniLibs/ and does not build anything.
@@ -30,6 +31,8 @@ set(LibraryVersion "library_name-v0.0.0") # generated; do not edit
 # installed. You should not increase this version, as doing so will cause
 # the plugin to fail to compile for some customers of the plugin.
 cmake_minimum_required(VERSION 3.10)
+
+project(PROJECT_NAME)
 
 # Download the binaries if they are not already present.
 set(LibRoot "${CMAKE_CURRENT_SOURCE_DIR}/src/main/jniLibs")


### PR DESCRIPTION
## Changes

Close #1619

## Checklist

- [ ] An issue to be fixed by this PR is listed above.
- [ ] New tests are added to ensure new features are working. Please refer to [this page](https://cjycode.com/flutter_rust_bridge/guides/contributing/tip) to see how to add a test.
- [ ] `./frb_internal precommit --mode slow` (or `fast`) is run (it internal runs code generator, does auto formatting, etc).
- [ ] If this PR adds/changes features, documentations (in the `./website` folder) are updated.
- [ ] CI is passing. Please refer to [this page](https://cjycode.com/flutter_rust_bridge/guides/contributing/tip) to see how to solve a failed CI.

## Remark for PR creator

- `./frb_internal --help` shows utilities for development.
- If fzyzcjy does not reply for a few days, maybe he just did not see it, so please ping him.
