### PR TITLE
Support multi-arch Docker development on Apple Silicon

### DIFF
--- a/.claude/skills/frb-docker/SKILL.md
+++ b/.claude/skills/frb-docker/SKILL.md
@@ -26,13 +26,7 @@ Prefer devcontainer for normal development.
 Dev Containers: Reopen in Container
 ```
 
-The devcontainer builds from `.devcontainer/Dockerfile` and runs:
-
-```shell
-./frb_internal pub-get-all
-```
-
-This prepares Dart/Flutter package dependencies. First Rust/wasm builds may still be slow because crate compilation caches are not warmed.
+The devcontainer builds from `.devcontainer/Dockerfile` and runs `./frb_internal pub-get-all` to prepare Dart/Flutter package dependencies; first Rust/wasm builds may still be slow because crate compilation caches are not warmed.
 
 ### Manual Docker Build
 

--- a/.claude/skills/frb-docker/SKILL.md
+++ b/.claude/skills/frb-docker/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: frb-docker
+description: Use when working with flutter_rust_bridge Docker/devcontainer setup, local Docker usage, Apple Silicon containers, or publishing the dev Docker image
+---
+
+# FRB Docker
+
+Use this skill for FRB Docker/devcontainer work: local container usage, Apple Silicon behavior, Dockerfile validation, and publishing `fzyzcjy/flutter_rust_bridge_dev`.
+
+## Source of Truth
+
+- Devcontainer config: `.devcontainer/devcontainer.json`
+- Dockerfile: `.devcontainer/Dockerfile`
+- Publish workflow: `.github/workflows/publish_dev_docker.yaml`
+- Published image: `fzyzcjy/flutter_rust_bridge_dev`
+
+The Dockerfile is the source of truth for tool versions. Derive image tags from its `ARG` values instead of hardcoding stale versions.
+
+## Daily Local Use
+
+Prefer devcontainer for normal development:
+
+```shell
+Dev Containers: Reopen in Container
+```
+
+The devcontainer builds from `.devcontainer/Dockerfile` and runs:
+
+```shell
+./frb_internal pub-get-all
+```
+
+This prepares Dart/Flutter package dependencies. First Rust/wasm builds may still be slow because crate compilation caches are not warmed.
+
+For manual Docker from the repo root:
+
+```shell
+docker build -f .devcontainer/Dockerfile -t frb-dev .devcontainer
+docker run --rm -it -v "$PWD:/workspace" -w /workspace frb-dev bash
+```
+
+Inside a fresh manual container, run:
+
+```shell
+./frb_internal pub-get-all
+```
+
+Then run normal development commands such as:
+
+```shell
+./frb_internal lint
+cargo check
+```
+
+To use the published image instead of building locally:
+
+```shell
+docker run --rm -it -v "$PWD:/workspace" -w /workspace fzyzcjy/flutter_rust_bridge_dev:latest bash
+```
+
+Prefer the full version tag when reproducibility matters.
+
+## Apple Silicon
+
+Apple Silicon Macs use the same commands as other platforms. Do not add `--platform linux/amd64` for normal local development.
+
+Docker should select `linux/arm64` automatically for multi-arch images. If a command only works with `--platform linux/amd64`, treat that as a regression to investigate.
+
+## Local Validation
+
+For Dockerfile changes, validate at least:
+
+```shell
+docker build -f .devcontainer/Dockerfile -t frb-dev .devcontainer
+docker run --rm -v "$PWD:/workspace" -w /workspace frb-dev bash -lc './frb_internal --help'
+```
+
+For environment changes, smoke-test the installed tools:
+
+```shell
+docker run --rm -v "$PWD:/workspace" -w /workspace frb-dev bash -lc '
+set -euo pipefail
+flutter --version
+dart --version
+node --version
+npm --version
+cargo --version
+wasm-pack --version
+"${CHROME_BIN}" --version
+'
+```
+
+For broader confidence, run:
+
+```shell
+docker run --rm -v "$PWD:/workspace" -w /workspace frb-dev bash -lc './frb_internal pub-get-all && ./frb_internal lint --fix'
+docker run --rm -v "$PWD:/workspace" -w /workspace/frb_rust frb-dev bash -lc 'cargo check && cargo check --target wasm32-unknown-unknown'
+```
+
+If generated files drift during lint/codegen, do not manually edit generated files. Restore unrelated generated drift unless the task intentionally changes generation outputs.
+
+## Publishing
+
+Publish the dev image from the workflow:
+
+```shell
+gh workflow run publish_dev_docker.yaml --ref master
+```
+
+Manual dispatch defaults to `publish=true`.
+
+To verify the workflow without publishing:
+
+```shell
+gh workflow run publish_dev_docker.yaml --ref master -f publish=false
+```
+
+The workflow builds and smoke-tests:
+
+- `linux/amd64` on `ubuntu-latest`
+- `linux/arm64` on `ubuntu-24.04-arm`
+
+When publishing, it pushes per-platform images and then creates multi-arch tags:
+
+- `latest`
+- `flutter-<flutter_version>-rust-<rust_version>-nightly-<rust_nightly_version>`
+- `sha-<short_sha>`
+
+After publishing, inspect the manifest:
+
+```shell
+docker buildx imagetools inspect fzyzcjy/flutter_rust_bridge_dev:latest
+```
+
+It should include `linux/amd64` and `linux/arm64`. BuildKit attestation manifests may appear as `unknown/unknown`; those are not platform images.
+
+## CI Workflow Guidance
+
+Avoid building the full Rust/Flutter arm64 image under QEMU on an amd64 runner; it is much slower than native arm64 and can make the workflow impractical. Use native arch runners for heavy image builds.
+
+If a dry-run passes but publishing fails, inspect whether Docker Hub login, per-platform push, or manifest creation failed; those are separate phases in the workflow.

--- a/.claude/skills/frb-docker/SKILL.md
+++ b/.claude/skills/frb-docker/SKILL.md
@@ -30,13 +30,13 @@ The devcontainer builds from `.devcontainer/Dockerfile` and runs `./frb_internal
 
 ### Published Image
 
-Use this when you want the prebuilt dev image instead of building `.devcontainer/Dockerfile` locally.
+Default behavior is still to build locally from `.devcontainer/Dockerfile`. If you want to use a prebuilt image instead, switch to the full version tag derived from the current Dockerfile args rather than `latest`.
 
 ```shell
 docker run --rm -it -v "$PWD:/workspace" -w /workspace fzyzcjy/flutter_rust_bridge_dev:latest bash
 ```
 
-Prefer the full version tag when reproducibility matters.
+Use `latest` only for quick local checks where reproducibility does not matter.
 
 ### Manual Docker Build
 

--- a/.claude/skills/frb-docker/SKILL.md
+++ b/.claude/skills/frb-docker/SKILL.md
@@ -72,7 +72,9 @@ Apple Silicon Macs use the same commands as other platforms. Do not add `--platf
 
 Docker should select `linux/arm64` automatically for multi-arch images. If a command only works with `--platform linux/amd64`, treat that as a regression to investigate.
 
-## Local Validation
+## Publishing
+
+### Local Validation
 
 For Dockerfile changes, validate at least:
 
@@ -105,7 +107,7 @@ docker run --rm -v "$PWD:/workspace" -w /workspace/frb_rust frb-dev bash -lc 'ca
 
 If generated files drift during lint/codegen, do not manually edit generated files. Restore unrelated generated drift unless the task intentionally changes generation outputs.
 
-## Publishing
+### Publish Workflow
 
 Publish the dev image from the workflow:
 

--- a/.claude/skills/frb-docker/SKILL.md
+++ b/.claude/skills/frb-docker/SKILL.md
@@ -18,7 +18,9 @@ The Dockerfile is the source of truth for tool versions. Derive image tags from 
 
 ## Daily Local Use
 
-Prefer devcontainer for normal development:
+### Devcontainer
+
+Prefer devcontainer for normal development.
 
 ```shell
 Dev Containers: Reopen in Container
@@ -32,7 +34,9 @@ The devcontainer builds from `.devcontainer/Dockerfile` and runs:
 
 This prepares Dart/Flutter package dependencies. First Rust/wasm builds may still be slow because crate compilation caches are not warmed.
 
-For manual Docker from the repo root:
+### Manual Docker Build
+
+Use this when not using VS Code devcontainers, or when validating local Dockerfile changes.
 
 ```shell
 docker build -f .devcontainer/Dockerfile -t frb-dev .devcontainer
@@ -52,7 +56,9 @@ Then run normal development commands such as:
 cargo check
 ```
 
-To use the published image instead of building locally:
+### Published Image
+
+Use this when you want the prebuilt dev image instead of building `.devcontainer/Dockerfile` locally.
 
 ```shell
 docker run --rm -it -v "$PWD:/workspace" -w /workspace fzyzcjy/flutter_rust_bridge_dev:latest bash

--- a/.claude/skills/frb-docker/SKILL.md
+++ b/.claude/skills/frb-docker/SKILL.md
@@ -28,6 +28,16 @@ Dev Containers: Reopen in Container
 
 The devcontainer builds from `.devcontainer/Dockerfile` and runs `./frb_internal pub-get-all` to prepare Dart/Flutter package dependencies; first Rust/wasm builds may still be slow because crate compilation caches are not warmed.
 
+### Published Image
+
+Use this when you want the prebuilt dev image instead of building `.devcontainer/Dockerfile` locally.
+
+```shell
+docker run --rm -it -v "$PWD:/workspace" -w /workspace fzyzcjy/flutter_rust_bridge_dev:latest bash
+```
+
+Prefer the full version tag when reproducibility matters.
+
 ### Manual Docker Build
 
 Use this when not using VS Code devcontainers, or when validating local Dockerfile changes.
@@ -49,16 +59,6 @@ Then run normal development commands such as:
 ./frb_internal lint
 cargo check
 ```
-
-### Published Image
-
-Use this when you want the prebuilt dev image instead of building `.devcontainer/Dockerfile` locally.
-
-```shell
-docker run --rm -it -v "$PWD:/workspace" -w /workspace fzyzcjy/flutter_rust_bridge_dev:latest bash
-```
-
-Prefer the full version tag when reproducibility matters.
 
 ## Apple Silicon
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,6 @@
 ARG FLUTTER_VERSION=3.41.2
-FROM ghcr.io/cirruslabs/flutter:${FLUTTER_VERSION}
+ARG FLUTTER_IMAGE_PLATFORM=linux/amd64
+FROM --platform=${FLUTTER_IMAGE_PLATFORM} instrumentisto/flutter:${FLUTTER_VERSION}
 
 # Configurable version parameters
 ARG RUST_VERSION=1.93.1

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -32,6 +32,7 @@ SHELL ["/bin/bash", "-c"]
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_VERSION} && \
     export PATH="$HOME/.cargo/bin:$PATH" && \
     rustup component add rustfmt clippy && \
+    rustup target add wasm32-unknown-unknown && \
     rustup toolchain install "nightly-${RUST_NIGHTLY_VERSION}" && \
     rustup component add rust-src --toolchain "nightly-${RUST_NIGHTLY_VERSION}" && \
     rustup target add wasm32-unknown-unknown --toolchain "nightly-${RUST_NIGHTLY_VERSION}"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 ARG FLUTTER_VERSION=3.41.2
-FROM instrumentisto/flutter:${FLUTTER_VERSION}
+FROM ghcr.io/cirruslabs/flutter:${FLUTTER_VERSION}
 
 # Configurable version parameters
 ARG RUST_VERSION=1.93.1
@@ -43,14 +43,19 @@ RUN cargo install wasm-pack
 RUN cargo install cargo-llvm-cov && \
     npm install -g all-contributors-cli
 
-# Install Chrome for web tests (headless testing)
+# Install Chrome/Chromium for web tests (headless testing)
 RUN apt-get update && apt-get install -y \
     wget \
     gnupg \
-    && wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg && \
-    echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list && \
-    apt-get update && apt-get install -y \
-    google-chrome-stable \
+    && if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
+        wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg && \
+        echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list && \
+        apt-get update && \
+        apt-get install -y google-chrome-stable; \
+    else \
+        apt-get install -y chromium && \
+        ln -s /usr/bin/chromium /usr/bin/google-chrome; \
+    fi \
     && rm -rf /var/lib/apt/lists/*
 ENV CHROME_BIN=/usr/bin/google-chrome
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,10 +1,10 @@
 ARG FLUTTER_VERSION=3.41.2
-ARG FLUTTER_IMAGE_PLATFORM=linux/amd64
-FROM --platform=${FLUTTER_IMAGE_PLATFORM} instrumentisto/flutter:${FLUTTER_VERSION}
+FROM ghcr.io/cirruslabs/flutter:${FLUTTER_VERSION}
 
 # Configurable version parameters
 ARG RUST_VERSION=1.93.1
 ARG RUST_NIGHTLY_VERSION=2025-02-01
+ARG NODE_VERSION=22.11.0
 
 # Environment variables
 ENV DEBIAN_FRONTEND=noninteractive
@@ -18,9 +18,8 @@ RUN apt-get update && apt-get install -y \
     ninja-build \
     pkg-config \
     libclang-dev \
-    nodejs \
-    npm \
     python3-pip \
+    xz-utils \
     && rm -rf /var/lib/apt/lists/*
 
 # Configure pip to allow system package installation (PEP 668)
@@ -38,6 +37,16 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --de
     rustup target add wasm32-unknown-unknown --toolchain "nightly-${RUST_NIGHTLY_VERSION}"
 ENV PATH="/root/.cargo/bin:${PATH}"
 
+# Install Node.js and npm from official multi-arch binaries.
+RUN ARCH="$(dpkg --print-architecture)" && \
+    case "$ARCH" in \
+        amd64) NODE_ARCH="x64" ;; \
+        arm64) NODE_ARCH="arm64" ;; \
+        *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; \
+    esac && \
+    curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" \
+        | tar -xJ -C /usr/local --strip-components=1
+
 # Install wasm-pack for web tests (using cargo for better reliability)
 RUN cargo install wasm-pack
 
@@ -45,20 +54,13 @@ RUN cargo install wasm-pack
 RUN cargo install cargo-llvm-cov && \
     npm install -g all-contributors-cli
 
-# Install Chrome/Chromium for web tests (headless testing)
-RUN apt-get update && apt-get install -y \
-    wget \
-    gnupg \
-    && if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
-        wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg && \
-        echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list && \
-        apt-get update && \
-        apt-get install -y google-chrome-stable; \
-    else \
-        apt-get install -y chromium && \
-        ln -s /usr/bin/chromium /usr/bin/google-chrome; \
-    fi \
-    && rm -rf /var/lib/apt/lists/*
+# Install Chromium for web tests (headless testing). Google Chrome does not
+# provide Linux arm64 builds yet, and Ubuntu's chromium-browser package is snap.
+ARG PLAYWRIGHT_VERSION=1.59.1
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright
+RUN npm install -g "playwright@${PLAYWRIGHT_VERSION}" && \
+    playwright install --with-deps chromium && \
+    ln -s "$(find "${PLAYWRIGHT_BROWSERS_PATH}" -path "*/chrome-linux/chrome" -type f | head -n 1)" /usr/bin/google-chrome
 ENV CHROME_BIN=/usr/bin/google-chrome
 
 # Working directory
@@ -66,6 +68,8 @@ WORKDIR /workspace
 
 RUN flutter --version && \
     dart --version && \
+    node --version && \
+    npm --version && \
     cargo --version && \
     rustup toolchain list | grep "nightly-${RUST_NIGHTLY_VERSION}" && \
     rustup target list --toolchain "nightly-${RUST_NIGHTLY_VERSION}" --installed | grep wasm32-unknown-unknown && \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -60,7 +60,7 @@ ARG PLAYWRIGHT_VERSION=1.59.1
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright
 RUN npm install -g "playwright@${PLAYWRIGHT_VERSION}" && \
     playwright install --with-deps chromium && \
-    ln -s "$(find "${PLAYWRIGHT_BROWSERS_PATH}" -path "*/chrome-linux/chrome" -type f | head -n 1)" /usr/bin/google-chrome
+    ln -s "$(find "${PLAYWRIGHT_BROWSERS_PATH}" -path "*/chrome-linux*/chrome" -type f | head -n 1)" /usr/bin/google-chrome
 ENV CHROME_BIN=/usr/bin/google-chrome
 
 # Working directory

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,8 @@
 {
   "name": "flutter_rust_bridge Development",
   "build": {
-    "dockerfile": "Dockerfile"
+    "dockerfile": "Dockerfile",
+    "options": ["--platform=linux/amd64"]
   },
   "workspaceFolder": "/workspace",
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,6 +7,7 @@
   },
   "workspaceFolder": "/workspace",
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
+  "postCreateCommand": "cd tools/frb_internal && dart pub get",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,7 @@
-// Default behavior is still to build locally from .devcontainer/Dockerfile. If you want to use a prebuilt image instead, switch to the full version tag derived from the current Dockerfile args rather than `latest`.
 {
   "name": "flutter_rust_bridge Development",
   "build": {
-    "dockerfile": "Dockerfile",
-    "options": ["--platform=linux/amd64"]
+    "dockerfile": "Dockerfile"
   },
   "workspaceFolder": "/workspace",
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
   },
   "workspaceFolder": "/workspace",
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
-  "postCreateCommand": "cd tools/frb_internal && dart pub get && cd /workspace && ./frb_internal pub-get-all",
+  "postCreateCommand": "./frb_internal pub-get-all",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
   },
   "workspaceFolder": "/workspace",
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
-  "postCreateCommand": "cd tools/frb_internal && dart pub get",
+  "postCreateCommand": "cd tools/frb_internal && dart pub get && cd /workspace && ./frb_internal pub-get-all",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.github/workflows/publish_dev_docker.yaml
+++ b/.github/workflows/publish_dev_docker.yaml
@@ -1,7 +1,13 @@
 name: Publish Dev Docker Image
 
 on:
-  workflow_dispatch: { }
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Publish the image to Docker Hub'
+        required: true
+        default: false
+        type: boolean
   push:
     branches:
       - master
@@ -30,6 +36,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
+        if: github.event_name == 'push' || inputs.publish
         uses: docker/login-action@v3
         with:
           registry: docker.io
@@ -123,6 +130,7 @@ jobs:
           '
 
       - name: Push image to Docker Hub
+        if: github.event_name == 'push' || inputs.publish
         uses: docker/build-push-action@v6
         with:
           context: .devcontainer
@@ -135,9 +143,14 @@ jobs:
         shell: bash
         run: |
           {
-            echo "## Dev Docker Image Published"
+            if [[ "${{ github.event_name }}" == "push" || "${{ inputs.publish }}" == "true" ]]; then
+              echo "## Dev Docker Image Published"
+            else
+              echo "## Dev Docker Image Verified"
+            fi
             echo
             echo "- Repository: \`${IMAGE_NAME}\`"
+            echo "- Published: \`${{ github.event_name == 'push' || inputs.publish }}\`"
             echo "- Flutter: \`${{ steps.metadata.outputs.flutter_version }}\`"
             echo "- Rust: \`${{ steps.metadata.outputs.rust_version }}\`"
             echo "- Rust nightly: \`${{ steps.metadata.outputs.rust_nightly_version }}\`"

--- a/.github/workflows/publish_dev_docker.yaml
+++ b/.github/workflows/publish_dev_docker.yaml
@@ -23,6 +23,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -45,7 +48,8 @@ jobs:
           short_sha="${GITHUB_SHA::7}"
           version_tag="flutter-${flutter_version}-rust-${rust_version}-nightly-${rust_nightly_version}"
           sha_tag="sha-${short_sha}"
-          local_tag="frb-dev-image-smoke:${short_sha}"
+          local_tag_amd64="frb-dev-image-smoke:${short_sha}-amd64"
+          local_tag_arm64="frb-dev-image-smoke:${short_sha}-arm64"
 
           {
             echo "flutter_version=${flutter_version}"
@@ -53,7 +57,8 @@ jobs:
             echo "rust_nightly_version=${rust_nightly_version}"
             echo "version_tag=${version_tag}"
             echo "sha_tag=${sha_tag}"
-            echo "local_tag=${local_tag}"
+            echo "local_tag_amd64=${local_tag_amd64}"
+            echo "local_tag_arm64=${local_tag_arm64}"
             echo "tags<<EOF"
             echo "${IMAGE_NAME}:latest"
             echo "${IMAGE_NAME}:${version_tag}"
@@ -61,7 +66,7 @@ jobs:
             echo "EOF"
           } >> "${GITHUB_OUTPUT}"
 
-      - name: Build local image for smoke test
+      - name: Build local amd64 image for smoke test
         uses: docker/build-push-action@v6
         with:
           context: .devcontainer
@@ -69,14 +74,42 @@ jobs:
           platforms: linux/amd64
           load: true
           push: false
-          tags: ${{ steps.metadata.outputs.local_tag }}
+          tags: ${{ steps.metadata.outputs.local_tag_amd64 }}
 
-      - name: Smoke test local image
+      - name: Smoke test local amd64 image
         shell: bash
         run: |
           set -euo pipefail
 
-          docker run --rm "${{ steps.metadata.outputs.local_tag }}" bash -lc '
+          docker run --rm --platform linux/amd64 "${{ steps.metadata.outputs.local_tag_amd64 }}" bash -lc '
+            set -euo pipefail
+            flutter --version
+            dart --version
+            cargo --version
+            rustup show
+            rustup target list --toolchain nightly-${{ steps.metadata.outputs.rust_nightly_version }} --installed
+            wasm-pack --version
+            "${CHROME_BIN}" --version
+            rustup target list --toolchain nightly-${{ steps.metadata.outputs.rust_nightly_version }} --installed | grep wasm32-unknown-unknown
+            rustup show | grep "nightly-${{ steps.metadata.outputs.rust_nightly_version }}"
+          '
+
+      - name: Build local arm64 image for smoke test
+        uses: docker/build-push-action@v6
+        with:
+          context: .devcontainer
+          file: .devcontainer/Dockerfile
+          platforms: linux/arm64
+          load: true
+          push: false
+          tags: ${{ steps.metadata.outputs.local_tag_arm64 }}
+
+      - name: Smoke test local arm64 image
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          docker run --rm --platform linux/arm64 "${{ steps.metadata.outputs.local_tag_arm64 }}" bash -lc '
             set -euo pipefail
             flutter --version
             dart --version
@@ -94,7 +127,7 @@ jobs:
         with:
           context: .devcontainer
           file: .devcontainer/Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.metadata.outputs.tags }}
 
@@ -108,6 +141,7 @@ jobs:
             echo "- Flutter: \`${{ steps.metadata.outputs.flutter_version }}\`"
             echo "- Rust: \`${{ steps.metadata.outputs.rust_version }}\`"
             echo "- Rust nightly: \`${{ steps.metadata.outputs.rust_nightly_version }}\`"
+            echo "- Platforms: \`linux/amd64\`, \`linux/arm64\`"
             echo "- Tags:"
             echo "  - \`latest\`"
             echo "  - \`${{ steps.metadata.outputs.version_tag }}\`"

--- a/.github/workflows/publish_dev_docker.yaml
+++ b/.github/workflows/publish_dev_docker.yaml
@@ -6,7 +6,7 @@ on:
       publish:
         description: 'Publish the image to Docker Hub'
         required: true
-        default: false
+        default: true
         type: boolean
   push:
     branches:

--- a/.github/workflows/publish_dev_docker.yaml
+++ b/.github/workflows/publish_dev_docker.yaml
@@ -19,29 +19,22 @@ env:
   IMAGE_NAME: fzyzcjy/flutter_rust_bridge_dev
 
 jobs:
-  publish:
-    name: Build, Test and Publish Dev Image
+  metadata:
+    name: Compute image metadata
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      flutter_version: ${{ steps.metadata.outputs.flutter_version }}
+      rust_version: ${{ steps.metadata.outputs.rust_version }}
+      rust_nightly_version: ${{ steps.metadata.outputs.rust_nightly_version }}
+      version_tag: ${{ steps.metadata.outputs.version_tag }}
+      sha_tag: ${{ steps.metadata.outputs.sha_tag }}
+      should_publish: ${{ steps.metadata.outputs.should_publish }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to Docker Hub
-        if: github.event_name == 'push' || inputs.publish
-        uses: docker/login-action@v3
-        with:
-          registry: docker.io
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Compute tags from Dockerfile
         id: metadata
@@ -55,8 +48,12 @@ jobs:
           short_sha="${GITHUB_SHA::7}"
           version_tag="flutter-${flutter_version}-rust-${rust_version}-nightly-${rust_nightly_version}"
           sha_tag="sha-${short_sha}"
-          local_tag_amd64="frb-dev-image-smoke:${short_sha}-amd64"
-          local_tag_arm64="frb-dev-image-smoke:${short_sha}-arm64"
+
+          if [[ "${{ github.event_name }}" == "push" || "${{ inputs.publish }}" == "true" ]]; then
+            should_publish="true"
+          else
+            should_publish="false"
+          fi
 
           {
             echo "flutter_version=${flutter_version}"
@@ -64,99 +61,142 @@ jobs:
             echo "rust_nightly_version=${rust_nightly_version}"
             echo "version_tag=${version_tag}"
             echo "sha_tag=${sha_tag}"
-            echo "local_tag_amd64=${local_tag_amd64}"
-            echo "local_tag_arm64=${local_tag_arm64}"
-            echo "tags<<EOF"
-            echo "${IMAGE_NAME}:latest"
-            echo "${IMAGE_NAME}:${version_tag}"
-            echo "${IMAGE_NAME}:${sha_tag}"
-            echo "EOF"
+            echo "should_publish=${should_publish}"
           } >> "${GITHUB_OUTPUT}"
 
-      - name: Build local amd64 image for smoke test
+  build:
+    name: Build and smoke test (${{ matrix.arch }})
+    needs: metadata
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        if: needs.metadata.outputs.should_publish == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build local image for smoke test
         uses: docker/build-push-action@v6
         with:
           context: .devcontainer
           file: .devcontainer/Dockerfile
-          platforms: linux/amd64
+          platforms: ${{ matrix.platform }}
           load: true
           push: false
-          tags: ${{ steps.metadata.outputs.local_tag_amd64 }}
+          tags: frb-dev-image-smoke:${{ needs.metadata.outputs.sha_tag }}-${{ matrix.arch }}
 
-      - name: Smoke test local amd64 image
+      - name: Smoke test local image
         shell: bash
         run: |
           set -euo pipefail
 
-          docker run --rm --platform linux/amd64 "${{ steps.metadata.outputs.local_tag_amd64 }}" bash -lc '
+          docker run --rm --platform "${{ matrix.platform }}" "frb-dev-image-smoke:${{ needs.metadata.outputs.sha_tag }}-${{ matrix.arch }}" bash -lc '
             set -euo pipefail
             flutter --version
             dart --version
             cargo --version
             rustup show
-            rustup target list --toolchain nightly-${{ steps.metadata.outputs.rust_nightly_version }} --installed
+            rustup target list --toolchain nightly-${{ needs.metadata.outputs.rust_nightly_version }} --installed
             wasm-pack --version
             "${CHROME_BIN}" --version
-            rustup target list --toolchain nightly-${{ steps.metadata.outputs.rust_nightly_version }} --installed | grep wasm32-unknown-unknown
-            rustup show | grep "nightly-${{ steps.metadata.outputs.rust_nightly_version }}"
+            rustup target list --toolchain nightly-${{ needs.metadata.outputs.rust_nightly_version }} --installed | grep wasm32-unknown-unknown
+            rustup show | grep "nightly-${{ needs.metadata.outputs.rust_nightly_version }}"
           '
 
-      - name: Build local arm64 image for smoke test
+      - name: Push platform image to Docker Hub
+        if: needs.metadata.outputs.should_publish == 'true'
         uses: docker/build-push-action@v6
         with:
           context: .devcontainer
           file: .devcontainer/Dockerfile
-          platforms: linux/arm64
-          load: true
-          push: false
-          tags: ${{ steps.metadata.outputs.local_tag_arm64 }}
-
-      - name: Smoke test local arm64 image
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          docker run --rm --platform linux/arm64 "${{ steps.metadata.outputs.local_tag_arm64 }}" bash -lc '
-            set -euo pipefail
-            flutter --version
-            dart --version
-            cargo --version
-            rustup show
-            rustup target list --toolchain nightly-${{ steps.metadata.outputs.rust_nightly_version }} --installed
-            wasm-pack --version
-            "${CHROME_BIN}" --version
-            rustup target list --toolchain nightly-${{ steps.metadata.outputs.rust_nightly_version }} --installed | grep wasm32-unknown-unknown
-            rustup show | grep "nightly-${{ steps.metadata.outputs.rust_nightly_version }}"
-          '
-
-      - name: Push image to Docker Hub
-        if: github.event_name == 'push' || inputs.publish
-        uses: docker/build-push-action@v6
-        with:
-          context: .devcontainer
-          file: .devcontainer/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
           push: true
-          tags: ${{ steps.metadata.outputs.tags }}
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ needs.metadata.outputs.sha_tag }}-${{ matrix.arch }}
+            ${{ env.IMAGE_NAME }}:${{ needs.metadata.outputs.version_tag }}-${{ matrix.arch }}
+            ${{ env.IMAGE_NAME }}:latest-${{ matrix.arch }}
+
+      - name: Build workflow summary
+        shell: bash
+        run: |
+          {
+            echo "## Dev Docker Image ${{ matrix.arch }} Verified"
+            echo
+            echo "- Repository: \`${IMAGE_NAME}\`"
+            echo "- Published platform image: \`${{ needs.metadata.outputs.should_publish }}\`"
+            echo "- Platform: \`${{ matrix.platform }}\`"
+            echo "- Flutter: \`${{ needs.metadata.outputs.flutter_version }}\`"
+            echo "- Rust: \`${{ needs.metadata.outputs.rust_version }}\`"
+            echo "- Rust nightly: \`${{ needs.metadata.outputs.rust_nightly_version }}\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  publish_manifest:
+    name: Publish multi-arch manifest
+    needs:
+      - metadata
+      - build
+    if: needs.metadata.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Publish multi-arch tags
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          docker buildx imagetools create \
+            -t "${IMAGE_NAME}:latest" \
+            -t "${IMAGE_NAME}:${{ needs.metadata.outputs.version_tag }}" \
+            -t "${IMAGE_NAME}:${{ needs.metadata.outputs.sha_tag }}" \
+            "${IMAGE_NAME}:${{ needs.metadata.outputs.sha_tag }}-amd64" \
+            "${IMAGE_NAME}:${{ needs.metadata.outputs.sha_tag }}-arm64"
 
       - name: Publish workflow summary
         shell: bash
         run: |
           {
-            if [[ "${{ github.event_name }}" == "push" || "${{ inputs.publish }}" == "true" ]]; then
-              echo "## Dev Docker Image Published"
-            else
-              echo "## Dev Docker Image Verified"
-            fi
+            echo "## Dev Docker Image Published"
             echo
             echo "- Repository: \`${IMAGE_NAME}\`"
-            echo "- Published: \`${{ github.event_name == 'push' || inputs.publish }}\`"
-            echo "- Flutter: \`${{ steps.metadata.outputs.flutter_version }}\`"
-            echo "- Rust: \`${{ steps.metadata.outputs.rust_version }}\`"
-            echo "- Rust nightly: \`${{ steps.metadata.outputs.rust_nightly_version }}\`"
             echo "- Platforms: \`linux/amd64\`, \`linux/arm64\`"
+            echo "- Flutter: \`${{ needs.metadata.outputs.flutter_version }}\`"
+            echo "- Rust: \`${{ needs.metadata.outputs.rust_version }}\`"
+            echo "- Rust nightly: \`${{ needs.metadata.outputs.rust_nightly_version }}\`"
             echo "- Tags:"
             echo "  - \`latest\`"
-            echo "  - \`${{ steps.metadata.outputs.version_tag }}\`"
-            echo "  - \`${{ steps.metadata.outputs.sha_tag }}\`"
+            echo "  - \`${{ needs.metadata.outputs.version_tag }}\`"
+            echo "  - \`${{ needs.metadata.outputs.sha_tag }}\`"
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,3 +19,4 @@
 - `frb-lint` - Lint and format checks
 - `frb-prepare-pr` - PR preparation
 - `frb-fix-ci` - CI fixes
+- `frb-docker` - Docker/devcontainer usage and dev image publishing

--- a/frb_internal
+++ b/frb_internal
@@ -1,4 +1,16 @@
 #!/usr/bin/env bash
 SCRIPT=$(readlink -f "$0")
 SCRIPT_PATH=$(dirname "$SCRIPT")
+
+PACKAGE_CONFIG="$SCRIPT_PATH/tools/frb_internal/.dart_tool/package_config.json"
+if [[ -f "$PACKAGE_CONFIG" ]]; then
+  while IFS= read -r root_uri; do
+    root_path="${root_uri#file://}"
+    if [[ "$root_path" = /* && ! -e "$root_path" ]]; then
+      rm -f "$PACKAGE_CONFIG"
+      break
+    fi
+  done < <(sed -nE 's/.*"rootUri":[[:space:]]*"([^"]+)".*/\1/p' "$PACKAGE_CONFIG")
+fi
+
 cd "$SCRIPT_PATH"/tools/frb_internal && exec dart run flutter_rust_bridge_internal "$@"

--- a/frb_internal
+++ b/frb_internal
@@ -13,4 +13,9 @@ if [[ -f "$PACKAGE_CONFIG" ]]; then
   done < <(sed -nE 's/.*"rootUri":[[:space:]]*"([^"]+)".*/\1/p' "$PACKAGE_CONFIG")
 fi
 
-cd "$SCRIPT_PATH"/tools/frb_internal && exec dart run flutter_rust_bridge_internal "$@"
+cd "$SCRIPT_PATH"/tools/frb_internal
+if [[ ! -f .dart_tool/package_config.json ]]; then
+  dart pub get
+fi
+
+exec dart run flutter_rust_bridge_internal "$@"

--- a/website/docs/guides/contributing/tip.md
+++ b/website/docs/guides/contributing/tip.md
@@ -22,13 +22,7 @@ Those version numbers are derived from the `ARG` values in `.devcontainer/Docker
 
 The default devcontainer configuration still builds locally from `.devcontainer/Dockerfile`. If you want to use the prebuilt image manually, use the full version tag above or regenerate it from the current Dockerfile args after version bumps.
 
-On Apple Silicon Macs, the local devcontainer build uses the Linux arm64 variant of the multi-arch Flutter base image from `ghcr.io/cirruslabs/flutter`. Docker Desktop should select the native platform automatically, so no `--platform linux/amd64` override is needed for normal local development.
-
-When running the image manually on Apple Silicon, use the same command as other platforms:
-
-```shell
-docker run --rm -it fzyzcjy/flutter_rust_bridge_dev:flutter-3.41.2-rust-1.93.1-nightly-2025-02-01 bash
-```
+Apple Silicon Macs use the same devcontainer and manual Docker commands as other platforms.
 
 ### The `./frb_internal`
 

--- a/website/docs/guides/contributing/tip.md
+++ b/website/docs/guides/contributing/tip.md
@@ -24,6 +24,12 @@ The default devcontainer configuration still builds locally from `.devcontainer/
 
 On Apple Silicon Macs, the local devcontainer build uses the same Linux amd64 Flutter image under Docker Desktop emulation, because the current `instrumentisto/flutter` tags are not published as Linux arm64 images. This keeps the environment aligned with Linux amd64 development machines, though it can be slower than a native arm64 image.
 
+When running the image manually on Apple Silicon, pass `--platform linux/amd64` to avoid Docker's platform warning:
+
+```shell
+docker run --rm -it --platform linux/amd64 fzyzcjy/flutter_rust_bridge_dev:flutter-3.27.4-rust-1.88.0-nightly-2025-02-01 bash
+```
+
 ### The `./frb_internal`
 
 The `./frb_internal whatever-command` (or `./frb_internal.bat`) delegates to the `./tools/frb_internal` dart package.

--- a/website/docs/guides/contributing/tip.md
+++ b/website/docs/guides/contributing/tip.md
@@ -15,19 +15,19 @@ The published development image is `fzyzcjy/flutter_rust_bridge_dev`. It package
 Prefer the full version tag when you want reproducible environments:
 
 ```shell
-docker run --rm -it fzyzcjy/flutter_rust_bridge_dev:flutter-3.27.4-rust-1.88.0-nightly-2025-02-01 bash
+docker run --rm -it fzyzcjy/flutter_rust_bridge_dev:flutter-3.41.2-rust-1.93.1-nightly-2025-02-01 bash
 ```
 
 Those version numbers are derived from the `ARG` values in `.devcontainer/Dockerfile`, which is the single source of truth. `latest` only means the current recommended image and is not intended for long-term reproducibility.
 
 The default devcontainer configuration still builds locally from `.devcontainer/Dockerfile`. If you want to use the prebuilt image manually, use the full version tag above or regenerate it from the current Dockerfile args after version bumps.
 
-On Apple Silicon Macs, the local devcontainer build uses the same Linux amd64 Flutter image under Docker Desktop emulation, because the current `instrumentisto/flutter` tags are not published as Linux arm64 images. This keeps the environment aligned with Linux amd64 development machines, though it can be slower than a native arm64 image.
+On Apple Silicon Macs, the local devcontainer build uses the Linux arm64 variant of the multi-arch Flutter base image from `ghcr.io/cirruslabs/flutter`. Docker Desktop should select the native platform automatically, so no `--platform linux/amd64` override is needed for normal local development.
 
-When running the image manually on Apple Silicon, pass `--platform linux/amd64` to avoid Docker's platform warning:
+When running the image manually on Apple Silicon, use the same command as other platforms:
 
 ```shell
-docker run --rm -it --platform linux/amd64 fzyzcjy/flutter_rust_bridge_dev:flutter-3.27.4-rust-1.88.0-nightly-2025-02-01 bash
+docker run --rm -it fzyzcjy/flutter_rust_bridge_dev:flutter-3.41.2-rust-1.93.1-nightly-2025-02-01 bash
 ```
 
 ### The `./frb_internal`

--- a/website/docs/guides/contributing/tip.md
+++ b/website/docs/guides/contributing/tip.md
@@ -22,6 +22,8 @@ Those version numbers are derived from the `ARG` values in `.devcontainer/Docker
 
 The default devcontainer configuration still builds locally from `.devcontainer/Dockerfile`. If you want to use the prebuilt image manually, use the full version tag above or regenerate it from the current Dockerfile args after version bumps.
 
+On Apple Silicon Macs, the local devcontainer build uses the native Linux arm64 base image from `ghcr.io/cirruslabs/flutter` and installs Chromium from the distro packages for web tests. On Linux amd64, it installs Google Chrome from Google's apt repository.
+
 ### The `./frb_internal`
 
 The `./frb_internal whatever-command` (or `./frb_internal.bat`) delegates to the `./tools/frb_internal` dart package.

--- a/website/docs/guides/contributing/tip.md
+++ b/website/docs/guides/contributing/tip.md
@@ -22,7 +22,7 @@ Those version numbers are derived from the `ARG` values in `.devcontainer/Docker
 
 The default devcontainer configuration still builds locally from `.devcontainer/Dockerfile`. If you want to use the prebuilt image manually, use the full version tag above or regenerate it from the current Dockerfile args after version bumps.
 
-On Apple Silicon Macs, the local devcontainer build uses the native Linux arm64 base image from `ghcr.io/cirruslabs/flutter` and installs Chromium from the distro packages for web tests. On Linux amd64, it installs Google Chrome from Google's apt repository.
+On Apple Silicon Macs, the local devcontainer build uses the same Linux amd64 Flutter image under Docker Desktop emulation, because the current `instrumentisto/flutter` tags are not published as Linux arm64 images. This keeps the environment aligned with Linux amd64 development machines, though it can be slower than a native arm64 image.
 
 ### The `./frb_internal`
 

--- a/website/docs/guides/contributing/tip.md
+++ b/website/docs/guides/contributing/tip.md
@@ -8,21 +8,7 @@ For common development workflows, see the skills in `.claude/skills/`.
 
 ### Docker and devcontainer
 
-Optionally, you can use Docker and/or devcontainer to quickly get a standardized development environment. The related code is in `.devcontainer`.
-
-The published development image is `fzyzcjy/flutter_rust_bridge_dev`. It packages the Flutter + Rust toolchain used for flutter_rust_bridge development, including the nightly toolchain, `wasm-pack`, and Chromium for web testing.
-
-Prefer the full version tag when you want reproducible environments:
-
-```shell
-docker run --rm -it fzyzcjy/flutter_rust_bridge_dev:flutter-3.41.2-rust-1.93.1-nightly-2025-02-01 bash
-```
-
-Those version numbers are derived from the `ARG` values in `.devcontainer/Dockerfile`, which is the single source of truth. `latest` only means the current recommended image and is not intended for long-term reproducibility.
-
-The default devcontainer configuration still builds locally from `.devcontainer/Dockerfile`. If you want to use the prebuilt image manually, use the full version tag above or regenerate it from the current Dockerfile args after version bumps.
-
-Apple Silicon Macs use the same devcontainer and manual Docker commands as other platforms.
+Optionally, you can use Docker and/or devcontainer to quickly get a standardized development environment. The related code is in `.devcontainer`. For daily use, manual Docker commands, Apple Silicon notes, and publishing the dev Docker image, see `.claude/skills/frb-docker/SKILL.md`.
 
 ### The `./frb_internal`
 


### PR DESCRIPTION
## Summary

This PR updates the FRB Docker/devcontainer development environment so it works cleanly on both Apple Silicon and Linux amd64 machines.

It contains several related changes:

- Switch the devcontainer base image from the archived `instrumentisto/flutter` image to the multi-arch `ghcr.io/cirruslabs/flutter` image.
- Remove the forced `linux/amd64` devcontainer platform override, allowing Docker to use native `linux/arm64` on Apple Silicon.
- Make the Dockerfile install cross-architecture tools explicitly:
  - Node.js from official multi-arch binaries.
  - Playwright Chromium instead of Google Chrome, because Google Chrome does not provide Linux arm64 builds.
  - Rust stable/nightly, wasm target, `wasm-pack`, `cargo-llvm-cov`, and `all-contributors`.
- Make `./frb_internal` recover when `tools/frb_internal/.dart_tool/package_config.json` is missing or points to a stale absolute path from another checkout/container.
- Simplify the devcontainer post-create setup to `./frb_internal pub-get-all`, relying on the wrapper to prepare its own Dart package first.
- Update the Docker image publishing workflow:
  - Build and smoke-test amd64 on `ubuntu-latest`.
  - Build and smoke-test arm64 on `ubuntu-24.04-arm`.
  - Push per-platform images, then publish multi-arch `latest`, version, and sha tags.
  - Keep `workflow_dispatch` defaulting to publish, while allowing explicit `publish=false` dry-runs.
- Add `.claude/skills/frb-docker/SKILL.md` with the daily Docker/devcontainer workflow, Apple Silicon guidance, validation checklist, publishing steps, and CI workflow notes.
- Keep contributor docs concise by pointing Docker/devcontainer details to the new `frb-docker` skill.

## Why

The previous devcontainer image path depended on `instrumentisto/flutter`, which is archived and did not provide usable Linux arm64 images for this workflow. On Apple Silicon, that forced Docker Desktop into amd64 emulation, which is slower and produced platform warnings.

Using the Cirrus multi-arch Flutter base lets local devcontainer builds run natively on Apple Silicon while still supporting amd64 Linux development machines. The publishing workflow uses native GitHub runners for both architectures to avoid slow arm64 builds under QEMU.

## Verification

Verified locally in the Apple Silicon / Linux arm64 Docker image:

- Built `.devcontainer/Dockerfile` successfully.
- Checked Flutter, Dart, Node/npm, Rust stable/nightly, wasm target, `wasm-pack`, `cargo-llvm-cov`, `all-contributors`, and Chromium.
- Ran `./frb_internal pub-get-all`.
- Ran `./frb_internal lint --fix`.
- Ran `cargo check` in `frb_rust`.
- Ran `cargo check --target wasm32-unknown-unknown` in `frb_rust`.
- Verified `./frb_internal --help` self-heals after deleting `tools/frb_internal/.dart_tool/package_config.json`.

Verified the Docker publish workflow:

- Dry-run workflow passed for amd64 and arm64 build/smoke without publishing: https://github.com/fzyzcjy/flutter_rust_bridge/actions/runs/25596670787
- Full publish workflow passed, including Docker Hub login, per-platform pushes, and multi-arch manifest publishing: https://github.com/fzyzcjy/flutter_rust_bridge/actions/runs/25596895867
- Confirmed `fzyzcjy/flutter_rust_bridge_dev:sha-139fe4a` contains both `linux/amd64` and `linux/arm64` manifests.

## Notes

The devcontainer still builds locally from `.devcontainer/Dockerfile`; that Dockerfile remains the source of truth. The published Docker Hub image now also supports pulling the matching architecture automatically.
