### PR TITLE
Fix threaded WASM build-web defaults for the website demo

### DIFF
--- a/frb_dart/lib/src/cli/build_web/executor.dart
+++ b/frb_dart/lib/src/cli/build_web/executor.dart
@@ -196,6 +196,7 @@ Future<void> _executeWasmPack(
   );
 }
 
+/// Resolved `RUSTFLAGS` output for a `wasm-pack` invocation.
 class WasmPackRustflagsResolution {
   /// The `RUSTFLAGS` value that will be passed to `wasm-pack`.
   final String rustflags;
@@ -231,6 +232,7 @@ bool _containsDefaultWasmPackRustflags(String rustflags) {
 }
 
 @visibleForTesting
+/// Resolves the effective `wasm-pack` rustflags and any warning to display.
 WasmPackRustflagsResolution computeWasmPackRustflagsResolution({
   required String? argsOverride,
 }) {

--- a/frb_dart/lib/src/cli/build_web/executor.dart
+++ b/frb_dart/lib/src/cli/build_web/executor.dart
@@ -197,15 +197,20 @@ Future<void> _executeWasmPack(
 }
 
 class WasmPackRustflagsResolution {
+  /// The `RUSTFLAGS` value that will be passed to `wasm-pack`.
   final String rustflags;
+
+  /// Optional warning shown when user-provided overrides drop required defaults.
   final String? warning;
 
+  /// Creates a resolved `wasm-pack` rustflags result.
   const WasmPackRustflagsResolution({
     required this.rustflags,
     required this.warning,
   });
 }
 
+/// Default threaded-WASM rustflag segments used by `build-web`.
 const buildWebDefaultWasmPackRustflagSegments = [
   '-C target-feature=+atomics,+bulk-memory,+mutable-globals',
   '-C link-args=--shared-memory',
@@ -217,6 +222,7 @@ const buildWebDefaultWasmPackRustflagSegments = [
   '-C link-args=--export=__tls_base',
 ];
 
+/// Default threaded-WASM rustflags used by `build-web`.
 final buildWebDefaultWasmPackRustflags = buildWebDefaultWasmPackRustflagSegments
     .join(' ');
 

--- a/frb_dart/lib/src/cli/build_web/executor.dart
+++ b/frb_dart/lib/src/cli/build_web/executor.dart
@@ -206,7 +206,7 @@ class WasmPackRustflagsResolution {
   });
 }
 
-const buildWebDefaultWasmPackRustflags = [
+const buildWebDefaultWasmPackRustflagSegments = [
   '-C target-feature=+atomics,+bulk-memory,+mutable-globals',
   '-C link-args=--shared-memory',
   '-C link-args=--max-memory=1073741824',
@@ -215,7 +215,14 @@ const buildWebDefaultWasmPackRustflags = [
   '-C link-args=--export=__tls_size',
   '-C link-args=--export=__tls_align',
   '-C link-args=--export=__tls_base',
-].join(' ');
+];
+
+const buildWebDefaultWasmPackRustflags = buildWebDefaultWasmPackRustflagSegments
+    .join(' ');
+
+bool _containsDefaultWasmPackRustflags(String rustflags) {
+  return buildWebDefaultWasmPackRustflagSegments.every(rustflags.contains);
+}
 
 @visibleForTesting
 WasmPackRustflagsResolution computeWasmPackRustflagsResolution({
@@ -228,7 +235,7 @@ WasmPackRustflagsResolution computeWasmPackRustflagsResolution({
     );
   }
 
-  final warning = argsOverride.contains(buildWebDefaultWasmPackRustflags)
+  final warning = _containsDefaultWasmPackRustflags(argsOverride)
       ? null
       : 'WARN: RUSTFLAGS will be `$argsOverride`, which does not contain the default threaded-WASM flags `$buildWebDefaultWasmPackRustflags`. Keep the default flags when overriding `--wasm-pack-rustflags`, otherwise worker startup may fail with errors such as `WebAssembly.Memory could not be cloned`.';
   return WasmPackRustflagsResolution(rustflags: argsOverride, warning: warning);

--- a/frb_dart/lib/src/cli/build_web/executor.dart
+++ b/frb_dart/lib/src/cli/build_web/executor.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 
 import 'package:flutter_rust_bridge/src/cli/cli_utils.dart';
 import 'package:flutter_rust_bridge/src/cli/run_command.dart';
+import 'package:meta/meta.dart';
 
 /// {@macro flutter_rust_bridge.cli}
 class BuildWebArgs {
@@ -158,6 +159,13 @@ Future<void> _executeWasmPack(
   BuildWebArgs args, {
   required String rustCrateName,
 }) async {
+  final rustflagsResolution = computeWasmPackRustflagsResolution(
+    argsOverride: args.wasmPackRustflags,
+  );
+  if (rustflagsResolution.warning != null) {
+    print(rustflagsResolution.warning);
+  }
+
   await runCommand(
     'wasm-pack',
     [
@@ -182,21 +190,48 @@ Future<void> _executeWasmPack(
     ],
     env: {
       'RUSTUP_TOOLCHAIN': args.wasmPackRustupToolchain ?? 'nightly',
-      'RUSTFLAGS': _computeRustflags(argsOverride: args.wasmPackRustflags),
+      'RUSTFLAGS': rustflagsResolution.rustflags,
       if (stdout.supportsAnsiEscapes) 'CARGO_TERM_COLOR': 'always',
     },
   );
 }
 
-String _computeRustflags({required String? argsOverride}) {
-  const kDefault = '-C target-feature=+atomics,+bulk-memory,+mutable-globals';
-  if (argsOverride == null) return kDefault;
-  if (!argsOverride.contains(kDefault)) {
-    print(
-      'WARN: RUSTFLAGS will be `$argsOverride`, which does not contain the default one `$kDefault`',
+class WasmPackRustflagsResolution {
+  final String rustflags;
+  final String? warning;
+
+  const WasmPackRustflagsResolution({
+    required this.rustflags,
+    required this.warning,
+  });
+}
+
+const buildWebDefaultWasmPackRustflags = [
+  '-C target-feature=+atomics,+bulk-memory,+mutable-globals',
+  '-C link-args=--shared-memory',
+  '-C link-args=--max-memory=1073741824',
+  '-C link-args=--import-memory',
+  '-C link-args=--export=__wasm_init_tls',
+  '-C link-args=--export=__tls_size',
+  '-C link-args=--export=__tls_align',
+  '-C link-args=--export=__tls_base',
+].join(' ');
+
+@visibleForTesting
+WasmPackRustflagsResolution computeWasmPackRustflagsResolution({
+  required String? argsOverride,
+}) {
+  if (argsOverride == null) {
+    return const WasmPackRustflagsResolution(
+      rustflags: buildWebDefaultWasmPackRustflags,
+      warning: null,
     );
   }
-  return argsOverride;
+
+  final warning = argsOverride.contains(buildWebDefaultWasmPackRustflags)
+      ? null
+      : 'WARN: RUSTFLAGS will be `$argsOverride`, which does not contain the default threaded-WASM flags `$buildWebDefaultWasmPackRustflags`. Keep the default flags when overriding `--wasm-pack-rustflags`, otherwise worker startup may fail with errors such as `WebAssembly.Memory could not be cloned`.';
+  return WasmPackRustflagsResolution(rustflags: argsOverride, warning: warning);
 }
 
 Future<void> _executeWasmBindgen(

--- a/frb_dart/lib/src/cli/build_web/executor.dart
+++ b/frb_dart/lib/src/cli/build_web/executor.dart
@@ -217,7 +217,7 @@ const buildWebDefaultWasmPackRustflagSegments = [
   '-C link-args=--export=__tls_base',
 ];
 
-const buildWebDefaultWasmPackRustflags = buildWebDefaultWasmPackRustflagSegments
+final buildWebDefaultWasmPackRustflags = buildWebDefaultWasmPackRustflagSegments
     .join(' ');
 
 bool _containsDefaultWasmPackRustflags(String rustflags) {
@@ -229,7 +229,7 @@ WasmPackRustflagsResolution computeWasmPackRustflagsResolution({
   required String? argsOverride,
 }) {
   if (argsOverride == null) {
-    return const WasmPackRustflagsResolution(
+    return WasmPackRustflagsResolution(
       rustflags: buildWebDefaultWasmPackRustflags,
       warning: null,
     );

--- a/frb_dart/test/build_web_executor_test.dart
+++ b/frb_dart/test/build_web_executor_test.dart
@@ -41,7 +41,7 @@ void main() {
   });
 
   test('override path with default threaded wasm flags does not warn', () {
-    const override =
+    final override =
         '$buildWebDefaultWasmPackRustflags -C link-args=--stack-first';
 
     final resolution = computeWasmPackRustflagsResolution(

--- a/frb_dart/test/build_web_executor_test.dart
+++ b/frb_dart/test/build_web_executor_test.dart
@@ -51,4 +51,27 @@ void main() {
     expect(resolution.rustflags, override);
     expect(resolution.warning, isNull);
   });
+
+  test(
+    'override path with reordered default threaded wasm flags does not warn',
+    () {
+      const override =
+          '-C link-args=--stack-first '
+          '-C link-args=--export=__tls_base '
+          '-C target-feature=+atomics,+bulk-memory,+mutable-globals '
+          '-C link-args=--export=__tls_align '
+          '-C link-args=--max-memory=1073741824 '
+          '-C link-args=--import-memory '
+          '-C link-args=--shared-memory '
+          '-C link-args=--export=__tls_size '
+          '-C link-args=--export=__wasm_init_tls';
+
+      final resolution = computeWasmPackRustflagsResolution(
+        argsOverride: override,
+      );
+
+      expect(resolution.rustflags, override);
+      expect(resolution.warning, isNull);
+    },
+  );
 }

--- a/frb_dart/test/build_web_executor_test.dart
+++ b/frb_dart/test/build_web_executor_test.dart
@@ -1,0 +1,54 @@
+@TestOn('vm')
+import 'package:flutter_rust_bridge/src/cli/build_web/executor.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('default path returns full threaded wasm rustflags', () {
+    final resolution = computeWasmPackRustflagsResolution(argsOverride: null);
+
+    expect(resolution.rustflags, buildWebDefaultWasmPackRustflags);
+    expect(resolution.rustflags, contains('-C link-args=--shared-memory'));
+    expect(resolution.rustflags, contains('-C link-args=--import-memory'));
+    expect(
+      resolution.rustflags,
+      contains('-C link-args=--export=__wasm_init_tls'),
+    );
+    expect(resolution.warning, isNull);
+  });
+
+  test('override path returns override unchanged', () {
+    const override = '-C target-feature=+atomics';
+
+    final resolution = computeWasmPackRustflagsResolution(
+      argsOverride: override,
+    );
+
+    expect(resolution.rustflags, override);
+  });
+
+  test('override path without default threaded wasm flags returns warning', () {
+    const override = '-C target-feature=+atomics';
+
+    final resolution = computeWasmPackRustflagsResolution(
+      argsOverride: override,
+    );
+
+    expect(resolution.warning, contains('default threaded-WASM flags'));
+    expect(
+      resolution.warning,
+      contains('WebAssembly.Memory could not be cloned'),
+    );
+  });
+
+  test('override path with default threaded wasm flags does not warn', () {
+    const override =
+        '$buildWebDefaultWasmPackRustflags -C link-args=--stack-first';
+
+    final resolution = computeWasmPackRustflagsResolution(
+      argsOverride: override,
+    );
+
+    expect(resolution.rustflags, override);
+    expect(resolution.warning, isNull);
+  });
+}

--- a/website/docs/manual/miscellaneous/02-web-cross-origin.md
+++ b/website/docs/manual/miscellaneous/02-web-cross-origin.md
@@ -11,6 +11,9 @@ the web server needs to respond with the following headers to enable shared buff
 Cross-origin isolated documents have less restrictions on advanced features, such as asynchronous WASM which utilize shared buffers.
 You can read more about crossOriginIsolation [here](https://developer.mozilla.org/en-US/docs/Web/API/Window/crossOriginIsolated).
 
+The `flutter_rust_bridge_codegen build-web` command emits the default Rust flags required by modern threaded WASM builds.
+If you override `--wasm-pack-rustflags`, you are responsible for preserving those defaults; otherwise worker startup may fail with errors such as `WebAssembly.Memory could not be cloned`.
+
 ## When `flutter run`
 
 Thanks to [this pull request](https://github.com/flutter/flutter/pull/136297), we can:

--- a/website/docs/quickstart.md
+++ b/website/docs/quickstart.md
@@ -149,6 +149,9 @@ flutter_rust_bridge_codegen build-web
 flutter run --web-header=Cross-Origin-Opener-Policy=same-origin --web-header=Cross-Origin-Embedder-Policy=require-corp
 ```
 
+`build-web` now supplies the shared-memory Rust flags needed by modern threaded WASM builds.
+If you override `--wasm-pack-rustflags`, keep the default threaded-WASM flags as well; otherwise the app may fail at runtime with errors such as `WebAssembly.Memory could not be cloned`.
+
 </TabItem>
 
 </Tabs>

--- a/website/docs/quickstart.md
+++ b/website/docs/quickstart.md
@@ -149,9 +149,6 @@ flutter_rust_bridge_codegen build-web
 flutter run --web-header=Cross-Origin-Opener-Policy=same-origin --web-header=Cross-Origin-Embedder-Policy=require-corp
 ```
 
-`build-web` now supplies the shared-memory Rust flags needed by modern threaded WASM builds.
-If you override `--wasm-pack-rustflags`, keep the default threaded-WASM flags as well; otherwise the app may fail at runtime with errors such as `WebAssembly.Memory could not be cloned`.
-
 </TabItem>
 
 </Tabs>


### PR DESCRIPTION
## Behavior changes

1. Flutter SDK: SDK Version : 3.41.2 is not installed.
[?25l? Would you like to install it now? (y/n) › yes                                  now uses a larger default  set for threaded WASM builds.

Previously the default only included:



Now it also includes:



2. Override validation for  is stricter.

Previously the warning logic only checked whether the override still contained the old atomics-related default string.
Now it checks whether the override preserves the full default threaded-WASM flag set, and warns more explicitly that dropping those defaults can lead to runtime failures such as .

3. Equivalent overrides with a different flag order no longer warn.

If the override contains the full default threaded-WASM flags but in a different order, it is now accepted without a warning.

## Unchanged behavior

- Passing  still fully overrides the default value; this PR does not merge user flags with the defaults automatically.
- The CLI surface, command entrypoint, and website/gallery app logic are unchanged.

## Testing

This PR adds unit tests for the rustflags resolution logic, covering:

- default resolution
- explicit override passthrough
- warning when required default threaded-WASM flags are missing
- no warning when the same defaults are present in a different order

End-to-end browser validation is still pending separately.