### PR TITLE
More friendly error message for Unit Struct

### DIFF
--- a/frb_codegen/src/library/codegen/parser/type_parser/structure.rs
+++ b/frb_codegen/src/library/codegen/parser/type_parser/structure.rs
@@ -36,7 +36,7 @@ impl<'a, 'b, 'c> TypeParserWithContext<'a, 'b, 'c> {
             Fields::Unnamed(FieldsUnnamed { unnamed, .. }) => (false, unnamed),
             // This will stop the whole generator and tell the users, so we do not care about testing it
             // frb-coverage:ignore-start
-            Fields::Unit => bail!("struct with unit fields are not supported yet, what about using `struct YourStructName {{}}` instead"),
+            Fields::Unit => bail!("struct with unit fields are not supported yet, what about using `struct {} {{}}` instead", src_struct.0.ident),
             // frb-coverage:ignore-end
         };
 


### PR DESCRIPTION
for unit struct:

```rust
pub struct App;
```

Error message before: 

```
struct with unit fields are not supported yet, what about using `struct YourStructName {}`
```

Error message after: 

```
struct with unit fields are not supported yet, what about using `struct App {}`
```

which is much more friendly for users to figure how to fix.

PS. I don't know how to write a good test for this ...