### PR TITLE
Refactor: Rename `ObjectId` to `MoiObjectId` in `frb_generated_moi_arc_def!` macro to prevent namespace collision with user-defined types

### DIFF
--- a/frb_rust/src/generalized_arc/moi_arc.rs
+++ b/frb_rust/src/generalized_arc/moi_arc.rs
@@ -9,7 +9,7 @@ macro_rules! frb_generated_moi_arc_def {
         #[derive(Debug)]
         pub struct MoiArc<T: ?Sized + MoiArcValue> {
             // `Option` for correct dropping
-            object_id: Option<ObjectId>,
+            object_id: Option<MoiObjectId>,
             // Mainly for `as_ref`. `Option` for correct dropping
             value: Option<Arc<T>>,
             _phantom: PhantomData<T>,
@@ -141,12 +141,12 @@ macro_rules! frb_generated_moi_arc_def {
             fn get_pool() -> &'static MoiArcPool<Self>;
         }
 
-        type ObjectId = usize;
+        type MoiObjectId = usize;
 
         pub type MoiArcPool<T> = std::sync::RwLock<MoiArcPoolInner<T>>;
 
         pub struct MoiArcPoolInner<T: ?Sized> {
-            map: HashMap<ObjectId, MoiArcPoolValue<T>>,
+            map: HashMap<MoiObjectId, MoiArcPoolValue<T>>,
             id_generator: IdGenerator,
         }
 
@@ -160,7 +160,7 @@ macro_rules! frb_generated_moi_arc_def {
         }
 
         struct IdGenerator {
-            next_id: ObjectId,
+            next_id: MoiObjectId,
         }
 
         impl Default for IdGenerator {
@@ -172,11 +172,11 @@ macro_rules! frb_generated_moi_arc_def {
         }
 
         impl IdGenerator {
-            const MIN_ID: ObjectId = 1;
+            const MIN_ID: MoiObjectId = 1;
             // Less than i32's max value to be extra safe
-            const MAX_ID: ObjectId = 2147483600;
+            const MAX_ID: MoiObjectId = 2147483600;
 
-            fn next_id(&mut self) -> ObjectId {
+            fn next_id(&mut self) -> MoiObjectId {
                 let ans = self.next_id;
 
                 self.next_id = if self.next_id >= Self::MAX_ID {


### PR DESCRIPTION
## Changes

Fixes https://github.com/fzyzcjy/flutter_rust_bridge/issues/3105

### Problem

The `frb_generated_moi_arc_def!` macro defines a local type alias `type ObjectId = usize;` which gets injected into the user's `frb_generated.rs` via `frb_generated_boilerplate!`.

`ObjectId` is an extremely common name in domain modeling: used widely in file systems, databases, ORMs, and document stores. When a user defines their own `ObjectId` type and exposes it through the FRB API, two conflicts arise:

1. **Duplicate type definition** — the macro's `type ObjectId = usize` shadows the user's `ObjectId` struct/enum in the generated file scope
2. **Missing trait impl** — `Trait SseEncode is not implemented for ObjectId [E0277]` because the compiler resolves `ObjectId` to `usize` (the macro alias) instead of the user's actual type, which does have `SseEncode` implemented

#### Steps to reproduce

1. Create a public struct named `ObjectId` in your Rust crate
2. Expose an API function to Dart that returns `ObjectId`
3. Run `flutter_rust_bridge_codegen generate`
4. Attempt to compile — the compiler will fail in `frb_generated.rs` because FRB's local `ObjectId` alias shadows the user's domain struct

### Solution

Renamed the internal `ObjectId` type alias to `MoiObjectId` throughout the `frb_generated_moi_arc_def!` macro. The `Moi` prefix already exists on all other related types (`MoiArc`, `MoiArcPool`, `MoiArcPoolInner`) so this is consistent with the existing naming convention and avoids polluting the user's generated file scope.

### Files Changed

- `flutter_rust_bridge/src/generalized_arc/moi_arc.rs` — renamed `ObjectId` → `MoiObjectId` in all occurrences within the macro