### PR TITLE
Only run `build.rs` if `api` directory changes

### DIFF
--- a/frb_example/dart_build_rs/rust/build.rs
+++ b/frb_example/dart_build_rs/rust/build.rs
@@ -3,7 +3,8 @@ use lib_flutter_rust_bridge_codegen::codegen::Config;
 use lib_flutter_rust_bridge_codegen::utils::logs::configure_opinionated_logging;
 
 fn main() -> anyhow::Result<()> {
-    // Uncomment the below line, if you only want to generate bindings on api directory change.
+    // Uncomment the line below, if you only want to generate bindings on api directory change.
+    //
     // NOTE: This accelerates the build process, but you will need to manually trigger binding
     // generation whenever there are changes to definitions outside of the api directory that it
     // depends on.

--- a/frb_example/dart_build_rs/rust/build.rs
+++ b/frb_example/dart_build_rs/rust/build.rs
@@ -3,6 +3,9 @@ use lib_flutter_rust_bridge_codegen::codegen::Config;
 use lib_flutter_rust_bridge_codegen::utils::logs::configure_opinionated_logging;
 
 fn main() -> anyhow::Result<()> {
+    // Only run binding generation, if the api directory changes.
+    println!("cargo:rerun-if-changed=src/api");
+
     // If you want to see logs
     // Alternatively, use `cargo build -vvv` (instead of `cargo build`) to see logs on screen
     configure_opinionated_logging("./logs/", true)?;

--- a/frb_example/dart_build_rs/rust/build.rs
+++ b/frb_example/dart_build_rs/rust/build.rs
@@ -3,8 +3,12 @@ use lib_flutter_rust_bridge_codegen::codegen::Config;
 use lib_flutter_rust_bridge_codegen::utils::logs::configure_opinionated_logging;
 
 fn main() -> anyhow::Result<()> {
-    // Only run binding generation, if the api directory changes.
-    println!("cargo:rerun-if-changed=src/api");
+    // Uncomment the below line, if you only want to generate bindings on api directory change.
+    // NOTE: This accelerates the build process, but you will need to manually trigger binding
+    // generation whenever there are changes to definitions outside of the api directory that it
+    // depends on.
+    //
+    // println!("cargo:rerun-if-changed=src/api");
 
     // If you want to see logs
     // Alternatively, use `cargo build -vvv` (instead of `cargo build`) to see logs on screen


### PR DESCRIPTION
## Changes

This is a simple change, that reruns the `build.rs` for generating the bindings only when the `api` directory changes using the [`"cargo:rerun-if-changed=dir"`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed) instruction.

## Checklist

- [ ] An issue to be fixed by this PR is listed above.
- [ ] New tests are added to ensure new features are working. Please refer to [this page](https://cjycode.com/flutter_rust_bridge/guides/contributing/tip) to see how to add a test.
- [ ] `./frb_internal precommit --mode slow` (or `fast`) is run (it internal runs code generator, does auto formatting, etc).
- [ ] If this PR adds/changes features, documentations (in the `./website` folder) are updated.
- [ ] CI is passing. Please refer to [this page](https://cjycode.com/flutter_rust_bridge/guides/contributing/tip) to see how to solve a failed CI.
