### PR TITLE
Allow specifying `pubspec.yaml` location in `build.rs`

### DIFF
--- a/frb_codegen/src/library/codegen/config/config_parser.rs
+++ b/frb_codegen/src/library/codegen/config/config_parser.rs
@@ -52,10 +52,9 @@ impl Config {
         Ok(None)
     }
 
-    /// Loads the [`Config`] from a spicified `pubspec.yaml` file.
+    /// Loads the [`Config`] from a specified `pubspec.yaml` file.
     ///
-    /// Returns [`None`] if the file does not contain the `flutter_rust_bridge`
-    /// section somewhere in the file.
+    /// Returns [`None`] if it doesn't contain the `flutter_rust_bridge` section somewhere in the file.
     pub fn from_pubspec_yaml(location: &str) -> Result<Option<Self>, Error> {
         #[derive(serde::Deserialize)]
         struct Needle {

--- a/frb_codegen/src/library/codegen/config/config_parser.rs
+++ b/frb_codegen/src/library/codegen/config/config_parser.rs
@@ -7,10 +7,12 @@ use std::path::PathBuf;
 
 impl Config {
     pub fn from_files_auto() -> Result<Self, Error> {
+        const PUBSPEC_LOCATION: &str = "pubspec.yaml";
+
         if let Some(config) = Self::from_config_files()? {
             return Ok(config);
         }
-        if let Some(config) = Self::from_pubspec_yaml()? {
+        if let Some(config) = Self::from_pubspec_yaml(PUBSPEC_LOCATION)? {
             return Ok(config);
             // This will stop the whole generator and tell the users, so we do not care about testing it
             // frb-coverage:ignore-start
@@ -50,23 +52,25 @@ impl Config {
         Ok(None)
     }
 
-    fn from_pubspec_yaml() -> Result<Option<Self>, Error> {
-        const PUBSPEC_LOCATION: &str = "pubspec.yaml";
-
+    /// Loads the [`Config`] from a spicified `pubspec.yaml` file.
+    ///
+    /// Returns [`None`] if the file does not contain the `flutter_rust_bridge`
+    /// section somewhere in the file.
+    pub fn from_pubspec_yaml(location: &str) -> Result<Option<Self>, Error> {
         #[derive(serde::Deserialize)]
         struct Needle {
             #[serde(rename = "flutter_rust_bridge")]
             data: Option<Config>,
         }
 
-        if let Ok(pubspec) = fs::File::open(PUBSPEC_LOCATION) {
+        if let Ok(pubspec) = fs::File::open(location) {
             return match serde_yaml::from_reader(pubspec) {
                 Ok(Needle { data: Some(data) }) => Ok(Some(data)),
                 // This will stop the whole generator and tell the users, so we do not care about testing it
                 // frb-coverage:ignore-start
                 Ok(Needle { data: None }) => Ok(None),
                 Err(err) => Err(Error::new(err).context(format!(
-                    "Could not parse the 'flutter_rust_bridge' entry in {PUBSPEC_LOCATION}"
+                    "Could not parse the 'flutter_rust_bridge' entry in {location}"
                 ))),
             };
         }


### PR DESCRIPTION
## Changes

Problem Description:

Currently there is no way to access `flutter_rust_bridge` options in the `pubspec.yaml` in `build.rs` (without manually parsing it) because it in the rust directory, there is a function `Config::from_config_file` that is used for loading just a config with a specified path (this requires having a separate file `flutter_rust_bridge.yaml` file).

PR:

Expose the already implemented `Config::from_pubspec_yaml` and let it accept a path like `Config::from_config_file`.

## Checklist

- [ ] An issue to be fixed by this PR is listed above.
- [ ] New tests are added to ensure new features are working. Please refer to [this page](https://cjycode.com/flutter_rust_bridge/guides/contributing/tip) to see how to add a test.
- [ ] `./frb_internal precommit --mode slow` (or `fast`) is run (it internal runs code generator, does auto formatting, etc).
- [ ] If this PR adds/changes features, documentations (in the `./website` folder) are updated.
- [ ] CI is passing. Please refer to [this page](https://cjycode.com/flutter_rust_bridge/guides/contributing/tip) to see how to solve a failed CI.
