### PR TITLE
Update java to 21

### DIFF
--- a/frb_codegen/assets/integration_template/app/rust_builder/android/build.gradle
+++ b/frb_codegen/assets/integration_template/app/rust_builder/android/build.gradle
@@ -40,8 +40,8 @@ android {
     ndkVersion android.ndkVersion
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_21
+        targetCompatibility JavaVersion.VERSION_21
     }
 
     defaultConfig {

--- a/frb_codegen/assets/integration_template/plugin/android/build.gradle
+++ b/frb_codegen/assets/integration_template/plugin/android/build.gradle
@@ -40,8 +40,8 @@ android {
     ndkVersion android.ndkVersion
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_21
+        targetCompatibility JavaVersion.VERSION_21
     }
 
     defaultConfig {


### PR DESCRIPTION
## Changes

Updates java to 21, since java 8 will be soon removed

## Procedure and Checklist

In order to quickly iterate and avoid slowing down development pace by making CI pass, only the following simplified steps are needed, and I (fzyzcjy) will handle the rest of CI / moving the tests currently (will have more automation in the future).

- [x] Implement the feature / fix the bug.
- [ ] Add tests in `frb_example/dart_minimal`.
- [ ] Make `dart_minimal`'s CI green.

Utility commands
- Run codegen: `cargo run --manifest-path /path/to/flutter_rust_bridge/frb_codegen/Cargo.toml -- generate`
- Run tests: `./frb_internal test-dart-native --package frb_example/dart_minimal`
