### PR TITLE
Update GitHub CI workflow to use new iOS simulators

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -827,8 +827,8 @@ jobs:
           - frb_example--rust_ui_todo_list--ui
           # no `frb_example--flutter_via_integrate` since it is similar to `flutter_via_create`
         device:
-          - "iPad (10th generation) Simulator (17.2)"
-          - "iPhone 15 Pro Max Simulator (17.2)"
+          - "iPad (10th generation) Simulator (18.6)"
+          - "iPhone 16 Pro Max Simulator (18.6)"
 
     steps:
       # setup


### PR DESCRIPTION
## Changes

Fixes #2865

## Procedure and Checklist

In order to quickly iterate and avoid slowing down development pace by making CI pass, only the following simplified steps are needed, and I (fzyzcjy) will handle the rest of CI / moving the tests currently (will have more automation in the future).

- [x] Implement the feature / fix the bug.
- [ ] Add tests in `frb_example/dart_minimal`.
- [ ] Make `dart_minimal`'s CI green.

Utility commands
- Run codegen: `cargo run --manifest-path /path/to/flutter_rust_bridge/frb_codegen/Cargo.toml -- generate`
- Run tests: `./frb_internal test-dart-native --package frb_example/dart_minimal`
