### PR TITLE
feat: support macos log

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ keywords = ["flutter", "dart", "ffi", "code-generation", "bindings"]
 categories = ["development-tools::ffi"]
 
 [workspace.dependencies]
-allo-isolate = { version = "0.1.25", features = ["anyhow"] }
+allo-isolate = "0.1.25"
 #allo-isolate = { git = "https://github.com/shekohex/allo-isolate", features = ["anyhow"] }
 anyhow = "1.0.64"
 chrono = "0.4.23"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ keywords = ["flutter", "dart", "ffi", "code-generation", "bindings"]
 categories = ["development-tools::ffi"]
 
 [workspace.dependencies]
-allo-isolate = "0.1.25"
+allo-isolate = { version = "0.1.25", features = ["anyhow"] }
 #allo-isolate = { git = "https://github.com/shekohex/allo-isolate", features = ["anyhow"] }
 anyhow = "1.0.64"
 chrono = "0.4.23"

--- a/frb_rust/Cargo.toml
+++ b/frb_rust/Cargo.toml
@@ -49,7 +49,7 @@ web-sys = { version = "0.3.58", features = [
 [target.'cfg(target_os = "android")'.dependencies]
 android_logger = { version = "0.13" , optional = true }
 
-[target.'cfg(target_os = "ios")'.dependencies]
+[target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
 oslog = { version = "0.1.0" , optional = true }
 
 [build-dependencies]

--- a/frb_rust/src/misc/user_utils.rs
+++ b/frb_rust/src/misc/user_utils.rs
@@ -28,7 +28,7 @@ fn setup_log_to_console() {
         android_logger::Config::default().with_max_level(log::LevelFilter::Trace),
     );
 
-    #[cfg(target_os = "ios")]
+    #[cfg(any(target_os = "ios", target_os = "macos"))]
     let _ = oslog::OsLogger::new("frb_user")
         .level_filter(log::LevelFilter::Trace)
         .init();


### PR DESCRIPTION
## Changes

Support logging on macOS in the same way as iOS.

Logs can be viewed through Instruments and Console.

## Checklist

- [ ] An issue to be fixed by this PR is listed above.
- [ ] New tests are added to ensure new features are working. Please refer to [this page](https://cjycode.com/flutter_rust_bridge/guides/contributing/tip) to see how to add a test.
- [ ] `./frb_internal precommit --mode slow` (or `fast`) is run (it internal runs code generator, does auto formatting, etc).
- [ ] If this PR adds/changes features, documentations (in the `./website` folder) are updated.
- [ ] CI is passing. Please refer to [this page](https://cjycode.com/flutter_rust_bridge/guides/contributing/tip) to see how to solve a failed CI.

## Remark for PR creator

- `./frb_internal --help` shows utilities for development.
- If fzyzcjy does not reply for a few days, maybe he just did not see it, so please ping him.
