### PR TITLE
fix(frb_rust): cfg-gate `wasm_bindgen::module()` call on emscripten target

### DIFF
--- a/frb_rust/src/third_party/wasm_bindgen/worker_pool.rs
+++ b/frb_rust/src/third_party/wasm_bindgen/worker_pool.rs
@@ -4,23 +4,36 @@
 
 use crate::misc::web_utils::script_path;
 use crate::web_transfer::transfer_closure::TransferClosure;
+// `Array`, `Object`, `Reflect`, `FromIterator`, `Blob`, `BlobPropertyBag`, `Url`
+// are used only by the non-emscripten `spawn` body; the emscripten stub doesn't
+// need them. Gate the imports so emscripten builds stay warning-free.
+#[cfg(not(target_os = "emscripten"))]
 use js_sys::{Array, Object, Reflect};
 use std::cell::RefCell;
+#[cfg(not(target_os = "emscripten"))]
 use std::iter::FromIterator;
 use std::rc::Rc;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
+#[cfg(not(target_os = "emscripten"))]
 use web_sys::BlobPropertyBag;
 use web_sys::ErrorEvent;
 use web_sys::MessageEvent;
+#[cfg(not(target_os = "emscripten"))]
 use web_sys::{Blob, Url};
 use web_sys::{Event, Worker};
 
 #[wasm_bindgen]
 pub struct WorkerPool {
     state: Rc<PoolState>,
+    // These fields are consumed only by the non-emscripten `spawn` body.
+    // `new_raw` still stores them on emscripten (the API signature is shared),
+    // so suppress the resulting dead-code warning rather than drop the fields.
+    #[cfg_attr(target_os = "emscripten", allow(dead_code))]
     script_src: String,
+    #[cfg_attr(target_os = "emscripten", allow(dead_code))]
     worker_js_preamble: String,
+    #[cfg_attr(target_os = "emscripten", allow(dead_code))]
     wasm_bindgen_name: String,
 }
 
@@ -77,10 +90,19 @@ impl WorkerPool {
             worker_js_preamble,
             wasm_bindgen_name,
         };
+        // On emscripten, `spawn` is a fail-fast stub (see its doc comment);
+        // eagerly priming the pool here would make `default()` — which uses
+        // `hardwareConcurrency` as `initial` — panic on startup for any
+        // program that just links the library, even if it never dispatches
+        // worker-bound work. Leave the pool empty on that target; explicit
+        // calls to `spawn` still return the same descriptive `Err`.
+        #[cfg(not(target_os = "emscripten"))]
         for _ in 0..initial {
             let worker = pool.spawn()?;
             pool.state.push(worker);
         }
+        #[cfg(target_os = "emscripten")]
+        let _ = initial; // silence unused-variable warning on emscripten
 
         Ok(pool)
     }
@@ -94,6 +116,12 @@ impl WorkerPool {
     ///
     /// Returns any error that may happen while a JS web worker is created and a
     /// message is sent to it.
+    ///
+    /// On `target_os = "emscripten"` this always returns `Err`: the worker init
+    /// path calls [`wasm_bindgen::module`], which is unsupported in
+    /// wasm-bindgen-cli's `OutputMode::Emscripten`. See the emscripten stub of
+    /// this function for the full context.
+    #[cfg(not(target_os = "emscripten"))]
     fn spawn(&self) -> Result<Worker, JsValue> {
         let worker_js_preamble = &self.worker_js_preamble;
         let script_src = &self.script_src;
@@ -146,6 +174,33 @@ impl WorkerPool {
         worker.post_message(&Array::from_iter([JsValue::from(wasm_init_object)]))?;
 
         Ok(worker)
+    }
+
+    /// Emscripten stub — see the non-emscripten variant for the normal
+    /// implementation.
+    ///
+    /// `wasm_bindgen::module()` is unsupported in wasm-bindgen-cli's
+    /// `OutputMode::Emscripten` (see `wasm-bindgen-cli-support/src/js/mod.rs`,
+    /// `Intrinsic::Module`, which bails for Bundler and Emscripten). That mode
+    /// is force-selected when an emscripten fork with `-sWASM_BINDGEN`
+    /// integration inserts a `__wasm_bindgen_emscripten_marker` custom
+    /// section, regardless of any explicit `--target` flag.
+    ///
+    /// The mere presence of a `wasm_bindgen::module()` call anywhere in the
+    /// dependency graph fails wasm-bindgen post-link on that target (bindings
+    /// cannot be generated for the `__wbindgen_module` import), even when
+    /// `spawn` is never actually called. The `cfg` gate keeps the import out
+    /// of the wasm entirely.
+    ///
+    /// At runtime, fail fast with a clear error rather than returning a
+    /// dead `Worker` initialised with a null module handle.
+    #[cfg(target_os = "emscripten")]
+    fn spawn(&self) -> Result<Worker, JsValue> {
+        Err(JsValue::from_str(
+            "flutter_rust_bridge::WorkerPool::spawn is not supported on \
+             target_os = \"emscripten\": wasm_bindgen::module() is \
+             unsupported in wasm-bindgen-cli's OutputMode::Emscripten",
+        ))
     }
 
     /// Fetches a worker from this pool, spawning one if necessary.


### PR DESCRIPTION
## Summary

`WorkerPool::spawn` in `frb_rust/src/third_party/wasm_bindgen/worker_pool.rs` calls `wasm_bindgen::module()` to forward the current Wasm module handle to a newly-spawned Web Worker. That intrinsic is only supported by `wasm-bindgen-cli`'s `OutputMode::{Web, NoModules, Node, Module}` — it explicitly bails for `Bundler` and `Emscripten` (see [`wasm-bindgen-cli-support/src/js/mod.rs`](https://github.com/rustwasm/wasm-bindgen/blob/main/crates/cli-support/src/js/mod.rs), `Intrinsic::Module`).

An emscripten fork with `-sWASM_BINDGEN` integration (e.g. the [walkingeyerobot/emscripten draft](https://github.com/emscripten-core/emscripten/pull/23493)) inserts a `__wasm_bindgen_emscripten_marker` custom section, which forces `wasm-bindgen-cli` into `OutputMode::Emscripten` regardless of any `--target` flag. In that mode the `__wbindgen_module` intrinsic bails, so `wasm-bindgen` post-link fails with:

```
failed to generates bindings for import of
`__wbindgen_placeholder__::__wbg___wbindgen_module_<hash>`
```

The failure happens even when `spawn` is never actually called — the mere reference in the dep graph is enough to pull the import into the wasm and kill the bindgen step. This makes `flutter_rust_bridge` unusable on `wasm32-unknown-emscripten` today.

## Fix

Two layered changes, both gated on `#[cfg(target_os = "emscripten")]`:

1. **Split `spawn` into two cfg variants.** Non-emscripten keeps the original implementation verbatim. Emscripten returns `Err(JsValue)` with a clear message pointing at the underlying cause.

2. **Skip the eager spawn loop in `new_raw`.** Otherwise `Default::default()` (which uses `navigator.hardwareConcurrency` as the initial count and then `.expect("fail to create WorkerPool")`s) would panic as soon as anything touches `THREAD_POOL` / `FLUTTER_RUST_BRIDGE_HANDLER` — meaning on the first FFI dispatch through flutter_rust_bridge's generated bindings. With the gate, the pool initialises empty on emscripten; explicit `spawn` / `execute` calls still return the same descriptive `Err`.

Imports and struct fields that are used only in the non-emscripten body are `cfg`-gated or `allow(dead_code)`-marked so emscripten builds stay warning-free.

## Why `target_os = "emscripten"` is the right gate

In principle someone could build for `wasm32-unknown-emscripten` without the walkingeyerobot fork (stock emscripten + manual `wasm-bindgen --target web`). In that case `OutputMode::Emscripten` wouldn't be auto-selected and `wasm_bindgen::module()` would work. In practice this is not how anyone uses wasm-bindgen with emscripten today — the fork exists specifically to bridge the two — and the fix is strictly additive for the stock-emscripten flow (they get a compile-time error at runtime instead of silently-maybe-working workers).

If a better per-toolchain detection exists, happy to switch.

## Verification

Compiled `frb_rust` on three targets; all warning-free after the cfg gates:

| Target | Result |
|---|---|
| `wasm32-unknown-emscripten` | ✅ 0 warnings |
| `wasm32-unknown-unknown` | ✅ 0 warnings |
| `aarch64-apple-darwin` (native) | ✅ 0 warnings |

End-to-end: a downstream crate that depends on `flutter_rust_bridge` now builds on `wasm32-unknown-emscripten` via the walkingeyerobot fork + wasm-bindgen-cli 0.2.118. The resulting ~15 MB release `.wasm` + matching JS glue load and instantiate in Node and expose all generated FRB dispatcher/opaque-handle symbols.

## Notes

- No public API change — `spawn` and `new_raw` are unchanged signatures; just their bodies differ per target.
- No behavior change on non-emscripten targets: the `#[cfg(not(target_os = "emscripten"))]` body is a verbatim copy of the existing code.
- Companion discussion about upstream wasm-bindgen Emscripten-mode gaps (Module intrinsic, Bundler fallback) is outside the scope of this PR — worth a separate issue if you want me to file one.
