### PR TITLE
Fix precommit autofix comments for fork PRs

### DIFF
--- a/.github/workflows/precommit_autofix.yaml
+++ b/.github/workflows/precommit_autofix.yaml
@@ -12,6 +12,9 @@ jobs:
   precommit_autofix:
     name: Generate precommit autofix patch
     runs-on: ubuntu-latest
+    # This job checks out and executes pull request code, including code from
+    # external forks. Keep it read-only; PR comments are written by the trusted
+    # workflow_run follow-up in precommit_autofix_comment.yaml.
     permissions:
       contents: read
 

--- a/.github/workflows/precommit_autofix.yaml
+++ b/.github/workflows/precommit_autofix.yaml
@@ -14,7 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
 
     steps:
       - name: Checkout
@@ -42,48 +41,3 @@ jobs:
         with:
           name: precommit-autofix-diff
           path: precommit-autofix.diff
-
-      - name: Update PR autofix comment
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/github-script@v8
-        env:
-          COMMENT_BODY: ${{ steps.autofix.outputs.comment_body }}
-        with:
-          script: |
-            const marker = '<!-- precommit-autofix-comment -->';
-            const issueNumber = context.payload.pull_request.number;
-            const body = process.env.COMMENT_BODY;
-
-            const comments = await github.paginate(
-              github.rest.issues.listComments,
-              {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issueNumber,
-                per_page: 100,
-              },
-            );
-
-            const existingComment = comments.find(
-              (comment) =>
-                comment.user?.type === 'Bot' &&
-                typeof comment.body === 'string' &&
-                comment.body.includes(marker),
-            );
-
-            if (existingComment) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existingComment.id,
-                body,
-              });
-              return;
-            }
-
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issueNumber,
-              body,
-            });

--- a/.github/workflows/precommit_autofix_comment.yaml
+++ b/.github/workflows/precommit_autofix_comment.yaml
@@ -2,6 +2,7 @@ name: Precommit Autofix Comment
 
 on:
   workflow_run:
+    # This matches the workflow's `name:`, not its filename.
     workflows: ["Precommit Autofix"]
     types: [completed]
 
@@ -14,6 +15,8 @@ jobs:
         github.event.workflow_run.conclusion == 'success'
       }}
     runs-on: ubuntu-latest
+    # This trusted follow-up is loaded from the base repository default branch.
+    # It may write the PR comment, but must not check out or execute fork code.
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/precommit_autofix_comment.yaml
+++ b/.github/workflows/precommit_autofix_comment.yaml
@@ -1,0 +1,157 @@
+name: Precommit Autofix Comment
+
+on:
+  workflow_run:
+    workflows: ["Precommit Autofix"]
+    types: [completed]
+
+jobs:
+  update_comment:
+    name: Update PR autofix comment
+    if: >-
+      ${{
+        github.event.workflow_run.event == 'pull_request' &&
+        github.event.workflow_run.conclusion == 'success'
+      }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+
+    steps:
+      - name: Update PR autofix comment
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const marker = '<!-- precommit-autofix-comment -->';
+            const artifactName = 'precommit-autofix-diff';
+            const patchFileName = 'precommit-autofix.diff';
+            const run = context.payload.workflow_run;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const issueNumber = await findPullRequestNumber({
+              github,
+              owner,
+              repo,
+              run,
+            });
+
+            const artifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts,
+              {
+                owner,
+                repo,
+                run_id: run.id,
+                per_page: 100,
+              },
+            );
+            const hasPatch = artifacts.some(
+              (artifact) => artifact.name === artifactName && !artifact.expired,
+            );
+
+            const body = buildCommentBody({
+              artifactName,
+              patchFileName,
+              headSha: run.head_sha,
+              hasPatch,
+              runId: run.id,
+            });
+
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner,
+                repo,
+                issue_number: issueNumber,
+                per_page: 100,
+              },
+            );
+
+            const existingComment = comments.find(
+              (comment) =>
+                comment.user?.type === 'Bot' &&
+                typeof comment.body === 'string' &&
+                comment.body.includes(marker),
+            );
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existingComment.id,
+                body,
+              });
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: issueNumber,
+              body,
+            });
+
+            async function findPullRequestNumber({github, owner, repo, run}) {
+              const pullRequests = run.pull_requests ?? [];
+              if (pullRequests.length > 0) {
+                return pullRequests[0].number;
+              }
+
+              const associated = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner,
+                repo,
+                commit_sha: run.head_sha,
+              });
+              const candidates = associated.data.filter(
+                (pullRequest) =>
+                  pullRequest.base.repo.full_name === `${owner}/${repo}` &&
+                  pullRequest.head.sha === run.head_sha,
+              );
+              if (candidates.length > 0) {
+                return candidates[0].number;
+              }
+
+              throw new Error(`Could not find pull request for workflow run ${run.id}`);
+            }
+
+            function buildCommentBody({
+              artifactName,
+              patchFileName,
+              headSha,
+              hasPatch,
+              runId,
+            }) {
+              if (!hasPatch) {
+                return [
+                  marker,
+                  '## Precommit Autofix',
+                  '',
+                  `Commit: \`${headSha}\``,
+                  `Run: \`${runId}\``,
+                  '',
+                  'CI produced no diff. The branch is already clean after precommit autofix.',
+                  '',
+                ].join('\n');
+              }
+
+              return [
+                marker,
+                '## Precommit Autofix',
+                '',
+                `Commit: \`${headSha}\``,
+                `Run: \`${runId}\``,
+                '',
+                `CI generated a non-empty autofix patch in artifact \`${artifactName}\`.`,
+                '',
+                'This usually means generated or normalized files were not committed. Download the artifact and apply it locally:',
+                '',
+                '```shell',
+                `artifact_dir="$(mktemp -d)" && gh run download ${runId} -n ${artifactName} -D "$artifact_dir" && git apply "$artifact_dir/${patchFileName}"`,
+                '```',
+                '',
+                'The workflow never pushes commits on your behalf; it only prepares a patch for review and application.',
+                '',
+              ].join('\n');
+            }

--- a/website/docs/guides/contributing/tip.md
+++ b/website/docs/guides/contributing/tip.md
@@ -20,6 +20,7 @@ For example, `./frb_internal precommit --mode fast` (or `--mode slow`) runs code
 ### CI autofix for generated changes
 
 If generated or normalized files are missing from a pull request, the `Precommit Autofix` bot comment explains how to apply its patch artifact locally.
+For fork pull requests, a follow-up trusted workflow posts the comment after the patch workflow completes, because the patch workflow itself runs with read-only permissions.
 
 ### The `just codegen`
 

--- a/website/docs/guides/contributing/tip.md
+++ b/website/docs/guides/contributing/tip.md
@@ -20,7 +20,7 @@ For example, `./frb_internal precommit --mode fast` (or `--mode slow`) runs code
 ### CI autofix for generated changes
 
 If generated or normalized files are missing from a pull request, the `Precommit Autofix` bot comment explains how to apply its patch artifact locally.
-For fork pull requests, a follow-up trusted workflow posts the comment after the patch workflow completes, because the patch workflow itself runs with read-only permissions.
+For fork pull requests, a follow-up trusted workflow posts the comment after the patch workflow completes, as the latter runs with read-only permissions.
 
 ### The `just codegen`
 


### PR DESCRIPTION
This fixes fork PR autofix comments by splitting the workflow into two trust domains.

The Precommit Autofix workflow still runs on pull_request, so it can safely check out and execute the contributor branch. For external forks, GitHub intentionally downgrades that workflow token to read-only, which is why the old inline comment step failed with Resource not accessible by integration.

The new Precommit Autofix Comment workflow runs via workflow_run after Precommit Autofix completes. A workflow_run workflow is loaded from the base repository default branch, so it can receive the repository-scoped issues: write permission needed to create or update the PR comment.

To keep that safe, the trusted follow-up workflow does not check out or execute fork code, and it does not publish arbitrary markdown produced by the fork. It only reads trusted workflow metadata plus the presence of the standard precommit-autofix-diff artifact, then reconstructs the bot comment itself.