### PR TITLE
feat: Use dart.library.js_interop rather than dart.library.html

### DIFF
--- a/frb_codegen/assets/integration_template/lib/src/rust/frb_generated.dart
+++ b/frb_codegen/assets/integration_template/lib/src/rust/frb_generated.dart
@@ -7,7 +7,8 @@ import 'api/simple.dart';
 import 'dart:async';
 import 'dart:convert';
 import 'frb_generated.dart';
-import 'frb_generated.io.dart' if (dart.library.html) 'frb_generated.web.dart';
+import 'frb_generated.io.dart'
+    if (dart.library.js_interop) 'frb_generated.web.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
 /// Main entrypoint of the Rust API

--- a/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/misc/mod.rs
+++ b/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/misc/mod.rs
@@ -115,7 +115,7 @@ fn generate_boilerplate(
                     "
                     {universal_imports}
                     import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
-                    import 'frb_generated.io.dart' if (dart.library.html) 'frb_generated.web.dart';
+                    import 'frb_generated.io.dart' if (dart.library.js_interop) 'frb_generated.web.dart';
                     "
                 ),
                 ..Default::default()
@@ -141,7 +141,7 @@ fn generate_boilerplate(
                       externalLibrary: externalLibrary,
                     );
                   }}
-                  
+
                   /// Dispose flutter_rust_bridge
                   ///
                   /// The call to this function is optional, since flutter_rust_bridge (and everything else)
@@ -153,7 +153,7 @@ fn generate_boilerplate(
 
                   @override
                   WireConstructor<{wire_class_name}> get wireConstructor => {wire_class_name}.fromExternalLibrary;
-                  
+
                   @override
                   Future<void> executeRustInitializers() async {{
                     {execute_rust_initializers}

--- a/frb_dart/lib/flutter_rust_bridge_for_generated.dart
+++ b/frb_dart/lib/flutter_rust_bridge_for_generated.dart
@@ -2,4 +2,4 @@
 library;
 
 export 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated_io.dart'
-    if (dart.library.html) 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated_web.dart';
+    if (dart.library.js_interop) 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated_web.dart';

--- a/frb_dart/lib/src/dart_c_object_into_dart/dart_c_object_into_dart.dart
+++ b/frb_dart/lib/src/dart_c_object_into_dart/dart_c_object_into_dart.dart
@@ -1,1 +1,1 @@
-export '_io.dart' if (dart.library.html) '_web.dart';
+export '_io.dart' if (dart.library.js_interop) '_web.dart';

--- a/frb_dart/lib/src/dart_opaque/dart_opaque.dart
+++ b/frb_dart/lib/src/dart_opaque/dart_opaque.dart
@@ -1,2 +1,2 @@
 export '_common.dart';
-export '_io.dart' if (dart.library.html) '_web.dart';
+export '_io.dart' if (dart.library.js_interop) '_web.dart';

--- a/frb_dart/lib/src/droppable/_common.dart
+++ b/frb_dart/lib/src/droppable/_common.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_rust_bridge/src/droppable/_io.dart'
-    if (dart.library.html) '_web.dart';
+    if (dart.library.js_interop) '_web.dart';
 import 'package:flutter_rust_bridge/src/exceptions.dart';
 import 'package:flutter_rust_bridge/src/platform_types/platform_types.dart';
 import 'package:meta/meta.dart';

--- a/frb_dart/lib/src/droppable/droppable.dart
+++ b/frb_dart/lib/src/droppable/droppable.dart
@@ -1,2 +1,2 @@
 export '_common.dart';
-export '_io.dart' if (dart.library.html) '_web.dart';
+export '_io.dart' if (dart.library.js_interop) '_web.dart';

--- a/frb_dart/lib/src/generalized_frb_rust_binding/generalized_frb_rust_binding.dart
+++ b/frb_dart/lib/src/generalized_frb_rust_binding/generalized_frb_rust_binding.dart
@@ -1,1 +1,1 @@
-export '_io.dart' if (dart.library.html) '_web.dart';
+export '_io.dart' if (dart.library.js_interop) '_web.dart';

--- a/frb_dart/lib/src/generalized_isolate/generalized_isolate.dart
+++ b/frb_dart/lib/src/generalized_isolate/generalized_isolate.dart
@@ -1,4 +1,4 @@
 /// Like Dart's `isolate`, but works for both native and Web.
 library;
 
-export '_io.dart' if (dart.library.html) '_web.dart';
+export '_io.dart' if (dart.library.js_interop) '_web.dart';

--- a/frb_dart/lib/src/generalized_typed_data/generalized_typed_data.dart
+++ b/frb_dart/lib/src/generalized_typed_data/generalized_typed_data.dart
@@ -1,4 +1,4 @@
 /// Like `dart:typed_data` but generalized
 library;
 
-export '_io.dart' if (dart.library.html) '_web.dart';
+export '_io.dart' if (dart.library.js_interop) '_web.dart';

--- a/frb_dart/lib/src/generalized_uint8list/generalized_uint8list.dart
+++ b/frb_dart/lib/src/generalized_uint8list/generalized_uint8list.dart
@@ -1,2 +1,2 @@
 export '_common.dart';
-export '_io.dart' if (dart.library.html) '_web.dart';
+export '_io.dart' if (dart.library.js_interop) '_web.dart';

--- a/frb_dart/lib/src/loader/loader.dart
+++ b/frb_dart/lib/src/loader/loader.dart
@@ -1,1 +1,1 @@
-export '_io.dart' if (dart.library.html) '_web.dart';
+export '_io.dart' if (dart.library.js_interop) '_web.dart';

--- a/frb_dart/lib/src/manual_impl/manual_impl.dart
+++ b/frb_dart/lib/src/manual_impl/manual_impl.dart
@@ -3,4 +3,4 @@
 library;
 
 export '_common.dart';
-export '_io.dart' if (dart.library.html) '_web.dart';
+export '_io.dart' if (dart.library.js_interop) '_web.dart';

--- a/frb_dart/lib/src/platform_types/platform_types.dart
+++ b/frb_dart/lib/src/platform_types/platform_types.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-export '_io.dart' if (dart.library.html) '_web.dart';
+export '_io.dart' if (dart.library.js_interop) '_web.dart';
 
 /// {@macro flutter_rust_bridge.internal}
 @internal

--- a/frb_dart/lib/src/platform_utils/platform_utils.dart
+++ b/frb_dart/lib/src/platform_utils/platform_utils.dart
@@ -1,1 +1,1 @@
-export '_io.dart' if (dart.library.html) '_web.dart';
+export '_io.dart' if (dart.library.js_interop) '_web.dart';

--- a/frb_dart/lib/src/rust_arc/rust_arc.dart
+++ b/frb_dart/lib/src/rust_arc/rust_arc.dart
@@ -1,2 +1,2 @@
 export '_common.dart';
-export '_io.dart' if (dart.library.html) '_web.dart';
+export '_io.dart' if (dart.library.js_interop) '_web.dart';

--- a/frb_dart/lib/src/third_party/flutter_foundation_serialization/extension_buffers.dart
+++ b/frb_dart/lib/src/third_party/flutter_foundation_serialization/extension_buffers.dart
@@ -1,1 +1,1 @@
-export '_io.dart' if (dart.library.html) '_web.dart';
+export '_io.dart' if (dart.library.js_interop) '_web.dart';

--- a/frb_dart/test/typed_data_test.dart
+++ b/frb_dart/test/typed_data_test.dart
@@ -7,7 +7,7 @@ import 'package:test/test.dart';
 final i64maxb = BigInt.parse('0x7FFFFFFFFFFFFFFF');
 final i64minb = BigInt.parse('-0x8000000000000000');
 final u64maxb = BigInt.parse('0xFFFFFFFFFFFFFFFF');
-const isWeb = bool.fromEnvironment('dart.library.html');
+const isWeb = bool.fromEnvironment('dart.library.js_interop');
 
 void main() {
   group('big lists', () {

--- a/frb_example/dart_build_rs/lib/src/rust/frb_generated.dart
+++ b/frb_example/dart_build_rs/lib/src/rust/frb_generated.dart
@@ -7,7 +7,8 @@ import 'api/minimal.dart';
 import 'dart:async';
 import 'dart:convert';
 import 'frb_generated.dart';
-import 'frb_generated.io.dart' if (dart.library.html) 'frb_generated.web.dart';
+import 'frb_generated.io.dart'
+    if (dart.library.js_interop) 'frb_generated.web.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
 /// Main entrypoint of the Rust API

--- a/frb_example/dart_minimal/lib/src/rust/frb_generated.dart
+++ b/frb_example/dart_minimal/lib/src/rust/frb_generated.dart
@@ -7,7 +7,8 @@ import 'api/minimal.dart';
 import 'dart:async';
 import 'dart:convert';
 import 'frb_generated.dart';
-import 'frb_generated.io.dart' if (dart.library.html) 'frb_generated.web.dart';
+import 'frb_generated.io.dart'
+    if (dart.library.js_interop) 'frb_generated.web.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
 /// Main entrypoint of the Rust API

--- a/frb_example/deliberate_bad/lib/src/rust/frb_generated.dart
+++ b/frb_example/deliberate_bad/lib/src/rust/frb_generated.dart
@@ -7,7 +7,8 @@ import 'api/simple.dart';
 import 'dart:async';
 import 'dart:convert';
 import 'frb_generated.dart';
-import 'frb_generated.io.dart' if (dart.library.html) 'frb_generated.web.dart';
+import 'frb_generated.io.dart'
+    if (dart.library.js_interop) 'frb_generated.web.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
 /// Main entrypoint of the Rust API

--- a/frb_example/flutter_via_create/lib/src/rust/frb_generated.dart
+++ b/frb_example/flutter_via_create/lib/src/rust/frb_generated.dart
@@ -7,7 +7,8 @@ import 'api/simple.dart';
 import 'dart:async';
 import 'dart:convert';
 import 'frb_generated.dart';
-import 'frb_generated.io.dart' if (dart.library.html) 'frb_generated.web.dart';
+import 'frb_generated.io.dart'
+    if (dart.library.js_interop) 'frb_generated.web.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
 /// Main entrypoint of the Rust API

--- a/frb_example/flutter_via_integrate/lib/src/rust/frb_generated.dart
+++ b/frb_example/flutter_via_integrate/lib/src/rust/frb_generated.dart
@@ -7,7 +7,8 @@ import 'api/simple.dart';
 import 'dart:async';
 import 'dart:convert';
 import 'frb_generated.dart';
-import 'frb_generated.io.dart' if (dart.library.html) 'frb_generated.web.dart';
+import 'frb_generated.io.dart'
+    if (dart.library.js_interop) 'frb_generated.web.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
 /// Main entrypoint of the Rust API

--- a/frb_example/gallery/lib/src/rust/frb_generated.dart
+++ b/frb_example/gallery/lib/src/rust/frb_generated.dart
@@ -7,7 +7,8 @@ import 'api/mandelbrot.dart';
 import 'dart:async';
 import 'dart:convert';
 import 'frb_generated.dart';
-import 'frb_generated.io.dart' if (dart.library.html) 'frb_generated.web.dart';
+import 'frb_generated.io.dart'
+    if (dart.library.js_interop) 'frb_generated.web.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
 /// Main entrypoint of the Rust API

--- a/frb_example/integrate_third_party/lib/src/rust/frb_generated.dart
+++ b/frb_example/integrate_third_party/lib/src/rust/frb_generated.dart
@@ -13,7 +13,8 @@ import 'api/simple.dart';
 import 'dart:async';
 import 'dart:convert';
 import 'frb_generated.dart';
-import 'frb_generated.io.dart' if (dart.library.html) 'frb_generated.web.dart';
+import 'frb_generated.io.dart'
+    if (dart.library.js_interop) 'frb_generated.web.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'package:freezed_annotation/freezed_annotation.dart' hide protected;
 import 'third_party/web_audio_api.dart';

--- a/frb_example/pure_dart_pde/lib/src/rust/frb_generated.dart
+++ b/frb_example/pure_dart_pde/lib/src/rust/frb_generated.dart
@@ -142,7 +142,8 @@ import 'dart:async';
 import 'dart:convert';
 import 'deliberate_name_conflict.dart';
 import 'frb_generated.dart';
-import 'frb_generated.io.dart' if (dart.library.html) 'frb_generated.web.dart';
+import 'frb_generated.io.dart'
+    if (dart.library.js_interop) 'frb_generated.web.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'package:freezed_annotation/freezed_annotation.dart' hide protected;
 import 'package:meta/meta.dart' as meta;

--- a/website/docs/manual/integrate/07-library/02-creating-libraries/01-dart-only.md
+++ b/website/docs/manual/integrate/07-library/02-creating-libraries/01-dart-only.md
@@ -244,7 +244,7 @@ cat << EOF >> lib/src/ffi.dart
 import 'bridge_generated.dart';
 import 'ffi/stub.dart'
     if (dart.library.io) 'ffi/io.dart'
-    if (dart.library.html) 'ffi/web.dart';
+    if (dart.library.js_interop) 'ffi/web.dart';
 
 $DART_CLASS_NAME? _wrapper;
 

--- a/website/docs/manual/integrate/07-library/02-creating-libraries/02-flutter-wrapper.md
+++ b/website/docs/manual/integrate/07-library/02-creating-libraries/02-flutter-wrapper.md
@@ -72,9 +72,9 @@ WasmModule createLibraryImpl() {
 import 'package:library_name/library_name.dart';
 import 'ffi/stub.dart'
     if (dart.library.io) 'ffi/io.dart'
-    if (dart.library.html) 'ffi/web.dart';
+    if (dart.library.js_interop) 'ffi/web.dart';
 
-LibraryName createLib() => 
+LibraryName createLib() =>
     createWrapper(createLibraryImpl());
 ```
 5. Run `melos bs`

--- a/website/v1_mdbook/src/help.txt
+++ b/website/v1_mdbook/src/help.txt
@@ -4,7 +4,7 @@ Usage: flutter_rust_bridge_codegen [OPTIONS] --rust-input <RUST_INPUT>... --dart
 Arguments:
   [CONFIG_FILE]
           Path to a YAML config file.
-          
+
           If present, other options and flags will be ignored. Accepts the same options as the CLI, but uses snake_case keys.
 
 Options:
@@ -34,7 +34,7 @@ Options:
 
       --dart-format-line-length <DART_FORMAT_LINE_LENGTH>
           Line length for Dart formatting
-          
+
           [default: 80]
 
       --dart-enums-style
@@ -60,8 +60,8 @@ Options:
 
       --extra-headers <EXTRA_HEADERS>
           extra_headers is used to add dependencies header
-          
-          Note that when no_use_bridge_in_method=true and extra_headers is not set, the default is `import 'ffi.io.dart' if (dart.library.html) 'ffi.web.dart'`.
+
+          Note that when no_use_bridge_in_method=true and extra_headers is not set, the default is `import 'ffi.io.dart' if (dart.library.js_interop) 'ffi.web.dart'`.
 
   -v, --verbose
           Show debug messages
@@ -77,7 +77,7 @@ Options:
 
       --dump [<DUMP>...]
           A list of data to be dumped. If specified without a value, defaults to all
-          
+
           [possible values: config, ir]
 
       --no-dart3

--- a/website/v1_mdbook/src/library/dart_only.md
+++ b/website/v1_mdbook/src/library/dart_only.md
@@ -244,7 +244,7 @@ cat << EOF >> lib/src/ffi.dart
 import 'bridge_generated.dart';
 import 'ffi/stub.dart'
     if (dart.library.io) 'ffi/io.dart'
-    if (dart.library.html) 'ffi/web.dart';
+    if (dart.library.js_interop) 'ffi/web.dart';
 
 $DART_CLASS_NAME? _wrapper;
 

--- a/website/v1_mdbook/src/library/flutter_wrapper.md
+++ b/website/v1_mdbook/src/library/flutter_wrapper.md
@@ -72,9 +72,9 @@ WasmModule createLibraryImpl() {
 import 'package:library_name/library_name.dart';
 import 'ffi/stub.dart'
     if (dart.library.io) 'ffi/io.dart'
-    if (dart.library.html) 'ffi/web.dart';
+    if (dart.library.js_interop) 'ffi/web.dart';
 
-LibraryName createLib() => 
+LibraryName createLib() =>
     createWrapper(createLibraryImpl());
 ```
 5. Run `melos bs`


### PR DESCRIPTION
Per Dart guidelines using dart.library.html is deprecated in favor of dart.library.js_interop. This is a find-replace fix.

https://dart.dev/interop/js-interop/package-web

## Changes

Fixes #2112

## Checklist

- [X ] An issue to be fixed by this PR is listed above.
- [ ] New tests are added to ensure new features are working. Please refer to [this page](https://cjycode.com/flutter_rust_bridge/guides/contributing/tip) to see how to add a test.
- [ ] `./frb_internal precommit --mode slow` (or `fast`) is run (it internal runs code generator, does auto formatting, etc).
- [X] If this PR adds/changes features, documentations (in the `./website` folder) are updated.
- [ ] CI is passing. Please refer to [this page](https://cjycode.com/flutter_rust_bridge/guides/contributing/tip) to see how to solve a failed CI.
