### PR TITLE
fix: use `fvm install` to prevent `flutter_rust_bridge_codegen generate` from hanging (closes #2832)

### DIFF
--- a/frb_codegen/src/library/commands/fvm.rs
+++ b/frb_codegen/src/library/commands/fvm.rs
@@ -11,6 +11,9 @@ fn should_use_fvm(pwd: Option<&Path>) -> bool {
         false
     } else {
         let has_fvm_installation_output = has_fvm_installation();
+        if has_fvm_installation_output {
+            fvm_install_flutter_version();
+        }
         if !has_fvm_installation_output {
             log::info!("Has .fvmrc but no fvm binary installation, thus skip using fvm.");
         }
@@ -35,5 +38,12 @@ fn has_fvmrc(pwd: &Path) -> bool {
 #[allow(clippy::vec_init_then_push)]
 fn has_fvm_installation() -> bool {
     command_run!(call_shell[None, Some(ExecuteCommandOptions { log_when_error: Some(false), ..Default::default() })], "fvm", "--version")
+        .map_or(false, |res| res.status.success())
+}
+
+fn fvm_install_flutter_version() -> bool {
+    log::info!("Installing Flutter version via FVM…");
+
+    command_run!(call_shell[None, Some(ExecuteCommandOptions { log_when_error: Some(false), ..Default::default() })], "fvm", "install")
         .map_or(false, |res| res.status.success())
 }

--- a/frb_codegen/src/library/commands/fvm.rs
+++ b/frb_codegen/src/library/commands/fvm.rs
@@ -41,6 +41,7 @@ fn has_fvm_installation() -> bool {
         .map_or(false, |res| res.status.success())
 }
 
+#[allow(clippy::vec_init_then_push)]
 fn fvm_install_flutter_version() -> bool {
     log::info!("Installing Flutter version via FVM…");
 


### PR DESCRIPTION
## Changes

Fixes #2832 

## Procedure and Checklist

In order to quickly iterate and avoid slowing down development pace by making CI pass, only the following simplified steps are needed, and I (fzyzcjy) will handle the rest of CI / moving the tests currently (will have more automation in the future).

- [x] Implement the feature / fix the bug.
- [ ] Add tests in `frb_example/dart_minimal`.
- [ ] Make `dart_minimal`'s CI green.

Utility commands
- Run codegen: `cargo run --manifest-path /path/to/flutter_rust_bridge/frb_codegen/Cargo.toml -- generate`
- Run tests: `./frb_internal test-dart-native --package frb_example/dart_minimal`
