### PR TITLE
Improve hints when user specify custom wasm-pack-rustflags but does not contain default one

### DIFF
--- a/frb_dart/lib/src/cli/build_web/executor.dart
+++ b/frb_dart/lib/src/cli/build_web/executor.dart
@@ -169,10 +169,19 @@ Future<void> _executeWasmPack(BuildWebArgs args,
     // if (config.cliOpts.features != null) '--features=${config.cliOpts.features}'
   ], env: {
     'RUSTUP_TOOLCHAIN': args.wasmPackRustupToolchain ?? 'nightly',
-    'RUSTFLAGS': args.wasmPackRustflags ??
-        '-C target-feature=+atomics,+bulk-memory,+mutable-globals',
+    'RUSTFLAGS': _computeRustflags(argsOverride: args.wasmPackRustflags),
     if (stdout.supportsAnsiEscapes) 'CARGO_TERM_COLOR': 'always',
   });
+}
+
+String _computeRustflags({required String? argsOverride}) {
+  const kDefault = '-C target-feature=+atomics,+bulk-memory,+mutable-globals';
+  if (argsOverride == null) return kDefault;
+  if (!argsOverride.contains(kDefault)) {
+    print(
+        'WARN: RUSTFLAGS will be `$argsOverride`, which does not contain the default one `$kDefault`');
+  }
+  return argsOverride;
 }
 
 Future<void> _executeWasmBindgen(BuildWebArgs args,


### PR DESCRIPTION
## Changes

Close #1909

## Checklist

- [ ] An issue to be fixed by this PR is listed above.
- [ ] New tests are added to ensure new features are working. Please refer to [this page](https://cjycode.com/flutter_rust_bridge/guides/contributing/tip) to see how to add a test.
- [ ] `./frb_internal precommit --mode slow` (or `fast`) is run (it internal runs code generator, does auto formatting, etc).
- [ ] If this PR adds/changes features, documentations (in the `./website` folder) are updated.
- [ ] CI is passing. Please refer to [this page](https://cjycode.com/flutter_rust_bridge/guides/contributing/tip) to see how to solve a failed CI.

## Remark for PR creator

- `./frb_internal --help` shows utilities for development.
- If fzyzcjy does not reply for a few days, maybe he just did not see it, so please ping him.
