### PR TITLE
feat: add #[frb(sync)] to RustState::new for synchronous initialization

### DIFF
--- a/frb_example/rust_ui_counter/src/app.rs
+++ b/frb_example/rust_ui_counter/src/app.rs
@@ -8,6 +8,7 @@ pub struct RustState {
 }
 
 impl RustState {
+    #[frb(sync)]
     pub fn new() -> Self {
         Self {
             count: 100,


### PR DESCRIPTION
## Fix “tearoff_of_generative_constructor_of_abstract_class” in `rust_ui_counter`

## Changes

Fixes error in [frb_example/rust_ui_counter/ui/lib/main.dart](https://github.com/fzyzcjy/flutter_rust_bridge/blob/master/frb_example/rust_ui_counter/ui/lib/main.dart)

```dart
void main() => runRustApp(body: body, state: RustState.new);
```

[Details](https://dart.dev/tools/diagnostics/tearoff_of_generative_constructor_of_abstract_class) about the 'tearoff_of_generative_constructor_of_abstract_class' diagnostic produced by the Dart analyzer.

```
A generative constructor of an abstract class can't be torn off.
Try tearing off a constructor of a concrete class, or a non-generative constructor.
```

```dart
abstract class RustState implements RustOpaqueInterface
```

To resolve this, when added this `#[frb(sync)]` attribute to `pub fn new() -> Self`, the generated wrapper class in Dart, allows us to use its constructor tear‑off safely.

## Version

- flutter_rust_bridge: 2.11.1
- rust: 1.93.1
- dart: Dart SDK version: 3.11.0 (stable)
- flutter: 3.41.2 (channel stable)
- os: MacOS Tahoe 26.0.1



