### PR TITLE
Fix failure of formatting Dart code when path is too long

### DIFF
--- a/frb_codegen/src/library/codegen/polisher/mod.rs
+++ b/frb_codegen/src/library/codegen/polisher/mod.rs
@@ -13,7 +13,7 @@ use itertools::Itertools;
 use lazy_static::lazy_static;
 use log::warn;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 pub(crate) mod add_mod_to_lib;
@@ -40,7 +40,7 @@ pub(super) fn polish(
         "execute_dart_format",
     );
     warn_if_fail(
-        execute_rust_format(output_paths, progress_bar_pack),
+        execute_rust_format(output_paths, &config.rust_crate_dir, progress_bar_pack),
         "execute_rust_format",
     );
 
@@ -113,10 +113,11 @@ fn execute_dart_format(
 
 fn execute_rust_format(
     output_paths: &[PathBuf],
+    base_path: &Path,
     progress_bar_pack: &GeneratorProgressBarPack,
 ) -> anyhow::Result<()> {
     let _pb = progress_bar_pack.polish_rust_formatter.start();
-    format_rust(&filter_paths_by_extension(output_paths, "rs"))
+    format_rust(&filter_paths_by_extension(output_paths, "rs"), base_path)
 }
 
 fn filter_paths_by_extension(paths: &[PathBuf], extension: &str) -> Vec<PathBuf> {

--- a/frb_codegen/src/library/codegen/polisher/mod.rs
+++ b/frb_codegen/src/library/codegen/polisher/mod.rs
@@ -106,6 +106,7 @@ fn execute_dart_format(
     let _pb = progress_bar_pack.polish_dart_formatter.start();
     format_dart(
         &filter_paths_by_extension(output_paths, "dart"),
+        &config.dart_root,
         config.dart_format_line_length,
     )
 }

--- a/frb_codegen/src/library/commands/command_runner.rs
+++ b/frb_codegen/src/library/commands/command_runner.rs
@@ -113,7 +113,7 @@ pub(crate) fn execute_command<'a>(
 
     let result = cmd
         .output()
-        .with_context(|| format!("\"{bin}\" \"{args_display}\" failed"))?;
+        .with_context(|| format!(r#""{bin}" "{args_display}" failed (cmd={cmd:?})"#))?;
 
     let stdout = String::from_utf8_lossy(&result.stdout);
     if result.status.success() {

--- a/frb_codegen/src/library/commands/format_dart.rs
+++ b/frb_codegen/src/library/commands/format_dart.rs
@@ -7,7 +7,13 @@ use std::path::{Path, PathBuf};
 
 #[allow(clippy::vec_init_then_push)]
 pub fn format_dart(paths: &[PathBuf], base_path: &Path, line_length: u32) -> anyhow::Result<()> {
-    let paths = normalize_windows_unc_paths(paths)?;
+    let paths = (paths.iter())
+        .map(|p| {
+            Ok(normalize_windows_unc_path(&path_to_string(p)?)
+                .to_owned()
+                .into())
+        })
+        .collect()?;
     debug!("execute format_dart path={path:?} line_length={line_length}");
 
     let res = command_run!(
@@ -20,14 +26,4 @@ pub fn format_dart(paths: &[PathBuf], base_path: &Path, line_length: u32) -> any
     )?;
     check_exit_code(&res)?;
     Ok(())
-}
-
-pub(super) fn normalize_windows_unc_paths(paths: &[PathBuf]) -> anyhow::Result<Vec<PathBuf>> {
-    (paths.iter())
-        .map(|p| {
-            Ok(normalize_windows_unc_path(&path_to_string(p)?)
-                .to_owned()
-                .into())
-        })
-        .collect()
 }

--- a/frb_codegen/src/library/commands/format_dart.rs
+++ b/frb_codegen/src/library/commands/format_dart.rs
@@ -3,10 +3,10 @@ use crate::commands::command_runner::call_shell;
 use crate::library::commands::command_runner::check_exit_code;
 use crate::utils::path_utils::{normalize_windows_unc_path, path_to_string};
 use log::debug;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[allow(clippy::vec_init_then_push)]
-pub fn format_dart(path: &[PathBuf], line_length: u32) -> anyhow::Result<()> {
+pub fn format_dart(path: &[PathBuf], base_path: &Path, line_length: u32) -> anyhow::Result<()> {
     let path = normalize_windows_unc_paths(path)?;
     debug!("execute format_dart path={path:?} line_length={line_length}");
 

--- a/frb_codegen/src/library/commands/format_dart.rs
+++ b/frb_codegen/src/library/commands/format_dart.rs
@@ -25,11 +25,12 @@ pub fn format_dart(paths: &[PathBuf], base_path: &Path, line_length: u32) -> any
 }
 
 pub(super) fn prepare_paths(paths: &[PathBuf], base_path: &Path) -> anyhow::Result<Vec<PathBuf>> {
+    let normalized_base_path = normalize_windows_unc_path(&path_to_string(base_path)?);
     (paths.iter())
         .map(|path| {
             let mut path: PathBuf =
                 (normalize_windows_unc_path(&path_to_string(path)?).to_owned()).into();
-            path = diff_paths(path, base_path).context("diff path")?;
+            path = diff_paths(path, normalized_base_path).context("diff path")?;
             if path_to_string(&path)?.is_empty() {
                 path = ".".into();
             }

--- a/frb_codegen/src/library/commands/format_dart.rs
+++ b/frb_codegen/src/library/commands/format_dart.rs
@@ -9,14 +9,7 @@ use std::path::{Path, PathBuf};
 
 #[allow(clippy::vec_init_then_push)]
 pub fn format_dart(paths: &[PathBuf], base_path: &Path, line_length: u32) -> anyhow::Result<()> {
-    let paths = (paths.iter())
-        .map(|path| {
-            let path: PathBuf =
-                (normalize_windows_unc_path(&path_to_string(path)?).to_owned()).into();
-            let path = diff_paths(path, base_path).context("diff path")?;
-            Ok(path)
-        })
-        .collect()?;
+    let paths = prepare_paths(paths, base_path)?;
     debug!("execute format_dart paths={paths:?} line_length={line_length}");
 
     let res = command_run!(
@@ -29,4 +22,15 @@ pub fn format_dart(paths: &[PathBuf], base_path: &Path, line_length: u32) -> any
     )?;
     check_exit_code(&res)?;
     Ok(())
+}
+
+pub(super) fn prepare_paths(paths: &[PathBuf], base_path: &Path) -> anyhow::Result<Vec<PathBuf>> {
+    (paths.iter())
+        .map(|path| {
+            let path: PathBuf =
+                (normalize_windows_unc_path(&path_to_string(path)?).to_owned()).into();
+            let path = diff_paths(path, base_path).context("diff path")?;
+            Ok(path)
+        })
+        .collect()
 }

--- a/frb_codegen/src/library/commands/format_dart.rs
+++ b/frb_codegen/src/library/commands/format_dart.rs
@@ -27,9 +27,12 @@ pub fn format_dart(paths: &[PathBuf], base_path: &Path, line_length: u32) -> any
 pub(super) fn prepare_paths(paths: &[PathBuf], base_path: &Path) -> anyhow::Result<Vec<PathBuf>> {
     (paths.iter())
         .map(|path| {
-            let path: PathBuf =
+            let mut path: PathBuf =
                 (normalize_windows_unc_path(&path_to_string(path)?).to_owned()).into();
-            let path = diff_paths(path, base_path).context("diff path")?;
+            path = diff_paths(path, base_path).context("diff path")?;
+            if path_to_string(&path)? == "" {
+                path = ".".into();
+            }
             Ok(path)
         })
         .collect()

--- a/frb_codegen/src/library/commands/format_dart.rs
+++ b/frb_codegen/src/library/commands/format_dart.rs
@@ -30,7 +30,7 @@ pub(super) fn prepare_paths(paths: &[PathBuf], base_path: &Path) -> anyhow::Resu
             let mut path: PathBuf =
                 (normalize_windows_unc_path(&path_to_string(path)?).to_owned()).into();
             path = diff_paths(path, base_path).context("diff path")?;
-            if path_to_string(&path)? == "" {
+            if path_to_string(&path)?.is_empty() {
                 path = ".".into();
             }
             Ok(path)

--- a/frb_codegen/src/library/commands/format_dart.rs
+++ b/frb_codegen/src/library/commands/format_dart.rs
@@ -25,7 +25,9 @@ pub fn format_dart(paths: &[PathBuf], base_path: &Path, line_length: u32) -> any
 }
 
 pub(super) fn prepare_paths(paths: &[PathBuf], base_path: &Path) -> anyhow::Result<Vec<PathBuf>> {
-    let normalized_base_path = normalize_windows_unc_path(&path_to_string(base_path)?);
+    let base_path_str = path_to_string(base_path)?;
+    let normalized_base_path = normalize_windows_unc_path(&base_path_str);
+
     (paths.iter())
         .map(|path| {
             let mut path: PathBuf =

--- a/frb_codegen/src/library/commands/format_dart.rs
+++ b/frb_codegen/src/library/commands/format_dart.rs
@@ -6,8 +6,8 @@ use log::debug;
 use std::path::{Path, PathBuf};
 
 #[allow(clippy::vec_init_then_push)]
-pub fn format_dart(path: &[PathBuf], base_path: &Path, line_length: u32) -> anyhow::Result<()> {
-    let path = normalize_windows_unc_paths(path)?;
+pub fn format_dart(paths: &[PathBuf], base_path: &Path, line_length: u32) -> anyhow::Result<()> {
+    let paths = normalize_windows_unc_paths(paths)?;
     debug!("execute format_dart path={path:?} line_length={line_length}");
 
     let res = command_run!(
@@ -16,7 +16,7 @@ pub fn format_dart(path: &[PathBuf], base_path: &Path, line_length: u32) -> anyh
         "format",
         "--line-length",
         line_length.to_string(),
-        *path
+        *paths
     )?;
     check_exit_code(&res)?;
     Ok(())

--- a/frb_codegen/src/library/commands/format_dart.rs
+++ b/frb_codegen/src/library/commands/format_dart.rs
@@ -2,22 +2,25 @@ use crate::command_run;
 use crate::commands::command_runner::call_shell;
 use crate::library::commands::command_runner::check_exit_code;
 use crate::utils::path_utils::{normalize_windows_unc_path, path_to_string};
+use anyhow::Context;
 use log::debug;
+use pathdiff::diff_paths;
 use std::path::{Path, PathBuf};
 
 #[allow(clippy::vec_init_then_push)]
 pub fn format_dart(paths: &[PathBuf], base_path: &Path, line_length: u32) -> anyhow::Result<()> {
     let paths = (paths.iter())
-        .map(|p| {
-            Ok(normalize_windows_unc_path(&path_to_string(p)?)
-                .to_owned()
-                .into())
+        .map(|path| {
+            let path: PathBuf =
+                (normalize_windows_unc_path(&path_to_string(path)?).to_owned()).into();
+            let path = diff_paths(path, base_path).context("diff path")?;
+            Ok(path)
         })
         .collect()?;
-    debug!("execute format_dart path={path:?} line_length={line_length}");
+    debug!("execute format_dart paths={paths:?} line_length={line_length}");
 
     let res = command_run!(
-        call_shell[None, None],
+        call_shell[Some(base_path), None],
         "dart",
         "format",
         "--line-length",

--- a/frb_codegen/src/library/commands/format_rust.rs
+++ b/frb_codegen/src/library/commands/format_rust.rs
@@ -1,6 +1,5 @@
 use crate::command_run;
 use crate::library::commands::command_runner::{call_shell, check_exit_code};
-use crate::library::commands::format_dart::normalize_windows_unc_paths;
 use log::debug;
 use std::path::PathBuf;
 

--- a/frb_codegen/src/library/commands/format_rust.rs
+++ b/frb_codegen/src/library/commands/format_rust.rs
@@ -1,17 +1,19 @@
 use crate::command_run;
 use crate::library::commands::command_runner::{call_shell, check_exit_code};
+use crate::library::commands::format_dart::prepare_paths;
 use log::debug;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-pub fn format_rust(path: &[PathBuf]) -> anyhow::Result<()> {
-    let path = normalize_windows_unc_paths(path)?;
-    debug!("execute format_rust path={path:?}");
+pub fn format_rust(paths: &[PathBuf], base_path: &Path) -> anyhow::Result<()> {
+    let paths = prepare_paths(paths, base_path)?;
+    debug!("execute format_rust paths={paths:?}");
+
     check_exit_code(&command_run!(
-        call_shell[None, None],
+        call_shell[Some(base_path), None],
         "rustfmt",
         // otherwise cannot understand `async move`
         "--edition",
         "2018",
-        *path
+        *paths
     )?)
 }

--- a/frb_codegen/src/library/integration/integrator.rs
+++ b/frb_codegen/src/library/integration/integrator.rs
@@ -55,7 +55,7 @@ pub fn integrate(config: IntegrateConfig) -> Result<()> {
 
     setup_cargokit_dependencies(&dart_root)?;
 
-    format_dart(&[dart_root], 80)?;
+    format_dart(&[dart_root], &dart_root, 80)?;
 
     Ok(())
 }

--- a/frb_codegen/src/library/integration/integrator.rs
+++ b/frb_codegen/src/library/integration/integrator.rs
@@ -55,7 +55,7 @@ pub fn integrate(config: IntegrateConfig) -> Result<()> {
 
     setup_cargokit_dependencies(&dart_root)?;
 
-    format_dart(&[dart_root], &dart_root, 80)?;
+    format_dart(&[dart_root.clone()], &dart_root, 80)?;
 
     Ok(())
 }

--- a/frb_codegen/src/library/internal/frb_rust_source_code.rs
+++ b/frb_codegen/src/library/internal/frb_rust_source_code.rs
@@ -32,7 +32,7 @@ pub(crate) fn generate_frb_rust_source_code(repo_base_dir: &Path) -> anyhow::Res
     );
 
     fs::write(&path_target, text)?;
-    format_rust(&[path_target.clone()], &path_target)?;
+    format_rust(&[path_target.clone()], &path_target.parent().unwrap())?;
 
     Ok(())
 }

--- a/frb_codegen/src/library/internal/frb_rust_source_code.rs
+++ b/frb_codegen/src/library/internal/frb_rust_source_code.rs
@@ -32,7 +32,7 @@ pub(crate) fn generate_frb_rust_source_code(repo_base_dir: &Path) -> anyhow::Res
     );
 
     fs::write(&path_target, text)?;
-    format_rust(&[path_target.clone()], &path_target.parent().unwrap())?;
+    format_rust(&[path_target.clone()], path_target.parent().unwrap())?;
 
     Ok(())
 }

--- a/frb_codegen/src/library/internal/frb_rust_source_code.rs
+++ b/frb_codegen/src/library/internal/frb_rust_source_code.rs
@@ -32,7 +32,7 @@ pub(crate) fn generate_frb_rust_source_code(repo_base_dir: &Path) -> anyhow::Res
     );
 
     fs::write(&path_target, text)?;
-    format_rust(&[path_target], &path_target)?;
+    format_rust(&[path_target.clone()], &path_target)?;
 
     Ok(())
 }

--- a/frb_codegen/src/library/internal/frb_rust_source_code.rs
+++ b/frb_codegen/src/library/internal/frb_rust_source_code.rs
@@ -32,7 +32,7 @@ pub(crate) fn generate_frb_rust_source_code(repo_base_dir: &Path) -> anyhow::Res
     );
 
     fs::write(&path_target, text)?;
-    format_rust(&[path_target])?;
+    format_rust(&[path_target], &path_target)?;
 
     Ok(())
 }


### PR DESCRIPTION
## Changes

_Please list issues fixed by this PR here, using format "Fixes #the-issue-number"._

## Checklist

- [ ] An issue to be fixed by this PR is listed above.
- [ ] New tests are added to ensure new features are working. Please refer to [this page](https://cjycode.com/flutter_rust_bridge/guides/contributing/tip) to see how to add a test.
- [ ] `./frb_internal precommit --mode slow` (or `fast`) is run (it internal runs code generator, does auto formatting, etc).
- [ ] If this PR adds/changes features, documentations (in the `./website` folder) are updated.
- [ ] CI is passing. Please refer to [this page](https://cjycode.com/flutter_rust_bridge/guides/contributing/tip) to see how to solve a failed CI.

## Remark for PR creator

- `./frb_internal --help` shows utilities for development.
- If fzyzcjy does not reply for a few days, maybe he just did not see it, so please ping him.
