### PR TITLE
Add checks when build_runner needs to be a dependency

### DIFF
--- a/frb_codegen/src/library/codegen/polisher/mod.rs
+++ b/frb_codegen/src/library/codegen/polisher/mod.rs
@@ -63,7 +63,11 @@ fn ensure_dependency_freezed(
             DartDependencyMode::Main,
             &ANY_REQUIREMENT,
         )?;
-        repo.has_specified_and_installed("build_runner", DartDependencyMode::Dev, &ANY_REQUIREMENT)?;
+        repo.has_specified_and_installed(
+            "build_runner",
+            DartDependencyMode::Dev,
+            &ANY_REQUIREMENT,
+        )?;
     }
     Ok(())
 }

--- a/frb_codegen/src/library/codegen/polisher/mod.rs
+++ b/frb_codegen/src/library/codegen/polisher/mod.rs
@@ -63,6 +63,7 @@ fn ensure_dependency_freezed(
             DartDependencyMode::Main,
             &ANY_REQUIREMENT,
         )?;
+        repo.has_specified_and_installed("build_runner", DartDependencyMode::Dev, &ANY_REQUIREMENT)?;
     }
     Ok(())
 }


### PR DESCRIPTION
## Changes

Close #1694

## Checklist

- [ ] An issue to be fixed by this PR is listed above.
- [ ] New tests are added to ensure new features are working. Please refer to [this page](https://cjycode.com/flutter_rust_bridge/guides/contributing/tip) to see how to add a test.
- [ ] `./frb_internal precommit --mode slow` (or `fast`) is run (it internal runs code generator, does auto formatting, etc).
- [ ] If this PR adds/changes features, documentations (in the `./website` folder) are updated.
- [ ] CI is passing. Please refer to [this page](https://cjycode.com/flutter_rust_bridge/guides/contributing/tip) to see how to solve a failed CI.

## Remark for PR creator

- `./frb_internal --help` shows utilities for development.
- If fzyzcjy does not reply for a few days, maybe he just did not see it, so please ping him.
