### PR TITLE
Add doc about property getter

### DIFF
--- a/website/docs/guides/miscellaneous/properties.md
+++ b/website/docs/guides/miscellaneous/properties.md
@@ -1,0 +1,26 @@
+# Properties
+
+Getters are currently supported.
+If you need setters, feel free to create an issue.
+
+It is often reasonable to use together with `sync` to create a sync Dart function.
+
+## Example
+
+```rust
+pub struct A { ... }
+
+impl A {
+    #[frb(sync, getter)]
+    pub fn something(&self) -> String { ... }
+}
+```
+
+It will provide the following getter automatically:
+
+```dart
+class A {
+    String get something { ... }
+    ...
+}
+```

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -179,6 +179,7 @@ const sidebars = {
                     items: [
                         'guides/miscellaneous/directory',
                         'guides/miscellaneous/methods',
+                        'guides/miscellaneous/properties',
                         'guides/miscellaneous/codec',
                         'guides/miscellaneous/build-rs',
                         'guides/miscellaneous/expanding-macros',


### PR DESCRIPTION
## Changes

Thanks @JustSimplyKyle for pointing out the missing doc in https://github.com/fzyzcjy/flutter_rust_bridge/pull/1600#issuecomment-1879899229

## Checklist

- [ ] An issue to be fixed by this PR is listed above.
- [ ] New tests are added to ensure new features are working. Please refer to [this page](https://cjycode.com/flutter_rust_bridge/guides/contributing/tip) to see how to add a test.
- [ ] `./frb_internal precommit --mode slow` (or `fast`) is run (it internal runs code generator, does auto formatting, etc).
- [ ] If this PR adds/changes features, documentations (in the `./website` folder) are updated.
- [ ] CI is passing. Please refer to [this page](https://cjycode.com/flutter_rust_bridge/guides/contributing/tip) to see how to solve a failed CI.

## Remark for PR creator

- `./frb_internal --help` shows utilities for development.
- If fzyzcjy does not reply for a few days, maybe he just did not see it, so please ping him.
