### PR TITLE
Allow frb_internal clean checks without git metadata

### DIFF
--- a/tools/frb_internal/lib/src/makefile_dart/generate.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/generate.dart
@@ -480,19 +480,91 @@ Future<void> wrapMaybeSetExitIfChangedRaw(
   bool enable,
   Future<void> Function() inner, {
   String? extraArgs,
+  Future<RunCommandOutput> Function(String command)? gitDiffExecutor,
+  bool? isCi,
 }) async {
   // Before actually executing anything, check whether git repository is already dirty
-  await _maybeSetExitIfChanged(enable, extraArgs: extraArgs);
+  await _maybeSetExitIfChanged(
+    enable,
+    extraArgs: extraArgs,
+    phase: _GitDiffPhase.before,
+    gitDiffExecutor: gitDiffExecutor,
+    isCi: isCi,
+  );
   await inner();
   // The real check
-  await _maybeSetExitIfChanged(enable, extraArgs: extraArgs);
+  await _maybeSetExitIfChanged(
+    enable,
+    extraArgs: extraArgs,
+    phase: _GitDiffPhase.after,
+    gitDiffExecutor: gitDiffExecutor,
+    isCi: isCi,
+  );
 }
 
-Future<void> _maybeSetExitIfChanged(bool enable, {String? extraArgs}) async {
+Future<void> _maybeSetExitIfChanged(
+  bool enable, {
+  String? extraArgs,
+  required _GitDiffPhase phase,
+  Future<RunCommandOutput> Function(String command)? gitDiffExecutor,
+  bool? isCi,
+}) async {
   if (enable) {
-    await exec('git diff --exit-code ${extraArgs ?? ""}');
+    final command = 'git diff --exit-code ${extraArgs ?? ""}';
+    final output = await (gitDiffExecutor ?? _executeGitDiff)(command);
+    final result = _classifyGitDiffExitCode(output.exitCode);
+
+    switch (result) {
+      case _GitDiffResult.clean:
+        return;
+      case _GitDiffResult.dirty:
+        if (phase == _GitDiffPhase.before) {
+          stderr.writeln(
+            'Warning: working tree is already dirty before running the command; continuing anyway.',
+          );
+          return;
+        }
+        throw ProcessException(
+          '/bin/sh',
+          ['-c', command],
+          'Bad exit code (${output.exitCode}). Working tree changed.',
+          output.exitCode,
+        );
+      case _GitDiffResult.unavailable:
+        final strict = isCi ?? _isCi();
+        if (strict) {
+          throw ProcessException(
+            '/bin/sh',
+            ['-c', command],
+            'Bad exit code (${output.exitCode}). Cannot check working tree cleanliness.',
+            output.exitCode,
+          );
+        }
+        stderr.writeln(
+          'Warning: cannot check working tree cleanliness because git metadata is unavailable; continuing anyway.',
+        );
+        return;
+    }
   }
 }
+
+Future<RunCommandOutput> _executeGitDiff(String command) =>
+    exec(command, checkExitCode: false);
+
+_GitDiffResult _classifyGitDiffExitCode(int exitCode) {
+  if (exitCode == 0) return _GitDiffResult.clean;
+  if (exitCode == 1) return _GitDiffResult.dirty;
+  return _GitDiffResult.unavailable;
+}
+
+bool _isCi() => Platform.environment['CI'] == 'true';
+
+enum _GitDiffPhase { before, after }
+
+enum _GitDiffResult { clean, dirty, unavailable }
+
+String classifyGitDiffExitCodeForTesting(int exitCode) =>
+    _classifyGitDiffExitCode(exitCode).name;
 
 Future<void> generateWebsite(GenerateWebsiteConfig config) async {
   await generateWebsiteBuild(config);

--- a/tools/frb_internal/lib/src/makefile_dart/generate.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/generate.dart
@@ -524,20 +524,18 @@ Future<void> _maybeSetExitIfChanged(
           );
           return;
         }
-        throw ProcessException(
-          '/bin/sh',
-          ['-c', command],
-          'Bad exit code (${output.exitCode}). Working tree changed.',
-          output.exitCode,
+        throw _gitDiffProcessException(
+          command: command,
+          output: output,
+          message: 'Working tree changed.',
         );
       case _GitDiffResult.unavailable:
         final strict = isCi ?? _isCi();
         if (strict) {
-          throw ProcessException(
-            '/bin/sh',
-            ['-c', command],
-            'Bad exit code (${output.exitCode}). Cannot check working tree cleanliness.',
-            output.exitCode,
+          throw _gitDiffProcessException(
+            command: command,
+            output: output,
+            message: 'Cannot check working tree cleanliness.',
           );
         }
         stderr.writeln(
@@ -559,12 +557,63 @@ _GitDiffResult _classifyGitDiffExitCode(int exitCode) {
 
 bool _isCi() => Platform.environment['CI'] == 'true';
 
+ProcessException _gitDiffProcessException({
+  required String command,
+  required RunCommandOutput output,
+  required String message,
+  bool? isWindows,
+}) {
+  final shellCommand = _shellCommandForProcessException(
+    command,
+    isWindows: isWindows,
+  );
+  return ProcessException(
+    shellCommand.executable,
+    shellCommand.arguments,
+    'Bad exit code (${output.exitCode}). $message',
+    output.exitCode,
+  );
+}
+
+_ShellCommand _shellCommandForProcessException(
+  String command, {
+  bool? isWindows,
+}) {
+  if (isWindows ?? Platform.isWindows) {
+    return _ShellCommand('powershell', [
+      '-noprofile',
+      '-command',
+      '& $command',
+    ]);
+  }
+  return _ShellCommand('/bin/sh', ['-c', command]);
+}
+
+class _ShellCommand {
+  const _ShellCommand(this.executable, this.arguments);
+
+  final String executable;
+  final List<String> arguments;
+}
+
 enum _GitDiffPhase { before, after }
 
 enum _GitDiffResult { clean, dirty, unavailable }
 
 String classifyGitDiffExitCodeForTesting(int exitCode) =>
     _classifyGitDiffExitCode(exitCode).name;
+
+ProcessException gitDiffProcessExceptionForTesting({
+  required String command,
+  required int exitCode,
+  required String message,
+  required bool isWindows,
+}) => _gitDiffProcessException(
+  command: command,
+  output: RunCommandOutput(stdout: '', stderr: '', exitCode: exitCode),
+  message: message,
+  isWindows: isWindows,
+);
 
 Future<void> generateWebsite(GenerateWebsiteConfig config) async {
   await generateWebsiteBuild(config);

--- a/tools/frb_internal/lib/src/makefile_dart/generate.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/generate.dart
@@ -504,7 +504,12 @@ Future<void> _maybeSetExitIfChanged(
   if (enable) {
     final command = 'git diff --exit-code ${extraArgs ?? ""}';
     final output = await _executeGitDiff(command);
-    _handleGitDiffResult(command: command, output: output, phase: phase);
+    _handleGitDiffResult(
+      command: command,
+      output: output,
+      phase: phase,
+      isCi: _isCi(),
+    );
   }
 }
 
@@ -512,31 +517,28 @@ void _handleGitDiffResult({
   required String command,
   required RunCommandOutput output,
   required _GitDiffPhase phase,
+  required bool isCi,
 }) {
-  final action = _decideGitDiffAction(
-    exitCode: output.exitCode,
-    phase: phase,
-    isCi: _isCi(),
-  );
-
-  switch (action) {
-    case _GitDiffAction.continueSilently:
+  switch (_classifyGitDiffExitCode(output.exitCode)) {
+    case _GitDiffResult.clean:
       return;
-    case _GitDiffAction.warnDirty:
-      stderr.writeln(
-        'Warning: working tree is already dirty before running the command; continuing anyway.',
-      );
-      return;
-    case _GitDiffAction.warnUnavailable:
-      stderr.writeln(
-        'Warning: cannot check working tree cleanliness because git metadata is unavailable; continuing anyway.',
-      );
-      return;
-    case _GitDiffAction.failDirty:
+    case _GitDiffResult.dirty:
+      if (phase == _GitDiffPhase.before) {
+        print(
+          'Warning: working tree is already dirty before running the command; continuing anyway.',
+        );
+        return;
+      }
       throw Exception(
         'Failed to check working tree after command: `$command` exited with ${output.exitCode}. Working tree changed.',
       );
-    case _GitDiffAction.failUnavailable:
+    case _GitDiffResult.unavailable:
+      if (!isCi) {
+        print(
+          'Warning: cannot check working tree cleanliness because git metadata is unavailable; continuing anyway.',
+        );
+        return;
+      }
       throw Exception(
         'Failed to check working tree cleanliness: `$command` exited with ${output.exitCode}.',
       );
@@ -558,46 +560,20 @@ enum _GitDiffPhase { before, after }
 
 enum _GitDiffResult { clean, dirty, unavailable }
 
-enum _GitDiffAction {
-  continueSilently,
-  warnDirty,
-  warnUnavailable,
-  failDirty,
-  failUnavailable,
-}
-
 String classifyGitDiffExitCodeForTesting(int exitCode) =>
     _classifyGitDiffExitCode(exitCode).name;
 
-_GitDiffAction _decideGitDiffAction({
-  required int exitCode,
-  required _GitDiffPhase phase,
-  required bool isCi,
-}) {
-  final result = _classifyGitDiffExitCode(exitCode);
-  switch (result) {
-    case _GitDiffResult.clean:
-      return _GitDiffAction.continueSilently;
-    case _GitDiffResult.dirty:
-      return phase == _GitDiffPhase.before
-          ? _GitDiffAction.warnDirty
-          : _GitDiffAction.failDirty;
-    case _GitDiffResult.unavailable:
-      return isCi
-          ? _GitDiffAction.failUnavailable
-          : _GitDiffAction.warnUnavailable;
-  }
-}
-
-String decideGitDiffActionForTesting({
+void handleGitDiffResultForTesting({
+  String command = 'git diff --exit-code',
   required int exitCode,
   required bool isBefore,
   required bool isCi,
-}) => _decideGitDiffAction(
-  exitCode: exitCode,
+}) => _handleGitDiffResult(
+  command: command,
+  output: RunCommandOutput(stdout: '', stderr: '', exitCode: exitCode),
   phase: isBefore ? _GitDiffPhase.before : _GitDiffPhase.after,
   isCi: isCi,
-).name;
+);
 
 Future<void> generateWebsite(GenerateWebsiteConfig config) async {
   await generateWebsiteBuild(config);

--- a/tools/frb_internal/lib/src/makefile_dart/generate.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/generate.dart
@@ -554,7 +554,12 @@ _GitDiffResult _classifyGitDiffExitCode(int exitCode) {
   return _GitDiffResult.unavailable;
 }
 
-bool _isCi() => Platform.environment['CI'] == 'true';
+bool _isCi({Map<String, String>? environment}) {
+  final effectiveEnvironment = environment ?? Platform.environment;
+  final ciRaw = effectiveEnvironment['CI']?.toLowerCase();
+  return effectiveEnvironment['GITHUB_ACTIONS'] == 'true' ||
+      (ciRaw != null && ciRaw != 'false' && ciRaw != '0');
+}
 
 enum _GitDiffPhase { before, after }
 
@@ -574,6 +579,9 @@ void handleGitDiffResultForTesting({
   phase: isBefore ? _GitDiffPhase.before : _GitDiffPhase.after,
   isCi: isCi,
 );
+
+bool isCiForTesting(Map<String, String> environment) =>
+    _isCi(environment: environment);
 
 Future<void> generateWebsite(GenerateWebsiteConfig config) async {
   await generateWebsiteBuild(config);

--- a/tools/frb_internal/lib/src/makefile_dart/generate.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/generate.dart
@@ -504,38 +504,42 @@ Future<void> _maybeSetExitIfChanged(
   if (enable) {
     final command = 'git diff --exit-code ${extraArgs ?? ""}';
     final output = await _executeGitDiff(command);
-    final action = _decideGitDiffAction(
-      exitCode: output.exitCode,
-      phase: phase,
-      isCi: _isCi(),
-    );
+    _handleGitDiffResult(command: command, output: output, phase: phase);
+  }
+}
 
-    switch (action) {
-      case _GitDiffAction.continueSilently:
-        return;
-      case _GitDiffAction.warnDirty:
-        stderr.writeln(
-          'Warning: working tree is already dirty before running the command; continuing anyway.',
-        );
-        return;
-      case _GitDiffAction.warnUnavailable:
-        stderr.writeln(
-          'Warning: cannot check working tree cleanliness because git metadata is unavailable; continuing anyway.',
-        );
-        return;
-      case _GitDiffAction.failDirty:
-        throw _processExceptionForCommand(
-          command: command,
-          output: output,
-          message: 'Working tree changed.',
-        );
-      case _GitDiffAction.failUnavailable:
-        throw _processExceptionForCommand(
-          command: command,
-          output: output,
-          message: 'Cannot check working tree cleanliness.',
-        );
-    }
+void _handleGitDiffResult({
+  required String command,
+  required RunCommandOutput output,
+  required _GitDiffPhase phase,
+}) {
+  final action = _decideGitDiffAction(
+    exitCode: output.exitCode,
+    phase: phase,
+    isCi: _isCi(),
+  );
+
+  switch (action) {
+    case _GitDiffAction.continueSilently:
+      return;
+    case _GitDiffAction.warnDirty:
+      stderr.writeln(
+        'Warning: working tree is already dirty before running the command; continuing anyway.',
+      );
+      return;
+    case _GitDiffAction.warnUnavailable:
+      stderr.writeln(
+        'Warning: cannot check working tree cleanliness because git metadata is unavailable; continuing anyway.',
+      );
+      return;
+    case _GitDiffAction.failDirty:
+      throw Exception(
+        'Failed to check working tree after command: `$command` exited with ${output.exitCode}. Working tree changed.',
+      );
+    case _GitDiffAction.failUnavailable:
+      throw Exception(
+        'Failed to check working tree cleanliness: `$command` exited with ${output.exitCode}.',
+      );
   }
 }
 
@@ -549,24 +553,6 @@ _GitDiffResult _classifyGitDiffExitCode(int exitCode) {
 }
 
 bool _isCi() => Platform.environment['CI'] == 'true';
-
-ProcessException _processExceptionForCommand({
-  required String command,
-  required RunCommandOutput output,
-  required String message,
-}) {
-  final executable = Platform.isWindows ? 'powershell' : '/bin/sh';
-  final arguments = Platform.isWindows
-      ? ['-noprofile', '-command', '& $command']
-      : ['-c', command];
-
-  return ProcessException(
-    executable,
-    arguments,
-    'Bad exit code (${output.exitCode}). $message',
-    output.exitCode,
-  );
-}
 
 enum _GitDiffPhase { before, after }
 

--- a/tools/frb_internal/lib/src/makefile_dart/generate.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/generate.dart
@@ -480,16 +480,12 @@ Future<void> wrapMaybeSetExitIfChangedRaw(
   bool enable,
   Future<void> Function() inner, {
   String? extraArgs,
-  Future<RunCommandOutput> Function(String command)? gitDiffExecutor,
-  bool? isCi,
 }) async {
   // Before actually executing anything, check whether git repository is already dirty
   await _maybeSetExitIfChanged(
     enable,
     extraArgs: extraArgs,
     phase: _GitDiffPhase.before,
-    gitDiffExecutor: gitDiffExecutor,
-    isCi: isCi,
   );
   await inner();
   // The real check
@@ -497,8 +493,6 @@ Future<void> wrapMaybeSetExitIfChangedRaw(
     enable,
     extraArgs: extraArgs,
     phase: _GitDiffPhase.after,
-    gitDiffExecutor: gitDiffExecutor,
-    isCi: isCi,
   );
 }
 
@@ -506,42 +500,41 @@ Future<void> _maybeSetExitIfChanged(
   bool enable, {
   String? extraArgs,
   required _GitDiffPhase phase,
-  Future<RunCommandOutput> Function(String command)? gitDiffExecutor,
-  bool? isCi,
 }) async {
   if (enable) {
     final command = 'git diff --exit-code ${extraArgs ?? ""}';
-    final output = await (gitDiffExecutor ?? _executeGitDiff)(command);
-    final result = _classifyGitDiffExitCode(output.exitCode);
+    final output = await _executeGitDiff(command);
+    final action = _decideGitDiffAction(
+      exitCode: output.exitCode,
+      phase: phase,
+      isCi: _isCi(),
+    );
 
-    switch (result) {
-      case _GitDiffResult.clean:
+    switch (action) {
+      case _GitDiffAction.continueSilently:
         return;
-      case _GitDiffResult.dirty:
-        if (phase == _GitDiffPhase.before) {
-          stderr.writeln(
-            'Warning: working tree is already dirty before running the command; continuing anyway.',
-          );
-          return;
-        }
-        throw _gitDiffProcessException(
-          command: command,
-          output: output,
-          message: 'Working tree changed.',
+      case _GitDiffAction.warnDirty:
+        stderr.writeln(
+          'Warning: working tree is already dirty before running the command; continuing anyway.',
         );
-      case _GitDiffResult.unavailable:
-        final strict = isCi ?? _isCi();
-        if (strict) {
-          throw _gitDiffProcessException(
-            command: command,
-            output: output,
-            message: 'Cannot check working tree cleanliness.',
-          );
-        }
+        return;
+      case _GitDiffAction.warnUnavailable:
         stderr.writeln(
           'Warning: cannot check working tree cleanliness because git metadata is unavailable; continuing anyway.',
         );
         return;
+      case _GitDiffAction.failDirty:
+        throw _processExceptionForCommand(
+          command: command,
+          output: output,
+          message: 'Working tree changed.',
+        );
+      case _GitDiffAction.failUnavailable:
+        throw _processExceptionForCommand(
+          command: command,
+          output: output,
+          message: 'Cannot check working tree cleanliness.',
+        );
     }
   }
 }
@@ -557,63 +550,68 @@ _GitDiffResult _classifyGitDiffExitCode(int exitCode) {
 
 bool _isCi() => Platform.environment['CI'] == 'true';
 
-ProcessException _gitDiffProcessException({
+ProcessException _processExceptionForCommand({
   required String command,
   required RunCommandOutput output,
   required String message,
-  bool? isWindows,
 }) {
-  final shellCommand = _shellCommandForProcessException(
-    command,
-    isWindows: isWindows,
-  );
+  final executable = Platform.isWindows ? 'powershell' : '/bin/sh';
+  final arguments = Platform.isWindows
+      ? ['-noprofile', '-command', '& $command']
+      : ['-c', command];
+
   return ProcessException(
-    shellCommand.executable,
-    shellCommand.arguments,
+    executable,
+    arguments,
     'Bad exit code (${output.exitCode}). $message',
     output.exitCode,
   );
-}
-
-_ShellCommand _shellCommandForProcessException(
-  String command, {
-  bool? isWindows,
-}) {
-  if (isWindows ?? Platform.isWindows) {
-    return _ShellCommand('powershell', [
-      '-noprofile',
-      '-command',
-      '& $command',
-    ]);
-  }
-  return _ShellCommand('/bin/sh', ['-c', command]);
-}
-
-class _ShellCommand {
-  const _ShellCommand(this.executable, this.arguments);
-
-  final String executable;
-  final List<String> arguments;
 }
 
 enum _GitDiffPhase { before, after }
 
 enum _GitDiffResult { clean, dirty, unavailable }
 
+enum _GitDiffAction {
+  continueSilently,
+  warnDirty,
+  warnUnavailable,
+  failDirty,
+  failUnavailable,
+}
+
 String classifyGitDiffExitCodeForTesting(int exitCode) =>
     _classifyGitDiffExitCode(exitCode).name;
 
-ProcessException gitDiffProcessExceptionForTesting({
-  required String command,
+_GitDiffAction _decideGitDiffAction({
   required int exitCode,
-  required String message,
-  required bool isWindows,
-}) => _gitDiffProcessException(
-  command: command,
-  output: RunCommandOutput(stdout: '', stderr: '', exitCode: exitCode),
-  message: message,
-  isWindows: isWindows,
-);
+  required _GitDiffPhase phase,
+  required bool isCi,
+}) {
+  final result = _classifyGitDiffExitCode(exitCode);
+  switch (result) {
+    case _GitDiffResult.clean:
+      return _GitDiffAction.continueSilently;
+    case _GitDiffResult.dirty:
+      return phase == _GitDiffPhase.before
+          ? _GitDiffAction.warnDirty
+          : _GitDiffAction.failDirty;
+    case _GitDiffResult.unavailable:
+      return isCi
+          ? _GitDiffAction.failUnavailable
+          : _GitDiffAction.warnUnavailable;
+  }
+}
+
+String decideGitDiffActionForTesting({
+  required int exitCode,
+  required bool isBefore,
+  required bool isCi,
+}) => _decideGitDiffAction(
+  exitCode: exitCode,
+  phase: isBefore ? _GitDiffPhase.before : _GitDiffPhase.after,
+  isCi: isCi,
+).name;
 
 Future<void> generateWebsite(GenerateWebsiteConfig config) async {
   await generateWebsiteBuild(config);

--- a/tools/frb_internal/test/makefile_dart_test.dart
+++ b/tools/frb_internal/test/makefile_dart_test.dart
@@ -89,6 +89,34 @@ late final callback = ptr.asFunction<voidFunction(ffi.Pointer<ffi.Void>)>();
       expect(classifyGitDiffExitCodeForTesting(128), 'unavailable');
     });
 
+    test('uses posix shell in git diff process exception outside Windows', () {
+      final exception = gitDiffProcessExceptionForTesting(
+        command: 'git diff --exit-code',
+        exitCode: 1,
+        message: 'Working tree changed.',
+        isWindows: false,
+      );
+
+      expect(exception.executable, '/bin/sh');
+      expect(exception.arguments, ['-c', 'git diff --exit-code']);
+    });
+
+    test('uses powershell in git diff process exception on Windows', () {
+      final exception = gitDiffProcessExceptionForTesting(
+        command: 'git diff --exit-code',
+        exitCode: 1,
+        message: 'Working tree changed.',
+        isWindows: true,
+      );
+
+      expect(exception.executable, 'powershell');
+      expect(exception.arguments, [
+        '-noprofile',
+        '-command',
+        '& git diff --exit-code',
+      ]);
+    });
+
     test('continues when git metadata is unavailable outside CI', () async {
       var innerDidRun = false;
       var checkCount = 0;

--- a/tools/frb_internal/test/makefile_dart_test.dart
+++ b/tools/frb_internal/test/makefile_dart_test.dart
@@ -1,6 +1,3 @@
-import 'dart:io';
-
-import 'package:flutter_rust_bridge/src/cli/run_command.dart';
 import 'package:flutter_rust_bridge_internal/src/frb_example_pure_dart_generator/generator.dart';
 import 'package:flutter_rust_bridge_internal/src/makefile_dart/generate.dart';
 import 'package:flutter_rust_bridge_internal/src/makefile_dart/lint.dart';
@@ -89,107 +86,56 @@ late final callback = ptr.asFunction<voidFunction(ffi.Pointer<ffi.Void>)>();
       expect(classifyGitDiffExitCodeForTesting(128), 'unavailable');
     });
 
-    test('uses posix shell in git diff process exception outside Windows', () {
-      final exception = gitDiffProcessExceptionForTesting(
-        command: 'git diff --exit-code',
-        exitCode: 1,
-        message: 'Working tree changed.',
-        isWindows: false,
+    test('decides clean git diff should continue silently', () {
+      expect(
+        decideGitDiffActionForTesting(
+          exitCode: 0,
+          isBefore: false,
+          isCi: false,
+        ),
+        'continueSilently',
       );
-
-      expect(exception.executable, '/bin/sh');
-      expect(exception.arguments, ['-c', 'git diff --exit-code']);
     });
 
-    test('uses powershell in git diff process exception on Windows', () {
-      final exception = gitDiffProcessExceptionForTesting(
-        command: 'git diff --exit-code',
-        exitCode: 1,
-        message: 'Working tree changed.',
-        isWindows: true,
+    test('decides pre-existing dirty tree should warn and continue', () {
+      expect(
+        decideGitDiffActionForTesting(exitCode: 1, isBefore: true, isCi: false),
+        'warnDirty',
       );
-
-      expect(exception.executable, 'powershell');
-      expect(exception.arguments, [
-        '-noprofile',
-        '-command',
-        '& git diff --exit-code',
-      ]);
     });
 
-    test('continues when git metadata is unavailable outside CI', () async {
-      var innerDidRun = false;
-      var checkCount = 0;
-
-      await wrapMaybeSetExitIfChangedRaw(
-        true,
-        () async {
-          innerDidRun = true;
-        },
-        gitDiffExecutor: (_) async {
-          checkCount++;
-          return const RunCommandOutput(stdout: '', stderr: '', exitCode: 128);
-        },
-        isCi: false,
+    test('decides post-command dirty tree should fail', () {
+      expect(
+        decideGitDiffActionForTesting(
+          exitCode: 1,
+          isBefore: false,
+          isCi: false,
+        ),
+        'failDirty',
       );
-
-      expect(innerDidRun, true);
-      expect(checkCount, 2);
     });
 
-    test('fails when git metadata is unavailable in CI', () async {
-      var innerDidRun = false;
+    test('decides unavailable git metadata should warn outside CI', () {
+      expect(
+        decideGitDiffActionForTesting(
+          exitCode: 128,
+          isBefore: false,
+          isCi: false,
+        ),
+        'warnUnavailable',
+      );
+    });
 
-      await expectLater(
-        wrapMaybeSetExitIfChangedRaw(
-          true,
-          () async {
-            innerDidRun = true;
-          },
-          gitDiffExecutor: (_) async {
-            return const RunCommandOutput(
-              stdout: '',
-              stderr: '',
-              exitCode: 128,
-            );
-          },
+    test('decides unavailable git metadata should fail in CI', () {
+      expect(
+        decideGitDiffActionForTesting(
+          exitCode: 128,
+          isBefore: false,
           isCi: true,
         ),
-        throwsA(isA<ProcessException>()),
+        'failUnavailable',
       );
-
-      expect(innerDidRun, false);
     });
-
-    test(
-      'warns on pre-existing dirty tree but still fails after dirty result',
-      () async {
-        var innerDidRun = false;
-        var checkCount = 0;
-
-        await expectLater(
-          wrapMaybeSetExitIfChangedRaw(
-            true,
-            () async {
-              innerDidRun = true;
-            },
-            gitDiffExecutor: (_) async {
-              checkCount++;
-              return const RunCommandOutput(
-                stdout: '',
-                stderr: '',
-                exitCode: 1,
-              );
-            },
-            isCi: false,
-          ),
-          throwsA(isA<ProcessException>()),
-        );
-
-        expect(innerDidRun, true);
-        expect(checkCount, 2);
-      },
-    );
   });
 
   group('test checkValgrindOutput', () {

--- a/tools/frb_internal/test/makefile_dart_test.dart
+++ b/tools/frb_internal/test/makefile_dart_test.dart
@@ -88,52 +88,68 @@ late final callback = ptr.asFunction<voidFunction(ffi.Pointer<ffi.Void>)>();
 
     test('decides clean git diff should continue silently', () {
       expect(
-        decideGitDiffActionForTesting(
+        () => handleGitDiffResultForTesting(
           exitCode: 0,
           isBefore: false,
           isCi: false,
         ),
-        'continueSilently',
+        returnsNormally,
       );
     });
 
-    test('decides pre-existing dirty tree should warn and continue', () {
+    test('warns when working tree is already dirty before command', () {
       expect(
-        decideGitDiffActionForTesting(exitCode: 1, isBefore: true, isCi: false),
-        'warnDirty',
+        () => handleGitDiffResultForTesting(
+          exitCode: 1,
+          isBefore: true,
+          isCi: false,
+        ),
+        prints(contains('working tree is already dirty')),
       );
     });
 
-    test('decides post-command dirty tree should fail', () {
+    test('fails when working tree changed after command', () {
       expect(
-        decideGitDiffActionForTesting(
+        () => handleGitDiffResultForTesting(
           exitCode: 1,
           isBefore: false,
           isCi: false,
         ),
-        'failDirty',
+        throwsA(
+          isA<Exception>().having(
+            (exception) => exception.toString(),
+            'message',
+            contains('Working tree changed'),
+          ),
+        ),
       );
     });
 
-    test('decides unavailable git metadata should warn outside CI', () {
+    test('warns when git metadata is unavailable outside CI', () {
       expect(
-        decideGitDiffActionForTesting(
+        () => handleGitDiffResultForTesting(
           exitCode: 128,
           isBefore: false,
           isCi: false,
         ),
-        'warnUnavailable',
+        prints(contains('git metadata is unavailable')),
       );
     });
 
-    test('decides unavailable git metadata should fail in CI', () {
+    test('fails when git metadata is unavailable in CI', () {
       expect(
-        decideGitDiffActionForTesting(
+        () => handleGitDiffResultForTesting(
           exitCode: 128,
           isBefore: false,
           isCi: true,
         ),
-        'failUnavailable',
+        throwsA(
+          isA<Exception>().having(
+            (exception) => exception.toString(),
+            'message',
+            contains('Failed to check working tree cleanliness'),
+          ),
+        ),
       );
     });
   });

--- a/tools/frb_internal/test/makefile_dart_test.dart
+++ b/tools/frb_internal/test/makefile_dart_test.dart
@@ -1,4 +1,8 @@
+import 'dart:io';
+
+import 'package:flutter_rust_bridge/src/cli/run_command.dart';
 import 'package:flutter_rust_bridge_internal/src/frb_example_pure_dart_generator/generator.dart';
+import 'package:flutter_rust_bridge_internal/src/makefile_dart/generate.dart';
 import 'package:flutter_rust_bridge_internal/src/makefile_dart/lint.dart';
 import 'package:flutter_rust_bridge_internal/src/makefile_dart/test.dart';
 import 'package:test/test.dart';
@@ -75,6 +79,88 @@ late final callback = ptr.asFunction<void Function(ffi.Pointer<ffi.Void>)>();
       normalizeFfigenLintText('''
 late final callback = ptr.asFunction<voidFunction(ffi.Pointer<ffi.Void>)>();
       '''),
+    );
+  });
+
+  group('git clean check', () {
+    test('classifies git diff exit codes', () {
+      expect(classifyGitDiffExitCodeForTesting(0), 'clean');
+      expect(classifyGitDiffExitCodeForTesting(1), 'dirty');
+      expect(classifyGitDiffExitCodeForTesting(128), 'unavailable');
+    });
+
+    test('continues when git metadata is unavailable outside CI', () async {
+      var innerDidRun = false;
+      var checkCount = 0;
+
+      await wrapMaybeSetExitIfChangedRaw(
+        true,
+        () async {
+          innerDidRun = true;
+        },
+        gitDiffExecutor: (_) async {
+          checkCount++;
+          return const RunCommandOutput(stdout: '', stderr: '', exitCode: 128);
+        },
+        isCi: false,
+      );
+
+      expect(innerDidRun, true);
+      expect(checkCount, 2);
+    });
+
+    test('fails when git metadata is unavailable in CI', () async {
+      var innerDidRun = false;
+
+      await expectLater(
+        wrapMaybeSetExitIfChangedRaw(
+          true,
+          () async {
+            innerDidRun = true;
+          },
+          gitDiffExecutor: (_) async {
+            return const RunCommandOutput(
+              stdout: '',
+              stderr: '',
+              exitCode: 128,
+            );
+          },
+          isCi: true,
+        ),
+        throwsA(isA<ProcessException>()),
+      );
+
+      expect(innerDidRun, false);
+    });
+
+    test(
+      'warns on pre-existing dirty tree but still fails after dirty result',
+      () async {
+        var innerDidRun = false;
+        var checkCount = 0;
+
+        await expectLater(
+          wrapMaybeSetExitIfChangedRaw(
+            true,
+            () async {
+              innerDidRun = true;
+            },
+            gitDiffExecutor: (_) async {
+              checkCount++;
+              return const RunCommandOutput(
+                stdout: '',
+                stderr: '',
+                exitCode: 1,
+              );
+            },
+            isCi: false,
+          ),
+          throwsA(isA<ProcessException>()),
+        );
+
+        expect(innerDidRun, true);
+        expect(checkCount, 2);
+      },
     );
   });
 

--- a/tools/frb_internal/test/makefile_dart_test.dart
+++ b/tools/frb_internal/test/makefile_dart_test.dart
@@ -86,6 +86,15 @@ late final callback = ptr.asFunction<voidFunction(ffi.Pointer<ffi.Void>)>();
       expect(classifyGitDiffExitCodeForTesting(128), 'unavailable');
     });
 
+    test('detects CI from common environment variables', () {
+      expect(isCiForTesting({'GITHUB_ACTIONS': 'true'}), true);
+      expect(isCiForTesting({'CI': 'true'}), true);
+      expect(isCiForTesting({'CI': '1'}), true);
+      expect(isCiForTesting({'CI': 'false'}), false);
+      expect(isCiForTesting({'CI': '0'}), false);
+      expect(isCiForTesting({}), false);
+    });
+
     test('decides clean git diff should continue silently', () {
       expect(
         () => handleGitDiffResultForTesting(


### PR DESCRIPTION
Summary:
- Allow frb_internal git clean checks to continue with a warning when git metadata is unavailable outside CI.
- Keep CI strict: unavailable git metadata still fails in CI.
- Keep generated-drift detection strict when git can run: post-command dirty results still fail.
- Detect CI via GitHub Actions or common `CI` environment values.

Manual testing:
- Verified in Tom local Docker from this Codex worktree after the latest code changes.
- Inside the container, `.git` points at a host worktree gitdir that is not mounted into the container.
- Inside the container, raw `git diff --exit-code` exits 128 with `fatal: not a git repository`.
- After this change, `./frb_internal test-dart-native --package tools/frb_internal --check-clean` prints `Warning: cannot check working tree cleanliness because git metadata is unavailable; continuing anyway.` for the clean checks and still completes successfully with `All tests passed!`.

Validation:
- `dart analyze lib/src/makefile_dart/generate.dart test/makefile_dart_test.dart`
- `dart test test/makefile_dart_test.dart`
- `git diff --check`