### PR TITLE
chore: Update dart:js_util import to dart:js_interop and bumped pkg:web to support 1.0.0

### DIFF
--- a/frb_dart/lib/src/dart_opaque/_web.dart
+++ b/frb_dart/lib/src/dart_opaque/_web.dart
@@ -1,4 +1,4 @@
-import 'dart:js_util';
+import 'dart:js_interop';
 
 import 'package:flutter_rust_bridge/src/dart_opaque/_common.dart';
 import 'package:flutter_rust_bridge/src/generalized_frb_rust_binding/generalized_frb_rust_binding.dart';
@@ -13,7 +13,7 @@ PlatformPointer encodeDartOpaque(Object raw, NativePortType dartHandlerPort,
 Object _prepareDartOpaque(Object raw) {
   // #2183
   if (raw is Function) {
-    return allowInterop(raw);
+    return raw.toJS;
   }
   return raw;
 }

--- a/frb_dart/pubspec.yaml
+++ b/frb_dart/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   build_cli_annotations: ^2.1.0
   meta: ^1.3.0
   path: ^1.8.1
-  web: ">=0.5.1 <2.0.0"
+  web: ^0.5.0
 dev_dependencies:
   build_cli: ^2.2.0
   build_runner: ^2.2.0

--- a/frb_dart/pubspec.yaml
+++ b/frb_dart/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   build_cli_annotations: ^2.1.0
   meta: ^1.3.0
   path: ^1.8.1
-  web: ^0.5.0
+  web: ">=0.5.1 <2.0.0"
 dev_dependencies:
   build_cli: ^2.2.0
   build_runner: ^2.2.0


### PR DESCRIPTION
The usage of dart:js_util prevents build for dart2wasm

## Changes
- Removed dart:js_util dependency, replaced allowInterop with .toJS Function
- Updated pkg web version constrain to ">=0.5.1 <2.0.0"

_Please list issues fixed by this PR here, using format "Fixes #the-issue-number"._
Fixes  #2237

## Checklist

- [x] An issue to be fixed by this PR is listed above.
- [ ] New tests are added to ensure new features are working. Please refer to [this page](https://cjycode.com/flutter_rust_bridge/guides/contributing/tip) to see how to add a test.
- [ ] `./frb_internal precommit --mode slow` (or `fast`) is run (it internal runs code generator, does auto formatting, etc).
- [ ] If this PR adds/changes features, documentations (in the `./website` folder) are updated.
- [ ] CI is passing. Please refer to [this page](https://cjycode.com/flutter_rust_bridge/guides/contributing/tip) to see how to solve a failed CI.

## Remark for PR creator

- `./frb_internal --help` shows utilities for development.
- If fzyzcjy does not reply for a few days, maybe he just did not see it, so please ping him.
