### PR TITLE
Fix `integrate` command's default template has `rust_lib` hardcoded instead of custom names

### DIFF
--- a/frb_codegen/assets/integration_template/lib/src/rust/frb_generated.dart
+++ b/frb_codegen/assets/integration_template/lib/src/rust/frb_generated.dart
@@ -54,7 +54,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
-    stem: 'rust_lib',
+    stem: 'REPLACE_ME_RUST_CRATE_NAME',
     ioDirectory: 'rust/target/release/',
     webPrefix: 'pkg/',
   );


### PR DESCRIPTION
## Changes

Close https://github.com/fzyzcjy/flutter_rust_bridge/issues/1668

## Checklist

- [ ] An issue to be fixed by this PR is listed above.
- [ ] New tests are added to ensure new features are working. Please refer to [this page](https://cjycode.com/flutter_rust_bridge/guides/contributing/tip) to see how to add a test.
- [ ] `./frb_internal precommit --mode slow` (or `fast`) is run (it internal runs code generator, does auto formatting, etc).
- [ ] If this PR adds/changes features, documentations (in the `./website` folder) are updated.
- [ ] CI is passing. Please refer to [this page](https://cjycode.com/flutter_rust_bridge/guides/contributing/tip) to see how to solve a failed CI.

## Remark for PR creator

- `./frb_internal --help` shows utilities for development.
- If fzyzcjy does not reply for a few days, maybe he just did not see it, so please ping him.
