### PR TITLE
Fix for #2899 "Windows 10 flutter_rust_bridge_codegen build-web fails (with solution)"

### DIFF
--- a/frb_codegen/src/library/commands/command_runner.rs
+++ b/frb_codegen/src/library/commands/command_runner.rs
@@ -151,7 +151,7 @@ pub(crate) fn call_shell_info(cmd: &[PathBuf]) -> CommandInfo {
 /// minimal set of escapes, then the alternative is to supply an new argument option to the `flutter_rust_bridge_codegen`
 /// CLI command that specifies the characters to be escaped for the argument tokens of the internal PowerShell 5.1 call, e.g.:
 ///     PS> flutter_rust_bridge_codegen build-web --ps51-escapes '"\ ' ...
-#[cfg(windows)]
+#[cfg(any(windows, test))]
 pub fn windows_escape_for_powershell(section_in: &str) -> String {
     let mut token_out = String::new();
     for c in section_in.chars() {


### PR DESCRIPTION
## Changes

Fixes #2899 "Windows 10 flutter_rust_bridge_codegen build-web fails (with solution)"

## Procedure and Checklist

In order to quickly iterate and avoid slowing down development pace by making CI pass, only the following simplified steps are needed, and I (fzyzcjy) will handle the rest of CI / moving the tests currently (will have more automation in the future).

- [ ✓ ] Implement the feature / fix the bug.
- [ ✓ ] Add tests in `frb_codegen/src/library/commands/command_runner.rs`.
- [ ✓? ] Add tests in `frb_example/dart_minimal` (tests added to `command_runner.rs` instead)
- [ ✓ ] Make `dart_minimal`'s CI green.

Utility commands
- Run codegen on Windows in PowerShell 7: `flutter_rust_bridge_codegen build-web "--wasm-pack-rustflags=--cfg getrandom_backend=`\`"wasm_js`\`" -C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-args=--shared-memory"`
- Run tests: `cargo.exe test --package flutter_rust_bridge_codegen --lib -- library::commands::command_runner::tests --show-output `
