### PR TITLE
Fix typo in `frb_example_pure_dart_exapmle_external_lib`

### DIFF
--- a/frb_example/pure_dart/rust/Cargo.lock
+++ b/frb_example/pure_dart/rust/Cargo.lock
@@ -290,7 +290,7 @@ dependencies = [
  "byteorder",
  "chrono",
  "flutter_rust_bridge",
- "frb_example_pure_dart_exapmle_external_lib",
+ "frb_example_pure_dart_example_external_lib",
  "futures",
  "lazy_static",
  "log",
@@ -303,7 +303,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "frb_example_pure_dart_exapmle_external_lib"
+name = "frb_example_pure_dart_example_external_lib"
 version = "0.1.0"
 
 [[package]]

--- a/frb_example/pure_dart/rust/Cargo.toml
+++ b/frb_example/pure_dart/rust/Cargo.toml
@@ -13,7 +13,7 @@ log = "0.4.19"
 backtrace = "0.3.68"
 chrono = "0.4.26"
 uuid = "1.4.1"
-frb_example_pure_dart_exapmle_external_lib = { path = "./example_external_lib" }
+frb_example_pure_dart_example_external_lib = { path = "./example_external_lib" }
 wasm-bindgen = "0.2.88" # TODO temp experiment
 byteorder = "1.5.0"
 lazy_static = "1.4.0"

--- a/frb_example/pure_dart/rust/example_external_lib/Cargo.toml
+++ b/frb_example/pure_dart/rust/example_external_lib/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "frb_example_pure_dart_exapmle_external_lib"
+name = "frb_example_pure_dart_example_external_lib"
 version = "0.1.0"
 
 [dependencies]

--- a/frb_example/pure_dart/rust/src/api/mirror.rs
+++ b/frb_example/pure_dart/rust/src/api/mirror.rs
@@ -6,7 +6,7 @@
 use crate::auxiliary::sample_types::{MyEnum, MyStruct};
 use crate::frb_generated::StreamSink;
 use flutter_rust_bridge::frb;
-pub use frb_example_pure_dart_exapmle_external_lib::{
+pub use frb_example_pure_dart_example_external_lib::{
     ApplicationEnv, ApplicationEnvVar, ApplicationMessage, ApplicationMode, ApplicationSettings,
     ListOfNestedRawStringMirrored, NestedRawStringMirrored, Numbers, RawStringEnumMirrored,
     RawStringMirrored, Sequences,
@@ -38,12 +38,12 @@ pub struct _ApplicationEnvTwinNormal {
 
 // This function can directly return an object of the external type ApplicationSettings because it has a mirror
 pub fn get_app_settings_twin_normal() -> ApplicationSettings {
-    frb_example_pure_dart_exapmle_external_lib::get_app_settings()
+    frb_example_pure_dart_example_external_lib::get_app_settings()
 }
 
 // This function can return a Result, that includes an object of the external type ApplicationSettings because it has a mirror
 pub fn get_fallible_app_settings_twin_normal() -> anyhow::Result<ApplicationSettings> {
-    Ok(frb_example_pure_dart_exapmle_external_lib::get_app_settings())
+    Ok(frb_example_pure_dart_example_external_lib::get_app_settings())
 }
 
 // Similarly, receiving an object from Dart works. Please note that the mirror definition must match entirely and the original struct must have all its fields public.
@@ -54,15 +54,15 @@ pub fn is_app_embedded_twin_normal(app_settings: ApplicationSettings) -> bool {
 
 // use a stream of a mirrored type
 pub fn app_settings_stream_twin_normal(sink: StreamSink<ApplicationSettings>) {
-    let app_settings = frb_example_pure_dart_exapmle_external_lib::get_app_settings();
+    let app_settings = frb_example_pure_dart_example_external_lib::get_app_settings();
     sink.add(app_settings).unwrap();
 }
 
 // use a stream of a vec of mirrored type
 pub fn app_settings_vec_stream_twin_normal(sink: StreamSink<Vec<ApplicationSettings>>) {
     let app_settings = vec![
-        frb_example_pure_dart_exapmle_external_lib::get_app_settings(),
-        frb_example_pure_dart_exapmle_external_lib::get_app_settings(),
+        frb_example_pure_dart_example_external_lib::get_app_settings(),
+        frb_example_pure_dart_example_external_lib::get_app_settings(),
     ];
     sink.add(app_settings).unwrap();
 }
@@ -77,12 +77,12 @@ pub struct MirrorStructTwinNormal {
 // use a Struct consisting of mirror types as argument to a Stream
 pub fn mirror_struct_stream_twin_normal(sink: StreamSink<MirrorStructTwinNormal>) {
     let val = MirrorStructTwinNormal {
-        a: frb_example_pure_dart_exapmle_external_lib::get_app_settings(),
+        a: frb_example_pure_dart_example_external_lib::get_app_settings(),
         b: MyStruct { content: true },
         c: vec![MyEnum::True, MyEnum::False],
         d: vec![
-            frb_example_pure_dart_exapmle_external_lib::get_app_settings(),
-            frb_example_pure_dart_exapmle_external_lib::get_app_settings(),
+            frb_example_pure_dart_example_external_lib::get_app_settings(),
+            frb_example_pure_dart_example_external_lib::get_app_settings(),
         ],
     };
     sink.add(val).unwrap();
@@ -93,7 +93,7 @@ pub fn mirror_tuple_stream_twin_normal(
     sink: StreamSink<(ApplicationSettings, RawStringEnumMirrored)>,
 ) {
     let tuple = (
-        frb_example_pure_dart_exapmle_external_lib::get_app_settings(),
+        frb_example_pure_dart_example_external_lib::get_app_settings(),
         RawStringEnumMirrored::Raw(RawStringMirrored {
             value: String::from("test"),
         }),
@@ -109,18 +109,18 @@ pub enum _ApplicationMessageTwinNormal {
 }
 
 pub fn get_message_twin_normal() -> ApplicationMessage {
-    frb_example_pure_dart_exapmle_external_lib::poll_messages()[1].clone()
+    frb_example_pure_dart_example_external_lib::poll_messages()[1].clone()
 }
 
 #[frb(mirror(Numbers, Sequences))]
 pub struct _NumbersTwinNormal(pub Vec<i32>);
 
 pub fn repeat_number_twin_normal(num: i32, times: usize) -> Numbers {
-    frb_example_pure_dart_exapmle_external_lib::repeat_number(num, times)
+    frb_example_pure_dart_example_external_lib::repeat_number(num, times)
 }
 
 pub fn repeat_sequence_twin_normal(seq: i32, times: usize) -> Sequences {
-    frb_example_pure_dart_exapmle_external_lib::repeat_sequences(seq, times)
+    frb_example_pure_dart_example_external_lib::repeat_sequences(seq, times)
 }
 
 pub fn first_number_twin_normal(nums: Numbers) -> Option<i32> {
@@ -213,7 +213,7 @@ pub fn test_list_of_nested_enums_mirrored_twin_normal() -> Vec<RawStringEnumMirr
 
 // TODO rm (use the auto-generated sync code)
 // pub fn sync_return_mirror_twin_normal() -> SyncReturn<ApplicationSettings> {
-//     SyncReturn(frb_example_pure_dart_exapmle_external_lib::get_app_settings())
+//     SyncReturn(frb_example_pure_dart_example_external_lib::get_app_settings())
 // }
 
 pub struct AnotherTwinNormal {

--- a/frb_example/pure_dart/rust/src/api/pseudo_manual/mirror_twin_rust_async.rs
+++ b/frb_example/pure_dart/rust/src/api/pseudo_manual/mirror_twin_rust_async.rs
@@ -10,7 +10,7 @@
 use crate::auxiliary::sample_types::{MyEnum, MyStruct};
 use crate::frb_generated::StreamSink;
 use flutter_rust_bridge::frb;
-pub use frb_example_pure_dart_exapmle_external_lib::{
+pub use frb_example_pure_dart_example_external_lib::{
     ApplicationEnv, ApplicationEnvVar, ApplicationMessage, ApplicationMode, ApplicationSettings,
     ListOfNestedRawStringMirrored, NestedRawStringMirrored, Numbers, RawStringEnumMirrored,
     RawStringMirrored, Sequences,
@@ -42,12 +42,12 @@ pub struct _ApplicationEnvTwinRustAsync {
 
 // This function can directly return an object of the external type ApplicationSettings because it has a mirror
 pub async fn get_app_settings_twin_rust_async() -> ApplicationSettings {
-    frb_example_pure_dart_exapmle_external_lib::get_app_settings()
+    frb_example_pure_dart_example_external_lib::get_app_settings()
 }
 
 // This function can return a Result, that includes an object of the external type ApplicationSettings because it has a mirror
 pub async fn get_fallible_app_settings_twin_rust_async() -> anyhow::Result<ApplicationSettings> {
-    Ok(frb_example_pure_dart_exapmle_external_lib::get_app_settings())
+    Ok(frb_example_pure_dart_example_external_lib::get_app_settings())
 }
 
 // Similarly, receiving an object from Dart works. Please note that the mirror definition must match entirely and the original struct must have all its fields public.
@@ -58,15 +58,15 @@ pub async fn is_app_embedded_twin_rust_async(app_settings: ApplicationSettings) 
 
 // use a stream of a mirrored type
 pub async fn app_settings_stream_twin_rust_async(sink: StreamSink<ApplicationSettings>) {
-    let app_settings = frb_example_pure_dart_exapmle_external_lib::get_app_settings();
+    let app_settings = frb_example_pure_dart_example_external_lib::get_app_settings();
     sink.add(app_settings).unwrap();
 }
 
 // use a stream of a vec of mirrored type
 pub async fn app_settings_vec_stream_twin_rust_async(sink: StreamSink<Vec<ApplicationSettings>>) {
     let app_settings = vec![
-        frb_example_pure_dart_exapmle_external_lib::get_app_settings(),
-        frb_example_pure_dart_exapmle_external_lib::get_app_settings(),
+        frb_example_pure_dart_example_external_lib::get_app_settings(),
+        frb_example_pure_dart_example_external_lib::get_app_settings(),
     ];
     sink.add(app_settings).unwrap();
 }
@@ -81,12 +81,12 @@ pub struct MirrorStructTwinRustAsync {
 // use a Struct consisting of mirror types as argument to a Stream
 pub async fn mirror_struct_stream_twin_rust_async(sink: StreamSink<MirrorStructTwinRustAsync>) {
     let val = MirrorStructTwinRustAsync {
-        a: frb_example_pure_dart_exapmle_external_lib::get_app_settings(),
+        a: frb_example_pure_dart_example_external_lib::get_app_settings(),
         b: MyStruct { content: true },
         c: vec![MyEnum::True, MyEnum::False],
         d: vec![
-            frb_example_pure_dart_exapmle_external_lib::get_app_settings(),
-            frb_example_pure_dart_exapmle_external_lib::get_app_settings(),
+            frb_example_pure_dart_example_external_lib::get_app_settings(),
+            frb_example_pure_dart_example_external_lib::get_app_settings(),
         ],
     };
     sink.add(val).unwrap();
@@ -97,7 +97,7 @@ pub async fn mirror_tuple_stream_twin_rust_async(
     sink: StreamSink<(ApplicationSettings, RawStringEnumMirrored)>,
 ) {
     let tuple = (
-        frb_example_pure_dart_exapmle_external_lib::get_app_settings(),
+        frb_example_pure_dart_example_external_lib::get_app_settings(),
         RawStringEnumMirrored::Raw(RawStringMirrored {
             value: String::from("test"),
         }),
@@ -113,18 +113,18 @@ pub enum _ApplicationMessageTwinRustAsync {
 }
 
 pub async fn get_message_twin_rust_async() -> ApplicationMessage {
-    frb_example_pure_dart_exapmle_external_lib::poll_messages()[1].clone()
+    frb_example_pure_dart_example_external_lib::poll_messages()[1].clone()
 }
 
 #[frb(mirror(Numbers, Sequences))]
 pub struct _NumbersTwinRustAsync(pub Vec<i32>);
 
 pub async fn repeat_number_twin_rust_async(num: i32, times: usize) -> Numbers {
-    frb_example_pure_dart_exapmle_external_lib::repeat_number(num, times)
+    frb_example_pure_dart_example_external_lib::repeat_number(num, times)
 }
 
 pub async fn repeat_sequence_twin_rust_async(seq: i32, times: usize) -> Sequences {
-    frb_example_pure_dart_exapmle_external_lib::repeat_sequences(seq, times)
+    frb_example_pure_dart_example_external_lib::repeat_sequences(seq, times)
 }
 
 pub async fn first_number_twin_rust_async(nums: Numbers) -> Option<i32> {
@@ -218,7 +218,7 @@ pub async fn test_list_of_nested_enums_mirrored_twin_rust_async() -> Vec<RawStri
 
 // TODO rm (use the auto-generated sync code)
 // pub async fn sync_return_mirror_twin_rust_async() -> SyncReturn<ApplicationSettings> {
-//     SyncReturn(frb_example_pure_dart_exapmle_external_lib::get_app_settings())
+//     SyncReturn(frb_example_pure_dart_example_external_lib::get_app_settings())
 // }
 
 pub struct AnotherTwinRustAsync {

--- a/frb_example/pure_dart/rust/src/api/pseudo_manual/mirror_twin_rust_async_sse.rs
+++ b/frb_example/pure_dart/rust/src/api/pseudo_manual/mirror_twin_rust_async_sse.rs
@@ -10,7 +10,7 @@
 use crate::auxiliary::sample_types::{MyEnum, MyStruct};
 use crate::frb_generated::StreamSink;
 use flutter_rust_bridge::frb;
-pub use frb_example_pure_dart_exapmle_external_lib::{
+pub use frb_example_pure_dart_example_external_lib::{
     ApplicationEnv, ApplicationEnvVar, ApplicationMessage, ApplicationMode, ApplicationSettings,
     ListOfNestedRawStringMirrored, NestedRawStringMirrored, Numbers, RawStringEnumMirrored,
     RawStringMirrored, Sequences,
@@ -43,14 +43,14 @@ pub struct _ApplicationEnvTwinRustAsyncSse {
 // This function can directly return an object of the external type ApplicationSettings because it has a mirror
 #[flutter_rust_bridge::frb(serialize)]
 pub async fn get_app_settings_twin_rust_async_sse() -> ApplicationSettings {
-    frb_example_pure_dart_exapmle_external_lib::get_app_settings()
+    frb_example_pure_dart_example_external_lib::get_app_settings()
 }
 
 // This function can return a Result, that includes an object of the external type ApplicationSettings because it has a mirror
 #[flutter_rust_bridge::frb(serialize)]
 pub async fn get_fallible_app_settings_twin_rust_async_sse() -> anyhow::Result<ApplicationSettings>
 {
-    Ok(frb_example_pure_dart_exapmle_external_lib::get_app_settings())
+    Ok(frb_example_pure_dart_example_external_lib::get_app_settings())
 }
 
 // Similarly, receiving an object from Dart works. Please note that the mirror definition must match entirely and the original struct must have all its fields public.
@@ -65,7 +65,7 @@ pub async fn is_app_embedded_twin_rust_async_sse(app_settings: ApplicationSettin
 pub async fn app_settings_stream_twin_rust_async_sse(
     sink: StreamSink<ApplicationSettings, flutter_rust_bridge::SseCodec>,
 ) {
-    let app_settings = frb_example_pure_dart_exapmle_external_lib::get_app_settings();
+    let app_settings = frb_example_pure_dart_example_external_lib::get_app_settings();
     sink.add(app_settings).unwrap();
 }
 
@@ -75,8 +75,8 @@ pub async fn app_settings_vec_stream_twin_rust_async_sse(
     sink: StreamSink<Vec<ApplicationSettings>, flutter_rust_bridge::SseCodec>,
 ) {
     let app_settings = vec![
-        frb_example_pure_dart_exapmle_external_lib::get_app_settings(),
-        frb_example_pure_dart_exapmle_external_lib::get_app_settings(),
+        frb_example_pure_dart_example_external_lib::get_app_settings(),
+        frb_example_pure_dart_example_external_lib::get_app_settings(),
     ];
     sink.add(app_settings).unwrap();
 }
@@ -94,12 +94,12 @@ pub async fn mirror_struct_stream_twin_rust_async_sse(
     sink: StreamSink<MirrorStructTwinRustAsyncSse, flutter_rust_bridge::SseCodec>,
 ) {
     let val = MirrorStructTwinRustAsyncSse {
-        a: frb_example_pure_dart_exapmle_external_lib::get_app_settings(),
+        a: frb_example_pure_dart_example_external_lib::get_app_settings(),
         b: MyStruct { content: true },
         c: vec![MyEnum::True, MyEnum::False],
         d: vec![
-            frb_example_pure_dart_exapmle_external_lib::get_app_settings(),
-            frb_example_pure_dart_exapmle_external_lib::get_app_settings(),
+            frb_example_pure_dart_example_external_lib::get_app_settings(),
+            frb_example_pure_dart_example_external_lib::get_app_settings(),
         ],
     };
     sink.add(val).unwrap();
@@ -111,7 +111,7 @@ pub async fn mirror_tuple_stream_twin_rust_async_sse(
     sink: StreamSink<(ApplicationSettings, RawStringEnumMirrored), flutter_rust_bridge::SseCodec>,
 ) {
     let tuple = (
-        frb_example_pure_dart_exapmle_external_lib::get_app_settings(),
+        frb_example_pure_dart_example_external_lib::get_app_settings(),
         RawStringEnumMirrored::Raw(RawStringMirrored {
             value: String::from("test"),
         }),
@@ -128,7 +128,7 @@ pub enum _ApplicationMessageTwinRustAsyncSse {
 
 #[flutter_rust_bridge::frb(serialize)]
 pub async fn get_message_twin_rust_async_sse() -> ApplicationMessage {
-    frb_example_pure_dart_exapmle_external_lib::poll_messages()[1].clone()
+    frb_example_pure_dart_example_external_lib::poll_messages()[1].clone()
 }
 
 #[frb(mirror(Numbers, Sequences))]
@@ -136,12 +136,12 @@ pub struct _NumbersTwinRustAsyncSse(pub Vec<i32>);
 
 #[flutter_rust_bridge::frb(serialize)]
 pub async fn repeat_number_twin_rust_async_sse(num: i32, times: usize) -> Numbers {
-    frb_example_pure_dart_exapmle_external_lib::repeat_number(num, times)
+    frb_example_pure_dart_example_external_lib::repeat_number(num, times)
 }
 
 #[flutter_rust_bridge::frb(serialize)]
 pub async fn repeat_sequence_twin_rust_async_sse(seq: i32, times: usize) -> Sequences {
-    frb_example_pure_dart_exapmle_external_lib::repeat_sequences(seq, times)
+    frb_example_pure_dart_example_external_lib::repeat_sequences(seq, times)
 }
 
 #[flutter_rust_bridge::frb(serialize)]
@@ -246,7 +246,7 @@ pub async fn test_list_of_nested_enums_mirrored_twin_rust_async_sse() -> Vec<Raw
 
 // TODO rm (use the auto-generated sync code)
 // #[flutter_rust_bridge::frb(serialize)] pub async fn sync_return_mirror_twin_rust_async_sse() -> SyncReturn<ApplicationSettings> {
-//     SyncReturn(frb_example_pure_dart_exapmle_external_lib::get_app_settings())
+//     SyncReturn(frb_example_pure_dart_example_external_lib::get_app_settings())
 // }
 
 pub struct AnotherTwinRustAsyncSse {

--- a/frb_example/pure_dart/rust/src/api/pseudo_manual/mirror_twin_sse.rs
+++ b/frb_example/pure_dart/rust/src/api/pseudo_manual/mirror_twin_sse.rs
@@ -10,7 +10,7 @@
 use crate::auxiliary::sample_types::{MyEnum, MyStruct};
 use crate::frb_generated::StreamSink;
 use flutter_rust_bridge::frb;
-pub use frb_example_pure_dart_exapmle_external_lib::{
+pub use frb_example_pure_dart_example_external_lib::{
     ApplicationEnv, ApplicationEnvVar, ApplicationMessage, ApplicationMode, ApplicationSettings,
     ListOfNestedRawStringMirrored, NestedRawStringMirrored, Numbers, RawStringEnumMirrored,
     RawStringMirrored, Sequences,
@@ -43,13 +43,13 @@ pub struct _ApplicationEnvTwinSse {
 // This function can directly return an object of the external type ApplicationSettings because it has a mirror
 #[flutter_rust_bridge::frb(serialize)]
 pub fn get_app_settings_twin_sse() -> ApplicationSettings {
-    frb_example_pure_dart_exapmle_external_lib::get_app_settings()
+    frb_example_pure_dart_example_external_lib::get_app_settings()
 }
 
 // This function can return a Result, that includes an object of the external type ApplicationSettings because it has a mirror
 #[flutter_rust_bridge::frb(serialize)]
 pub fn get_fallible_app_settings_twin_sse() -> anyhow::Result<ApplicationSettings> {
-    Ok(frb_example_pure_dart_exapmle_external_lib::get_app_settings())
+    Ok(frb_example_pure_dart_example_external_lib::get_app_settings())
 }
 
 // Similarly, receiving an object from Dart works. Please note that the mirror definition must match entirely and the original struct must have all its fields public.
@@ -64,7 +64,7 @@ pub fn is_app_embedded_twin_sse(app_settings: ApplicationSettings) -> bool {
 pub fn app_settings_stream_twin_sse(
     sink: StreamSink<ApplicationSettings, flutter_rust_bridge::SseCodec>,
 ) {
-    let app_settings = frb_example_pure_dart_exapmle_external_lib::get_app_settings();
+    let app_settings = frb_example_pure_dart_example_external_lib::get_app_settings();
     sink.add(app_settings).unwrap();
 }
 
@@ -74,8 +74,8 @@ pub fn app_settings_vec_stream_twin_sse(
     sink: StreamSink<Vec<ApplicationSettings>, flutter_rust_bridge::SseCodec>,
 ) {
     let app_settings = vec![
-        frb_example_pure_dart_exapmle_external_lib::get_app_settings(),
-        frb_example_pure_dart_exapmle_external_lib::get_app_settings(),
+        frb_example_pure_dart_example_external_lib::get_app_settings(),
+        frb_example_pure_dart_example_external_lib::get_app_settings(),
     ];
     sink.add(app_settings).unwrap();
 }
@@ -93,12 +93,12 @@ pub fn mirror_struct_stream_twin_sse(
     sink: StreamSink<MirrorStructTwinSse, flutter_rust_bridge::SseCodec>,
 ) {
     let val = MirrorStructTwinSse {
-        a: frb_example_pure_dart_exapmle_external_lib::get_app_settings(),
+        a: frb_example_pure_dart_example_external_lib::get_app_settings(),
         b: MyStruct { content: true },
         c: vec![MyEnum::True, MyEnum::False],
         d: vec![
-            frb_example_pure_dart_exapmle_external_lib::get_app_settings(),
-            frb_example_pure_dart_exapmle_external_lib::get_app_settings(),
+            frb_example_pure_dart_example_external_lib::get_app_settings(),
+            frb_example_pure_dart_example_external_lib::get_app_settings(),
         ],
     };
     sink.add(val).unwrap();
@@ -110,7 +110,7 @@ pub fn mirror_tuple_stream_twin_sse(
     sink: StreamSink<(ApplicationSettings, RawStringEnumMirrored), flutter_rust_bridge::SseCodec>,
 ) {
     let tuple = (
-        frb_example_pure_dart_exapmle_external_lib::get_app_settings(),
+        frb_example_pure_dart_example_external_lib::get_app_settings(),
         RawStringEnumMirrored::Raw(RawStringMirrored {
             value: String::from("test"),
         }),
@@ -127,7 +127,7 @@ pub enum _ApplicationMessageTwinSse {
 
 #[flutter_rust_bridge::frb(serialize)]
 pub fn get_message_twin_sse() -> ApplicationMessage {
-    frb_example_pure_dart_exapmle_external_lib::poll_messages()[1].clone()
+    frb_example_pure_dart_example_external_lib::poll_messages()[1].clone()
 }
 
 #[frb(mirror(Numbers, Sequences))]
@@ -135,12 +135,12 @@ pub struct _NumbersTwinSse(pub Vec<i32>);
 
 #[flutter_rust_bridge::frb(serialize)]
 pub fn repeat_number_twin_sse(num: i32, times: usize) -> Numbers {
-    frb_example_pure_dart_exapmle_external_lib::repeat_number(num, times)
+    frb_example_pure_dart_example_external_lib::repeat_number(num, times)
 }
 
 #[flutter_rust_bridge::frb(serialize)]
 pub fn repeat_sequence_twin_sse(seq: i32, times: usize) -> Sequences {
-    frb_example_pure_dart_exapmle_external_lib::repeat_sequences(seq, times)
+    frb_example_pure_dart_example_external_lib::repeat_sequences(seq, times)
 }
 
 #[flutter_rust_bridge::frb(serialize)]
@@ -240,7 +240,7 @@ pub fn test_list_of_nested_enums_mirrored_twin_sse() -> Vec<RawStringEnumMirrore
 
 // TODO rm (use the auto-generated sync code)
 // #[flutter_rust_bridge::frb(serialize)] pub fn sync_return_mirror_twin_sse() -> SyncReturn<ApplicationSettings> {
-//     SyncReturn(frb_example_pure_dart_exapmle_external_lib::get_app_settings())
+//     SyncReturn(frb_example_pure_dart_example_external_lib::get_app_settings())
 // }
 
 pub struct AnotherTwinSse {

--- a/frb_example/pure_dart/rust/src/api/pseudo_manual/mirror_twin_sync.rs
+++ b/frb_example/pure_dart/rust/src/api/pseudo_manual/mirror_twin_sync.rs
@@ -10,7 +10,7 @@
 use crate::auxiliary::sample_types::{MyEnum, MyStruct};
 use crate::frb_generated::StreamSink;
 use flutter_rust_bridge::frb;
-pub use frb_example_pure_dart_exapmle_external_lib::{
+pub use frb_example_pure_dart_example_external_lib::{
     ApplicationEnv, ApplicationEnvVar, ApplicationMessage, ApplicationMode, ApplicationSettings,
     ListOfNestedRawStringMirrored, NestedRawStringMirrored, Numbers, RawStringEnumMirrored,
     RawStringMirrored, Sequences,
@@ -43,13 +43,13 @@ pub struct _ApplicationEnvTwinSync {
 // This function can directly return an object of the external type ApplicationSettings because it has a mirror
 #[flutter_rust_bridge::frb(sync)]
 pub fn get_app_settings_twin_sync() -> ApplicationSettings {
-    frb_example_pure_dart_exapmle_external_lib::get_app_settings()
+    frb_example_pure_dart_example_external_lib::get_app_settings()
 }
 
 // This function can return a Result, that includes an object of the external type ApplicationSettings because it has a mirror
 #[flutter_rust_bridge::frb(sync)]
 pub fn get_fallible_app_settings_twin_sync() -> anyhow::Result<ApplicationSettings> {
-    Ok(frb_example_pure_dart_exapmle_external_lib::get_app_settings())
+    Ok(frb_example_pure_dart_example_external_lib::get_app_settings())
 }
 
 // Similarly, receiving an object from Dart works. Please note that the mirror definition must match entirely and the original struct must have all its fields public.
@@ -62,7 +62,7 @@ pub fn is_app_embedded_twin_sync(app_settings: ApplicationSettings) -> bool {
 // use a stream of a mirrored type
 #[flutter_rust_bridge::frb(sync)]
 pub fn app_settings_stream_twin_sync(sink: StreamSink<ApplicationSettings>) {
-    let app_settings = frb_example_pure_dart_exapmle_external_lib::get_app_settings();
+    let app_settings = frb_example_pure_dart_example_external_lib::get_app_settings();
     sink.add(app_settings).unwrap();
 }
 
@@ -70,8 +70,8 @@ pub fn app_settings_stream_twin_sync(sink: StreamSink<ApplicationSettings>) {
 #[flutter_rust_bridge::frb(sync)]
 pub fn app_settings_vec_stream_twin_sync(sink: StreamSink<Vec<ApplicationSettings>>) {
     let app_settings = vec![
-        frb_example_pure_dart_exapmle_external_lib::get_app_settings(),
-        frb_example_pure_dart_exapmle_external_lib::get_app_settings(),
+        frb_example_pure_dart_example_external_lib::get_app_settings(),
+        frb_example_pure_dart_example_external_lib::get_app_settings(),
     ];
     sink.add(app_settings).unwrap();
 }
@@ -87,12 +87,12 @@ pub struct MirrorStructTwinSync {
 #[flutter_rust_bridge::frb(sync)]
 pub fn mirror_struct_stream_twin_sync(sink: StreamSink<MirrorStructTwinSync>) {
     let val = MirrorStructTwinSync {
-        a: frb_example_pure_dart_exapmle_external_lib::get_app_settings(),
+        a: frb_example_pure_dart_example_external_lib::get_app_settings(),
         b: MyStruct { content: true },
         c: vec![MyEnum::True, MyEnum::False],
         d: vec![
-            frb_example_pure_dart_exapmle_external_lib::get_app_settings(),
-            frb_example_pure_dart_exapmle_external_lib::get_app_settings(),
+            frb_example_pure_dart_example_external_lib::get_app_settings(),
+            frb_example_pure_dart_example_external_lib::get_app_settings(),
         ],
     };
     sink.add(val).unwrap();
@@ -104,7 +104,7 @@ pub fn mirror_tuple_stream_twin_sync(
     sink: StreamSink<(ApplicationSettings, RawStringEnumMirrored)>,
 ) {
     let tuple = (
-        frb_example_pure_dart_exapmle_external_lib::get_app_settings(),
+        frb_example_pure_dart_example_external_lib::get_app_settings(),
         RawStringEnumMirrored::Raw(RawStringMirrored {
             value: String::from("test"),
         }),
@@ -121,7 +121,7 @@ pub enum _ApplicationMessageTwinSync {
 
 #[flutter_rust_bridge::frb(sync)]
 pub fn get_message_twin_sync() -> ApplicationMessage {
-    frb_example_pure_dart_exapmle_external_lib::poll_messages()[1].clone()
+    frb_example_pure_dart_example_external_lib::poll_messages()[1].clone()
 }
 
 #[frb(mirror(Numbers, Sequences))]
@@ -129,12 +129,12 @@ pub struct _NumbersTwinSync(pub Vec<i32>);
 
 #[flutter_rust_bridge::frb(sync)]
 pub fn repeat_number_twin_sync(num: i32, times: usize) -> Numbers {
-    frb_example_pure_dart_exapmle_external_lib::repeat_number(num, times)
+    frb_example_pure_dart_example_external_lib::repeat_number(num, times)
 }
 
 #[flutter_rust_bridge::frb(sync)]
 pub fn repeat_sequence_twin_sync(seq: i32, times: usize) -> Sequences {
-    frb_example_pure_dart_exapmle_external_lib::repeat_sequences(seq, times)
+    frb_example_pure_dart_example_external_lib::repeat_sequences(seq, times)
 }
 
 #[flutter_rust_bridge::frb(sync)]
@@ -234,7 +234,7 @@ pub fn test_list_of_nested_enums_mirrored_twin_sync() -> Vec<RawStringEnumMirror
 
 // TODO rm (use the auto-generated sync code)
 // #[flutter_rust_bridge::frb(sync)] pub fn sync_return_mirror_twin_sync() -> SyncReturn<ApplicationSettings> {
-//     SyncReturn(frb_example_pure_dart_exapmle_external_lib::get_app_settings())
+//     SyncReturn(frb_example_pure_dart_example_external_lib::get_app_settings())
 // }
 
 pub struct AnotherTwinSync {

--- a/frb_example/pure_dart/rust/src/api/pseudo_manual/mirror_twin_sync_sse.rs
+++ b/frb_example/pure_dart/rust/src/api/pseudo_manual/mirror_twin_sync_sse.rs
@@ -10,7 +10,7 @@
 use crate::auxiliary::sample_types::{MyEnum, MyStruct};
 use crate::frb_generated::StreamSink;
 use flutter_rust_bridge::frb;
-pub use frb_example_pure_dart_exapmle_external_lib::{
+pub use frb_example_pure_dart_example_external_lib::{
     ApplicationEnv, ApplicationEnvVar, ApplicationMessage, ApplicationMode, ApplicationSettings,
     ListOfNestedRawStringMirrored, NestedRawStringMirrored, Numbers, RawStringEnumMirrored,
     RawStringMirrored, Sequences,
@@ -44,14 +44,14 @@ pub struct _ApplicationEnvTwinSyncSse {
 #[flutter_rust_bridge::frb(serialize)]
 #[flutter_rust_bridge::frb(sync)]
 pub fn get_app_settings_twin_sync_sse() -> ApplicationSettings {
-    frb_example_pure_dart_exapmle_external_lib::get_app_settings()
+    frb_example_pure_dart_example_external_lib::get_app_settings()
 }
 
 // This function can return a Result, that includes an object of the external type ApplicationSettings because it has a mirror
 #[flutter_rust_bridge::frb(serialize)]
 #[flutter_rust_bridge::frb(sync)]
 pub fn get_fallible_app_settings_twin_sync_sse() -> anyhow::Result<ApplicationSettings> {
-    Ok(frb_example_pure_dart_exapmle_external_lib::get_app_settings())
+    Ok(frb_example_pure_dart_example_external_lib::get_app_settings())
 }
 
 // Similarly, receiving an object from Dart works. Please note that the mirror definition must match entirely and the original struct must have all its fields public.
@@ -68,7 +68,7 @@ pub fn is_app_embedded_twin_sync_sse(app_settings: ApplicationSettings) -> bool 
 pub fn app_settings_stream_twin_sync_sse(
     sink: StreamSink<ApplicationSettings, flutter_rust_bridge::SseCodec>,
 ) {
-    let app_settings = frb_example_pure_dart_exapmle_external_lib::get_app_settings();
+    let app_settings = frb_example_pure_dart_example_external_lib::get_app_settings();
     sink.add(app_settings).unwrap();
 }
 
@@ -79,8 +79,8 @@ pub fn app_settings_vec_stream_twin_sync_sse(
     sink: StreamSink<Vec<ApplicationSettings>, flutter_rust_bridge::SseCodec>,
 ) {
     let app_settings = vec![
-        frb_example_pure_dart_exapmle_external_lib::get_app_settings(),
-        frb_example_pure_dart_exapmle_external_lib::get_app_settings(),
+        frb_example_pure_dart_example_external_lib::get_app_settings(),
+        frb_example_pure_dart_example_external_lib::get_app_settings(),
     ];
     sink.add(app_settings).unwrap();
 }
@@ -99,12 +99,12 @@ pub fn mirror_struct_stream_twin_sync_sse(
     sink: StreamSink<MirrorStructTwinSyncSse, flutter_rust_bridge::SseCodec>,
 ) {
     let val = MirrorStructTwinSyncSse {
-        a: frb_example_pure_dart_exapmle_external_lib::get_app_settings(),
+        a: frb_example_pure_dart_example_external_lib::get_app_settings(),
         b: MyStruct { content: true },
         c: vec![MyEnum::True, MyEnum::False],
         d: vec![
-            frb_example_pure_dart_exapmle_external_lib::get_app_settings(),
-            frb_example_pure_dart_exapmle_external_lib::get_app_settings(),
+            frb_example_pure_dart_example_external_lib::get_app_settings(),
+            frb_example_pure_dart_example_external_lib::get_app_settings(),
         ],
     };
     sink.add(val).unwrap();
@@ -117,7 +117,7 @@ pub fn mirror_tuple_stream_twin_sync_sse(
     sink: StreamSink<(ApplicationSettings, RawStringEnumMirrored), flutter_rust_bridge::SseCodec>,
 ) {
     let tuple = (
-        frb_example_pure_dart_exapmle_external_lib::get_app_settings(),
+        frb_example_pure_dart_example_external_lib::get_app_settings(),
         RawStringEnumMirrored::Raw(RawStringMirrored {
             value: String::from("test"),
         }),
@@ -135,7 +135,7 @@ pub enum _ApplicationMessageTwinSyncSse {
 #[flutter_rust_bridge::frb(serialize)]
 #[flutter_rust_bridge::frb(sync)]
 pub fn get_message_twin_sync_sse() -> ApplicationMessage {
-    frb_example_pure_dart_exapmle_external_lib::poll_messages()[1].clone()
+    frb_example_pure_dart_example_external_lib::poll_messages()[1].clone()
 }
 
 #[frb(mirror(Numbers, Sequences))]
@@ -144,13 +144,13 @@ pub struct _NumbersTwinSyncSse(pub Vec<i32>);
 #[flutter_rust_bridge::frb(serialize)]
 #[flutter_rust_bridge::frb(sync)]
 pub fn repeat_number_twin_sync_sse(num: i32, times: usize) -> Numbers {
-    frb_example_pure_dart_exapmle_external_lib::repeat_number(num, times)
+    frb_example_pure_dart_example_external_lib::repeat_number(num, times)
 }
 
 #[flutter_rust_bridge::frb(serialize)]
 #[flutter_rust_bridge::frb(sync)]
 pub fn repeat_sequence_twin_sync_sse(seq: i32, times: usize) -> Sequences {
-    frb_example_pure_dart_exapmle_external_lib::repeat_sequences(seq, times)
+    frb_example_pure_dart_example_external_lib::repeat_sequences(seq, times)
 }
 
 #[flutter_rust_bridge::frb(serialize)]
@@ -259,7 +259,7 @@ pub fn test_list_of_nested_enums_mirrored_twin_sync_sse() -> Vec<RawStringEnumMi
 
 // TODO rm (use the auto-generated sync code)
 // #[flutter_rust_bridge::frb(serialize)] #[flutter_rust_bridge::frb(sync)] pub fn sync_return_mirror_twin_sync_sse() -> SyncReturn<ApplicationSettings> {
-//     SyncReturn(frb_example_pure_dart_exapmle_external_lib::get_app_settings())
+//     SyncReturn(frb_example_pure_dart_example_external_lib::get_app_settings())
 // }
 
 pub struct AnotherTwinSyncSse {


### PR DESCRIPTION
Fixes a typo in package name, just a find-replace

## Changes

No issue, fixes a typo

## Checklist

- [ ] An issue to be fixed by this PR is listed above.
- [ ] New tests are added to ensure new features are working. Please refer to [this page](https://cjycode.com/flutter_rust_bridge/guides/contributing/tip) to see how to add a test.
- [ ] `./frb_internal precommit --mode slow` (or `fast`) is run (it internal runs code generator, does auto formatting, etc).
- [ ] If this PR adds/changes features, documentations (in the `./website` folder) are updated.
- [ ] CI is passing. Please refer to [this page](https://cjycode.com/flutter_rust_bridge/guides/contributing/tip) to see how to solve a failed CI.

## Remark for PR creator

- `./frb_internal --help` shows utilities for development.
- If fzyzcjy does not reply for a few days, maybe he just did not see it, so please ping him.
