### PR TITLE
docs: Revise troubleshooting steps for Cargokit and Flutter

### DIFF
--- a/website/docs/manual/troubleshooting.md
+++ b/website/docs/manual/troubleshooting.md
@@ -171,8 +171,9 @@ then maybe try to execute that command directly in the shell and see whether it 
 
 flutter_rust_bridge is compatible with both old and new Flutter. If you see error like `Flutter plugin not found, CargoKit plugin will not be applied.` or `dlopen failed: library "librust_lib_my_app.so" not found` in `flutter run --verbose`, then it is probably because the Cargokit (`rust_builder/cargokit`) version in your project () does not match the Flutter version and need the following changes:
 
-* To match Flutter <3.32.0: use Cargokit by copy-pasting into `rust_builder/carogkit` before
-https://github.com/irondash/cargokit/commit/9b878b73cdcc8e8e00b3094257eefa4143af24f1
+## Cargokit compatibility with Flutter
+
+* To match Flutter <3.32.0: use Cargokit by copy-pasting into `rust_builder/carogkit` before the https://github.com/irondash/cargokit/commit/9b878b73cdcc8e8e00b3094257eefa4143af24f1 commit
 * To match Flutter >=3.32.0: use Cargokit after that commit or just use it
 * Or change by yourself like https://github.com/irondash/cargokit/pull/118
 


### PR DESCRIPTION
Updated troubleshooting instructions for Cargokit compatibility with different Flutter versions.

Flutter Gradle Plugin breaking changes(use kotlin and change some api) start at [tag 3.32.0-0.0.pre](https://github.com/flutter/flutter/tree/3.32.0-0.0.pre/packages/flutter_tools/gradle/src/main).

pre tag [tag 3.31.0-0.1.pre](https://github.com/flutter/flutter/tree/3.31.0-0.1.pre/packages/flutter_tools/gradle/src/main) still use groovy.


## Changes

Fixes #2806 

