### PR TITLE
add target support for windows arm builds

### DIFF
--- a/frb_example/flutter_package/cargokit/build_tool/lib/src/target.dart
+++ b/frb_example/flutter_package/cargokit/build_tool/lib/src/target.dart
@@ -47,6 +47,10 @@ class Target {
       flutter: 'windows-x64',
     ),
     Target(
+      rust: 'aarch64-pc-windows-msvc',
+      flutter: 'windows-arm64',
+    ),
+    Target(
       rust: 'x86_64-unknown-linux-gnu',
       flutter: 'linux-x64',
     ),


### PR DESCRIPTION
## Changes

Opened up the same PR upstream here https://github.com/irondash/cargokit/pull/99 but copying it here, for transparency and since I'm not sure how often the changes over there get synced over here, and whether or not you have laid additional changes on top of the stock `cargokit` code.

I was testing out some basic scaffolding of a Flutter+Rust project using this library on a Windows ARM VM running on my M2 Mac and, after a long slog trying to get the Windows tooling figured out, realized that the generated rust builder files don't have a target for Windows-based ARM builds specified, so this adds one. Here's the build output from `flutter run -d windows --verbose` without the change:

```
[+1488 ms]   SEVERE: ================================================================================
[  +14 ms] SEVERE : Cargokit BuildTool failed with error :
[C:\Users\vagrant\flutter-template\client\build\windows\arm64\plugins\rust_lib_client\rust_lib_client_cargokit.vcxproj]
[        ]   SEVERE: --------------------------------------------------------------------------------
[        ]   SEVERE: Exception: Unknown target platform: windows-arm64
```