### PR TITLE
🔥 Uses the output path of Dart when executing formats

### DIFF
--- a/frb_codegen/src/library/codegen/polisher/mod.rs
+++ b/frb_codegen/src/library/codegen/polisher/mod.rs
@@ -43,7 +43,7 @@ pub(super) fn polish(
     // Even if formatting generated code fails, it is not a big problem, and our codegen should not fail.
     if config.dart_format {
         warn_if_fail(
-            execute_dart_format(config, output_paths, progress_bar_pack),
+            execute_dart_format(config, progress_bar_pack),
             "execute_dart_format",
         );
     }
@@ -144,13 +144,11 @@ fn execute_dart_fix(
 
 fn execute_dart_format(
     config: &PolisherInternalConfig,
-    output_paths: &[PathBuf],
     progress_bar_pack: &GeneratorProgressBarPack,
 ) -> anyhow::Result<()> {
     let _pb = progress_bar_pack.polish_dart_formatter.start();
     dart_format(
-        &filter_paths_by_extension(output_paths, "dart"),
-        &config.dart_root,
+        &config.dart_output,
         config.dart_format_line_length,
         &["g.dart", "freezed.dart"],
     )

--- a/frb_codegen/src/library/commands/dart_format.rs
+++ b/frb_codegen/src/library/commands/dart_format.rs
@@ -2,26 +2,17 @@ use crate::command_run;
 use crate::commands::command_runner::call_shell;
 use crate::library::commands::command_runner::check_exit_code;
 use crate::library::commands::fvm::command_arg_maybe_fvm;
-use crate::utils::path_utils::{normalize_windows_unc_path, path_to_string};
-use anyhow::Context;
-use itertools::Itertools;
+use anyhow::Result;
 use log::debug;
-use pathdiff::diff_paths;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 #[allow(clippy::vec_init_then_push)]
 pub fn dart_format(
-    paths: &[PathBuf],
     base_path: &Path,
     line_length: u32,
     extra_extensions: &[&str],
 ) -> anyhow::Result<()> {
-    if paths.is_empty() {
-        return Ok(());
-    }
-
-    let paths = prepare_paths(paths, base_path, extra_extensions)?;
-    debug!("execute dart_format paths={paths:?} line_length={line_length}");
+    debug!("execute dart_format base_path={base_path:?} line_length={line_length}");
 
     let res = command_run!(
         call_shell[Some(base_path), None],
@@ -30,46 +21,8 @@ pub fn dart_format(
         "format",
         "--line-length",
         line_length.to_string(),
-        *paths
+        ".",
     )?;
     check_exit_code(&res)?;
     Ok(())
-}
-
-pub(super) fn prepare_paths(
-    paths: &[PathBuf],
-    base_path: &Path,
-    extra_extensions: &[&str],
-) -> anyhow::Result<Vec<PathBuf>> {
-    let base_path_str = path_to_string(base_path)?;
-    let normalized_base_path = normalize_windows_unc_path(&base_path_str);
-
-    Ok(paths
-        .iter()
-        .map(|path| {
-            let mut path: PathBuf = normalize_windows_unc_path(&path_to_string(path)?)
-                .to_owned()
-                .into();
-            path = diff_paths(path, normalized_base_path).context("diff path")?;
-            if path_to_string(&path)?.is_empty() {
-                path = ".".into();
-            }
-            Ok(path)
-        })
-        .collect::<anyhow::Result<Vec<_>>>()?
-        .into_iter()
-        .flat_map(|path| {
-            vec![path.clone()].into_iter().chain(
-                extra_extensions
-                    .iter()
-                    .map(move |ext| with_extension(path.clone(), ext))
-                    .filter(|path| path.exists()),
-            )
-        })
-        .collect_vec())
-}
-
-fn with_extension(mut path: PathBuf, ext: &str) -> PathBuf {
-    path.set_extension(ext);
-    path
 }

--- a/frb_codegen/src/library/integration/integrator.rs
+++ b/frb_codegen/src/library/integration/integrator.rs
@@ -80,7 +80,7 @@ pub fn integrate(config: IntegrateConfig) -> Result<()> {
     dart_fix(&dart_root)?;
 
     info!("Format Dart code");
-    dart_format(&[dart_root.clone()], &dart_root, 80, &[])?;
+    dart_format(&dart_root, 80, &[])?;
 
     Ok(())
 }


### PR DESCRIPTION
## Changes

The Rust library can be huge, thus, the amount of output files is massive too. With the current implementation, the command size of `dart format` would probably exceed the platform limitation (like 8191 on Windows).

So instead of splitting the paths into batches, let's try formatting the output directory directly, just like what we've done with `dart fix`.