### PR TITLE
Fix for strict-casts lint

### DIFF
--- a/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/codec/dco/decoder/ty/primitive.rs
+++ b/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/codec/dco/decoder/ty/primitive.rs
@@ -8,10 +8,10 @@ impl WireDartCodecDcoGeneratorDecoderTrait for PrimitiveWireDartCodecDcoGenerato
         match self.mir {
             MirTypePrimitive::Unit => "return;".to_owned(),
             MirTypePrimitive::I64 | MirTypePrimitive::Isize => {
-                "return dcoDecodeI64(raw);".to_owned()
+                "return dcoDecodeI64(raw as int);".to_owned()
             }
             MirTypePrimitive::U64 | MirTypePrimitive::Usize => {
-                "return dcoDecodeU64(raw);".to_owned()
+                "return dcoDecodeU64(raw as int);".to_owned()
             }
             _ => gen_decode_simple_type_cast(self.mir.clone().into(), self.context),
         }


### PR DESCRIPTION
I started using the `strict-casts` lint (https://dart.dev/tools/analysis#enabling-additional-type-checks) and then my `frb_generated.dart` contained errors.

It's not a big issue as this file can be excluded from the analyzer and this lint is optional anyway, but I thought it would be nice that everything would work out-of-the box for people enabling this lint.

Feel free to disagree, it's not important.