### PR TITLE
feat: remove default case in enums

### DIFF
--- a/frb_codegen/src/library/codegen/generator/codec/sse/ty/enumeration.rs
+++ b/frb_codegen/src/library/codegen/generator/codec/sse/ty/enumeration.rs
@@ -111,11 +111,7 @@ pub(crate) fn generate_enum_encode_rust_general(
         })
         .collect_vec();
 
-    lang.switch_expr(
-        self_ref,
-        &variants,
-        Some(format!("{};", lang.throw_unimplemented(""))),
-    )
+    lang.switch_expr(self_ref, &variants, None)
 }
 
 fn pattern_match_enum_variant(lang: &Lang, variant: &MirEnumVariant) -> String {


### PR DESCRIPTION
## Changes

Removes the `default` case that is no longer needed in Dart 3.0

Context: rhttp is getting analyzer warnings: https://pub.dev/packages/rhttp/versions/0.9.6/score

Running any `./frb_internal` command gets stuck at `Running /Users/<User>/flutter_rust_bridge/target/debug/flutter_rust_bridge_codegen generate` at some point. So I could not update the resources

## Checklist

- [ ] An issue to be fixed by this PR is listed above.
- [ ] New tests are added to ensure new features are working. Please refer to [this page](https://cjycode.com/flutter_rust_bridge/guides/contributing/tip) to see how to add a test.
- [ ] `./frb_internal precommit --mode slow` (or `fast`) is run (it internal runs code generator, does auto formatting, etc).
- [ ] If this PR adds/changes features, documentations (in the `./website` folder) are updated.
- [ ] CI is passing. Please refer to [this page](https://cjycode.com/flutter_rust_bridge/guides/contributing/tip) to see how to solve a failed CI.

## Remark for PR creator

- `./frb_internal --help` shows utilities for development.
- If fzyzcjy does not reply for a few days, maybe he just did not see it, so please ping him.
