### PR TITLE
Fix main CI generated drift and threaded wasm build

### DIFF
--- a/frb_dart/lib/src/cli/build_web/executor.dart
+++ b/frb_dart/lib/src/cli/build_web/executor.dart
@@ -217,6 +217,7 @@ const buildWebDefaultWasmPackRustflagSegments = [
   '-C link-args=--shared-memory',
   '-C link-args=--max-memory=1073741824',
   '-C link-args=--import-memory',
+  '-C link-args=--export=__heap_base',
   '-C link-args=--export=__wasm_init_tls',
   '-C link-args=--export=__tls_size',
   '-C link-args=--export=__tls_align',

--- a/frb_dart/test/build_web_executor_test.dart
+++ b/frb_dart/test/build_web_executor_test.dart
@@ -9,6 +9,7 @@ void main() {
     expect(resolution.rustflags, buildWebDefaultWasmPackRustflags);
     expect(resolution.rustflags, contains('-C link-args=--shared-memory'));
     expect(resolution.rustflags, contains('-C link-args=--import-memory'));
+    expect(resolution.rustflags, contains('-C link-args=--export=__heap_base'));
     expect(
       resolution.rustflags,
       contains('-C link-args=--export=__wasm_init_tls'),
@@ -62,6 +63,7 @@ void main() {
           '-C link-args=--export=__tls_align '
           '-C link-args=--max-memory=1073741824 '
           '-C link-args=--import-memory '
+          '-C link-args=--export=__heap_base '
           '-C link-args=--shared-memory '
           '-C link-args=--export=__tls_size '
           '-C link-args=--export=__wasm_init_tls';

--- a/frb_example/flutter_package/example/pubspec.lock
+++ b/frb_example/flutter_package/example/pubspec.lock
@@ -289,10 +289,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
+      sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.2"
+    version: "15.2.0"
   web:
     dependency: transitive
     description:

--- a/frb_example/flutter_via_create/pubspec.lock
+++ b/frb_example/flutter_via_create/pubspec.lock
@@ -289,10 +289,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
+      sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.2"
+    version: "15.2.0"
   web:
     dependency: transitive
     description:

--- a/frb_example/flutter_via_integrate/pubspec.lock
+++ b/frb_example/flutter_via_integrate/pubspec.lock
@@ -289,10 +289,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
+      sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.2"
+    version: "15.2.0"
   web:
     dependency: transitive
     description:

--- a/frb_rust/src/dart_api/dart_api.h
+++ b/frb_rust/src/dart_api/dart_api.h
@@ -837,7 +837,7 @@ typedef Dart_Handle (*Dart_GetVMServiceAssetsArchive)(void);
  * The current version of the Dart_InitializeFlags. Should be incremented every
  * time Dart_InitializeFlags changes in a binary incompatible way.
  */
-#define DART_INITIALIZE_PARAMS_CURRENT_VERSION (0x00000009)
+#define DART_INITIALIZE_PARAMS_CURRENT_VERSION (0x0000000A)
 
 /** Forward declaration */
 struct Dart_CodeObserver;
@@ -943,14 +943,6 @@ typedef struct {
    */
   Dart_CodeObserver* code_observer;
 
-#if defined(__Fuchsia__)
-  /**
-   * The resource needed to use zx_vmo_replace_as_executable. Can be
-   * ZX_HANDLE_INVALID if the process has ambient-replace-as-executable or if
-   * executable memory is not needed (e.g., this is an AOT runtime).
-   */
-  zx_handle_t vmex_resource;
-#endif
 } Dart_InitializeParams;
 
 /**

--- a/frb_rust/src/dart_api/dart_api.h
+++ b/frb_rust/src/dart_api/dart_api.h
@@ -942,7 +942,6 @@ typedef struct {
    * as early as during the Dart_Initialize() call.
    */
   Dart_CodeObserver* code_observer;
-
 } Dart_InitializeParams;
 
 /**


### PR DESCRIPTION
## Summary

- refresh CI-generated Dart SDK header drift from `generate-internal`
- refresh integrate example `pubspec.lock` drift for `vm_service`
- export `__heap_base` in default threaded wasm RUSTFLAGS so `wasm-bindgen` can prepare threaded modules
- cover the new default flag in build-web executor tests

## Notes

The `vm_service` lockfile change is caused by the integrate CI rebuilding these examples from scratch instead of simply reusing the checked-in lockfiles. The Flutter/Dart SDK version is fixed in CI, but a fresh pub resolution can still select newer compatible transitive packages from pub.dev. With the current CI toolchain, the regenerated examples resolve `vm_service` from `15.0.2` to `15.2.0`.

## Verification

- `./frb_internal test-dart-native --package frb_dart` (fails locally: `dart` not found)
- `./frb_internal lint-dart` (fails locally: `dart` not found)
- `./frb_internal lint --fix` (fails locally: `dart` not found)

CI should provide the authoritative verification for the unavailable local Dart/Flutter environment.
