### PR TITLE
Fix web DartOpaque, StreamSink, and MoiArc flakes

### DIFF
--- a/frb_example/pure_dart/test/rust_auto_opaque_moi_repro_entrypoint.dart
+++ b/frb_example/pure_dart/test/rust_auto_opaque_moi_repro_entrypoint.dart
@@ -1,0 +1,38 @@
+import 'dart:async';
+
+import 'package:flutter_rust_bridge_utils/flutter_rust_bridge_utils_web.dart';
+import 'package:frb_example_pure_dart/src/rust/api/pseudo_manual/rust_auto_opaque_twin_moi.dart';
+import 'package:frb_example_pure_dart/src/rust/frb_generated.dart';
+import 'package:test/test.dart';
+
+Future<void> main() async {
+  await dartWebTestEntrypoint(() async {
+    await RustLib.init();
+
+    test('dispose while workers mutate MoiArc pool does not block main thread',
+        () async {
+      for (var iteration = 0; iteration < 50; ++iteration) {
+        final objects = await Future.wait([
+          for (var index = 0; index < 32; ++index)
+            rustAutoOpaqueReturnOwnTwinMoi(initial: iteration * 1000 + index),
+        ]);
+
+        final futures = [
+          for (var index = 0; index < 128; ++index)
+            rustAutoOpaqueReturnOwnTwinMoi(initial: iteration * 10000 + index),
+        ];
+
+        for (final object in objects) {
+          object.dispose();
+        }
+
+        final created = await Future.wait(futures);
+        for (final object in created) {
+          object.dispose();
+        }
+
+        await Future<void>.delayed(Duration.zero);
+      }
+    });
+  });
+}

--- a/frb_rust/src/generalized_arc/moi_arc.rs
+++ b/frb_rust/src/generalized_arc/moi_arc.rs
@@ -116,11 +116,58 @@ macro_rules! frb_generated_moi_arc_def {
                 map.get_mut(&raw).unwrap().ref_count += 1;
             }
 
+            #[cfg(not(target_family = "wasm"))]
             pub fn decrement_strong_count(raw: usize) {
                 let mut pool = T::get_pool().write().unwrap();
                 let object = Self::decrement_strong_count_raw(raw, &mut pool);
                 drop(pool);
                 drop(object);
+            }
+
+            #[cfg(target_family = "wasm")]
+            pub fn decrement_strong_count(raw: usize) {
+                match T::get_pool().try_write() {
+                    Ok(mut pool) => {
+                        let object = Self::decrement_strong_count_raw(raw, &mut pool);
+                        drop(pool);
+                        drop(object);
+                    }
+                    Err(std::sync::TryLockError::WouldBlock) => {
+                        Self::decrement_strong_count_later(raw);
+                    }
+                    Err(std::sync::TryLockError::Poisoned(error)) => {
+                        let mut pool = error.into_inner();
+                        let object = Self::decrement_strong_count_raw(raw, &mut pool);
+                        drop(pool);
+                        drop(object);
+                    }
+                }
+            }
+
+            #[cfg(target_family = "wasm")]
+            fn decrement_strong_count_later(raw: usize) {
+                use $crate::for_generated::wasm_bindgen::JsCast;
+
+                let callback = $crate::for_generated::wasm_bindgen::closure::Closure::once_into_js(
+                    move || Self::decrement_strong_count(raw),
+                );
+                let global = $crate::for_generated::js_sys::global();
+                let set_timeout = $crate::for_generated::js_sys::Reflect::get(
+                    &global,
+                    &$crate::for_generated::wasm_bindgen::JsValue::from_str("setTimeout"),
+                )
+                .expect("setTimeout should exist");
+                let set_timeout = set_timeout
+                    .dyn_ref::<$crate::for_generated::js_sys::Function>()
+                    .expect("setTimeout should be a function");
+
+                set_timeout
+                    .call2(
+                        &global,
+                        &callback,
+                        &$crate::for_generated::wasm_bindgen::JsValue::from_f64(0.0),
+                    )
+                    .expect("setTimeout should accept callback");
             }
 
             fn decrement_strong_count_raw(

--- a/frb_rust/src/generalized_isolate/web/channel.rs
+++ b/frb_rust/src/generalized_isolate/web/channel.rs
@@ -35,6 +35,12 @@ impl Channel {
 #[derive(Clone)]
 pub struct SendableChannelHandle(SendableMessagePortHandle);
 
+impl SendableChannelHandle {
+    pub(crate) fn cache_key(&self) -> String {
+        self.0.cache_key()
+    }
+}
+
 pub fn channel_to_handle(channel: &Channel) -> SendableChannelHandle {
     SendableChannelHandle(message_port_to_handle(&channel.port))
 }

--- a/frb_rust/src/platform_types/web.rs
+++ b/frb_rust/src/platform_types/web.rs
@@ -12,6 +12,12 @@ pub type DartAbi = wasm_bindgen::JsValue;
 #[derive(Clone, Debug)]
 pub struct SendableMessagePortHandle(String);
 
+impl SendableMessagePortHandle {
+    pub(crate) fn cache_key(&self) -> String {
+        self.0.clone()
+    }
+}
+
 pub fn message_port_to_handle(port: &MessagePort) -> SendableMessagePortHandle {
     SendableMessagePortHandle(
         port.dyn_ref::<BroadcastChannel>()

--- a/frb_rust/src/stream/closer.rs
+++ b/frb_rust/src/stream/closer.rs
@@ -1,5 +1,4 @@
 use crate::codec::BaseCodec;
-use crate::codec::Rust2DartMessageTrait;
 use crate::generalized_isolate::SendableChannelHandle;
 use std::marker::PhantomData;
 
@@ -20,7 +19,6 @@ impl<Rust2DartCodec: BaseCodec> StreamSinkCloser<Rust2DartCodec> {
 
 impl<Rust2DartCodec: BaseCodec> Drop for StreamSinkCloser<Rust2DartCodec> {
     fn drop(&mut self) {
-        super::stream_sink::sender(&self.sendable_channel_handle)
-            .send_or_warn(Rust2DartCodec::encode_close_stream().into_dart_abi())
+        super::stream_sink::close_stream::<Rust2DartCodec>(&self.sendable_channel_handle)
     }
 }

--- a/frb_rust/src/stream/stream_sink.rs
+++ b/frb_rust/src/stream/stream_sink.rs
@@ -8,8 +8,19 @@ use crate::generalized_isolate::{
 use crate::platform_types::{deserialize_sendable_message_port_handle, handle_to_message_port};
 use crate::rust2dart::sender::{Rust2DartSendError, Rust2DartSender};
 use crate::stream::closer::StreamSinkCloser;
+#[cfg(target_family = "wasm")]
+use std::cell::RefCell;
+#[cfg(target_family = "wasm")]
+use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::sync::Arc;
+
+#[cfg(target_family = "wasm")]
+thread_local! {
+    // A single BroadcastChannel sender preserves message ordering for a stream sink.
+    static STREAM_SINK_SENDERS: RefCell<HashMap<String, Rust2DartSender>> =
+        RefCell::new(HashMap::new());
+}
 
 /// A sink to send asynchronous data back to Dart.
 /// Represented as a Dart
@@ -41,8 +52,35 @@ impl<T, Rust2DartCodec: BaseCodec> StreamSinkBase<T, Rust2DartCodec> {
     }
 }
 
+#[cfg(not(target_family = "wasm"))]
 pub(super) fn sender(sendable_channel_handle: &SendableChannelHandle) -> Rust2DartSender {
     Rust2DartSender::new(handle_to_channel(sendable_channel_handle))
+}
+
+#[cfg(target_family = "wasm")]
+pub(super) fn sender(sendable_channel_handle: &SendableChannelHandle) -> Rust2DartSender {
+    let cache_key = sendable_channel_handle.cache_key();
+    STREAM_SINK_SENDERS.with(|senders| {
+        let mut senders = senders.borrow_mut();
+        senders
+            .entry(cache_key)
+            .or_insert_with(|| Rust2DartSender::new(handle_to_channel(sendable_channel_handle)))
+            .clone()
+    })
+}
+
+pub(super) fn close_stream<Rust2DartCodec: BaseCodec>(
+    sendable_channel_handle: &SendableChannelHandle,
+) {
+    sender(sendable_channel_handle)
+        .send_or_warn(Rust2DartCodec::encode_close_stream().into_dart_abi());
+
+    #[cfg(target_family = "wasm")]
+    STREAM_SINK_SENDERS.with(|senders| {
+        senders
+            .borrow_mut()
+            .remove(&sendable_channel_handle.cache_key());
+    });
 }
 
 // frb-coverage:ignore-start

--- a/frb_rust/src/third_party/wasm_bindgen/worker_pool.rs
+++ b/frb_rust/src/third_party/wasm_bindgen/worker_pool.rs
@@ -116,6 +116,8 @@ impl WorkerPool {
                         if (transfer[0] && typeof transfer[0].postMessage === 'function') {{
                             // panic
                             transfer[0].postMessage([FRB_ACTION_PANIC, err.toString()])
+                            postMessage(null)
+                            return
                         }}
                         setTimeout(() => {{ throw err }})
                         postMessage(null)


### PR DESCRIPTION
Close #3078

## How to reliably reproduce the bug

### MoiArc `Atomics.wait` failure from the issue body

The `Atomics.wait cannot be called in this context` example in #3078 can be reproduced deterministically with the focused entrypoint added by this PR.

1. Check out the PR branch and use the pre-MoiArc-fix commit plus only the repro entrypoint:

```sh
git fetch origin codex/fix-web-stream-sink-order
git checkout 6917b351f5
git checkout origin/codex/fix-web-stream-sink-order -- frb_example/pure_dart/test/rust_auto_opaque_moi_repro_entrypoint.dart
```

2. Run the repro in Tom's local FRB container:

```sh
/Users/tom/.claude/skills/tom-frb-env/tom_frb_env.py exec -- /bin/sh -lc 'cd frb_utils && env PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome dart run flutter_rust_bridge_utils test-web --entrypoint ../frb_example/pure_dart/test/rust_auto_opaque_moi_repro_entrypoint.dart --rust-features internal_feature_for_testing'
```

3. On the pre-fix runtime, this fails mechanically with the same stack shape as #3078:

```text
RuntimeError: Atomics.wait cannot be called in this context
std::sys::sync::rwlock::futex::RwLock::write
std::sync::poison::rwlock::RwLock<T>::write
frb_example_pure_dart::frb_generated::MoiArc<T>::decrement_strong_count
rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinMoi
```

4. Check out this PR tip and rerun the exact same command:

```sh
git checkout origin/codex/fix-web-stream-sink-order
/Users/tom/.claude/skills/tom-frb-env/tom_frb_env.py exec -- /bin/sh -lc 'cd frb_utils && env PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome dart run flutter_rust_bridge_utils test-web --entrypoint ../frb_example/pure_dart/test/rust_auto_opaque_moi_repro_entrypoint.dart --rust-features internal_feature_for_testing'
```

The fixed runtime exits with `All tests passed!`.

### Other #3078 web signals already covered by this PR

The original linked failed job also had a real StreamSink assertion failure (`Expected: [0, 1, 2, 3, 4]`, `Actual: [2, 3, 4]`). The issue text also showed DartOpaque panic page errors (`RuntimeError: unreachable` / `Failed to initialize`). Earlier commits in this PR fix those separately.

## Bug root cause

For the MoiArc failure, Dart `dispose()` calls the generated `rust_arc_decrement_strong_count_*` wasm export synchronously on the browser main thread. That export called `MoiArc::decrement_strong_count`, which used blocking `RwLock::write()` on the shared MoiArc pool. If a worker thread was touching the same pool at that moment, Rust's wasm futex path tried `Atomics.wait`, which browsers forbid on the main thread.

For StreamSink, web code recreated a new BroadcastChannel sender for each value and close message, so close/value ordering was not guaranteed.

For DartOpaque panics, the worker sent the panic back to Dart but then rethrew it, producing extra page-level worker errors after Dart had already received `PanicException`.

## Why the fix works

On wasm, `MoiArc::decrement_strong_count` now uses `try_write()`. If the pool lock is available, release is immediate. If it is contended, release is scheduled with `setTimeout(..., 0)` and retried later, so the browser main thread never enters the blocking futex/`Atomics.wait` path. Native/non-wasm behavior is unchanged.

The StreamSink fix keeps one cached sender per stream channel until close, preserving message order. The DartOpaque worker fix returns after reporting a panic through the reply port instead of rethrowing the same already-reported panic.

## Verification

- Pre-fix MoiArc focused repro: fails with `RuntimeError: Atomics.wait cannot be called in this context`.
- Post-fix MoiArc focused repro: `All tests passed!`.
- `cargo fmt --check --manifest-path frb_rust/Cargo.toml` passed.
- `./frb_internal test-rust-package --package frb_rust` passed.
- Relevant PR web CI jobs in run `25623139670` passed before the MoiArc follow-up; this push will rerun CI for the final tip.
