### PR TITLE
🧑‍💻 Allow bypassing codegen version check and produce log when enabled assertion

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,10 +30,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: subosito/flutter-action@v2
+      - uses: flutter-actions/setup-flutter@v4
         with:
           cache: true
-          flutter-version: ${{ env.FRB_MAIN_FLUTTER_VERSION }}
+          version: ${{ env.FRB_MAIN_FLUTTER_VERSION }}
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: nightly
@@ -104,10 +104,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: subosito/flutter-action@v2
+      - uses: flutter-actions/setup-flutter@v4
         with:
           cache: true
-          flutter-version: ${{ env.FRB_MAIN_FLUTTER_VERSION }}
+          version: ${{ env.FRB_MAIN_FLUTTER_VERSION }}
 
       # execute
       - run: ./frb_internal lint-dart
@@ -210,11 +210,10 @@ jobs:
         with:
           toolchain: ${{ env.FRB_MAIN_RUST_VERSION }}
           components: rustfmt, clippy
-      - uses: subosito/flutter-action@v2
+      - uses: flutter-actions/setup-flutter@v4
         with:
           cache: true
-          flutter-version: ${{ env.FRB_MAIN_FLUTTER_VERSION }}
-          architecture: x64
+          version: ${{ env.FRB_MAIN_FLUTTER_VERSION }}
       - uses: taiki-e/install-action@cargo-llvm-cov
 
       # execute
@@ -256,11 +255,10 @@ jobs:
         with:
           toolchain: ${{ env.FRB_MAIN_RUST_VERSION }}
           components: rustfmt, clippy
-      - uses: subosito/flutter-action@v2
+      - uses: flutter-actions/setup-flutter@v4
         with:
           cache: true
-          flutter-version: ${{ env.FRB_MAIN_FLUTTER_VERSION }}
-          architecture: x64
+          version: ${{ env.FRB_MAIN_FLUTTER_VERSION }}
       - uses: taiki-e/install-action@cargo-llvm-cov
 
       # execute
@@ -290,11 +288,10 @@ jobs:
           components: rustfmt, clippy
       - run: rustup toolchain install nightly && rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu
       - run: yarn global add all-contributors-cli
-      - uses: subosito/flutter-action@v2
+      - uses: flutter-actions/setup-flutter@v4
         with:
           cache: true
-          flutter-version: ${{ env.FRB_MAIN_FLUTTER_VERSION }}
-          architecture: x64
+          version: ${{ env.FRB_MAIN_FLUTTER_VERSION }}
       - uses: taiki-e/install-action@cargo-llvm-cov
 
       # execute
@@ -415,11 +412,10 @@ jobs:
       # https://docs.flutter.dev/get-started/install/linux#linux-prerequisites
       - if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install clang cmake git ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev
-      - uses: subosito/flutter-action@v2
+      - uses: flutter-actions/setup-flutter@v4
         with:
           cache: true
-          flutter-version: ${{ env.FRB_MAIN_FLUTTER_VERSION }}
-          architecture: x64
+          version: ${{ env.FRB_MAIN_FLUTTER_VERSION }}
 
       # execute
       - run: ./frb_internal build-flutter --target ${{ matrix.info.target }}
@@ -456,11 +452,10 @@ jobs:
         with:
           toolchain: ${{ env.FRB_MAIN_RUST_VERSION }}
           components: rustfmt
-      - uses: subosito/flutter-action@v2
+      - uses: flutter-actions/setup-flutter@v4
         with:
           cache: true
-          flutter-version: ${{ env.FRB_MAIN_FLUTTER_VERSION }}
-          architecture: x64
+          version: ${{ env.FRB_MAIN_FLUTTER_VERSION }}
       # https://docs.flutter.dev/get-started/install/linux#linux-prerequisites
       - if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install clang cmake git ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev
@@ -494,11 +489,10 @@ jobs:
         with:
           toolchain: ${{ env.FRB_MAIN_RUST_VERSION }}
           components: rustfmt
-      - uses: subosito/flutter-action@v2
+      - uses: flutter-actions/setup-flutter@v4
         with:
           cache: true
-          flutter-version: ${{ env.FRB_MAIN_FLUTTER_VERSION }}
-          architecture: x64
+          version: ${{ env.FRB_MAIN_FLUTTER_VERSION }}
       # https://docs.flutter.dev/get-started/install/linux#linux-prerequisites
       - if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install clang cmake git ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev
@@ -776,11 +770,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: subosito/flutter-action@v2
+      - uses: flutter-actions/setup-flutter@v4
         with:
           cache: true
-          flutter-version: ${{ env.FRB_MAIN_FLUTTER_VERSION }}
-          architecture: x64
+          version: ${{ env.FRB_MAIN_FLUTTER_VERSION }}
       # Otherwise it fails and Flutter doctor say "You need Java 11 or higher to build your app with this version of Gradle."
       - uses: actions/setup-java@v2
         with:
@@ -851,11 +844,10 @@ jobs:
           UDID=$(xcrun xctrace list devices | grep '${{ matrix.device }} (' | awk '{print $NF}' | tr -d '()')
           echo UDID=$UDID
           xcrun simctl boot "${UDID:?No Simulator with this name found}"
-      - uses: subosito/flutter-action@v2
+      - uses: flutter-actions/setup-flutter@v4
         with:
           cache: true
-          flutter-version: ${{ env.FRB_MAIN_FLUTTER_VERSION }}
-          architecture: x64
+          version: ${{ env.FRB_MAIN_FLUTTER_VERSION }}
 
       # execute
       - run: ./frb_internal test-flutter-native --package ${{ matrix.package }}
@@ -934,11 +926,10 @@ jobs:
         run: sudo apt-get update && sudo apt-get install clang cmake git ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev
       - if: runner.os == 'Linux'
         uses: pyvista/setup-headless-display-action@v3
-      - uses: subosito/flutter-action@v2
+      - uses: flutter-actions/setup-flutter@v4
         with:
           cache: true
-          flutter-version: ${{ env.FRB_MAIN_FLUTTER_VERSION }}
-          architecture: x64
+          version: ${{ env.FRB_MAIN_FLUTTER_VERSION }}
 
       # execute
       - run: ./frb_internal test-flutter-native --flutter-test-args '--device-id ${{ matrix.info.platform }}' --package ${{ matrix.info.package }}
@@ -965,11 +956,10 @@ jobs:
       # https://github.com/puppeteer/puppeteer/pull/13196
       - name: Disable AppArmor
         run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
-      - uses: subosito/flutter-action@v2
+      - uses: flutter-actions/setup-flutter@v4
         with:
           cache: true
-          flutter-version: ${{ env.FRB_MAIN_FLUTTER_VERSION }}
-          architecture: x64
+          version: ${{ env.FRB_MAIN_FLUTTER_VERSION }}
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.FRB_MAIN_RUST_VERSION }}
@@ -1063,10 +1053,10 @@ jobs:
 #          rustup target add wasm32-unknown-unknown
 #          rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu
 #          cargo install cargo-expand
-#      - uses: subosito/flutter-action@v2
+#      - uses: flutter-actions/setup-flutter@v4
 #        with:
 #          cache: true
-#          flutter-version: ${{ env.FRB_MAIN_FLUTTER_VERSION }}
+#          version: ${{ env.FRB_MAIN_FLUTTER_VERSION }}
 #
 #      # execute
 #      - run: ./frb_internal precommit --mode ${{ matrix.mode }}

--- a/.github/workflows/post_release.yaml
+++ b/.github/workflows/post_release.yaml
@@ -50,11 +50,10 @@ jobs:
         with:
           toolchain: ${{ env.FRB_MAIN_RUST_VERSION }}
           components: rustfmt
-      - uses: subosito/flutter-action@v2
+      - uses: flutter-actions/setup-flutter@v4
         with:
           cache: true
-          flutter-version: ${{ env.FRB_MAIN_FLUTTER_VERSION }}
-          architecture: x64
+          version: ${{ env.FRB_MAIN_FLUTTER_VERSION }}
       - if: matrix.codegen_install_mode == 'cargo-binstall'
         uses: cargo-bins/cargo-binstall@main
       - if: runner.os == 'Windows' && matrix.codegen_install_mode == 'scoop'

--- a/frb_codegen/assets/integration_template/shared/lib/src/rust/frb_generated.dart
+++ b/frb_codegen/assets/integration_template/shared/lib/src/rust/frb_generated.dart
@@ -23,11 +23,13 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
     RustLibApi? api,
     BaseHandler? handler,
     ExternalLibrary? externalLibrary,
+    bool forceSameCodegenVersion = true,
   }) async {
     await instance.initImpl(
       api: api,
       handler: handler,
       externalLibrary: externalLibrary,
+      forceSameCodegenVersion: forceSameCodegenVersion,
     );
   }
 

--- a/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/misc/mod.rs
+++ b/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/misc/mod.rs
@@ -151,11 +151,13 @@ fn generate_boilerplate(
                     {api_class_name}? api,
                     BaseHandler? handler,
                     ExternalLibrary? externalLibrary,
+                    bool forceSameCodegenVersion = true,
                   }}) async {{
                     await instance.initImpl(
                       api: api,
                       handler: handler,
                       externalLibrary: externalLibrary,
+                      forceSameCodegenVersion: forceSameCodegenVersion,
                     );
                   }}
 

--- a/frb_dart/lib/src/main_components/entrypoint.dart
+++ b/frb_dart/lib/src/main_components/entrypoint.dart
@@ -38,12 +38,13 @@ abstract class BaseEntrypoint<A extends BaseApi, AI extends BaseApiImpl,
     A? api,
     BaseHandler? handler,
     ExternalLibrary? externalLibrary,
+    bool forceSameCodegenVersion = true,
   }) async {
     if (__state != null) {
       throw StateError('Should not initialize flutter_rust_bridge twice');
     }
 
-    _sanityCheckCodegenVersion();
+    _sanityCheckCodegenVersion(forceSameCodegenVersion);
 
     externalLibrary ??= await _loadDefaultExternalLibrary();
     handler ??= BaseHandler();
@@ -91,12 +92,26 @@ abstract class BaseEntrypoint<A extends BaseApi, AI extends BaseApiImpl,
     __state = null;
   }
 
-  void _sanityCheckCodegenVersion() {
-    if (codegenVersion != kFlutterRustBridgeRuntimeVersion) {
+  void _sanityCheckCodegenVersion(bool forceSameCodegenVersion) {
+    if (codegenVersion == kFlutterRustBridgeRuntimeVersion) {
+      return;
+    }
+    final stem = defaultExternalLibraryLoaderConfig.stem;
+    if (forceSameCodegenVersion) {
       throw StateError(
-        "flutter_rust_bridge's codegen version ($codegenVersion) should be the same as runtime version ($kFlutterRustBridgeRuntimeVersion). "
+        "$stem's codegen version ($codegenVersion) should be "
+        "the same as runtime version ($kFlutterRustBridgeRuntimeVersion). "
         "See https://cjycode.com/flutter_rust_bridge/guides/miscellaneous/upgrade/regular for details.",
       );
+    } else {
+      assert(() {
+        // ignore: avoid_print
+        print(
+          "Bypassing mismatched $stem's codegen version: "
+          "$codegenVersion vs $kFlutterRustBridgeRuntimeVersion",
+        );
+        return true;
+      }());
     }
   }
 

--- a/frb_dart/test/entrypoint_test.dart
+++ b/frb_dart/test/entrypoint_test.dart
@@ -14,7 +14,7 @@ void main() {
   });
 
   test('Codegen version check', () {
-    final entrypoint = _FakeBaseEntrypointWithCodegenVersion('2.0.0');
+    final entrypoint = _FakeBaseEntrypointWithCodegenVersion('999.999.999');
 
     // Version does not match, will throw a [StateError].
     expectLater(

--- a/frb_dart/test/entrypoint_test.dart
+++ b/frb_dart/test/entrypoint_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart'
     show ExternalLibrary;
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated_common.dart';
+import 'package:flutter_rust_bridge/src/consts.dart' show kIsWeb;
 import 'package:test/test.dart';
 
 void main() {
@@ -42,7 +43,7 @@ void main() {
       ),
       throwsA(isA<ArgumentError>()),
     );
-  });
+  }, skip: kIsWeb);
 }
 
 class _FakeBaseEntrypointWithCodegenVersion extends _FakeBaseEntrypoint {

--- a/frb_dart/test/entrypoint_test.dart
+++ b/frb_dart/test/entrypoint_test.dart
@@ -1,3 +1,5 @@
+import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart'
+    show ExternalLibrary;
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated_common.dart';
 import 'package:test/test.dart';
 
@@ -15,17 +17,29 @@ void main() {
   test('Codegen version check', () {
     final entrypoint = _FakeBaseEntrypointWithCodegenVersion('2.0.0');
 
+    ExternalLibrary getExternalLibrary() {
+      return ExternalLibrary.process(iKnowHowToUseIt: true);
+    }
+
     // Version does not match, will throw a [StateError].
     expectLater(
       // ignore: invalid_use_of_protected_member
-      entrypoint.initImpl(api: _FakeApi(), forceSameCodegenVersion: true),
+      entrypoint.initImpl(
+        api: _FakeApi(),
+        externalLibrary: getExternalLibrary(),
+        forceSameCodegenVersion: true,
+      ),
       throwsA(isA<StateError>()),
     );
 
     // Version matched but the stem is fake, will throw an [ArgumentError].
     expectLater(
       // ignore: invalid_use_of_protected_member
-      entrypoint.initImpl(api: _FakeApi(), forceSameCodegenVersion: false),
+      entrypoint.initImpl(
+        api: _FakeApi(),
+        externalLibrary: getExternalLibrary(),
+        forceSameCodegenVersion: false,
+      ),
       throwsA(isA<ArgumentError>()),
     );
   });
@@ -66,7 +80,7 @@ class _FakeBaseEntrypoint extends BaseEntrypoint {
 
   @override
   get wireConstructor => throw UnimplementedError();
-  // frb-coverage:ignore-end
+// frb-coverage:ignore-end
 }
 
 class _FakeApi implements BaseApi {}

--- a/frb_dart/test/entrypoint_test.dart
+++ b/frb_dart/test/entrypoint_test.dart
@@ -11,6 +11,39 @@ void main() {
     expect(entrypoint.initialized, true);
     expect(entrypoint.api, isA<_FakeApi>());
   });
+
+  test('Codegen version check', () {
+    final entrypoint = _FakeBaseEntrypointWithCodegenVersion('2.0.0');
+
+    // Version does not match, will throw a [StateError].
+    expectLater(
+      // ignore: invalid_use_of_protected_member
+      entrypoint.initImpl(api: _FakeApi(), forceSameCodegenVersion: true),
+      throwsA(isA<StateError>()),
+    );
+
+    // Version matched but the stem is fake, will throw an [ArgumentError].
+    expectLater(
+      // ignore: invalid_use_of_protected_member
+      entrypoint.initImpl(api: _FakeApi(), forceSameCodegenVersion: false),
+      throwsA(isA<ArgumentError>()),
+    );
+  });
+}
+
+class _FakeBaseEntrypointWithCodegenVersion extends _FakeBaseEntrypoint {
+  _FakeBaseEntrypointWithCodegenVersion(this.codegenVersion);
+
+  @override
+  final String codegenVersion;
+
+  @override
+  ExternalLibraryLoaderConfig get defaultExternalLibraryLoaderConfig =>
+      const ExternalLibraryLoaderConfig(
+        stem: 'fake_codegen_version',
+        ioDirectory: null,
+        webPrefix: null,
+      );
 }
 
 class _FakeBaseEntrypoint extends BaseEntrypoint {

--- a/frb_dart/test/entrypoint_test.dart
+++ b/frb_dart/test/entrypoint_test.dart
@@ -1,7 +1,4 @@
-import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart'
-    show ExternalLibrary;
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated_common.dart';
-import 'package:flutter_rust_bridge/src/consts.dart' show kIsWeb;
 import 'package:test/test.dart';
 
 void main() {
@@ -18,32 +15,20 @@ void main() {
   test('Codegen version check', () {
     final entrypoint = _FakeBaseEntrypointWithCodegenVersion('2.0.0');
 
-    ExternalLibrary getExternalLibrary() {
-      return ExternalLibrary.process(iKnowHowToUseIt: true);
-    }
-
     // Version does not match, will throw a [StateError].
     expectLater(
       // ignore: invalid_use_of_protected_member
-      entrypoint.initImpl(
-        api: _FakeApi(),
-        externalLibrary: getExternalLibrary(),
-        forceSameCodegenVersion: true,
-      ),
+      entrypoint.initImpl(api: _FakeApi(), forceSameCodegenVersion: true),
       throwsA(isA<StateError>()),
     );
 
     // Version matched but the stem is fake, will throw an [ArgumentError].
     expectLater(
       // ignore: invalid_use_of_protected_member
-      entrypoint.initImpl(
-        api: _FakeApi(),
-        externalLibrary: getExternalLibrary(),
-        forceSameCodegenVersion: false,
-      ),
+      entrypoint.initImpl(api: _FakeApi(), forceSameCodegenVersion: false),
       throwsA(isA<ArgumentError>()),
     );
-  }, skip: kIsWeb);
+  });
 }
 
 class _FakeBaseEntrypointWithCodegenVersion extends _FakeBaseEntrypoint {
@@ -56,8 +41,8 @@ class _FakeBaseEntrypointWithCodegenVersion extends _FakeBaseEntrypoint {
   ExternalLibraryLoaderConfig get defaultExternalLibraryLoaderConfig =>
       const ExternalLibraryLoaderConfig(
         stem: 'fake_codegen_version',
-        ioDirectory: null,
-        webPrefix: null,
+        ioDirectory: 'fake_dir',
+        webPrefix: 'fake',
       );
 }
 

--- a/frb_dart/test/entrypoint_test.dart
+++ b/frb_dart/test/entrypoint_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated_common.dart';
+import 'package:flutter_rust_bridge/src/consts.dart' show kIsWeb;
 import 'package:test/test.dart';
 
 void main() {
@@ -28,7 +29,7 @@ void main() {
       entrypoint.initImpl(api: _FakeApi(), forceSameCodegenVersion: false),
       throwsA(isA<ArgumentError>()),
     );
-  });
+  }, skip: kIsWeb);
 }
 
 class _FakeBaseEntrypointWithCodegenVersion extends _FakeBaseEntrypoint {

--- a/frb_example/dart_build_rs/lib/src/rust/frb_generated.dart
+++ b/frb_example/dart_build_rs/lib/src/rust/frb_generated.dart
@@ -23,11 +23,13 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
     RustLibApi? api,
     BaseHandler? handler,
     ExternalLibrary? externalLibrary,
+    bool forceSameCodegenVersion = true,
   }) async {
     await instance.initImpl(
       api: api,
       handler: handler,
       externalLibrary: externalLibrary,
+      forceSameCodegenVersion: forceSameCodegenVersion,
     );
   }
 

--- a/frb_example/dart_minimal/lib/src/rust/frb_generated.dart
+++ b/frb_example/dart_minimal/lib/src/rust/frb_generated.dart
@@ -23,11 +23,13 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
     RustLibApi? api,
     BaseHandler? handler,
     ExternalLibrary? externalLibrary,
+    bool forceSameCodegenVersion = true,
   }) async {
     await instance.initImpl(
       api: api,
       handler: handler,
       externalLibrary: externalLibrary,
+      forceSameCodegenVersion: forceSameCodegenVersion,
     );
   }
 

--- a/frb_example/deliberate_bad/lib/src/rust/frb_generated.dart
+++ b/frb_example/deliberate_bad/lib/src/rust/frb_generated.dart
@@ -23,11 +23,13 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
     RustLibApi? api,
     BaseHandler? handler,
     ExternalLibrary? externalLibrary,
+    bool forceSameCodegenVersion = true,
   }) async {
     await instance.initImpl(
       api: api,
       handler: handler,
       externalLibrary: externalLibrary,
+      forceSameCodegenVersion: forceSameCodegenVersion,
     );
   }
 

--- a/frb_example/flutter_package/lib/src/rust/frb_generated.dart
+++ b/frb_example/flutter_package/lib/src/rust/frb_generated.dart
@@ -23,11 +23,13 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
     RustLibApi? api,
     BaseHandler? handler,
     ExternalLibrary? externalLibrary,
+    bool forceSameCodegenVersion = true,
   }) async {
     await instance.initImpl(
       api: api,
       handler: handler,
       externalLibrary: externalLibrary,
+      forceSameCodegenVersion: forceSameCodegenVersion,
     );
   }
 

--- a/frb_example/flutter_via_create/lib/src/rust/frb_generated.dart
+++ b/frb_example/flutter_via_create/lib/src/rust/frb_generated.dart
@@ -23,11 +23,13 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
     RustLibApi? api,
     BaseHandler? handler,
     ExternalLibrary? externalLibrary,
+    bool forceSameCodegenVersion = true,
   }) async {
     await instance.initImpl(
       api: api,
       handler: handler,
       externalLibrary: externalLibrary,
+      forceSameCodegenVersion: forceSameCodegenVersion,
     );
   }
 

--- a/frb_example/flutter_via_integrate/lib/src/rust/frb_generated.dart
+++ b/frb_example/flutter_via_integrate/lib/src/rust/frb_generated.dart
@@ -23,11 +23,13 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
     RustLibApi? api,
     BaseHandler? handler,
     ExternalLibrary? externalLibrary,
+    bool forceSameCodegenVersion = true,
   }) async {
     await instance.initImpl(
       api: api,
       handler: handler,
       externalLibrary: externalLibrary,
+      forceSameCodegenVersion: forceSameCodegenVersion,
     );
   }
 

--- a/frb_example/gallery/lib/src/rust/frb_generated.dart
+++ b/frb_example/gallery/lib/src/rust/frb_generated.dart
@@ -23,11 +23,13 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
     RustLibApi? api,
     BaseHandler? handler,
     ExternalLibrary? externalLibrary,
+    bool forceSameCodegenVersion = true,
   }) async {
     await instance.initImpl(
       api: api,
       handler: handler,
       externalLibrary: externalLibrary,
+      forceSameCodegenVersion: forceSameCodegenVersion,
     );
   }
 

--- a/frb_example/integrate_third_party/lib/src/rust/frb_generated.dart
+++ b/frb_example/integrate_third_party/lib/src/rust/frb_generated.dart
@@ -38,11 +38,13 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
     RustLibApi? api,
     BaseHandler? handler,
     ExternalLibrary? externalLibrary,
+    bool forceSameCodegenVersion = true,
   }) async {
     await instance.initImpl(
       api: api,
       handler: handler,
       externalLibrary: externalLibrary,
+      forceSameCodegenVersion: forceSameCodegenVersion,
     );
   }
 

--- a/frb_example/pure_dart_pde/lib/src/rust/frb_generated.dart
+++ b/frb_example/pure_dart_pde/lib/src/rust/frb_generated.dart
@@ -164,11 +164,13 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
     RustLibApi? api,
     BaseHandler? handler,
     ExternalLibrary? externalLibrary,
+    bool forceSameCodegenVersion = true,
   }) async {
     await instance.initImpl(
       api: api,
       handler: handler,
       externalLibrary: externalLibrary,
+      forceSameCodegenVersion: forceSameCodegenVersion,
     );
   }
 

--- a/frb_example/rust_ui_counter/ui/lib/src/rust/frb_generated.dart
+++ b/frb_example/rust_ui_counter/ui/lib/src/rust/frb_generated.dart
@@ -28,11 +28,13 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
     RustLibApi? api,
     BaseHandler? handler,
     ExternalLibrary? externalLibrary,
+    bool forceSameCodegenVersion = true,
   }) async {
     await instance.initImpl(
       api: api,
       handler: handler,
       externalLibrary: externalLibrary,
+      forceSameCodegenVersion: forceSameCodegenVersion,
     );
   }
 

--- a/frb_example/rust_ui_todo_list/ui/lib/src/rust/frb_generated.dart
+++ b/frb_example/rust_ui_todo_list/ui/lib/src/rust/frb_generated.dart
@@ -28,11 +28,13 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
     RustLibApi? api,
     BaseHandler? handler,
     ExternalLibrary? externalLibrary,
+    bool forceSameCodegenVersion = true,
   }) async {
     await instance.initImpl(
       api: api,
       handler: handler,
       externalLibrary: externalLibrary,
+      forceSameCodegenVersion: forceSameCodegenVersion,
     );
   }
 


### PR DESCRIPTION
Per offline discussion, some generated libraries will not change after upgrades, so checking their version would cause extra effort for maintainers to upgrade periodically.

Introducing `forceSameCodegenVersion` to allow users to bypass the check when they feel confident to do so.

## Procedure and Checklist

- [x] Implement the feature / fix the bug.
- [x] Add tests in `frb_example/dart_minimal`.
- [x] Make `dart_minimal`'s CI green.
