### PR TITLE
Update cargokit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -614,6 +614,7 @@ jobs:
         with:
           sdk: stable
           architecture: x64
+      - run: sudo apt-get update
 
       # execute
       - run: ./frb_internal test-dart-valgrind --package ${{ matrix.package }}


### PR DESCRIPTION
## Changes

Fix https://github.com/fzyzcjy/flutter_rust_bridge/issues/1606

## Checklist

:white_check_mark: An issue to be fixed by this PR is listed above.

:x: New tests are added to ensure new features are working. Please refer to [this page](https://cjycode.com/flutter_rust_bridge/guides/contributing/tip) to see how to add a test.
--> I don't really know how to test it and if it is worth the trouble as it it more a cargokit issue...
  Add a test and check there no 'warning' in stdout ?

:x: `./frb_internal precommit --mode slow` (or `fast`) is run (it internal runs code generator, does auto formatting, etc).
-> Both fail with the following error. But master also fail, so it is not because of this PR. The CI does not seem to run `./frb_internal precommit --mode slow`.
Is this command outdated ?

<details>
  <summary>Errors</summary>

```
    Checking frb_example_pure_dart v0.1.0 (/home/julien/AndroidStudioProjects/flutter_rust_bridge/frb_example/pure_dart/rust)
error[E0425]: cannot find function `slice_from_byte_buffer` in module `flutter_rust_bridge::for_generated`
     --> src/frb_generated.web.rs:11241:45
      |
11241 |         flutter_rust_bridge::for_generated::slice_from_byte_buffer(buf.to_vec()).into()
      |                                             ^^^^^^^^^^^^^^^^^^^^^^ not found in `flutter_rust_bridge::for_generated`

error[E0425]: cannot find function `slice_from_byte_buffer` in module `flutter_rust_bridge::for_generated`
     --> src/frb_generated.web.rs:11271:45
      |
11271 |         flutter_rust_bridge::for_generated::slice_from_byte_buffer(buf.to_vec()).into()
      |                                             ^^^^^^^^^^^^^^^^^^^^^^ not found in `flutter_rust_bridge::for_generated`

For more information about this error, try `rustc --explain E0425`.
error: could not compile `frb_example_pure_dart` (lib) due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
error: could not compile `frb_example_pure_dart` (lib test) due to 2 previous errors
Unhandled exception:
ProcessException: Bad exit code (101). If you want to see extra information, set FRB_DART_RUN_COMMAND_STDERR=1
  Command: /bin/sh -c cargo clippy --target wasm32-unknown-unknown --fix --allow-dirty --allow-staged -- -D warnings
#0      runCommand (package:flutter_rust_bridge/src/cli/run_command.dart:67:5)
<asynchronous suspension>
#1      SimpleExecutor.call (package:flutter_rust_bridge_internal/src/utils/makefile_dart_infra.dart:32:12)
<asynchronous suspension>
#2      lintRustClippy (package:flutter_rust_bridge_internal/src/makefile_dart/lint.dart:60:5)
<asynchronous suspension>
#3      precommit.<anonymous closure> (package:flutter_rust_bridge_internal/src/makefile_dart/misc.dart:70:7)
<asynchronous suspension>
#4      Future.wait.<anonymous closure> (dart:async/future.dart:523:21)
<asynchronous suspension>
#5      precommit (package:flutter_rust_bridge_internal/src/makefile_dart/misc.dart:64:3)
<asynchronous suspension>
#6      SimpleConfigCommand.run (package:flutter_rust_bridge_internal/src/utils/makefile_dart_infra.dart:88:31)
<asynchronous suspension>
#7      CommandRunner.runCommand (package:args/command_runner.dart:212:13)
<asynchronous suspension>
#8      main (file:///home/julien/AndroidStudioProjects/flutter_rust_bridge/tools/frb_internal/bin/flutter_rust_bridge_internal.dart:30:3)
<asynchronous suspension>
```
</details>

:black_square_button: CI is passing. Please refer to [this page](https://cjycode.com/flutter_rust_bridge/guides/contributing/tip) to see how to solve a failed CI.
-> Waiting for CI...

