### PR TITLE
Fix web worker panic propagation

### DIFF
--- a/frb_rust/src/third_party/wasm_bindgen/worker_pool.rs
+++ b/frb_rust/src/third_party/wasm_bindgen/worker_pool.rs
@@ -116,6 +116,8 @@ impl WorkerPool {
                         if (transfer[0] && typeof transfer[0].postMessage === 'function') {{
                             // panic
                             transfer[0].postMessage([FRB_ACTION_PANIC, err.toString()])
+                            postMessage(null)
+                            return
                         }}
                         setTimeout(() => {{ throw err }})
                         postMessage(null)


### PR DESCRIPTION
Related #3078

Draft note: this PR currently fixes a deterministic reproduction of the DartOpaque worker page-error signal, but it has not yet been proven against a local reproduction of the original flaky web-test failure. Do not merge as-is until the real failing scenario is reproduced and verified.

## Current deterministic signal

A focused DartOpaque web entrypoint can reproduce the underlying page-level error before the fix: Dart receives the expected `PanicException`, but Puppeteer also logs `Page.onError Evaluation failed: RuntimeError: unreachable`.

This is not by itself the same as the original failing CI job, because the focused command can still exit successfully.

## Remaining work

- Reproduce the original `frb_example--pure_dart` web test failure locally with a non-zero exit.
- Verify whether this worker-panic change removes that failure, not just the focused page-error signal.
- Only then change this back from draft and use `Close #3078`.