### PR TITLE
Add docs and warning if user provides absolute rust_crate_dir

### DIFF
--- a/frb_codegen/src/binary/commands.rs
+++ b/frb_codegen/src/binary/commands.rs
@@ -224,7 +224,7 @@ pub(crate) struct CreateOrIntegrateCommandCommonArgs {
     #[arg(long)]
     pub rust_crate_name: Option<String>,
 
-    /// The directory of the generated Rust crate
+    /// The directory of the generated Rust crate, relative to the project path
     #[arg(long)]
     pub rust_crate_dir: Option<String>,
 

--- a/frb_codegen/src/main.rs
+++ b/frb_codegen/src/main.rs
@@ -11,7 +11,8 @@ use clap::Parser;
 use lib_flutter_rust_bridge_codegen::integration::{CreateConfig, IntegrateConfig};
 use lib_flutter_rust_bridge_codegen::utils::logs::configure_opinionated_logging;
 use lib_flutter_rust_bridge_codegen::*;
-use log::debug;
+use log::{debug, warn};
+use std::path::Path;
 
 fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
@@ -52,7 +53,12 @@ fn main_given_cli(cli: Cli) -> anyhow::Result<()> {
 }
 
 fn compute_rust_crate_dir(config: &CreateOrIntegrateCommandCommonArgs) -> String {
-    config.rust_crate_dir.clone().unwrap_or("rust".to_owned())
+    let rust_crate_dir = config.rust_crate_dir.clone().unwrap_or("rust".to_owned());
+    let path = Path::new(&rust_crate_dir);
+    if path.is_absolute() {
+        warn!("Argument given to --rust-crate-dir was an absolute Path. It will still be interpreted as relative to the new project root.")
+    }
+    rust_crate_dir
 }
 
 #[cfg(test)]

--- a/website/docs/generated/_frb-codegen-command-create.mdx
+++ b/website/docs/generated/_frb-codegen-command-create.mdx
@@ -15,7 +15,7 @@ Options:
           The name of the generated Rust crate
 
       --rust-crate-dir <RUST_CRATE_DIR>
-          The directory of the generated Rust crate
+          The directory of the generated Rust crate, relative to the project path
 
   -t, --template <TEMPLATE>
           The template type to use to generate the flutter files

--- a/website/docs/generated/_frb-codegen-command-integrate.mdx
+++ b/website/docs/generated/_frb-codegen-command-integrate.mdx
@@ -11,7 +11,7 @@ Options:
           The name of the generated Rust crate
 
       --rust-crate-dir <RUST_CRATE_DIR>
-          The directory of the generated Rust crate
+          The directory of the generated Rust crate, relative to the project path
 
   -t, --template <TEMPLATE>
           The template type to use for integration. This should usually match the type of flutter project being integrating with


### PR DESCRIPTION
## Changes
Addresses #2334 by adding a warning if a user provides a absolute Path, and extend the documentation on the Clap doc string. 

Close #2334 (<--- edited by fzyzcjy to allow github auto close that)



