### PR TITLE
Support std and tokio time typemaps

### DIFF
--- a/frb_codegen/src/library/codegen/generator/api_dart/spec_generator/info.rs
+++ b/frb_codegen/src/library/codegen/generator/api_dart/spec_generator/info.rs
@@ -62,8 +62,13 @@ impl ApiDartGeneratorInfoTrait for DelegateApiDartGenerator<'_> {
                 MirTypeDelegateTime::Local
                 | MirTypeDelegateTime::Utc
                 | MirTypeDelegateTime::NaiveDate
-                | MirTypeDelegateTime::NaiveDateTime => "DateTime".to_string(),
-                MirTypeDelegateTime::Duration => "Duration".to_string(),
+                | MirTypeDelegateTime::NaiveDateTime
+                | MirTypeDelegateTime::StdSystemTime
+                | MirTypeDelegateTime::StdInstant
+                | MirTypeDelegateTime::TokioInstant => "DateTime".to_string(),
+                MirTypeDelegateTime::Duration | MirTypeDelegateTime::StdDuration => {
+                    "Duration".to_string()
+                }
             },
             // MirTypeDelegate::TimeList(
             //     MirTypeDelegateTime::Local | MirTypeDelegateTime::Utc | MirTypeDelegateTime::Naive,

--- a/frb_codegen/src/library/codegen/generator/api_dart/spec_generator/info.rs
+++ b/frb_codegen/src/library/codegen/generator/api_dart/spec_generator/info.rs
@@ -63,9 +63,7 @@ impl ApiDartGeneratorInfoTrait for DelegateApiDartGenerator<'_> {
                 | MirTypeDelegateTime::Utc
                 | MirTypeDelegateTime::NaiveDate
                 | MirTypeDelegateTime::NaiveDateTime
-                | MirTypeDelegateTime::StdSystemTime
-                | MirTypeDelegateTime::StdInstant
-                | MirTypeDelegateTime::TokioInstant => "DateTime".to_string(),
+                | MirTypeDelegateTime::StdSystemTime => "DateTime".to_string(),
                 MirTypeDelegateTime::Duration | MirTypeDelegateTime::StdDuration => {
                     "Duration".to_string()
                 }

--- a/frb_codegen/src/library/codegen/generator/codec/sse/ty/delegate.rs
+++ b/frb_codegen/src/library/codegen/generator/codec/sse/ty/delegate.rs
@@ -323,14 +323,17 @@ pub(crate) fn decode_std_duration(value: &str) -> String {
 
 pub(crate) fn encode_std_system_time(value: &str) -> String {
     format!(
-        r#"{value}.duration_since(std::time::SystemTime::UNIX_EPOCH).expect("time is before UNIX_EPOCH").as_micros().try_into().expect("cannot get microseconds from time")"#
+        r#"match {value}.duration_since(std::time::SystemTime::UNIX_EPOCH) {{
+            Ok(duration) => duration.as_micros().try_into().expect("cannot get microseconds from time"),
+            Err(error) => -i64::try_from(error.duration().as_micros()).expect("cannot get microseconds from time"),
+        }}"#
     )
 }
 
 pub(crate) fn decode_std_system_time(value: &str) -> String {
     format!(
         r#"if {value} >= 0 {{
-            std::time::SystemTime::UNIX_EPOCH.checked_add(std::time::Duration::from_micros({value}.try_into().expect("invalid timestamp"))).expect("timestamp out of range")
+            std::time::SystemTime::UNIX_EPOCH.checked_add(std::time::Duration::from_micros({value}.unsigned_abs())).expect("timestamp out of range")
         }} else {{
             std::time::SystemTime::UNIX_EPOCH.checked_sub(std::time::Duration::from_micros({value}.unsigned_abs())).expect("timestamp out of range")
         }}"#
@@ -340,12 +343,13 @@ pub(crate) fn decode_std_system_time(value: &str) -> String {
 pub(crate) fn encode_std_instant(value: &str) -> String {
     format!(
         r#"{{
+            let value = {value};
             let now_instant = std::time::Instant::now();
             let now_system_time = std::time::SystemTime::now();
-            let system_time = if {value} >= now_instant {{
-                now_system_time.checked_add({value}.duration_since(now_instant)).expect("instant out of range")
+            let system_time = if value >= now_instant {{
+                now_system_time.checked_add(value.duration_since(now_instant)).expect("instant out of range")
             }} else {{
-                now_system_time.checked_sub(now_instant.duration_since({value})).expect("instant out of range")
+                now_system_time.checked_sub(now_instant.duration_since(value)).expect("instant out of range")
             }};
             {system_time}
         }}"#,

--- a/frb_codegen/src/library/codegen/generator/codec/sse/ty/delegate.rs
+++ b/frb_codegen/src/library/codegen/generator/codec/sse/ty/delegate.rs
@@ -33,10 +33,13 @@ impl CodecSseTyTrait for DelegateCodecSseTy<'_> {
                     MirTypeDelegateTime::Utc
                     | MirTypeDelegateTime::Local
                     | MirTypeDelegateTime::NaiveDate
-                    | MirTypeDelegateTime::NaiveDateTime => {
+                    | MirTypeDelegateTime::NaiveDateTime
+                    | MirTypeDelegateTime::StdSystemTime
+                    | MirTypeDelegateTime::StdInstant
+                    | MirTypeDelegateTime::TokioInstant => {
                         "PlatformInt64Util.from(self.microsecondsSinceEpoch)".to_owned()
                     }
-                    MirTypeDelegateTime::Duration => {
+                    MirTypeDelegateTime::Duration | MirTypeDelegateTime::StdDuration => {
                         "PlatformInt64Util.from(self.inMicroseconds)".to_owned()
                     }
                 },
@@ -108,6 +111,10 @@ impl CodecSseTyTrait for DelegateCodecSseTy<'_> {
                         r#"self.num_microseconds().expect("cannot get microseconds from time")"#
                             .to_owned()
                     }
+                    MirTypeDelegateTime::StdSystemTime => encode_std_system_time("self"),
+                    MirTypeDelegateTime::StdInstant => encode_std_instant("self"),
+                    MirTypeDelegateTime::StdDuration => encode_std_duration("self"),
+                    MirTypeDelegateTime::TokioInstant => encode_tokio_instant("self"),
                 },
                 MirTypeDelegate::Uuid => "self.as_bytes().to_vec()".to_owned(),
                 MirTypeDelegate::SerdeJsonValue => {
@@ -168,14 +175,16 @@ impl CodecSseTyTrait for DelegateCodecSseTy<'_> {
                         MirTypeDelegateTime::Utc
                         | MirTypeDelegateTime::Local
                         | MirTypeDelegateTime::NaiveDate
-                        | MirTypeDelegateTime::NaiveDateTime => {
+                        | MirTypeDelegateTime::NaiveDateTime
+                        | MirTypeDelegateTime::StdSystemTime
+                        | MirTypeDelegateTime::StdInstant
+                        | MirTypeDelegateTime::TokioInstant => {
                             format!(
                             "DateTime.fromMicrosecondsSinceEpoch(inner.toInt(), isUtc: {is_utc})",
-                            is_utc =
-                                matches!(mir, MirTypeDelegateTime::NaiveDateTime | MirTypeDelegateTime::NaiveDate | MirTypeDelegateTime::Utc),
+                            is_utc = is_dart_datetime_utc(mir),
                         )
                         }
-                        MirTypeDelegateTime::Duration => {
+                        MirTypeDelegateTime::Duration | MirTypeDelegateTime::StdDuration => {
                             "Duration(microseconds: inner.toInt())".to_owned()
                         }
                     },
@@ -229,6 +238,10 @@ impl CodecSseTyTrait for DelegateCodecSseTy<'_> {
                         MirTypeDelegateTime::Duration => {
                             "chrono::Duration::microseconds(inner)".to_owned()
                         }
+                        MirTypeDelegateTime::StdSystemTime => decode_std_system_time("inner"),
+                        MirTypeDelegateTime::StdInstant => decode_std_instant("inner"),
+                        MirTypeDelegateTime::StdDuration => decode_std_duration("inner"),
+                        MirTypeDelegateTime::TokioInstant => decode_tokio_instant("inner"),
                     }
                 }
                 MirTypeDelegate::Uuid => {
@@ -276,6 +289,94 @@ pub(super) fn simple_delegate_decode(
         return {wrapper_expr};",
         lang.call_decode(inner_ty),
         var_decl = lang.var_decl()
+    )
+}
+
+pub(crate) fn is_dart_datetime_utc(mir: &MirTypeDelegateTime) -> bool {
+    matches!(
+        mir,
+        MirTypeDelegateTime::NaiveDateTime
+            | MirTypeDelegateTime::NaiveDate
+            | MirTypeDelegateTime::Utc
+            | MirTypeDelegateTime::StdSystemTime
+            | MirTypeDelegateTime::StdInstant
+            | MirTypeDelegateTime::TokioInstant
+    )
+}
+
+pub(crate) fn is_duration(mir: &MirTypeDelegateTime) -> bool {
+    matches!(
+        mir,
+        MirTypeDelegateTime::Duration | MirTypeDelegateTime::StdDuration
+    )
+}
+
+pub(crate) fn encode_std_duration(value: &str) -> String {
+    format!(r#"{value}.as_micros().try_into().expect("cannot get microseconds from time")"#)
+}
+
+pub(crate) fn decode_std_duration(value: &str) -> String {
+    format!(
+        r#"std::time::Duration::from_micros({value}.try_into().expect("negative duration is not valid for std::time::Duration"))"#
+    )
+}
+
+pub(crate) fn encode_std_system_time(value: &str) -> String {
+    format!(
+        r#"{value}.duration_since(std::time::SystemTime::UNIX_EPOCH).expect("time is before UNIX_EPOCH").as_micros().try_into().expect("cannot get microseconds from time")"#
+    )
+}
+
+pub(crate) fn decode_std_system_time(value: &str) -> String {
+    format!(
+        r#"if {value} >= 0 {{
+            std::time::SystemTime::UNIX_EPOCH.checked_add(std::time::Duration::from_micros({value}.try_into().expect("invalid timestamp"))).expect("timestamp out of range")
+        }} else {{
+            std::time::SystemTime::UNIX_EPOCH.checked_sub(std::time::Duration::from_micros({value}.unsigned_abs())).expect("timestamp out of range")
+        }}"#
+    )
+}
+
+pub(crate) fn encode_std_instant(value: &str) -> String {
+    format!(
+        r#"{{
+            let now_instant = std::time::Instant::now();
+            let now_system_time = std::time::SystemTime::now();
+            let system_time = if {value} >= now_instant {{
+                now_system_time.checked_add({value}.duration_since(now_instant)).expect("instant out of range")
+            }} else {{
+                now_system_time.checked_sub(now_instant.duration_since({value})).expect("instant out of range")
+            }};
+            {system_time}
+        }}"#,
+        system_time = encode_std_system_time("system_time")
+    )
+}
+
+pub(crate) fn decode_std_instant(value: &str) -> String {
+    format!(
+        r#"{{
+            let now_system_time = std::time::SystemTime::now();
+            let now_instant = std::time::Instant::now();
+            let target_system_time = {target_system_time};
+            if target_system_time >= now_system_time {{
+                now_instant.checked_add(target_system_time.duration_since(now_system_time).expect("invalid timestamp")).expect("instant out of range")
+            }} else {{
+                now_instant.checked_sub(now_system_time.duration_since(target_system_time).expect("invalid timestamp")).expect("instant out of range")
+            }}
+        }}"#,
+        target_system_time = decode_std_system_time(value)
+    )
+}
+
+pub(crate) fn encode_tokio_instant(value: &str) -> String {
+    encode_std_instant(&format!("{value}.into_std()"))
+}
+
+pub(crate) fn decode_tokio_instant(value: &str) -> String {
+    format!(
+        "tokio::time::Instant::from_std({})",
+        decode_std_instant(value)
     )
 }
 

--- a/frb_codegen/src/library/codegen/generator/codec/sse/ty/delegate.rs
+++ b/frb_codegen/src/library/codegen/generator/codec/sse/ty/delegate.rs
@@ -332,10 +332,13 @@ pub(crate) fn encode_std_system_time(value: &str) -> String {
 
 pub(crate) fn decode_std_system_time(value: &str) -> String {
     format!(
-        r#"if {value} >= 0 {{
-            std::time::SystemTime::UNIX_EPOCH.checked_add(std::time::Duration::from_micros({value}.unsigned_abs())).expect("timestamp out of range")
-        }} else {{
-            std::time::SystemTime::UNIX_EPOCH.checked_sub(std::time::Duration::from_micros({value}.unsigned_abs())).expect("timestamp out of range")
+        r#"{{
+            let value = {value};
+            if value >= 0 {{
+                std::time::SystemTime::UNIX_EPOCH.checked_add(std::time::Duration::from_micros(value.unsigned_abs())).expect("timestamp out of range")
+            }} else {{
+                std::time::SystemTime::UNIX_EPOCH.checked_sub(std::time::Duration::from_micros(value.unsigned_abs())).expect("timestamp out of range")
+            }}
         }}"#
     )
 }

--- a/frb_codegen/src/library/codegen/generator/codec/sse/ty/delegate.rs
+++ b/frb_codegen/src/library/codegen/generator/codec/sse/ty/delegate.rs
@@ -325,7 +325,10 @@ pub(crate) fn encode_std_system_time(value: &str) -> String {
     format!(
         r#"match {value}.duration_since(std::time::SystemTime::UNIX_EPOCH) {{
             Ok(duration) => duration.as_micros().try_into().expect("cannot get microseconds from time"),
-            Err(error) => i64::try_from(-(error.duration().as_micros() as i128)).expect("cannot get microseconds from time"),
+            Err(error) => {{
+                let micros = i128::try_from(error.duration().as_micros()).expect("cannot get microseconds from time");
+                i64::try_from(-micros).expect("cannot get microseconds from time")
+            }},
         }}"#
     )
 }

--- a/frb_codegen/src/library/codegen/generator/codec/sse/ty/delegate.rs
+++ b/frb_codegen/src/library/codegen/generator/codec/sse/ty/delegate.rs
@@ -34,9 +34,7 @@ impl CodecSseTyTrait for DelegateCodecSseTy<'_> {
                     | MirTypeDelegateTime::Local
                     | MirTypeDelegateTime::NaiveDate
                     | MirTypeDelegateTime::NaiveDateTime
-                    | MirTypeDelegateTime::StdSystemTime
-                    | MirTypeDelegateTime::StdInstant
-                    | MirTypeDelegateTime::TokioInstant => {
+                    | MirTypeDelegateTime::StdSystemTime => {
                         "PlatformInt64Util.from(self.microsecondsSinceEpoch)".to_owned()
                     }
                     MirTypeDelegateTime::Duration | MirTypeDelegateTime::StdDuration => {
@@ -112,9 +110,7 @@ impl CodecSseTyTrait for DelegateCodecSseTy<'_> {
                             .to_owned()
                     }
                     MirTypeDelegateTime::StdSystemTime => encode_std_system_time("self"),
-                    MirTypeDelegateTime::StdInstant => encode_std_instant("self"),
                     MirTypeDelegateTime::StdDuration => encode_std_duration("self"),
-                    MirTypeDelegateTime::TokioInstant => encode_tokio_instant("self"),
                 },
                 MirTypeDelegate::Uuid => "self.as_bytes().to_vec()".to_owned(),
                 MirTypeDelegate::SerdeJsonValue => {
@@ -176,9 +172,7 @@ impl CodecSseTyTrait for DelegateCodecSseTy<'_> {
                         | MirTypeDelegateTime::Local
                         | MirTypeDelegateTime::NaiveDate
                         | MirTypeDelegateTime::NaiveDateTime
-                        | MirTypeDelegateTime::StdSystemTime
-                        | MirTypeDelegateTime::StdInstant
-                        | MirTypeDelegateTime::TokioInstant => {
+                        | MirTypeDelegateTime::StdSystemTime => {
                             format!(
                             "DateTime.fromMicrosecondsSinceEpoch(inner.toInt(), isUtc: {is_utc})",
                             is_utc = is_dart_datetime_utc(mir),
@@ -239,9 +233,7 @@ impl CodecSseTyTrait for DelegateCodecSseTy<'_> {
                             "chrono::Duration::microseconds(inner)".to_owned()
                         }
                         MirTypeDelegateTime::StdSystemTime => decode_std_system_time("inner"),
-                        MirTypeDelegateTime::StdInstant => decode_std_instant("inner"),
                         MirTypeDelegateTime::StdDuration => decode_std_duration("inner"),
-                        MirTypeDelegateTime::TokioInstant => decode_tokio_instant("inner"),
                     }
                 }
                 MirTypeDelegate::Uuid => {
@@ -299,8 +291,6 @@ pub(crate) fn is_dart_datetime_utc(mir: &MirTypeDelegateTime) -> bool {
             | MirTypeDelegateTime::NaiveDate
             | MirTypeDelegateTime::Utc
             | MirTypeDelegateTime::StdSystemTime
-            | MirTypeDelegateTime::StdInstant
-            | MirTypeDelegateTime::TokioInstant
     )
 }
 
@@ -343,50 +333,6 @@ pub(crate) fn decode_std_system_time(value: &str) -> String {
                 std::time::SystemTime::UNIX_EPOCH.checked_sub(std::time::Duration::from_micros(value.unsigned_abs())).expect("timestamp out of range")
             }}
         }}"#
-    )
-}
-
-pub(crate) fn encode_std_instant(value: &str) -> String {
-    format!(
-        r#"{{
-            let value = {value}.clone();
-            let now_instant = std::time::Instant::now();
-            let now_system_time = std::time::SystemTime::now();
-            let system_time = if value >= now_instant {{
-                now_system_time.checked_add(value.duration_since(now_instant)).expect("instant out of range")
-            }} else {{
-                now_system_time.checked_sub(now_instant.duration_since(value)).expect("instant out of range")
-            }};
-            {system_time}
-        }}"#,
-        system_time = encode_std_system_time("system_time")
-    )
-}
-
-pub(crate) fn decode_std_instant(value: &str) -> String {
-    format!(
-        r#"{{
-            let now_system_time = std::time::SystemTime::now();
-            let now_instant = std::time::Instant::now();
-            let target_system_time = {target_system_time};
-            if target_system_time >= now_system_time {{
-                now_instant.checked_add(target_system_time.duration_since(now_system_time).expect("invalid timestamp")).expect("instant out of range")
-            }} else {{
-                now_instant.checked_sub(now_system_time.duration_since(target_system_time).expect("invalid timestamp")).expect("instant out of range")
-            }}
-        }}"#,
-        target_system_time = decode_std_system_time(value)
-    )
-}
-
-pub(crate) fn encode_tokio_instant(value: &str) -> String {
-    encode_std_instant(&format!("{value}.into_std()"))
-}
-
-pub(crate) fn decode_tokio_instant(value: &str) -> String {
-    format!(
-        "tokio::time::Instant::from_std({})",
-        decode_std_instant(value)
     )
 }
 

--- a/frb_codegen/src/library/codegen/generator/codec/sse/ty/delegate.rs
+++ b/frb_codegen/src/library/codegen/generator/codec/sse/ty/delegate.rs
@@ -346,7 +346,7 @@ pub(crate) fn decode_std_system_time(value: &str) -> String {
 pub(crate) fn encode_std_instant(value: &str) -> String {
     format!(
         r#"{{
-            let value = {value};
+            let value = {value}.clone();
             let now_instant = std::time::Instant::now();
             let now_system_time = std::time::SystemTime::now();
             let system_time = if value >= now_instant {{

--- a/frb_codegen/src/library/codegen/generator/codec/sse/ty/delegate.rs
+++ b/frb_codegen/src/library/codegen/generator/codec/sse/ty/delegate.rs
@@ -325,7 +325,7 @@ pub(crate) fn encode_std_system_time(value: &str) -> String {
     format!(
         r#"match {value}.duration_since(std::time::SystemTime::UNIX_EPOCH) {{
             Ok(duration) => duration.as_micros().try_into().expect("cannot get microseconds from time"),
-            Err(error) => -i64::try_from(error.duration().as_micros()).expect("cannot get microseconds from time"),
+            Err(error) => i64::try_from(-(error.duration().as_micros() as i128)).expect("cannot get microseconds from time"),
         }}"#
     )
 }

--- a/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/codec/cst/encoder/ty/delegate.rs
+++ b/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/codec/cst/encoder/ty/delegate.rs
@@ -84,9 +84,7 @@ impl WireDartCodecCstGeneratorEncoderTrait for DelegateWireDartCodecCstGenerator
                 | MirTypeDelegateTime::Local
                 | MirTypeDelegateTime::NaiveDate
                 | MirTypeDelegateTime::NaiveDateTime
-                | MirTypeDelegateTime::StdSystemTime
-                | MirTypeDelegateTime::StdInstant
-                | MirTypeDelegateTime::TokioInstant => Acc {
+                | MirTypeDelegateTime::StdSystemTime => Acc {
                     io: Some("return cst_encode_i_64(raw.microsecondsSinceEpoch);".into()),
                     web: Some(
                         "return cst_encode_i_64(BigInt.from(raw.millisecondsSinceEpoch));".into(),

--- a/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/codec/cst/encoder/ty/delegate.rs
+++ b/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/codec/cst/encoder/ty/delegate.rs
@@ -1,6 +1,6 @@
 use crate::codegen::generator::acc::Acc;
 use crate::codegen::generator::codec::sse::ty::delegate::{
-    generate_set_to_list, generate_stream_sink_setup_and_serialize,
+    generate_set_to_list, generate_stream_sink_setup_and_serialize, is_duration,
 };
 use crate::codegen::generator::misc::target::Target;
 use crate::codegen::generator::wire::dart::spec_generator::codec::cst::base::*;
@@ -83,18 +83,24 @@ impl WireDartCodecCstGeneratorEncoderTrait for DelegateWireDartCodecCstGenerator
                 MirTypeDelegateTime::Utc
                 | MirTypeDelegateTime::Local
                 | MirTypeDelegateTime::NaiveDate
-                | MirTypeDelegateTime::NaiveDateTime => Acc {
+                | MirTypeDelegateTime::NaiveDateTime
+                | MirTypeDelegateTime::StdSystemTime
+                | MirTypeDelegateTime::StdInstant
+                | MirTypeDelegateTime::TokioInstant => Acc {
                     io: Some("return cst_encode_i_64(raw.microsecondsSinceEpoch);".into()),
                     web: Some(
                         "return cst_encode_i_64(BigInt.from(raw.millisecondsSinceEpoch));".into(),
                     ),
                     ..Default::default()
                 },
-                MirTypeDelegateTime::Duration => Acc {
+                _ if is_duration(mir) => Acc {
                     io: Some("return cst_encode_i_64(raw.inMicroseconds);".into()),
                     web: Some("return cst_encode_i_64(BigInt.from(raw.inMilliseconds));".into()),
                     ..Default::default()
                 },
+                // frb-coverage:ignore-start
+                _ => unreachable!(),
+                // frb-coverage:ignore-end
             },
             // MirTypeDelegate::TimeList(t) => Acc::distribute(Some(format!(
             //     "final ans = Int64List(raw.length);

--- a/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/codec/cst/encoder/ty/delegate.rs
+++ b/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/codec/cst/encoder/ty/delegate.rs
@@ -1,6 +1,6 @@
 use crate::codegen::generator::acc::Acc;
 use crate::codegen::generator::codec::sse::ty::delegate::{
-    generate_set_to_list, generate_stream_sink_setup_and_serialize, is_duration,
+    generate_set_to_list, generate_stream_sink_setup_and_serialize,
 };
 use crate::codegen::generator::misc::target::Target;
 use crate::codegen::generator::wire::dart::spec_generator::codec::cst::base::*;
@@ -93,14 +93,11 @@ impl WireDartCodecCstGeneratorEncoderTrait for DelegateWireDartCodecCstGenerator
                     ),
                     ..Default::default()
                 },
-                _ if is_duration(mir) => Acc {
+                MirTypeDelegateTime::Duration | MirTypeDelegateTime::StdDuration => Acc {
                     io: Some("return cst_encode_i_64(raw.inMicroseconds);".into()),
                     web: Some("return cst_encode_i_64(BigInt.from(raw.inMilliseconds));".into()),
                     ..Default::default()
                 },
-                // frb-coverage:ignore-start
-                _ => unreachable!(),
-                // frb-coverage:ignore-end
             },
             // MirTypeDelegate::TimeList(t) => Acc::distribute(Some(format!(
             //     "final ans = Int64List(raw.length);

--- a/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/codec/dco/decoder/ty/delegate.rs
+++ b/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/codec/dco/decoder/ty/delegate.rs
@@ -2,10 +2,13 @@ use crate::codegen::generator::wire::dart::spec_generator::codec::dco::base::*;
 use crate::codegen::generator::wire::dart::spec_generator::codec::dco::decoder::misc::gen_decode_simple_type_cast;
 use crate::codegen::generator::wire::dart::spec_generator::codec::dco::decoder::ty::WireDartCodecDcoGeneratorDecoderTrait;
 use crate::codegen::ir::mir::ty::delegate::{
-    MirTypeDelegate, MirTypeDelegateArrayMode, MirTypeDelegatePrimitiveEnum, MirTypeDelegateTime,
+    MirTypeDelegate, MirTypeDelegateArrayMode, MirTypeDelegatePrimitiveEnum,
 };
 use crate::library::codegen::generator::api_dart::spec_generator::base::ApiDartGenerator;
 use crate::library::codegen::generator::api_dart::spec_generator::info::ApiDartGeneratorInfoTrait;
+use crate::library::codegen::generator::codec::sse::ty::delegate::{
+    is_dart_datetime_utc, is_duration,
+};
 use crate::library::codegen::ir::mir::ty::MirTypeTrait;
 
 impl WireDartCodecDcoGeneratorDecoderTrait for DelegateWireDartCodecDcoGenerator<'_> {
@@ -53,12 +56,12 @@ impl WireDartCodecDcoGeneratorDecoderTrait for DelegateWireDartCodecDcoGenerator
                 ) // here `as int` is neccessary in strict dynamic mode
             }
             MirTypeDelegate::Time(mir) => {
-                if mir == &MirTypeDelegateTime::Duration {
+                if is_duration(mir) {
                     "return dcoDecodeDuration(dco_decode_i_64(raw).toInt());".to_owned()
                 } else {
                     format!(
                         "return dcoDecodeTimestamp(ts: dco_decode_i_64(raw).toInt(), isUtc: {is_utc});",
-                        is_utc = matches!(mir, MirTypeDelegateTime::NaiveDateTime | MirTypeDelegateTime::NaiveDate | MirTypeDelegateTime::Utc)
+                        is_utc = is_dart_datetime_utc(mir)
                     )
                 }
             }

--- a/frb_codegen/src/library/codegen/generator/wire/rust/spec_generator/codec/cst/decoder/ty/delegate.rs
+++ b/frb_codegen/src/library/codegen/generator/wire/rust/spec_generator/codec/cst/decoder/ty/delegate.rs
@@ -1,7 +1,6 @@
 use crate::codegen::generator::acc::Acc;
 use crate::codegen::generator::codec::sse::ty::delegate::{
-    decode_std_duration, decode_std_instant, decode_std_system_time, decode_tokio_instant,
-    rust_decode_primitive_enum,
+    decode_std_duration, decode_std_system_time, rust_decode_primitive_enum,
 };
 use crate::codegen::generator::misc::is_js_value;
 use crate::codegen::generator::misc::target::{Target, TargetOrCommon};
@@ -68,8 +67,6 @@ impl WireRustCodecCstGeneratorDecoderTrait for DelegateWireRustCodecCstGenerator
                     MirTypeDelegateTime::Utc => codegen_utc,
                     MirTypeDelegateTime::Local => codegen_local,
                     MirTypeDelegateTime::StdSystemTime => decode_std_system_time("self"),
-                    MirTypeDelegateTime::StdInstant => decode_std_instant("self"),
-                    MirTypeDelegateTime::TokioInstant => decode_tokio_instant("self"),
                     // frb-coverage:ignore-start
                     MirTypeDelegateTime::Duration
                     | MirTypeDelegateTime::StdDuration => unreachable!(),
@@ -79,8 +76,6 @@ impl WireRustCodecCstGeneratorDecoderTrait for DelegateWireRustCodecCstGenerator
                     common: Some(if matches!(
                         mir,
                         MirTypeDelegateTime::StdSystemTime
-                            | MirTypeDelegateTime::StdInstant
-                            | MirTypeDelegateTime::TokioInstant
                     ) {
                         codegen_conversion
                     } else {
@@ -169,12 +164,6 @@ impl WireRustCodecCstGeneratorDecoderTrait for DelegateWireRustCodecCstGenerator
                 }
                 MirTypeDelegateTime::StdSystemTime => {
                     decode_js_value_millis_once_then(&decode_std_system_time)
-                }
-                MirTypeDelegateTime::StdInstant => {
-                    decode_js_value_millis_once_then(&decode_std_instant)
-                }
-                MirTypeDelegateTime::TokioInstant => {
-                    decode_js_value_millis_once_then(&decode_tokio_instant)
                 }
                 _ => "CstDecode::<i64>::cst_decode(self).cst_decode()".into(),
             },

--- a/frb_codegen/src/library/codegen/generator/wire/rust/spec_generator/codec/cst/decoder/ty/delegate.rs
+++ b/frb_codegen/src/library/codegen/generator/wire/rust/spec_generator/codec/cst/decoder/ty/delegate.rs
@@ -56,7 +56,8 @@ impl WireRustCodecCstGeneratorDecoderTrait for DelegateWireRustCodecCstGenerator
                 }
                 if mir == &MirTypeDelegateTime::StdSystemTime {
                     return Acc {
-                        common: Some(decode_std_system_time("self")),
+                        io: Some(decode_std_system_time("self")),
+                        web: None,
                         ..Default::default()
                     };
                 }

--- a/frb_codegen/src/library/codegen/generator/wire/rust/spec_generator/codec/cst/decoder/ty/delegate.rs
+++ b/frb_codegen/src/library/codegen/generator/wire/rust/spec_generator/codec/cst/decoder/ty/delegate.rs
@@ -165,16 +165,16 @@ impl WireRustCodecCstGeneratorDecoderTrait for DelegateWireRustCodecCstGenerator
             MirTypeDelegate::Time(mir) => match mir {
                 MirTypeDelegateTime::Duration => "chrono::Duration::milliseconds(CstDecode::<i64>::cst_decode(self))".into(),
                 MirTypeDelegateTime::StdDuration => {
-                    decode_js_value_once_then(&decode_std_duration)
+                    decode_js_value_millis_once_then(&decode_std_duration)
                 }
                 MirTypeDelegateTime::StdSystemTime => {
-                    decode_js_value_once_then(&decode_std_system_time)
+                    decode_js_value_millis_once_then(&decode_std_system_time)
                 }
                 MirTypeDelegateTime::StdInstant => {
-                    decode_js_value_once_then(&decode_std_instant)
+                    decode_js_value_millis_once_then(&decode_std_instant)
                 }
                 MirTypeDelegateTime::TokioInstant => {
-                    decode_js_value_once_then(&decode_tokio_instant)
+                    decode_js_value_millis_once_then(&decode_tokio_instant)
                 }
                 _ => "CstDecode::<i64>::cst_decode(self).cst_decode()".into(),
             },
@@ -243,11 +243,12 @@ impl DelegateWireRustCodecCstGenerator<'_> {
     }
 }
 
-fn decode_js_value_once_then(
+fn decode_js_value_millis_once_then(
     generate_conversion: &dyn Fn(&str) -> String,
 ) -> std::borrow::Cow<'static, str> {
     format!(
-        "let inner = CstDecode::<i64>::cst_decode(self);
+        "let millis = CstDecode::<i64>::cst_decode(self);
+        let inner = millis.checked_mul(1000).expect(\"timestamp out of range\");
         {}",
         generate_conversion("inner")
     )

--- a/frb_codegen/src/library/codegen/generator/wire/rust/spec_generator/codec/cst/decoder/ty/delegate.rs
+++ b/frb_codegen/src/library/codegen/generator/wire/rust/spec_generator/codec/cst/decoder/ty/delegate.rs
@@ -170,16 +170,16 @@ impl WireRustCodecCstGeneratorDecoderTrait for DelegateWireRustCodecCstGenerator
             MirTypeDelegate::Time(mir) => match mir {
                 MirTypeDelegateTime::Duration => "chrono::Duration::milliseconds(CstDecode::<i64>::cst_decode(self))".into(),
                 MirTypeDelegateTime::StdDuration => {
-                    decode_std_duration("CstDecode::<i64>::cst_decode(self)").into()
+                    decode_js_value_once_then(&decode_std_duration)
                 }
                 MirTypeDelegateTime::StdSystemTime => {
-                    decode_std_system_time("CstDecode::<i64>::cst_decode(self)").into()
+                    decode_js_value_once_then(&decode_std_system_time)
                 }
                 MirTypeDelegateTime::StdInstant => {
-                    decode_std_instant("CstDecode::<i64>::cst_decode(self)").into()
+                    decode_js_value_once_then(&decode_std_instant)
                 }
                 MirTypeDelegateTime::TokioInstant => {
-                    decode_tokio_instant("CstDecode::<i64>::cst_decode(self)").into()
+                    decode_js_value_once_then(&decode_tokio_instant)
                 }
                 _ => "CstDecode::<i64>::cst_decode(self).cst_decode()".into(),
             },
@@ -246,6 +246,17 @@ impl DelegateWireRustCodecCstGenerator<'_> {
             Acc::distribute(Some(acc))
         }
     }
+}
+
+fn decode_js_value_once_then(
+    generate_conversion: &dyn Fn(&str) -> String,
+) -> std::borrow::Cow<'static, str> {
+    format!(
+        "let inner = CstDecode::<i64>::cst_decode(self);
+        {}",
+        generate_conversion("inner")
+    )
+    .into()
 }
 
 fn generate_decode_array(array: &MirTypeDelegateArray) -> String {

--- a/frb_codegen/src/library/codegen/generator/wire/rust/spec_generator/codec/cst/decoder/ty/delegate.rs
+++ b/frb_codegen/src/library/codegen/generator/wire/rust/spec_generator/codec/cst/decoder/ty/delegate.rs
@@ -1,7 +1,7 @@
 use crate::codegen::generator::acc::Acc;
 use crate::codegen::generator::codec::sse::ty::delegate::{
     decode_std_duration, decode_std_instant, decode_std_system_time, decode_tokio_instant,
-    is_duration, rust_decode_primitive_enum,
+    rust_decode_primitive_enum,
 };
 use crate::codegen::generator::misc::is_js_value;
 use crate::codegen::generator::misc::target::{Target, TargetOrCommon};
@@ -48,14 +48,9 @@ impl WireRustCodecCstGeneratorDecoderTrait for DelegateWireRustCodecCstGenerator
                         ..Default::default()
                     };
                 }
-                if is_duration(mir) {
+                if mir == &MirTypeDelegateTime::StdDuration {
                     return Acc {
-                        io: Some(match mir {
-                            MirTypeDelegateTime::StdDuration => decode_std_duration("self"),
-                            // frb-coverage:ignore-start
-                            _ => unreachable!(),
-                            // frb-coverage:ignore-end
-                        }),
+                        io: Some(decode_std_duration("self")),
                         web: None,
                         ..Default::default()
                     };

--- a/frb_codegen/src/library/codegen/generator/wire/rust/spec_generator/codec/cst/decoder/ty/delegate.rs
+++ b/frb_codegen/src/library/codegen/generator/wire/rust/spec_generator/codec/cst/decoder/ty/delegate.rs
@@ -54,6 +54,12 @@ impl WireRustCodecCstGeneratorDecoderTrait for DelegateWireRustCodecCstGenerator
                         ..Default::default()
                     };
                 }
+                if mir == &MirTypeDelegateTime::StdSystemTime {
+                    return Acc {
+                        common: Some(decode_std_system_time("self")),
+                        ..Default::default()
+                    };
+                }
                 let codegen_timestamp = "let flutter_rust_bridge::for_generated::Timestamp { s, ns } = flutter_rust_bridge::for_generated::decode_timestamp(self);";
                 let codegen_naive_date_time =
                     "chrono::DateTime::from_timestamp(s, ns).expect(\"invalid or out-of-range datetime\").naive_utc()";
@@ -66,21 +72,14 @@ impl WireRustCodecCstGeneratorDecoderTrait for DelegateWireRustCodecCstGenerator
                     MirTypeDelegateTime::NaiveDateTime => codegen_naive_date_time.to_owned(),
                     MirTypeDelegateTime::Utc => codegen_utc,
                     MirTypeDelegateTime::Local => codegen_local,
-                    MirTypeDelegateTime::StdSystemTime => decode_std_system_time("self"),
                     // frb-coverage:ignore-start
                     MirTypeDelegateTime::Duration
-                    | MirTypeDelegateTime::StdDuration => unreachable!(),
+                    | MirTypeDelegateTime::StdDuration
+                    | MirTypeDelegateTime::StdSystemTime => unreachable!(),
                     // frb-coverage:ignore-end
                 };
                 Acc {
-                    common: Some(if matches!(
-                        mir,
-                        MirTypeDelegateTime::StdSystemTime
-                    ) {
-                        codegen_conversion
-                    } else {
-                        format!("{codegen_timestamp}{codegen_conversion}")
-                    }),
+                    common: Some(format!("{codegen_timestamp}{codegen_conversion}")),
                     ..Default::default()
                 }
             },

--- a/frb_codegen/src/library/codegen/generator/wire/rust/spec_generator/codec/cst/decoder/ty/delegate.rs
+++ b/frb_codegen/src/library/codegen/generator/wire/rust/spec_generator/codec/cst/decoder/ty/delegate.rs
@@ -1,5 +1,8 @@
 use crate::codegen::generator::acc::Acc;
-use crate::codegen::generator::codec::sse::ty::delegate::rust_decode_primitive_enum;
+use crate::codegen::generator::codec::sse::ty::delegate::{
+    decode_std_duration, decode_std_instant, decode_std_system_time, decode_tokio_instant,
+    is_duration, rust_decode_primitive_enum,
+};
 use crate::codegen::generator::misc::is_js_value;
 use crate::codegen::generator::misc::target::{Target, TargetOrCommon};
 use crate::codegen::generator::wire::rust::spec_generator::codec::cst::base::*;
@@ -45,6 +48,18 @@ impl WireRustCodecCstGeneratorDecoderTrait for DelegateWireRustCodecCstGenerator
                         ..Default::default()
                     };
                 }
+                if is_duration(mir) {
+                    return Acc {
+                        io: Some(match mir {
+                            MirTypeDelegateTime::StdDuration => decode_std_duration("self"),
+                            // frb-coverage:ignore-start
+                            _ => unreachable!(),
+                            // frb-coverage:ignore-end
+                        }),
+                        web: None,
+                        ..Default::default()
+                    };
+                }
                 let codegen_timestamp = "let flutter_rust_bridge::for_generated::Timestamp { s, ns } = flutter_rust_bridge::for_generated::decode_timestamp(self);";
                 let codegen_naive_date_time =
                     "chrono::DateTime::from_timestamp(s, ns).expect(\"invalid or out-of-range datetime\").naive_utc()";
@@ -53,16 +68,29 @@ impl WireRustCodecCstGeneratorDecoderTrait for DelegateWireRustCodecCstGenerator
                 let codegen_utc = format!("chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset({codegen_naive_date_time}, chrono::Utc)");
                 let codegen_local = format!("chrono::DateTime::<chrono::Local>::from({codegen_utc})");
                 let codegen_conversion = match mir {
-                    MirTypeDelegateTime::NaiveDate => codegen_naive_date.as_str(),
-                    MirTypeDelegateTime::NaiveDateTime => codegen_naive_date_time,
-                    MirTypeDelegateTime::Utc => codegen_utc.as_str(),
-                    MirTypeDelegateTime::Local => codegen_local.as_str(),
+                    MirTypeDelegateTime::NaiveDate => codegen_naive_date,
+                    MirTypeDelegateTime::NaiveDateTime => codegen_naive_date_time.to_owned(),
+                    MirTypeDelegateTime::Utc => codegen_utc,
+                    MirTypeDelegateTime::Local => codegen_local,
+                    MirTypeDelegateTime::StdSystemTime => decode_std_system_time("self"),
+                    MirTypeDelegateTime::StdInstant => decode_std_instant("self"),
+                    MirTypeDelegateTime::TokioInstant => decode_tokio_instant("self"),
                     // frb-coverage:ignore-start
-                    MirTypeDelegateTime::Duration => unreachable!(),
+                    MirTypeDelegateTime::Duration
+                    | MirTypeDelegateTime::StdDuration => unreachable!(),
                     // frb-coverage:ignore-end
                 };
                 Acc {
-                    common: Some(format!("{codegen_timestamp}{codegen_conversion}")),
+                    common: Some(if matches!(
+                        mir,
+                        MirTypeDelegateTime::StdSystemTime
+                            | MirTypeDelegateTime::StdInstant
+                            | MirTypeDelegateTime::TokioInstant
+                    ) {
+                        codegen_conversion
+                    } else {
+                        format!("{codegen_timestamp}{codegen_conversion}")
+                    }),
                     ..Default::default()
                 }
             },
@@ -141,6 +169,18 @@ impl WireRustCodecCstGeneratorDecoderTrait for DelegateWireRustCodecCstGenerator
             // }
             MirTypeDelegate::Time(mir) => match mir {
                 MirTypeDelegateTime::Duration => "chrono::Duration::milliseconds(CstDecode::<i64>::cst_decode(self))".into(),
+                MirTypeDelegateTime::StdDuration => {
+                    decode_std_duration("CstDecode::<i64>::cst_decode(self)").into()
+                }
+                MirTypeDelegateTime::StdSystemTime => {
+                    decode_std_system_time("CstDecode::<i64>::cst_decode(self)").into()
+                }
+                MirTypeDelegateTime::StdInstant => {
+                    decode_std_instant("CstDecode::<i64>::cst_decode(self)").into()
+                }
+                MirTypeDelegateTime::TokioInstant => {
+                    decode_tokio_instant("CstDecode::<i64>::cst_decode(self)").into()
+                }
                 _ => "CstDecode::<i64>::cst_decode(self).cst_decode()".into(),
             },
             // MirTypeDelegate::TimeList(_) =>

--- a/frb_codegen/src/library/codegen/generator/wire/rust/spec_generator/codec/dco/encoder/ty/delegate.rs
+++ b/frb_codegen/src/library/codegen/generator/wire/rust/spec_generator/codec/dco/encoder/ty/delegate.rs
@@ -66,17 +66,9 @@ impl WireRustCodecDcoGeneratorEncoderTrait for DelegateWireRustCodecDcoGenerator
                     "std::time::SystemTime",
                     &encode_std_system_time_for_dco("self.0"),
                 )),
-                MirTypeDelegateTime::StdInstant => Some(generate_impl_into_dart_for_time(
-                    "std::time::Instant",
-                    &encode_std_instant_for_dco("self.0"),
-                )),
                 MirTypeDelegateTime::StdDuration => Some(generate_impl_into_dart_for_time(
                     "std::time::Duration",
                     &encode_std_duration_for_dco("self.0"),
-                )),
-                MirTypeDelegateTime::TokioInstant => Some(generate_impl_into_dart_for_time(
-                    "tokio::time::Instant",
-                    &encode_tokio_instant_for_dco("self.0"),
                 )),
                 _ => None,
             },
@@ -131,25 +123,4 @@ fn encode_std_system_time_for_dco(value: &str) -> String {
         }}"#,
         micros = encode_std_system_time(value)
     )
-}
-
-fn encode_std_instant_for_dco(value: &str) -> String {
-    format!(
-        r#"{{
-            let value = {value}.clone();
-            let now_instant = std::time::Instant::now();
-            let now_system_time = std::time::SystemTime::now();
-            let system_time = if value >= now_instant {{
-                now_system_time.checked_add(value.duration_since(now_instant)).expect("instant out of range")
-            }} else {{
-                now_system_time.checked_sub(now_instant.duration_since(value)).expect("instant out of range")
-            }};
-            {system_time}
-        }}"#,
-        system_time = encode_std_system_time_for_dco("system_time")
-    )
-}
-
-fn encode_tokio_instant_for_dco(value: &str) -> String {
-    encode_std_instant_for_dco(&format!("{value}.into_std()"))
 }

--- a/frb_codegen/src/library/codegen/generator/wire/rust/spec_generator/codec/dco/encoder/ty/delegate.rs
+++ b/frb_codegen/src/library/codegen/generator/wire/rust/spec_generator/codec/dco/encoder/ty/delegate.rs
@@ -1,3 +1,6 @@
+use crate::codegen::generator::codec::sse::ty::delegate::{
+    encode_std_duration, encode_std_instant, encode_std_system_time, encode_tokio_instant,
+};
 use crate::codegen::generator::wire::rust::spec_generator::codec::dco::base::*;
 use crate::codegen::generator::wire::rust::spec_generator::codec::dco::encoder::misc::{
     generate_impl_into_dart, generate_impl_into_into_dart,
@@ -6,7 +9,9 @@ use crate::codegen::generator::wire::rust::spec_generator::codec::dco::encoder::
     generate_enum_access_object_core, parse_wrapper_name_into_dart_name_and_self_path,
 };
 use crate::codegen::generator::wire::rust::spec_generator::codec::dco::encoder::ty::WireRustCodecDcoGeneratorEncoderTrait;
-use crate::codegen::ir::mir::ty::delegate::{MirTypeDelegate, MirTypeDelegatePrimitiveEnum};
+use crate::codegen::ir::mir::ty::delegate::{
+    MirTypeDelegate, MirTypeDelegatePrimitiveEnum, MirTypeDelegateTime,
+};
 use itertools::Itertools;
 
 impl WireRustCodecDcoGeneratorEncoderTrait for DelegateWireRustCodecDcoGenerator<'_> {
@@ -56,7 +61,36 @@ impl WireRustCodecDcoGeneratorEncoderTrait for DelegateWireRustCodecDcoGenerator
                         + &generate_impl_into_into_dart(&name, &Some(wrapper_name.clone())),
                 )
             }
+            MirTypeDelegate::Time(mir) => match mir {
+                MirTypeDelegateTime::StdSystemTime => Some(generate_impl_into_dart_for_time(
+                    "std::time::SystemTime",
+                    &encode_std_system_time("self.0"),
+                )),
+                MirTypeDelegateTime::StdInstant => Some(generate_impl_into_dart_for_time(
+                    "std::time::Instant",
+                    &encode_std_instant("self.0"),
+                )),
+                MirTypeDelegateTime::StdDuration => Some(generate_impl_into_dart_for_time(
+                    "std::time::Duration",
+                    &encode_std_duration("self.0"),
+                )),
+                MirTypeDelegateTime::TokioInstant => Some(generate_impl_into_dart_for_time(
+                    "tokio::time::Instant",
+                    &encode_tokio_instant("self.0"),
+                )),
+                _ => None,
+            },
             _ => None,
         }
     }
+}
+
+fn generate_impl_into_dart_for_time(name: &str, body: &str) -> String {
+    let wrapper_name = format!("FrbWrapper<{name}>");
+    let body = format!(
+        "let value: i64 = {body};
+        value.into_dart()"
+    );
+    generate_impl_into_dart(&wrapper_name, &body)
+        + &generate_impl_into_into_dart(name, &Some(wrapper_name))
 }

--- a/frb_codegen/src/library/codegen/generator/wire/rust/spec_generator/codec/dco/encoder/ty/delegate.rs
+++ b/frb_codegen/src/library/codegen/generator/wire/rust/spec_generator/codec/dco/encoder/ty/delegate.rs
@@ -1,5 +1,5 @@
 use crate::codegen::generator::codec::sse::ty::delegate::{
-    encode_std_duration, encode_std_instant, encode_std_system_time, encode_tokio_instant,
+    encode_std_duration, encode_std_system_time,
 };
 use crate::codegen::generator::wire::rust::spec_generator::codec::dco::base::*;
 use crate::codegen::generator::wire::rust::spec_generator::codec::dco::encoder::misc::{
@@ -64,19 +64,19 @@ impl WireRustCodecDcoGeneratorEncoderTrait for DelegateWireRustCodecDcoGenerator
             MirTypeDelegate::Time(mir) => match mir {
                 MirTypeDelegateTime::StdSystemTime => Some(generate_impl_into_dart_for_time(
                     "std::time::SystemTime",
-                    &encode_std_system_time("self.0"),
+                    &encode_std_system_time_for_dco("self.0"),
                 )),
                 MirTypeDelegateTime::StdInstant => Some(generate_impl_into_dart_for_time(
                     "std::time::Instant",
-                    &encode_std_instant("self.0"),
+                    &encode_std_instant_for_dco("self.0"),
                 )),
                 MirTypeDelegateTime::StdDuration => Some(generate_impl_into_dart_for_time(
                     "std::time::Duration",
-                    &encode_std_duration("self.0"),
+                    &encode_std_duration_for_dco("self.0"),
                 )),
                 MirTypeDelegateTime::TokioInstant => Some(generate_impl_into_dart_for_time(
                     "tokio::time::Instant",
-                    &encode_tokio_instant("self.0"),
+                    &encode_tokio_instant_for_dco("self.0"),
                 )),
                 _ => None,
             },
@@ -93,4 +93,63 @@ fn generate_impl_into_dart_for_time(name: &str, body: &str) -> String {
     );
     generate_impl_into_dart(&wrapper_name, &body)
         + &generate_impl_into_into_dart(name, &Some(wrapper_name))
+}
+
+fn encode_std_duration_for_dco(value: &str) -> String {
+    format!(
+        r#"{{
+            #[cfg(target_arch = "wasm32")]
+            {{
+                {value}.as_millis().try_into().expect("cannot get milliseconds from time")
+            }}
+            #[cfg(not(target_arch = "wasm32"))]
+            {{
+                {micros}
+            }}
+        }}"#,
+        micros = encode_std_duration(value)
+    )
+}
+
+fn encode_std_system_time_for_dco(value: &str) -> String {
+    format!(
+        r#"{{
+            #[cfg(target_arch = "wasm32")]
+            {{
+                match {value}.duration_since(std::time::SystemTime::UNIX_EPOCH) {{
+                    Ok(duration) => duration.as_millis().try_into().expect("cannot get milliseconds from time"),
+                    Err(error) => {{
+                        let millis = i128::try_from(error.duration().as_millis()).expect("cannot get milliseconds from time");
+                        i64::try_from(-millis).expect("cannot get milliseconds from time")
+                    }},
+                }}
+            }}
+            #[cfg(not(target_arch = "wasm32"))]
+            {{
+                {micros}
+            }}
+        }}"#,
+        micros = encode_std_system_time(value)
+    )
+}
+
+fn encode_std_instant_for_dco(value: &str) -> String {
+    format!(
+        r#"{{
+            let value = {value}.clone();
+            let now_instant = std::time::Instant::now();
+            let now_system_time = std::time::SystemTime::now();
+            let system_time = if value >= now_instant {{
+                now_system_time.checked_add(value.duration_since(now_instant)).expect("instant out of range")
+            }} else {{
+                now_system_time.checked_sub(now_instant.duration_since(value)).expect("instant out of range")
+            }};
+            {system_time}
+        }}"#,
+        system_time = encode_std_system_time_for_dco("system_time")
+    )
+}
+
+fn encode_tokio_instant_for_dco(value: &str) -> String {
+    encode_std_instant_for_dco(&format!("{value}.into_std()"))
 }

--- a/frb_codegen/src/library/codegen/ir/mir/ty/delegate.rs
+++ b/frb_codegen/src/library/codegen/ir/mir/ty/delegate.rs
@@ -66,9 +66,7 @@ pub enum MirTypeDelegateTime {
     NaiveDateTime,
     Duration,
     StdSystemTime,
-    StdInstant,
     StdDuration,
-    TokioInstant,
 }
 
 pub struct MirTypeDelegateMap {
@@ -185,10 +183,9 @@ impl MirTypeTrait for MirTypeDelegate {
                 | MirTypeDelegateTime::NaiveDate
                 | MirTypeDelegateTime::NaiveDateTime
                 | MirTypeDelegateTime::Duration => format!("Chrono_{mir}"),
-                MirTypeDelegateTime::StdSystemTime
-                | MirTypeDelegateTime::StdInstant
-                | MirTypeDelegateTime::StdDuration => format!("StdTime_{mir}"),
-                MirTypeDelegateTime::TokioInstant => format!("TokioTime_{mir}"),
+                MirTypeDelegateTime::StdSystemTime | MirTypeDelegateTime::StdDuration => {
+                    format!("StdTime_{mir}")
+                }
             },
             // MirTypeDelegate::TimeList(mir) => format!("Chrono_{}List", mir),
             MirTypeDelegate::Uuid => "Uuid".to_owned(),
@@ -271,9 +268,7 @@ impl MirTypeTrait for MirTypeDelegate {
                 MirTypeDelegateTime::Utc => "chrono::DateTime::<chrono::Utc>",
                 MirTypeDelegateTime::Duration => "chrono::Duration",
                 MirTypeDelegateTime::StdSystemTime => "std::time::SystemTime",
-                MirTypeDelegateTime::StdInstant => "std::time::Instant",
                 MirTypeDelegateTime::StdDuration => "std::time::Duration",
-                MirTypeDelegateTime::TokioInstant => "tokio::time::Instant",
             }
             .to_owned(),
             // MirTypeDelegate::TimeList(mir) => match mir {

--- a/frb_codegen/src/library/codegen/ir/mir/ty/delegate.rs
+++ b/frb_codegen/src/library/codegen/ir/mir/ty/delegate.rs
@@ -65,6 +65,10 @@ pub enum MirTypeDelegateTime {
     NaiveDate,
     NaiveDateTime,
     Duration,
+    StdSystemTime,
+    StdInstant,
+    StdDuration,
+    TokioInstant,
 }
 
 pub struct MirTypeDelegateMap {
@@ -175,7 +179,17 @@ impl MirTypeTrait for MirTypeDelegate {
             //     "ZeroCopyBuffer_".to_owned() + &self.get_delegate().safe_ident()
             // }
             MirTypeDelegate::PrimitiveEnum(mir) => mir.mir.safe_ident(),
-            MirTypeDelegate::Time(mir) => format!("Chrono_{mir}"),
+            MirTypeDelegate::Time(mir) => match mir {
+                MirTypeDelegateTime::Local
+                | MirTypeDelegateTime::Utc
+                | MirTypeDelegateTime::NaiveDate
+                | MirTypeDelegateTime::NaiveDateTime
+                | MirTypeDelegateTime::Duration => format!("Chrono_{mir}"),
+                MirTypeDelegateTime::StdSystemTime
+                | MirTypeDelegateTime::StdInstant
+                | MirTypeDelegateTime::StdDuration => format!("StdTime_{mir}"),
+                MirTypeDelegateTime::TokioInstant => format!("TokioTime_{mir}"),
+            },
             // MirTypeDelegate::TimeList(mir) => format!("Chrono_{}List", mir),
             MirTypeDelegate::Uuid => "Uuid".to_owned(),
             // MirTypeDelegate::Uuids => "Uuids".to_owned(),
@@ -256,6 +270,10 @@ impl MirTypeTrait for MirTypeDelegate {
                 MirTypeDelegateTime::Local => "chrono::DateTime::<chrono::Local>",
                 MirTypeDelegateTime::Utc => "chrono::DateTime::<chrono::Utc>",
                 MirTypeDelegateTime::Duration => "chrono::Duration",
+                MirTypeDelegateTime::StdSystemTime => "std::time::SystemTime",
+                MirTypeDelegateTime::StdInstant => "std::time::Instant",
+                MirTypeDelegateTime::StdDuration => "std::time::Duration",
+                MirTypeDelegateTime::TokioInstant => "tokio::time::Instant",
             }
             .to_owned(),
             // MirTypeDelegate::TimeList(mir) => match mir {

--- a/frb_codegen/src/library/codegen/parser/mir/parser/ty/concrete.rs
+++ b/frb_codegen/src/library/codegen/parser/mir/parser/ty/concrete.rs
@@ -38,9 +38,7 @@ impl TypeParserWithContext<'_, '_, '_> {
             ("NaiveDateTime", []) if check_prefix("chrono") => Delegate(MirTypeDelegate::Time(MirTypeDelegateTime::NaiveDateTime)),
             ("DateTime", args) if check_prefix("chrono") => self.parse_datetime(args)?,
             ("SystemTime", []) if check_prefix("std::time") => Delegate(MirTypeDelegate::Time(MirTypeDelegateTime::StdSystemTime)),
-            ("Instant", []) if check_prefix("std::time") => Delegate(MirTypeDelegate::Time(MirTypeDelegateTime::StdInstant)),
             ("Duration", []) if check_prefix("std::time") => Delegate(MirTypeDelegate::Time(MirTypeDelegateTime::StdDuration)),
-            ("Instant", []) if check_prefix("tokio::time") => Delegate(MirTypeDelegate::Time(MirTypeDelegateTime::TokioInstant)),
             ("Duration", []) if check_prefix("tokio::time") => Delegate(MirTypeDelegate::Time(MirTypeDelegateTime::StdDuration)),
 
             ("Uuid", []) if check_prefix("uuid") => Delegate(MirTypeDelegate::Uuid),

--- a/frb_codegen/src/library/codegen/parser/mir/parser/ty/concrete.rs
+++ b/frb_codegen/src/library/codegen/parser/mir/parser/ty/concrete.rs
@@ -37,6 +37,11 @@ impl TypeParserWithContext<'_, '_, '_> {
             ("NaiveDate", []) if check_prefix("chrono") => Delegate(MirTypeDelegate::Time(MirTypeDelegateTime::NaiveDate)),
             ("NaiveDateTime", []) if check_prefix("chrono") => Delegate(MirTypeDelegate::Time(MirTypeDelegateTime::NaiveDateTime)),
             ("DateTime", args) if check_prefix("chrono") => self.parse_datetime(args)?,
+            ("SystemTime", []) if check_prefix("std::time") => Delegate(MirTypeDelegate::Time(MirTypeDelegateTime::StdSystemTime)),
+            ("Instant", []) if check_prefix("std::time") => Delegate(MirTypeDelegate::Time(MirTypeDelegateTime::StdInstant)),
+            ("Duration", []) if check_prefix("std::time") => Delegate(MirTypeDelegate::Time(MirTypeDelegateTime::StdDuration)),
+            ("Instant", []) if check_prefix("tokio::time") => Delegate(MirTypeDelegate::Time(MirTypeDelegateTime::TokioInstant)),
+            ("Duration", []) if check_prefix("tokio::time") => Delegate(MirTypeDelegate::Time(MirTypeDelegateTime::StdDuration)),
 
             ("Uuid", []) if check_prefix("uuid") => Delegate(MirTypeDelegate::Uuid),
             ("Value", []) if check_prefix("serde_json") => Delegate(MirTypeDelegate::SerdeJsonValue),

--- a/frb_codegen/test_fixtures/library/codegen/parser/mod/qualified_names/expect_hir_flat.json
+++ b/frb_codegen/test_fixtures/library/codegen/parser/mod/qualified_names/expect_hir_flat.json
@@ -43,6 +43,14 @@
       "sources": [
         "Normal"
       ]
+    },
+    {
+      "item_fn": "GeneralizedItemFn(name=func_std_time, vis=Some(Visibility::Public(Pub)), attrs=[])",
+      "namespace": "crate::api",
+      "owner": "Function",
+      "sources": [
+        "Normal"
+      ]
     }
   ],
   "skips": [],

--- a/frb_codegen/test_fixtures/library/codegen/parser/mod/qualified_names/expect_mir.json
+++ b/frb_codegen/test_fixtures/library/codegen/parser/mod/qualified_names/expect_mir.json
@@ -268,31 +268,6 @@
           },
           "needs_extend_lifetime": false,
           "ownership_mode": "Owned"
-        },
-        {
-          "inner": {
-            "comments": [],
-            "default": null,
-            "is_final": true,
-            "is_rust_public": null,
-            "name": {
-              "dart_style": null,
-              "rust_style": "instant"
-            },
-            "settings": {
-              "is_in_mirrored_enum": false,
-              "skip_auto_accessors": false
-            },
-            "ty": {
-              "data": {
-                "Time": "StdInstant"
-              },
-              "safe_ident": "StdTime_StdInstant",
-              "type": "Delegate"
-            }
-          },
-          "needs_extend_lifetime": false,
-          "ownership_mode": "Owned"
         }
       ],
       "mode": "Normal",

--- a/frb_codegen/test_fixtures/library/codegen/parser/mod/qualified_names/expect_mir.json
+++ b/frb_codegen/test_fixtures/library/codegen/parser/mod/qualified_names/expect_mir.json
@@ -205,6 +205,115 @@
       "rust_async": false,
       "rust_call_code": null,
       "stream_dart_await": false
+    },
+    {
+      "accessor": null,
+      "arg_mode": "Named",
+      "codec_mode_pack": {
+        "dart2rust": "Cst",
+        "rust2dart": "Dco"
+      },
+      "comments": [],
+      "id": 5,
+      "impl_mode": "Normal",
+      "init_dart_code": null,
+      "initializer": false,
+      "inputs": [
+        {
+          "inner": {
+            "comments": [],
+            "default": null,
+            "is_final": true,
+            "is_rust_public": null,
+            "name": {
+              "dart_style": null,
+              "rust_style": "duration"
+            },
+            "settings": {
+              "is_in_mirrored_enum": false,
+              "skip_auto_accessors": false
+            },
+            "ty": {
+              "data": {
+                "Time": "StdDuration"
+              },
+              "safe_ident": "StdTime_StdDuration",
+              "type": "Delegate"
+            }
+          },
+          "needs_extend_lifetime": false,
+          "ownership_mode": "Owned"
+        },
+        {
+          "inner": {
+            "comments": [],
+            "default": null,
+            "is_final": true,
+            "is_rust_public": null,
+            "name": {
+              "dart_style": null,
+              "rust_style": "system_time"
+            },
+            "settings": {
+              "is_in_mirrored_enum": false,
+              "skip_auto_accessors": false
+            },
+            "ty": {
+              "data": {
+                "Time": "StdSystemTime"
+              },
+              "safe_ident": "StdTime_StdSystemTime",
+              "type": "Delegate"
+            }
+          },
+          "needs_extend_lifetime": false,
+          "ownership_mode": "Owned"
+        },
+        {
+          "inner": {
+            "comments": [],
+            "default": null,
+            "is_final": true,
+            "is_rust_public": null,
+            "name": {
+              "dart_style": null,
+              "rust_style": "instant"
+            },
+            "settings": {
+              "is_in_mirrored_enum": false,
+              "skip_auto_accessors": false
+            },
+            "ty": {
+              "data": {
+                "Time": "StdInstant"
+              },
+              "safe_ident": "StdTime_StdInstant",
+              "type": "Delegate"
+            }
+          },
+          "needs_extend_lifetime": false,
+          "ownership_mode": "Owned"
+        }
+      ],
+      "mode": "Normal",
+      "name": {
+        "dart_style": null,
+        "rust_style": "func_std_time"
+      },
+      "namespace": "crate::api",
+      "output": {
+        "error": null,
+        "normal": {
+          "data": "Unit",
+          "safe_ident": "unit",
+          "type": "Primitive"
+        }
+      },
+      "owner": "Function",
+      "rust_aop_after": null,
+      "rust_async": false,
+      "rust_call_code": null,
+      "stream_dart_await": false
     }
   ],
   "skips": [],

--- a/frb_codegen/test_fixtures/library/codegen/parser/mod/qualified_names/src/api.rs
+++ b/frb_codegen/test_fixtures/library/codegen/parser/mod/qualified_names/src/api.rs
@@ -1,5 +1,12 @@
 pub fn func_1(chrono_duration: chrono::Duration, uuid_uuid: uuid::Uuid) {}
 
+pub fn func_std_time(
+    duration: std::time::Duration,
+    system_time: std::time::SystemTime,
+    instant: std::time::Instant,
+) {
+}
+
 pub fn func_result() -> Result<i32, String> {
     panic!()
 }

--- a/frb_codegen/test_fixtures/library/codegen/parser/mod/qualified_names/src/api.rs
+++ b/frb_codegen/test_fixtures/library/codegen/parser/mod/qualified_names/src/api.rs
@@ -3,7 +3,6 @@ pub fn func_1(chrono_duration: chrono::Duration, uuid_uuid: uuid::Uuid) {}
 pub fn func_std_time(
     duration: std::time::Duration,
     system_time: std::time::SystemTime,
-    instant: std::time::Instant,
 ) {
 }
 

--- a/frb_example/pure_dart/frb_generated.h
+++ b/frb_example/pure_dart/frb_generated.h
@@ -13326,6 +13326,72 @@ WireSyncRust2DartSse frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manua
 
 WireSyncRust2DartDco frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__method_twin_sync__static_only_twin_sync_static_method_twin_sync(int32_t a);
 
+void frbgen_frb_example_pure_dart_wire__crate__api__chrono_type__std_time_duration_twin_normal(int64_t port_,
+                                                                                               int64_t d);
+
+void frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_duration_twin_rust_async(int64_t port_,
+                                                                                                                                  int64_t d);
+
+void frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__std_time_duration_twin_rust_async_sse(int64_t port_,
+                                                                                                                                          uint8_t *ptr_,
+                                                                                                                                          int32_t rust_vec_len_,
+                                                                                                                                          int32_t data_len_);
+
+void frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__std_time_duration_twin_sse(int64_t port_,
+                                                                                                                    uint8_t *ptr_,
+                                                                                                                    int32_t rust_vec_len_,
+                                                                                                                    int32_t data_len_);
+
+WireSyncRust2DartDco frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_duration_twin_sync(int64_t d);
+
+WireSyncRust2DartSse frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__std_time_duration_twin_sync_sse(uint8_t *ptr_,
+                                                                                                                                              int32_t rust_vec_len_,
+                                                                                                                                              int32_t data_len_);
+
+void frbgen_frb_example_pure_dart_wire__crate__api__chrono_type__std_time_instant_twin_normal(int64_t port_,
+                                                                                              int64_t d);
+
+void frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_instant_twin_rust_async(int64_t port_,
+                                                                                                                                 int64_t d);
+
+void frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__std_time_instant_twin_rust_async_sse(int64_t port_,
+                                                                                                                                         uint8_t *ptr_,
+                                                                                                                                         int32_t rust_vec_len_,
+                                                                                                                                         int32_t data_len_);
+
+void frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__std_time_instant_twin_sse(int64_t port_,
+                                                                                                                   uint8_t *ptr_,
+                                                                                                                   int32_t rust_vec_len_,
+                                                                                                                   int32_t data_len_);
+
+WireSyncRust2DartDco frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_instant_twin_sync(int64_t d);
+
+WireSyncRust2DartSse frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__std_time_instant_twin_sync_sse(uint8_t *ptr_,
+                                                                                                                                             int32_t rust_vec_len_,
+                                                                                                                                             int32_t data_len_);
+
+void frbgen_frb_example_pure_dart_wire__crate__api__chrono_type__std_time_system_time_twin_normal(int64_t port_,
+                                                                                                  int64_t d);
+
+void frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_system_time_twin_rust_async(int64_t port_,
+                                                                                                                                     int64_t d);
+
+void frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__std_time_system_time_twin_rust_async_sse(int64_t port_,
+                                                                                                                                             uint8_t *ptr_,
+                                                                                                                                             int32_t rust_vec_len_,
+                                                                                                                                             int32_t data_len_);
+
+void frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__std_time_system_time_twin_sse(int64_t port_,
+                                                                                                                       uint8_t *ptr_,
+                                                                                                                       int32_t rust_vec_len_,
+                                                                                                                       int32_t data_len_);
+
+WireSyncRust2DartDco frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_system_time_twin_sync(int64_t d);
+
+WireSyncRust2DartSse frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__std_time_system_time_twin_sync_sse(uint8_t *ptr_,
+                                                                                                                                                 int32_t rust_vec_len_,
+                                                                                                                                                 int32_t data_len_);
+
 void frbgen_frb_example_pure_dart_wire__crate__api__stream_misc__stream_sink_dart_async_twin_normal(int64_t port_,
                                                                                                     struct wire_cst_list_prim_u_8_strict *sink);
 
@@ -13924,6 +13990,50 @@ WireSyncRust2DartDco frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manua
 WireSyncRust2DartSse frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__exception_twin_sync_sse__throw_anyhow_twin_sync_sse(uint8_t *ptr_,
                                                                                                                                        int32_t rust_vec_len_,
                                                                                                                                        int32_t data_len_);
+
+void frbgen_frb_example_pure_dart_wire__crate__api__chrono_type__tokio_time_duration_twin_normal(int64_t port_,
+                                                                                                 int64_t d);
+
+void frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__tokio_time_duration_twin_rust_async(int64_t port_,
+                                                                                                                                    int64_t d);
+
+void frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__tokio_time_duration_twin_rust_async_sse(int64_t port_,
+                                                                                                                                            uint8_t *ptr_,
+                                                                                                                                            int32_t rust_vec_len_,
+                                                                                                                                            int32_t data_len_);
+
+void frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__tokio_time_duration_twin_sse(int64_t port_,
+                                                                                                                      uint8_t *ptr_,
+                                                                                                                      int32_t rust_vec_len_,
+                                                                                                                      int32_t data_len_);
+
+WireSyncRust2DartDco frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__tokio_time_duration_twin_sync(int64_t d);
+
+WireSyncRust2DartSse frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__tokio_time_duration_twin_sync_sse(uint8_t *ptr_,
+                                                                                                                                                int32_t rust_vec_len_,
+                                                                                                                                                int32_t data_len_);
+
+void frbgen_frb_example_pure_dart_wire__crate__api__chrono_type__tokio_time_instant_twin_normal(int64_t port_,
+                                                                                                int64_t d);
+
+void frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__tokio_time_instant_twin_rust_async(int64_t port_,
+                                                                                                                                   int64_t d);
+
+void frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__tokio_time_instant_twin_rust_async_sse(int64_t port_,
+                                                                                                                                           uint8_t *ptr_,
+                                                                                                                                           int32_t rust_vec_len_,
+                                                                                                                                           int32_t data_len_);
+
+void frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__tokio_time_instant_twin_sse(int64_t port_,
+                                                                                                                     uint8_t *ptr_,
+                                                                                                                     int32_t rust_vec_len_,
+                                                                                                                     int32_t data_len_);
+
+WireSyncRust2DartDco frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__tokio_time_instant_twin_sync(int64_t d);
+
+WireSyncRust2DartSse frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__tokio_time_instant_twin_sync_sse(uint8_t *ptr_,
+                                                                                                                                               int32_t rust_vec_len_,
+                                                                                                                                               int32_t data_len_);
 
 void frbgen_frb_example_pure_dart_wire__crate__api__dart_code__translatable_struct_with_dart_code_twin_normal_normal_method_twin_normal(int64_t port_,
                                                                                                                                         struct wire_cst_translatable_struct_with_dart_code_twin_normal *that);
@@ -16789,8 +16899,13 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__chrono_type__naivedate_twin_normal);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__chrono_type__naivedatetime_twin_normal);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__chrono_type__optional_empty_datetime_utc_twin_normal);
+    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__chrono_type__std_time_duration_twin_normal);
+    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__chrono_type__std_time_instant_twin_normal);
+    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__chrono_type__std_time_system_time_twin_normal);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__chrono_type__test_chrono_twin_normal);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__chrono_type__test_precise_chrono_twin_normal);
+    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__chrono_type__tokio_time_duration_twin_normal);
+    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__chrono_type__tokio_time_instant_twin_normal);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__collection_equality__echo_struct_with_deep_collection_equality_twin_normal);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__collection_equality__echo_struct_with_shallow_collection_equality_twin_normal);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__comment__function_with_comments_slash_star_star_twin_normal);
@@ -17729,8 +17844,13 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__naivedate_twin_rust_async);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__naivedatetime_twin_rust_async);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__optional_empty_datetime_utc_twin_rust_async);
+    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_duration_twin_rust_async);
+    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_instant_twin_rust_async);
+    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_system_time_twin_rust_async);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__test_chrono_twin_rust_async);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__test_precise_chrono_twin_rust_async);
+    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__tokio_time_duration_twin_rust_async);
+    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__tokio_time_instant_twin_rust_async);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__datetime_local_twin_rust_async_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__datetime_utc_twin_rust_async_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__duration_twin_rust_async_sse);
@@ -17740,8 +17860,13 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__naivedate_twin_rust_async_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__naivedatetime_twin_rust_async_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__optional_empty_datetime_utc_twin_rust_async_sse);
+    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__std_time_duration_twin_rust_async_sse);
+    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__std_time_instant_twin_rust_async_sse);
+    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__std_time_system_time_twin_rust_async_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__test_chrono_twin_rust_async_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__test_precise_chrono_twin_rust_async_sse);
+    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__tokio_time_duration_twin_rust_async_sse);
+    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__tokio_time_instant_twin_rust_async_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__datetime_local_twin_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__datetime_utc_twin_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__duration_twin_sse);
@@ -17751,8 +17876,13 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__naivedate_twin_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__naivedatetime_twin_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__optional_empty_datetime_utc_twin_sse);
+    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__std_time_duration_twin_sse);
+    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__std_time_instant_twin_sse);
+    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__std_time_system_time_twin_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__test_chrono_twin_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__test_precise_chrono_twin_sse);
+    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__tokio_time_duration_twin_sse);
+    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__tokio_time_instant_twin_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__datetime_local_twin_sync);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__datetime_utc_twin_sync);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__duration_twin_sync);
@@ -17762,8 +17892,13 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__naivedate_twin_sync);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__naivedatetime_twin_sync);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__optional_empty_datetime_utc_twin_sync);
+    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_duration_twin_sync);
+    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_instant_twin_sync);
+    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_system_time_twin_sync);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__test_chrono_twin_sync);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__test_precise_chrono_twin_sync);
+    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__tokio_time_duration_twin_sync);
+    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__tokio_time_instant_twin_sync);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__datetime_local_twin_sync_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__datetime_utc_twin_sync_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__duration_twin_sync_sse);
@@ -17773,8 +17908,13 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__naivedate_twin_sync_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__naivedatetime_twin_sync_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__optional_empty_datetime_utc_twin_sync_sse);
+    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__std_time_duration_twin_sync_sse);
+    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__std_time_instant_twin_sync_sse);
+    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__std_time_system_time_twin_sync_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__test_chrono_twin_sync_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__test_precise_chrono_twin_sync_sse);
+    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__tokio_time_duration_twin_sync_sse);
+    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__tokio_time_instant_twin_sync_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__collection_equality_twin_rust_async__echo_struct_with_deep_collection_equality_twin_rust_async);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__collection_equality_twin_rust_async__echo_struct_with_shallow_collection_equality_twin_rust_async);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__collection_equality_twin_rust_async_sse__echo_struct_with_deep_collection_equality_twin_rust_async_sse);

--- a/frb_example/pure_dart/frb_generated.h
+++ b/frb_example/pure_dart/frb_generated.h
@@ -13370,6 +13370,28 @@ WireSyncRust2DartSse frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manua
                                                                                                                                              int32_t rust_vec_len_,
                                                                                                                                              int32_t data_len_);
 
+void frbgen_frb_example_pure_dart_wire__crate__api__chrono_type__std_time_system_time_before_epoch_twin_normal(int64_t port_,
+                                                                                                               int64_t d);
+
+void frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_system_time_before_epoch_twin_rust_async(int64_t port_,
+                                                                                                                                                  int64_t d);
+
+void frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__std_time_system_time_before_epoch_twin_rust_async_sse(int64_t port_,
+                                                                                                                                                          uint8_t *ptr_,
+                                                                                                                                                          int32_t rust_vec_len_,
+                                                                                                                                                          int32_t data_len_);
+
+void frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__std_time_system_time_before_epoch_twin_sse(int64_t port_,
+                                                                                                                                    uint8_t *ptr_,
+                                                                                                                                    int32_t rust_vec_len_,
+                                                                                                                                    int32_t data_len_);
+
+WireSyncRust2DartDco frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_system_time_before_epoch_twin_sync(int64_t d);
+
+WireSyncRust2DartSse frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__std_time_system_time_before_epoch_twin_sync_sse(uint8_t *ptr_,
+                                                                                                                                                              int32_t rust_vec_len_,
+                                                                                                                                                              int32_t data_len_);
+
 void frbgen_frb_example_pure_dart_wire__crate__api__chrono_type__std_time_system_time_twin_normal(int64_t port_,
                                                                                                   int64_t d);
 
@@ -16901,6 +16923,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__chrono_type__optional_empty_datetime_utc_twin_normal);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__chrono_type__std_time_duration_twin_normal);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__chrono_type__std_time_instant_twin_normal);
+    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__chrono_type__std_time_system_time_before_epoch_twin_normal);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__chrono_type__std_time_system_time_twin_normal);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__chrono_type__test_chrono_twin_normal);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__chrono_type__test_precise_chrono_twin_normal);
@@ -17846,6 +17869,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__optional_empty_datetime_utc_twin_rust_async);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_duration_twin_rust_async);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_instant_twin_rust_async);
+    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_system_time_before_epoch_twin_rust_async);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_system_time_twin_rust_async);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__test_chrono_twin_rust_async);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__test_precise_chrono_twin_rust_async);
@@ -17862,6 +17886,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__optional_empty_datetime_utc_twin_rust_async_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__std_time_duration_twin_rust_async_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__std_time_instant_twin_rust_async_sse);
+    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__std_time_system_time_before_epoch_twin_rust_async_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__std_time_system_time_twin_rust_async_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__test_chrono_twin_rust_async_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__test_precise_chrono_twin_rust_async_sse);
@@ -17878,6 +17903,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__optional_empty_datetime_utc_twin_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__std_time_duration_twin_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__std_time_instant_twin_sse);
+    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__std_time_system_time_before_epoch_twin_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__std_time_system_time_twin_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__test_chrono_twin_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__test_precise_chrono_twin_sse);
@@ -17894,6 +17920,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__optional_empty_datetime_utc_twin_sync);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_duration_twin_sync);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_instant_twin_sync);
+    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_system_time_before_epoch_twin_sync);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_system_time_twin_sync);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__test_chrono_twin_sync);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__test_precise_chrono_twin_sync);
@@ -17910,6 +17937,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__optional_empty_datetime_utc_twin_sync_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__std_time_duration_twin_sync_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__std_time_instant_twin_sync_sse);
+    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__std_time_system_time_before_epoch_twin_sync_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__std_time_system_time_twin_sync_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__test_chrono_twin_sync_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__test_precise_chrono_twin_sync_sse);

--- a/frb_example/pure_dart/frb_generated.h
+++ b/frb_example/pure_dart/frb_generated.h
@@ -13348,28 +13348,6 @@ WireSyncRust2DartSse frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manua
                                                                                                                                               int32_t rust_vec_len_,
                                                                                                                                               int32_t data_len_);
 
-void frbgen_frb_example_pure_dart_wire__crate__api__chrono_type__std_time_instant_twin_normal(int64_t port_,
-                                                                                              int64_t d);
-
-void frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_instant_twin_rust_async(int64_t port_,
-                                                                                                                                 int64_t d);
-
-void frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__std_time_instant_twin_rust_async_sse(int64_t port_,
-                                                                                                                                         uint8_t *ptr_,
-                                                                                                                                         int32_t rust_vec_len_,
-                                                                                                                                         int32_t data_len_);
-
-void frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__std_time_instant_twin_sse(int64_t port_,
-                                                                                                                   uint8_t *ptr_,
-                                                                                                                   int32_t rust_vec_len_,
-                                                                                                                   int32_t data_len_);
-
-WireSyncRust2DartDco frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_instant_twin_sync(int64_t d);
-
-WireSyncRust2DartSse frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__std_time_instant_twin_sync_sse(uint8_t *ptr_,
-                                                                                                                                             int32_t rust_vec_len_,
-                                                                                                                                             int32_t data_len_);
-
 void frbgen_frb_example_pure_dart_wire__crate__api__chrono_type__std_time_system_time_before_epoch_twin_normal(int64_t port_,
                                                                                                                int64_t d);
 
@@ -14034,28 +14012,6 @@ WireSyncRust2DartDco frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manua
 WireSyncRust2DartSse frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__tokio_time_duration_twin_sync_sse(uint8_t *ptr_,
                                                                                                                                                 int32_t rust_vec_len_,
                                                                                                                                                 int32_t data_len_);
-
-void frbgen_frb_example_pure_dart_wire__crate__api__chrono_type__tokio_time_instant_twin_normal(int64_t port_,
-                                                                                                int64_t d);
-
-void frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__tokio_time_instant_twin_rust_async(int64_t port_,
-                                                                                                                                   int64_t d);
-
-void frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__tokio_time_instant_twin_rust_async_sse(int64_t port_,
-                                                                                                                                           uint8_t *ptr_,
-                                                                                                                                           int32_t rust_vec_len_,
-                                                                                                                                           int32_t data_len_);
-
-void frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__tokio_time_instant_twin_sse(int64_t port_,
-                                                                                                                     uint8_t *ptr_,
-                                                                                                                     int32_t rust_vec_len_,
-                                                                                                                     int32_t data_len_);
-
-WireSyncRust2DartDco frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__tokio_time_instant_twin_sync(int64_t d);
-
-WireSyncRust2DartSse frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__tokio_time_instant_twin_sync_sse(uint8_t *ptr_,
-                                                                                                                                               int32_t rust_vec_len_,
-                                                                                                                                               int32_t data_len_);
 
 void frbgen_frb_example_pure_dart_wire__crate__api__dart_code__translatable_struct_with_dart_code_twin_normal_normal_method_twin_normal(int64_t port_,
                                                                                                                                         struct wire_cst_translatable_struct_with_dart_code_twin_normal *that);
@@ -16922,13 +16878,11 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__chrono_type__naivedatetime_twin_normal);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__chrono_type__optional_empty_datetime_utc_twin_normal);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__chrono_type__std_time_duration_twin_normal);
-    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__chrono_type__std_time_instant_twin_normal);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__chrono_type__std_time_system_time_before_epoch_twin_normal);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__chrono_type__std_time_system_time_twin_normal);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__chrono_type__test_chrono_twin_normal);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__chrono_type__test_precise_chrono_twin_normal);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__chrono_type__tokio_time_duration_twin_normal);
-    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__chrono_type__tokio_time_instant_twin_normal);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__collection_equality__echo_struct_with_deep_collection_equality_twin_normal);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__collection_equality__echo_struct_with_shallow_collection_equality_twin_normal);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__comment__function_with_comments_slash_star_star_twin_normal);
@@ -17868,13 +17822,11 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__naivedatetime_twin_rust_async);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__optional_empty_datetime_utc_twin_rust_async);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_duration_twin_rust_async);
-    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_instant_twin_rust_async);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_system_time_before_epoch_twin_rust_async);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_system_time_twin_rust_async);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__test_chrono_twin_rust_async);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__test_precise_chrono_twin_rust_async);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__tokio_time_duration_twin_rust_async);
-    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__tokio_time_instant_twin_rust_async);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__datetime_local_twin_rust_async_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__datetime_utc_twin_rust_async_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__duration_twin_rust_async_sse);
@@ -17885,13 +17837,11 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__naivedatetime_twin_rust_async_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__optional_empty_datetime_utc_twin_rust_async_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__std_time_duration_twin_rust_async_sse);
-    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__std_time_instant_twin_rust_async_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__std_time_system_time_before_epoch_twin_rust_async_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__std_time_system_time_twin_rust_async_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__test_chrono_twin_rust_async_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__test_precise_chrono_twin_rust_async_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__tokio_time_duration_twin_rust_async_sse);
-    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__tokio_time_instant_twin_rust_async_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__datetime_local_twin_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__datetime_utc_twin_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__duration_twin_sse);
@@ -17902,13 +17852,11 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__naivedatetime_twin_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__optional_empty_datetime_utc_twin_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__std_time_duration_twin_sse);
-    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__std_time_instant_twin_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__std_time_system_time_before_epoch_twin_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__std_time_system_time_twin_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__test_chrono_twin_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__test_precise_chrono_twin_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__tokio_time_duration_twin_sse);
-    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sse__tokio_time_instant_twin_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__datetime_local_twin_sync);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__datetime_utc_twin_sync);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__duration_twin_sync);
@@ -17919,13 +17867,11 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__naivedatetime_twin_sync);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__optional_empty_datetime_utc_twin_sync);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_duration_twin_sync);
-    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_instant_twin_sync);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_system_time_before_epoch_twin_sync);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_system_time_twin_sync);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__test_chrono_twin_sync);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__test_precise_chrono_twin_sync);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__tokio_time_duration_twin_sync);
-    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync__tokio_time_instant_twin_sync);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__datetime_local_twin_sync_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__datetime_utc_twin_sync_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__duration_twin_sync_sse);
@@ -17936,13 +17882,11 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__naivedatetime_twin_sync_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__optional_empty_datetime_utc_twin_sync_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__std_time_duration_twin_sync_sse);
-    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__std_time_instant_twin_sync_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__std_time_system_time_before_epoch_twin_sync_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__std_time_system_time_twin_sync_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__test_chrono_twin_sync_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__test_precise_chrono_twin_sync_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__tokio_time_duration_twin_sync_sse);
-    dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__tokio_time_instant_twin_sync_sse);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__collection_equality_twin_rust_async__echo_struct_with_deep_collection_equality_twin_rust_async);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__collection_equality_twin_rust_async__echo_struct_with_shallow_collection_equality_twin_rust_async);
     dummy_var ^= ((int64_t) (void*) frbgen_frb_example_pure_dart_wire__crate__api__pseudo_manual__collection_equality_twin_rust_async_sse__echo_struct_with_deep_collection_equality_twin_rust_async_sse);

--- a/frb_example/pure_dart/lib/src/rust/api/chrono_type.dart
+++ b/frb_example/pure_dart/lib/src/rust/api/chrono_type.dart
@@ -40,14 +40,8 @@ Future<DateTime> stdTimeSystemTimeBeforeEpochTwinNormal(
     RustLib.instance.api
         .crateApiChronoTypeStdTimeSystemTimeBeforeEpochTwinNormal(d: d);
 
-Future<DateTime> stdTimeInstantTwinNormal({required DateTime d}) =>
-    RustLib.instance.api.crateApiChronoTypeStdTimeInstantTwinNormal(d: d);
-
 Future<Duration> tokioTimeDurationTwinNormal({required Duration d}) =>
     RustLib.instance.api.crateApiChronoTypeTokioTimeDurationTwinNormal(d: d);
-
-Future<DateTime> tokioTimeInstantTwinNormal({required DateTime d}) =>
-    RustLib.instance.api.crateApiChronoTypeTokioTimeInstantTwinNormal(d: d);
 
 Future<List<Duration>> handleTimestampsTwinNormal(
         {required List<DateTime> timestamps, required DateTime epoch}) =>

--- a/frb_example/pure_dart/lib/src/rust/api/chrono_type.dart
+++ b/frb_example/pure_dart/lib/src/rust/api/chrono_type.dart
@@ -35,6 +35,11 @@ Future<Duration> stdTimeDurationTwinNormal({required Duration d}) =>
 Future<DateTime> stdTimeSystemTimeTwinNormal({required DateTime d}) =>
     RustLib.instance.api.crateApiChronoTypeStdTimeSystemTimeTwinNormal(d: d);
 
+Future<DateTime> stdTimeSystemTimeBeforeEpochTwinNormal(
+        {required DateTime d}) =>
+    RustLib.instance.api
+        .crateApiChronoTypeStdTimeSystemTimeBeforeEpochTwinNormal(d: d);
+
 Future<DateTime> stdTimeInstantTwinNormal({required DateTime d}) =>
     RustLib.instance.api.crateApiChronoTypeStdTimeInstantTwinNormal(d: d);
 

--- a/frb_example/pure_dart/lib/src/rust/api/chrono_type.dart
+++ b/frb_example/pure_dart/lib/src/rust/api/chrono_type.dart
@@ -29,6 +29,21 @@ Future<DateTime?> optionalEmptyDatetimeUtcTwinNormal({DateTime? d}) =>
 Future<Duration> durationTwinNormal({required Duration d}) =>
     RustLib.instance.api.crateApiChronoTypeDurationTwinNormal(d: d);
 
+Future<Duration> stdTimeDurationTwinNormal({required Duration d}) =>
+    RustLib.instance.api.crateApiChronoTypeStdTimeDurationTwinNormal(d: d);
+
+Future<DateTime> stdTimeSystemTimeTwinNormal({required DateTime d}) =>
+    RustLib.instance.api.crateApiChronoTypeStdTimeSystemTimeTwinNormal(d: d);
+
+Future<DateTime> stdTimeInstantTwinNormal({required DateTime d}) =>
+    RustLib.instance.api.crateApiChronoTypeStdTimeInstantTwinNormal(d: d);
+
+Future<Duration> tokioTimeDurationTwinNormal({required Duration d}) =>
+    RustLib.instance.api.crateApiChronoTypeTokioTimeDurationTwinNormal(d: d);
+
+Future<DateTime> tokioTimeInstantTwinNormal({required DateTime d}) =>
+    RustLib.instance.api.crateApiChronoTypeTokioTimeInstantTwinNormal(d: d);
+
 Future<List<Duration>> handleTimestampsTwinNormal(
         {required List<DateTime> timestamps, required DateTime epoch}) =>
     RustLib.instance.api.crateApiChronoTypeHandleTimestampsTwinNormal(

--- a/frb_example/pure_dart/lib/src/rust/api/pseudo_manual/chrono_type_twin_rust_async.dart
+++ b/frb_example/pure_dart/lib/src/rust/api/pseudo_manual/chrono_type_twin_rust_async.dart
@@ -53,19 +53,9 @@ Future<DateTime> stdTimeSystemTimeBeforeEpochTwinRustAsync(
         .crateApiPseudoManualChronoTypeTwinRustAsyncStdTimeSystemTimeBeforeEpochTwinRustAsync(
             d: d);
 
-Future<DateTime> stdTimeInstantTwinRustAsync({required DateTime d}) =>
-    RustLib.instance.api
-        .crateApiPseudoManualChronoTypeTwinRustAsyncStdTimeInstantTwinRustAsync(
-            d: d);
-
 Future<Duration> tokioTimeDurationTwinRustAsync({required Duration d}) => RustLib
     .instance.api
     .crateApiPseudoManualChronoTypeTwinRustAsyncTokioTimeDurationTwinRustAsync(
-        d: d);
-
-Future<DateTime> tokioTimeInstantTwinRustAsync({required DateTime d}) => RustLib
-    .instance.api
-    .crateApiPseudoManualChronoTypeTwinRustAsyncTokioTimeInstantTwinRustAsync(
         d: d);
 
 Future<List<Duration>> handleTimestampsTwinRustAsync(

--- a/frb_example/pure_dart/lib/src/rust/api/pseudo_manual/chrono_type_twin_rust_async.dart
+++ b/frb_example/pure_dart/lib/src/rust/api/pseudo_manual/chrono_type_twin_rust_async.dart
@@ -47,6 +47,12 @@ Future<DateTime> stdTimeSystemTimeTwinRustAsync({required DateTime d}) => RustLi
     .crateApiPseudoManualChronoTypeTwinRustAsyncStdTimeSystemTimeTwinRustAsync(
         d: d);
 
+Future<DateTime> stdTimeSystemTimeBeforeEpochTwinRustAsync(
+        {required DateTime d}) =>
+    RustLib.instance.api
+        .crateApiPseudoManualChronoTypeTwinRustAsyncStdTimeSystemTimeBeforeEpochTwinRustAsync(
+            d: d);
+
 Future<DateTime> stdTimeInstantTwinRustAsync({required DateTime d}) =>
     RustLib.instance.api
         .crateApiPseudoManualChronoTypeTwinRustAsyncStdTimeInstantTwinRustAsync(

--- a/frb_example/pure_dart/lib/src/rust/api/pseudo_manual/chrono_type_twin_rust_async.dart
+++ b/frb_example/pure_dart/lib/src/rust/api/pseudo_manual/chrono_type_twin_rust_async.dart
@@ -37,6 +37,31 @@ Future<Duration> durationTwinRustAsync({required Duration d}) =>
     RustLib.instance.api
         .crateApiPseudoManualChronoTypeTwinRustAsyncDurationTwinRustAsync(d: d);
 
+Future<Duration> stdTimeDurationTwinRustAsync({required Duration d}) => RustLib
+    .instance.api
+    .crateApiPseudoManualChronoTypeTwinRustAsyncStdTimeDurationTwinRustAsync(
+        d: d);
+
+Future<DateTime> stdTimeSystemTimeTwinRustAsync({required DateTime d}) => RustLib
+    .instance.api
+    .crateApiPseudoManualChronoTypeTwinRustAsyncStdTimeSystemTimeTwinRustAsync(
+        d: d);
+
+Future<DateTime> stdTimeInstantTwinRustAsync({required DateTime d}) =>
+    RustLib.instance.api
+        .crateApiPseudoManualChronoTypeTwinRustAsyncStdTimeInstantTwinRustAsync(
+            d: d);
+
+Future<Duration> tokioTimeDurationTwinRustAsync({required Duration d}) => RustLib
+    .instance.api
+    .crateApiPseudoManualChronoTypeTwinRustAsyncTokioTimeDurationTwinRustAsync(
+        d: d);
+
+Future<DateTime> tokioTimeInstantTwinRustAsync({required DateTime d}) => RustLib
+    .instance.api
+    .crateApiPseudoManualChronoTypeTwinRustAsyncTokioTimeInstantTwinRustAsync(
+        d: d);
+
 Future<List<Duration>> handleTimestampsTwinRustAsync(
         {required List<DateTime> timestamps, required DateTime epoch}) =>
     RustLib.instance.api

--- a/frb_example/pure_dart/lib/src/rust/api/pseudo_manual/chrono_type_twin_rust_async_sse.dart
+++ b/frb_example/pure_dart/lib/src/rust/api/pseudo_manual/chrono_type_twin_rust_async_sse.dart
@@ -56,20 +56,10 @@ Future<DateTime> stdTimeSystemTimeBeforeEpochTwinRustAsyncSse(
         .crateApiPseudoManualChronoTypeTwinRustAsyncSseStdTimeSystemTimeBeforeEpochTwinRustAsyncSse(
             d: d);
 
-Future<DateTime> stdTimeInstantTwinRustAsyncSse({required DateTime d}) => RustLib
-    .instance.api
-    .crateApiPseudoManualChronoTypeTwinRustAsyncSseStdTimeInstantTwinRustAsyncSse(
-        d: d);
-
 Future<Duration> tokioTimeDurationTwinRustAsyncSse({required Duration d}) =>
     RustLib.instance.api
         .crateApiPseudoManualChronoTypeTwinRustAsyncSseTokioTimeDurationTwinRustAsyncSse(
             d: d);
-
-Future<DateTime> tokioTimeInstantTwinRustAsyncSse({required DateTime d}) => RustLib
-    .instance.api
-    .crateApiPseudoManualChronoTypeTwinRustAsyncSseTokioTimeInstantTwinRustAsyncSse(
-        d: d);
 
 Future<List<Duration>> handleTimestampsTwinRustAsyncSse(
         {required List<DateTime> timestamps, required DateTime epoch}) =>

--- a/frb_example/pure_dart/lib/src/rust/api/pseudo_manual/chrono_type_twin_rust_async_sse.dart
+++ b/frb_example/pure_dart/lib/src/rust/api/pseudo_manual/chrono_type_twin_rust_async_sse.dart
@@ -40,6 +40,31 @@ Future<Duration> durationTwinRustAsyncSse({required Duration d}) =>
         .crateApiPseudoManualChronoTypeTwinRustAsyncSseDurationTwinRustAsyncSse(
             d: d);
 
+Future<Duration> stdTimeDurationTwinRustAsyncSse({required Duration d}) => RustLib
+    .instance.api
+    .crateApiPseudoManualChronoTypeTwinRustAsyncSseStdTimeDurationTwinRustAsyncSse(
+        d: d);
+
+Future<DateTime> stdTimeSystemTimeTwinRustAsyncSse({required DateTime d}) =>
+    RustLib.instance.api
+        .crateApiPseudoManualChronoTypeTwinRustAsyncSseStdTimeSystemTimeTwinRustAsyncSse(
+            d: d);
+
+Future<DateTime> stdTimeInstantTwinRustAsyncSse({required DateTime d}) => RustLib
+    .instance.api
+    .crateApiPseudoManualChronoTypeTwinRustAsyncSseStdTimeInstantTwinRustAsyncSse(
+        d: d);
+
+Future<Duration> tokioTimeDurationTwinRustAsyncSse({required Duration d}) =>
+    RustLib.instance.api
+        .crateApiPseudoManualChronoTypeTwinRustAsyncSseTokioTimeDurationTwinRustAsyncSse(
+            d: d);
+
+Future<DateTime> tokioTimeInstantTwinRustAsyncSse({required DateTime d}) => RustLib
+    .instance.api
+    .crateApiPseudoManualChronoTypeTwinRustAsyncSseTokioTimeInstantTwinRustAsyncSse(
+        d: d);
+
 Future<List<Duration>> handleTimestampsTwinRustAsyncSse(
         {required List<DateTime> timestamps, required DateTime epoch}) =>
     RustLib.instance.api

--- a/frb_example/pure_dart/lib/src/rust/api/pseudo_manual/chrono_type_twin_rust_async_sse.dart
+++ b/frb_example/pure_dart/lib/src/rust/api/pseudo_manual/chrono_type_twin_rust_async_sse.dart
@@ -50,6 +50,12 @@ Future<DateTime> stdTimeSystemTimeTwinRustAsyncSse({required DateTime d}) =>
         .crateApiPseudoManualChronoTypeTwinRustAsyncSseStdTimeSystemTimeTwinRustAsyncSse(
             d: d);
 
+Future<DateTime> stdTimeSystemTimeBeforeEpochTwinRustAsyncSse(
+        {required DateTime d}) =>
+    RustLib.instance.api
+        .crateApiPseudoManualChronoTypeTwinRustAsyncSseStdTimeSystemTimeBeforeEpochTwinRustAsyncSse(
+            d: d);
+
 Future<DateTime> stdTimeInstantTwinRustAsyncSse({required DateTime d}) => RustLib
     .instance.api
     .crateApiPseudoManualChronoTypeTwinRustAsyncSseStdTimeInstantTwinRustAsyncSse(

--- a/frb_example/pure_dart/lib/src/rust/api/pseudo_manual/chrono_type_twin_sse.dart
+++ b/frb_example/pure_dart/lib/src/rust/api/pseudo_manual/chrono_type_twin_sse.dart
@@ -32,6 +32,26 @@ Future<DateTime?> optionalEmptyDatetimeUtcTwinSse({DateTime? d}) => RustLib
 Future<Duration> durationTwinSse({required Duration d}) => RustLib.instance.api
     .crateApiPseudoManualChronoTypeTwinSseDurationTwinSse(d: d);
 
+Future<Duration> stdTimeDurationTwinSse({required Duration d}) =>
+    RustLib.instance.api
+        .crateApiPseudoManualChronoTypeTwinSseStdTimeDurationTwinSse(d: d);
+
+Future<DateTime> stdTimeSystemTimeTwinSse({required DateTime d}) =>
+    RustLib.instance.api
+        .crateApiPseudoManualChronoTypeTwinSseStdTimeSystemTimeTwinSse(d: d);
+
+Future<DateTime> stdTimeInstantTwinSse({required DateTime d}) =>
+    RustLib.instance.api
+        .crateApiPseudoManualChronoTypeTwinSseStdTimeInstantTwinSse(d: d);
+
+Future<Duration> tokioTimeDurationTwinSse({required Duration d}) =>
+    RustLib.instance.api
+        .crateApiPseudoManualChronoTypeTwinSseTokioTimeDurationTwinSse(d: d);
+
+Future<DateTime> tokioTimeInstantTwinSse({required DateTime d}) =>
+    RustLib.instance.api
+        .crateApiPseudoManualChronoTypeTwinSseTokioTimeInstantTwinSse(d: d);
+
 Future<List<Duration>> handleTimestampsTwinSse(
         {required List<DateTime> timestamps, required DateTime epoch}) =>
     RustLib.instance.api

--- a/frb_example/pure_dart/lib/src/rust/api/pseudo_manual/chrono_type_twin_sse.dart
+++ b/frb_example/pure_dart/lib/src/rust/api/pseudo_manual/chrono_type_twin_sse.dart
@@ -45,17 +45,9 @@ Future<DateTime> stdTimeSystemTimeBeforeEpochTwinSse({required DateTime d}) =>
         .crateApiPseudoManualChronoTypeTwinSseStdTimeSystemTimeBeforeEpochTwinSse(
             d: d);
 
-Future<DateTime> stdTimeInstantTwinSse({required DateTime d}) =>
-    RustLib.instance.api
-        .crateApiPseudoManualChronoTypeTwinSseStdTimeInstantTwinSse(d: d);
-
 Future<Duration> tokioTimeDurationTwinSse({required Duration d}) =>
     RustLib.instance.api
         .crateApiPseudoManualChronoTypeTwinSseTokioTimeDurationTwinSse(d: d);
-
-Future<DateTime> tokioTimeInstantTwinSse({required DateTime d}) =>
-    RustLib.instance.api
-        .crateApiPseudoManualChronoTypeTwinSseTokioTimeInstantTwinSse(d: d);
 
 Future<List<Duration>> handleTimestampsTwinSse(
         {required List<DateTime> timestamps, required DateTime epoch}) =>

--- a/frb_example/pure_dart/lib/src/rust/api/pseudo_manual/chrono_type_twin_sse.dart
+++ b/frb_example/pure_dart/lib/src/rust/api/pseudo_manual/chrono_type_twin_sse.dart
@@ -40,6 +40,11 @@ Future<DateTime> stdTimeSystemTimeTwinSse({required DateTime d}) =>
     RustLib.instance.api
         .crateApiPseudoManualChronoTypeTwinSseStdTimeSystemTimeTwinSse(d: d);
 
+Future<DateTime> stdTimeSystemTimeBeforeEpochTwinSse({required DateTime d}) =>
+    RustLib.instance.api
+        .crateApiPseudoManualChronoTypeTwinSseStdTimeSystemTimeBeforeEpochTwinSse(
+            d: d);
+
 Future<DateTime> stdTimeInstantTwinSse({required DateTime d}) =>
     RustLib.instance.api
         .crateApiPseudoManualChronoTypeTwinSseStdTimeInstantTwinSse(d: d);

--- a/frb_example/pure_dart/lib/src/rust/api/pseudo_manual/chrono_type_twin_sync.dart
+++ b/frb_example/pure_dart/lib/src/rust/api/pseudo_manual/chrono_type_twin_sync.dart
@@ -42,15 +42,9 @@ DateTime stdTimeSystemTimeBeforeEpochTwinSync({required DateTime d}) => RustLib
     .crateApiPseudoManualChronoTypeTwinSyncStdTimeSystemTimeBeforeEpochTwinSync(
         d: d);
 
-DateTime stdTimeInstantTwinSync({required DateTime d}) => RustLib.instance.api
-    .crateApiPseudoManualChronoTypeTwinSyncStdTimeInstantTwinSync(d: d);
-
 Duration tokioTimeDurationTwinSync({required Duration d}) =>
     RustLib.instance.api
         .crateApiPseudoManualChronoTypeTwinSyncTokioTimeDurationTwinSync(d: d);
-
-DateTime tokioTimeInstantTwinSync({required DateTime d}) => RustLib.instance.api
-    .crateApiPseudoManualChronoTypeTwinSyncTokioTimeInstantTwinSync(d: d);
 
 List<Duration> handleTimestampsTwinSync(
         {required List<DateTime> timestamps, required DateTime epoch}) =>

--- a/frb_example/pure_dart/lib/src/rust/api/pseudo_manual/chrono_type_twin_sync.dart
+++ b/frb_example/pure_dart/lib/src/rust/api/pseudo_manual/chrono_type_twin_sync.dart
@@ -30,6 +30,23 @@ DateTime? optionalEmptyDatetimeUtcTwinSync({DateTime? d}) =>
 Duration durationTwinSync({required Duration d}) => RustLib.instance.api
     .crateApiPseudoManualChronoTypeTwinSyncDurationTwinSync(d: d);
 
+Duration stdTimeDurationTwinSync({required Duration d}) => RustLib.instance.api
+    .crateApiPseudoManualChronoTypeTwinSyncStdTimeDurationTwinSync(d: d);
+
+DateTime stdTimeSystemTimeTwinSync({required DateTime d}) =>
+    RustLib.instance.api
+        .crateApiPseudoManualChronoTypeTwinSyncStdTimeSystemTimeTwinSync(d: d);
+
+DateTime stdTimeInstantTwinSync({required DateTime d}) => RustLib.instance.api
+    .crateApiPseudoManualChronoTypeTwinSyncStdTimeInstantTwinSync(d: d);
+
+Duration tokioTimeDurationTwinSync({required Duration d}) =>
+    RustLib.instance.api
+        .crateApiPseudoManualChronoTypeTwinSyncTokioTimeDurationTwinSync(d: d);
+
+DateTime tokioTimeInstantTwinSync({required DateTime d}) => RustLib.instance.api
+    .crateApiPseudoManualChronoTypeTwinSyncTokioTimeInstantTwinSync(d: d);
+
 List<Duration> handleTimestampsTwinSync(
         {required List<DateTime> timestamps, required DateTime epoch}) =>
     RustLib.instance.api

--- a/frb_example/pure_dart/lib/src/rust/api/pseudo_manual/chrono_type_twin_sync.dart
+++ b/frb_example/pure_dart/lib/src/rust/api/pseudo_manual/chrono_type_twin_sync.dart
@@ -37,6 +37,11 @@ DateTime stdTimeSystemTimeTwinSync({required DateTime d}) =>
     RustLib.instance.api
         .crateApiPseudoManualChronoTypeTwinSyncStdTimeSystemTimeTwinSync(d: d);
 
+DateTime stdTimeSystemTimeBeforeEpochTwinSync({required DateTime d}) => RustLib
+    .instance.api
+    .crateApiPseudoManualChronoTypeTwinSyncStdTimeSystemTimeBeforeEpochTwinSync(
+        d: d);
+
 DateTime stdTimeInstantTwinSync({required DateTime d}) => RustLib.instance.api
     .crateApiPseudoManualChronoTypeTwinSyncStdTimeInstantTwinSync(d: d);
 

--- a/frb_example/pure_dart/lib/src/rust/api/pseudo_manual/chrono_type_twin_sync_sse.dart
+++ b/frb_example/pure_dart/lib/src/rust/api/pseudo_manual/chrono_type_twin_sync_sse.dart
@@ -30,6 +30,28 @@ DateTime? optionalEmptyDatetimeUtcTwinSyncSse({DateTime? d}) => RustLib
 Duration durationTwinSyncSse({required Duration d}) => RustLib.instance.api
     .crateApiPseudoManualChronoTypeTwinSyncSseDurationTwinSyncSse(d: d);
 
+Duration stdTimeDurationTwinSyncSse({required Duration d}) => RustLib
+    .instance.api
+    .crateApiPseudoManualChronoTypeTwinSyncSseStdTimeDurationTwinSyncSse(d: d);
+
+DateTime stdTimeSystemTimeTwinSyncSse({required DateTime d}) => RustLib
+    .instance.api
+    .crateApiPseudoManualChronoTypeTwinSyncSseStdTimeSystemTimeTwinSyncSse(
+        d: d);
+
+DateTime stdTimeInstantTwinSyncSse({required DateTime d}) => RustLib
+    .instance.api
+    .crateApiPseudoManualChronoTypeTwinSyncSseStdTimeInstantTwinSyncSse(d: d);
+
+Duration tokioTimeDurationTwinSyncSse({required Duration d}) => RustLib
+    .instance.api
+    .crateApiPseudoManualChronoTypeTwinSyncSseTokioTimeDurationTwinSyncSse(
+        d: d);
+
+DateTime tokioTimeInstantTwinSyncSse({required DateTime d}) => RustLib
+    .instance.api
+    .crateApiPseudoManualChronoTypeTwinSyncSseTokioTimeInstantTwinSyncSse(d: d);
+
 List<Duration> handleTimestampsTwinSyncSse(
         {required List<DateTime> timestamps, required DateTime epoch}) =>
     RustLib.instance.api

--- a/frb_example/pure_dart/lib/src/rust/api/pseudo_manual/chrono_type_twin_sync_sse.dart
+++ b/frb_example/pure_dart/lib/src/rust/api/pseudo_manual/chrono_type_twin_sync_sse.dart
@@ -44,18 +44,10 @@ DateTime stdTimeSystemTimeBeforeEpochTwinSyncSse({required DateTime d}) => RustL
     .crateApiPseudoManualChronoTypeTwinSyncSseStdTimeSystemTimeBeforeEpochTwinSyncSse(
         d: d);
 
-DateTime stdTimeInstantTwinSyncSse({required DateTime d}) => RustLib
-    .instance.api
-    .crateApiPseudoManualChronoTypeTwinSyncSseStdTimeInstantTwinSyncSse(d: d);
-
 Duration tokioTimeDurationTwinSyncSse({required Duration d}) => RustLib
     .instance.api
     .crateApiPseudoManualChronoTypeTwinSyncSseTokioTimeDurationTwinSyncSse(
         d: d);
-
-DateTime tokioTimeInstantTwinSyncSse({required DateTime d}) => RustLib
-    .instance.api
-    .crateApiPseudoManualChronoTypeTwinSyncSseTokioTimeInstantTwinSyncSse(d: d);
 
 List<Duration> handleTimestampsTwinSyncSse(
         {required List<DateTime> timestamps, required DateTime epoch}) =>

--- a/frb_example/pure_dart/lib/src/rust/api/pseudo_manual/chrono_type_twin_sync_sse.dart
+++ b/frb_example/pure_dart/lib/src/rust/api/pseudo_manual/chrono_type_twin_sync_sse.dart
@@ -39,6 +39,11 @@ DateTime stdTimeSystemTimeTwinSyncSse({required DateTime d}) => RustLib
     .crateApiPseudoManualChronoTypeTwinSyncSseStdTimeSystemTimeTwinSyncSse(
         d: d);
 
+DateTime stdTimeSystemTimeBeforeEpochTwinSyncSse({required DateTime d}) => RustLib
+    .instance.api
+    .crateApiPseudoManualChronoTypeTwinSyncSseStdTimeSystemTimeBeforeEpochTwinSyncSse(
+        d: d);
+
 DateTime stdTimeInstantTwinSyncSse({required DateTime d}) => RustLib
     .instance.api
     .crateApiPseudoManualChronoTypeTwinSyncSseStdTimeInstantTwinSyncSse(d: d);

--- a/frb_example/pure_dart/lib/src/rust/frb_generated.web.dart
+++ b/frb_example/pure_dart/lib/src/rust/frb_generated.web.dart
@@ -4226,9 +4226,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   Duration dco_decode_StdTime_StdDuration(dynamic raw);
 
   @protected
-  DateTime dco_decode_StdTime_StdInstant(dynamic raw);
-
-  @protected
   DateTime dco_decode_StdTime_StdSystemTime(dynamic raw);
 
   @protected
@@ -4492,9 +4489,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   String dco_decode_String(dynamic raw);
-
-  @protected
-  DateTime dco_decode_TokioTime_TokioInstant(dynamic raw);
 
   @protected
   Issue2170Trait dco_decode_TraitDef_Issue2170Trait(dynamic raw);
@@ -13695,9 +13689,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   Duration sse_decode_StdTime_StdDuration(SseDeserializer deserializer);
 
   @protected
-  DateTime sse_decode_StdTime_StdInstant(SseDeserializer deserializer);
-
-  @protected
   DateTime sse_decode_StdTime_StdSystemTime(SseDeserializer deserializer);
 
   @protected
@@ -13998,9 +13989,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   String sse_decode_String(SseDeserializer deserializer);
-
-  @protected
-  DateTime sse_decode_TokioTime_TokioInstant(SseDeserializer deserializer);
 
   @protected
   BigInt sse_decode_U128(SseDeserializer deserializer);
@@ -21508,12 +21496,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   }
 
   @protected
-  JSAny cst_encode_StdTime_StdInstant(DateTime raw) {
-    // Codec=Cst (C-struct based), see doc to use other codecs
-    return cst_encode_i_64(BigInt.from(raw.millisecondsSinceEpoch));
-  }
-
-  @protected
   JSAny cst_encode_StdTime_StdSystemTime(DateTime raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
     return cst_encode_i_64(BigInt.from(raw.millisecondsSinceEpoch));
@@ -21885,12 +21867,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   String cst_encode_String(String raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
     return raw;
-  }
-
-  @protected
-  JSAny cst_encode_TokioTime_TokioInstant(DateTime raw) {
-    // Codec=Cst (C-struct based), see doc to use other codecs
-    return cst_encode_i_64(BigInt.from(raw.millisecondsSinceEpoch));
   }
 
   @protected
@@ -34096,9 +34072,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_StdTime_StdDuration(Duration self, SseSerializer serializer);
 
   @protected
-  void sse_encode_StdTime_StdInstant(DateTime self, SseSerializer serializer);
-
-  @protected
   void sse_encode_StdTime_StdSystemTime(
       DateTime self, SseSerializer serializer);
 
@@ -34385,10 +34358,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_String(String self, SseSerializer serializer);
-
-  @protected
-  void sse_encode_TokioTime_TokioInstant(
-      DateTime self, SseSerializer serializer);
 
   @protected
   void sse_encode_U128(BigInt self, SseSerializer serializer);
@@ -60896,51 +60865,6 @@ class RustLibWire implements BaseWire {
               .wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__std_time_duration_twin_sync_sse(
                   ptr_, rust_vec_len_, data_len_);
 
-  void wire__crate__api__chrono_type__std_time_instant_twin_normal(
-          NativePortType port_, JSAny d) =>
-      wasmModule.wire__crate__api__chrono_type__std_time_instant_twin_normal(
-          port_, d);
-
-  void wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_instant_twin_rust_async(
-          NativePortType port_, JSAny d) =>
-      wasmModule
-          .wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_instant_twin_rust_async(
-              port_, d);
-
-  void wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__std_time_instant_twin_rust_async_sse(
-          NativePortType port_,
-          PlatformGeneralizedUint8ListPtr ptr_,
-          int rust_vec_len_,
-          int data_len_) =>
-      wasmModule
-          .wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__std_time_instant_twin_rust_async_sse(
-              port_, ptr_, rust_vec_len_, data_len_);
-
-  void wire__crate__api__pseudo_manual__chrono_type_twin_sse__std_time_instant_twin_sse(
-          NativePortType port_,
-          PlatformGeneralizedUint8ListPtr ptr_,
-          int rust_vec_len_,
-          int data_len_) =>
-      wasmModule
-          .wire__crate__api__pseudo_manual__chrono_type_twin_sse__std_time_instant_twin_sse(
-              port_, ptr_, rust_vec_len_, data_len_);
-
-  JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */
-      wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_instant_twin_sync(
-              JSAny d) =>
-          wasmModule
-              .wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_instant_twin_sync(
-                  d);
-
-  JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartSse */
-      wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__std_time_instant_twin_sync_sse(
-              PlatformGeneralizedUint8ListPtr ptr_,
-              int rust_vec_len_,
-              int data_len_) =>
-          wasmModule
-              .wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__std_time_instant_twin_sync_sse(
-                  ptr_, rust_vec_len_, data_len_);
-
   void wire__crate__api__chrono_type__std_time_system_time_before_epoch_twin_normal(
           NativePortType port_, JSAny d) =>
       wasmModule
@@ -62347,51 +62271,6 @@ class RustLibWire implements BaseWire {
               int data_len_) =>
           wasmModule
               .wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__tokio_time_duration_twin_sync_sse(
-                  ptr_, rust_vec_len_, data_len_);
-
-  void wire__crate__api__chrono_type__tokio_time_instant_twin_normal(
-          NativePortType port_, JSAny d) =>
-      wasmModule.wire__crate__api__chrono_type__tokio_time_instant_twin_normal(
-          port_, d);
-
-  void wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__tokio_time_instant_twin_rust_async(
-          NativePortType port_, JSAny d) =>
-      wasmModule
-          .wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__tokio_time_instant_twin_rust_async(
-              port_, d);
-
-  void wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__tokio_time_instant_twin_rust_async_sse(
-          NativePortType port_,
-          PlatformGeneralizedUint8ListPtr ptr_,
-          int rust_vec_len_,
-          int data_len_) =>
-      wasmModule
-          .wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__tokio_time_instant_twin_rust_async_sse(
-              port_, ptr_, rust_vec_len_, data_len_);
-
-  void wire__crate__api__pseudo_manual__chrono_type_twin_sse__tokio_time_instant_twin_sse(
-          NativePortType port_,
-          PlatformGeneralizedUint8ListPtr ptr_,
-          int rust_vec_len_,
-          int data_len_) =>
-      wasmModule
-          .wire__crate__api__pseudo_manual__chrono_type_twin_sse__tokio_time_instant_twin_sse(
-              port_, ptr_, rust_vec_len_, data_len_);
-
-  JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */
-      wire__crate__api__pseudo_manual__chrono_type_twin_sync__tokio_time_instant_twin_sync(
-              JSAny d) =>
-          wasmModule
-              .wire__crate__api__pseudo_manual__chrono_type_twin_sync__tokio_time_instant_twin_sync(
-                  d);
-
-  JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartSse */
-      wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__tokio_time_instant_twin_sync_sse(
-              PlatformGeneralizedUint8ListPtr ptr_,
-              int rust_vec_len_,
-              int data_len_) =>
-          wasmModule
-              .wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__tokio_time_instant_twin_sync_sse(
                   ptr_, rust_vec_len_, data_len_);
 
   void wire__crate__api__dart_code__translatable_struct_with_dart_code_twin_normal_normal_method_twin_normal(
@@ -79232,37 +79111,6 @@ extension type RustLibWasmModule._(JSObject _) implements JSObject {
           int rust_vec_len_,
           int data_len_);
 
-  external void wire__crate__api__chrono_type__std_time_instant_twin_normal(
-      NativePortType port_, JSAny d);
-
-  external void
-      wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_instant_twin_rust_async(
-          NativePortType port_, JSAny d);
-
-  external void
-      wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__std_time_instant_twin_rust_async_sse(
-          NativePortType port_,
-          PlatformGeneralizedUint8ListPtr ptr_,
-          int rust_vec_len_,
-          int data_len_);
-
-  external void
-      wire__crate__api__pseudo_manual__chrono_type_twin_sse__std_time_instant_twin_sse(
-          NativePortType port_,
-          PlatformGeneralizedUint8ListPtr ptr_,
-          int rust_vec_len_,
-          int data_len_);
-
-  external JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */
-      wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_instant_twin_sync(
-          JSAny d);
-
-  external JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartSse */
-      wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__std_time_instant_twin_sync_sse(
-          PlatformGeneralizedUint8ListPtr ptr_,
-          int rust_vec_len_,
-          int data_len_);
-
   external void
       wire__crate__api__chrono_type__std_time_system_time_before_epoch_twin_normal(
           NativePortType port_, JSAny d);
@@ -80235,37 +80083,6 @@ extension type RustLibWasmModule._(JSObject _) implements JSObject {
 
   external JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartSse */
       wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__tokio_time_duration_twin_sync_sse(
-          PlatformGeneralizedUint8ListPtr ptr_,
-          int rust_vec_len_,
-          int data_len_);
-
-  external void wire__crate__api__chrono_type__tokio_time_instant_twin_normal(
-      NativePortType port_, JSAny d);
-
-  external void
-      wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__tokio_time_instant_twin_rust_async(
-          NativePortType port_, JSAny d);
-
-  external void
-      wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__tokio_time_instant_twin_rust_async_sse(
-          NativePortType port_,
-          PlatformGeneralizedUint8ListPtr ptr_,
-          int rust_vec_len_,
-          int data_len_);
-
-  external void
-      wire__crate__api__pseudo_manual__chrono_type_twin_sse__tokio_time_instant_twin_sse(
-          NativePortType port_,
-          PlatformGeneralizedUint8ListPtr ptr_,
-          int rust_vec_len_,
-          int data_len_);
-
-  external JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */
-      wire__crate__api__pseudo_manual__chrono_type_twin_sync__tokio_time_instant_twin_sync(
-          JSAny d);
-
-  external JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartSse */
-      wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__tokio_time_instant_twin_sync_sse(
           PlatformGeneralizedUint8ListPtr ptr_,
           int rust_vec_len_,
           int data_len_);

--- a/frb_example/pure_dart/lib/src/rust/frb_generated.web.dart
+++ b/frb_example/pure_dart/lib/src/rust/frb_generated.web.dart
@@ -60941,6 +60941,52 @@ class RustLibWire implements BaseWire {
               .wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__std_time_instant_twin_sync_sse(
                   ptr_, rust_vec_len_, data_len_);
 
+  void wire__crate__api__chrono_type__std_time_system_time_before_epoch_twin_normal(
+          NativePortType port_, JSAny d) =>
+      wasmModule
+          .wire__crate__api__chrono_type__std_time_system_time_before_epoch_twin_normal(
+              port_, d);
+
+  void wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_system_time_before_epoch_twin_rust_async(
+          NativePortType port_, JSAny d) =>
+      wasmModule
+          .wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_system_time_before_epoch_twin_rust_async(
+              port_, d);
+
+  void wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__std_time_system_time_before_epoch_twin_rust_async_sse(
+          NativePortType port_,
+          PlatformGeneralizedUint8ListPtr ptr_,
+          int rust_vec_len_,
+          int data_len_) =>
+      wasmModule
+          .wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__std_time_system_time_before_epoch_twin_rust_async_sse(
+              port_, ptr_, rust_vec_len_, data_len_);
+
+  void wire__crate__api__pseudo_manual__chrono_type_twin_sse__std_time_system_time_before_epoch_twin_sse(
+          NativePortType port_,
+          PlatformGeneralizedUint8ListPtr ptr_,
+          int rust_vec_len_,
+          int data_len_) =>
+      wasmModule
+          .wire__crate__api__pseudo_manual__chrono_type_twin_sse__std_time_system_time_before_epoch_twin_sse(
+              port_, ptr_, rust_vec_len_, data_len_);
+
+  JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */
+      wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_system_time_before_epoch_twin_sync(
+              JSAny d) =>
+          wasmModule
+              .wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_system_time_before_epoch_twin_sync(
+                  d);
+
+  JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartSse */
+      wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__std_time_system_time_before_epoch_twin_sync_sse(
+              PlatformGeneralizedUint8ListPtr ptr_,
+              int rust_vec_len_,
+              int data_len_) =>
+          wasmModule
+              .wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__std_time_system_time_before_epoch_twin_sync_sse(
+                  ptr_, rust_vec_len_, data_len_);
+
   void wire__crate__api__chrono_type__std_time_system_time_twin_normal(
           NativePortType port_, JSAny d) =>
       wasmModule
@@ -79213,6 +79259,38 @@ extension type RustLibWasmModule._(JSObject _) implements JSObject {
 
   external JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartSse */
       wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__std_time_instant_twin_sync_sse(
+          PlatformGeneralizedUint8ListPtr ptr_,
+          int rust_vec_len_,
+          int data_len_);
+
+  external void
+      wire__crate__api__chrono_type__std_time_system_time_before_epoch_twin_normal(
+          NativePortType port_, JSAny d);
+
+  external void
+      wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_system_time_before_epoch_twin_rust_async(
+          NativePortType port_, JSAny d);
+
+  external void
+      wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__std_time_system_time_before_epoch_twin_rust_async_sse(
+          NativePortType port_,
+          PlatformGeneralizedUint8ListPtr ptr_,
+          int rust_vec_len_,
+          int data_len_);
+
+  external void
+      wire__crate__api__pseudo_manual__chrono_type_twin_sse__std_time_system_time_before_epoch_twin_sse(
+          NativePortType port_,
+          PlatformGeneralizedUint8ListPtr ptr_,
+          int rust_vec_len_,
+          int data_len_);
+
+  external JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */
+      wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_system_time_before_epoch_twin_sync(
+          JSAny d);
+
+  external JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartSse */
+      wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__std_time_system_time_before_epoch_twin_sync_sse(
           PlatformGeneralizedUint8ListPtr ptr_,
           int rust_vec_len_,
           int data_len_);

--- a/frb_example/pure_dart/lib/src/rust/frb_generated.web.dart
+++ b/frb_example/pure_dart/lib/src/rust/frb_generated.web.dart
@@ -4223,6 +4223,15 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   Set<int> dco_decode_Set_i_32_None(dynamic raw);
 
   @protected
+  Duration dco_decode_StdTime_StdDuration(dynamic raw);
+
+  @protected
+  DateTime dco_decode_StdTime_StdInstant(dynamic raw);
+
+  @protected
+  DateTime dco_decode_StdTime_StdSystemTime(dynamic raw);
+
+  @protected
   RustStreamSink<NonCloneSimpleTwinMoi>
       dco_decode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinMoi_Dco(
           dynamic raw);
@@ -4483,6 +4492,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   String dco_decode_String(dynamic raw);
+
+  @protected
+  DateTime dco_decode_TokioTime_TokioInstant(dynamic raw);
 
   @protected
   Issue2170Trait dco_decode_TraitDef_Issue2170Trait(dynamic raw);
@@ -13680,6 +13692,15 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   Set<int> sse_decode_Set_i_32_None(SseDeserializer deserializer);
 
   @protected
+  Duration sse_decode_StdTime_StdDuration(SseDeserializer deserializer);
+
+  @protected
+  DateTime sse_decode_StdTime_StdInstant(SseDeserializer deserializer);
+
+  @protected
+  DateTime sse_decode_StdTime_StdSystemTime(SseDeserializer deserializer);
+
+  @protected
   RustStreamSink<NonCloneSimpleTwinMoi>
       sse_decode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinMoi_Dco(
           SseDeserializer deserializer);
@@ -13977,6 +13998,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   String sse_decode_String(SseDeserializer deserializer);
+
+  @protected
+  DateTime sse_decode_TokioTime_TokioInstant(SseDeserializer deserializer);
 
   @protected
   BigInt sse_decode_U128(SseDeserializer deserializer);
@@ -21478,6 +21502,24 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   }
 
   @protected
+  JSAny cst_encode_StdTime_StdDuration(Duration raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return cst_encode_i_64(BigInt.from(raw.inMilliseconds));
+  }
+
+  @protected
+  JSAny cst_encode_StdTime_StdInstant(DateTime raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return cst_encode_i_64(BigInt.from(raw.millisecondsSinceEpoch));
+  }
+
+  @protected
+  JSAny cst_encode_StdTime_StdSystemTime(DateTime raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return cst_encode_i_64(BigInt.from(raw.millisecondsSinceEpoch));
+  }
+
+  @protected
   String
       cst_encode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinMoi_Dco(
           RustStreamSink<NonCloneSimpleTwinMoi> raw) {
@@ -21843,6 +21885,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   String cst_encode_String(String raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
     return raw;
+  }
+
+  @protected
+  JSAny cst_encode_TokioTime_TokioInstant(DateTime raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return cst_encode_i_64(BigInt.from(raw.millisecondsSinceEpoch));
   }
 
   @protected
@@ -34045,6 +34093,16 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_Set_i_32_None(Set<int> self, SseSerializer serializer);
 
   @protected
+  void sse_encode_StdTime_StdDuration(Duration self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_StdTime_StdInstant(DateTime self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_StdTime_StdSystemTime(
+      DateTime self, SseSerializer serializer);
+
+  @protected
   void
       sse_encode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinMoi_Dco(
           RustStreamSink<NonCloneSimpleTwinMoi> self, SseSerializer serializer);
@@ -34327,6 +34385,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_String(String self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_TokioTime_TokioInstant(
+      DateTime self, SseSerializer serializer);
 
   @protected
   void sse_encode_U128(BigInt self, SseSerializer serializer);
@@ -60789,6 +60851,142 @@ class RustLibWire implements BaseWire {
               .wire__crate__api__pseudo_manual__method_twin_sync__static_only_twin_sync_static_method_twin_sync(
                   a);
 
+  void wire__crate__api__chrono_type__std_time_duration_twin_normal(
+          NativePortType port_, JSAny d) =>
+      wasmModule.wire__crate__api__chrono_type__std_time_duration_twin_normal(
+          port_, d);
+
+  void wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_duration_twin_rust_async(
+          NativePortType port_, JSAny d) =>
+      wasmModule
+          .wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_duration_twin_rust_async(
+              port_, d);
+
+  void wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__std_time_duration_twin_rust_async_sse(
+          NativePortType port_,
+          PlatformGeneralizedUint8ListPtr ptr_,
+          int rust_vec_len_,
+          int data_len_) =>
+      wasmModule
+          .wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__std_time_duration_twin_rust_async_sse(
+              port_, ptr_, rust_vec_len_, data_len_);
+
+  void wire__crate__api__pseudo_manual__chrono_type_twin_sse__std_time_duration_twin_sse(
+          NativePortType port_,
+          PlatformGeneralizedUint8ListPtr ptr_,
+          int rust_vec_len_,
+          int data_len_) =>
+      wasmModule
+          .wire__crate__api__pseudo_manual__chrono_type_twin_sse__std_time_duration_twin_sse(
+              port_, ptr_, rust_vec_len_, data_len_);
+
+  JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */
+      wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_duration_twin_sync(
+              JSAny d) =>
+          wasmModule
+              .wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_duration_twin_sync(
+                  d);
+
+  JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartSse */
+      wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__std_time_duration_twin_sync_sse(
+              PlatformGeneralizedUint8ListPtr ptr_,
+              int rust_vec_len_,
+              int data_len_) =>
+          wasmModule
+              .wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__std_time_duration_twin_sync_sse(
+                  ptr_, rust_vec_len_, data_len_);
+
+  void wire__crate__api__chrono_type__std_time_instant_twin_normal(
+          NativePortType port_, JSAny d) =>
+      wasmModule.wire__crate__api__chrono_type__std_time_instant_twin_normal(
+          port_, d);
+
+  void wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_instant_twin_rust_async(
+          NativePortType port_, JSAny d) =>
+      wasmModule
+          .wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_instant_twin_rust_async(
+              port_, d);
+
+  void wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__std_time_instant_twin_rust_async_sse(
+          NativePortType port_,
+          PlatformGeneralizedUint8ListPtr ptr_,
+          int rust_vec_len_,
+          int data_len_) =>
+      wasmModule
+          .wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__std_time_instant_twin_rust_async_sse(
+              port_, ptr_, rust_vec_len_, data_len_);
+
+  void wire__crate__api__pseudo_manual__chrono_type_twin_sse__std_time_instant_twin_sse(
+          NativePortType port_,
+          PlatformGeneralizedUint8ListPtr ptr_,
+          int rust_vec_len_,
+          int data_len_) =>
+      wasmModule
+          .wire__crate__api__pseudo_manual__chrono_type_twin_sse__std_time_instant_twin_sse(
+              port_, ptr_, rust_vec_len_, data_len_);
+
+  JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */
+      wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_instant_twin_sync(
+              JSAny d) =>
+          wasmModule
+              .wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_instant_twin_sync(
+                  d);
+
+  JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartSse */
+      wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__std_time_instant_twin_sync_sse(
+              PlatformGeneralizedUint8ListPtr ptr_,
+              int rust_vec_len_,
+              int data_len_) =>
+          wasmModule
+              .wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__std_time_instant_twin_sync_sse(
+                  ptr_, rust_vec_len_, data_len_);
+
+  void wire__crate__api__chrono_type__std_time_system_time_twin_normal(
+          NativePortType port_, JSAny d) =>
+      wasmModule
+          .wire__crate__api__chrono_type__std_time_system_time_twin_normal(
+              port_, d);
+
+  void wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_system_time_twin_rust_async(
+          NativePortType port_, JSAny d) =>
+      wasmModule
+          .wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_system_time_twin_rust_async(
+              port_, d);
+
+  void wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__std_time_system_time_twin_rust_async_sse(
+          NativePortType port_,
+          PlatformGeneralizedUint8ListPtr ptr_,
+          int rust_vec_len_,
+          int data_len_) =>
+      wasmModule
+          .wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__std_time_system_time_twin_rust_async_sse(
+              port_, ptr_, rust_vec_len_, data_len_);
+
+  void wire__crate__api__pseudo_manual__chrono_type_twin_sse__std_time_system_time_twin_sse(
+          NativePortType port_,
+          PlatformGeneralizedUint8ListPtr ptr_,
+          int rust_vec_len_,
+          int data_len_) =>
+      wasmModule
+          .wire__crate__api__pseudo_manual__chrono_type_twin_sse__std_time_system_time_twin_sse(
+              port_, ptr_, rust_vec_len_, data_len_);
+
+  JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */
+      wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_system_time_twin_sync(
+              JSAny d) =>
+          wasmModule
+              .wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_system_time_twin_sync(
+                  d);
+
+  JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartSse */
+      wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__std_time_system_time_twin_sync_sse(
+              PlatformGeneralizedUint8ListPtr ptr_,
+              int rust_vec_len_,
+              int data_len_) =>
+          wasmModule
+              .wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__std_time_system_time_twin_sync_sse(
+                  ptr_, rust_vec_len_, data_len_);
+
   void wire__crate__api__stream_misc__stream_sink_dart_async_twin_normal(
           NativePortType port_, String sink) =>
       wasmModule
@@ -62058,6 +62256,96 @@ class RustLibWire implements BaseWire {
               int data_len_) =>
           wasmModule
               .wire__crate__api__pseudo_manual__exception_twin_sync_sse__throw_anyhow_twin_sync_sse(
+                  ptr_, rust_vec_len_, data_len_);
+
+  void wire__crate__api__chrono_type__tokio_time_duration_twin_normal(
+          NativePortType port_, JSAny d) =>
+      wasmModule.wire__crate__api__chrono_type__tokio_time_duration_twin_normal(
+          port_, d);
+
+  void wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__tokio_time_duration_twin_rust_async(
+          NativePortType port_, JSAny d) =>
+      wasmModule
+          .wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__tokio_time_duration_twin_rust_async(
+              port_, d);
+
+  void wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__tokio_time_duration_twin_rust_async_sse(
+          NativePortType port_,
+          PlatformGeneralizedUint8ListPtr ptr_,
+          int rust_vec_len_,
+          int data_len_) =>
+      wasmModule
+          .wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__tokio_time_duration_twin_rust_async_sse(
+              port_, ptr_, rust_vec_len_, data_len_);
+
+  void wire__crate__api__pseudo_manual__chrono_type_twin_sse__tokio_time_duration_twin_sse(
+          NativePortType port_,
+          PlatformGeneralizedUint8ListPtr ptr_,
+          int rust_vec_len_,
+          int data_len_) =>
+      wasmModule
+          .wire__crate__api__pseudo_manual__chrono_type_twin_sse__tokio_time_duration_twin_sse(
+              port_, ptr_, rust_vec_len_, data_len_);
+
+  JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */
+      wire__crate__api__pseudo_manual__chrono_type_twin_sync__tokio_time_duration_twin_sync(
+              JSAny d) =>
+          wasmModule
+              .wire__crate__api__pseudo_manual__chrono_type_twin_sync__tokio_time_duration_twin_sync(
+                  d);
+
+  JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartSse */
+      wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__tokio_time_duration_twin_sync_sse(
+              PlatformGeneralizedUint8ListPtr ptr_,
+              int rust_vec_len_,
+              int data_len_) =>
+          wasmModule
+              .wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__tokio_time_duration_twin_sync_sse(
+                  ptr_, rust_vec_len_, data_len_);
+
+  void wire__crate__api__chrono_type__tokio_time_instant_twin_normal(
+          NativePortType port_, JSAny d) =>
+      wasmModule.wire__crate__api__chrono_type__tokio_time_instant_twin_normal(
+          port_, d);
+
+  void wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__tokio_time_instant_twin_rust_async(
+          NativePortType port_, JSAny d) =>
+      wasmModule
+          .wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__tokio_time_instant_twin_rust_async(
+              port_, d);
+
+  void wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__tokio_time_instant_twin_rust_async_sse(
+          NativePortType port_,
+          PlatformGeneralizedUint8ListPtr ptr_,
+          int rust_vec_len_,
+          int data_len_) =>
+      wasmModule
+          .wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__tokio_time_instant_twin_rust_async_sse(
+              port_, ptr_, rust_vec_len_, data_len_);
+
+  void wire__crate__api__pseudo_manual__chrono_type_twin_sse__tokio_time_instant_twin_sse(
+          NativePortType port_,
+          PlatformGeneralizedUint8ListPtr ptr_,
+          int rust_vec_len_,
+          int data_len_) =>
+      wasmModule
+          .wire__crate__api__pseudo_manual__chrono_type_twin_sse__tokio_time_instant_twin_sse(
+              port_, ptr_, rust_vec_len_, data_len_);
+
+  JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */
+      wire__crate__api__pseudo_manual__chrono_type_twin_sync__tokio_time_instant_twin_sync(
+              JSAny d) =>
+          wasmModule
+              .wire__crate__api__pseudo_manual__chrono_type_twin_sync__tokio_time_instant_twin_sync(
+                  d);
+
+  JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartSse */
+      wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__tokio_time_instant_twin_sync_sse(
+              PlatformGeneralizedUint8ListPtr ptr_,
+              int rust_vec_len_,
+              int data_len_) =>
+          wasmModule
+              .wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__tokio_time_instant_twin_sync_sse(
                   ptr_, rust_vec_len_, data_len_);
 
   void wire__crate__api__dart_code__translatable_struct_with_dart_code_twin_normal_normal_method_twin_normal(
@@ -78867,6 +79155,99 @@ extension type RustLibWasmModule._(JSObject _) implements JSObject {
       wire__crate__api__pseudo_manual__method_twin_sync__static_only_twin_sync_static_method_twin_sync(
           int a);
 
+  external void wire__crate__api__chrono_type__std_time_duration_twin_normal(
+      NativePortType port_, JSAny d);
+
+  external void
+      wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_duration_twin_rust_async(
+          NativePortType port_, JSAny d);
+
+  external void
+      wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__std_time_duration_twin_rust_async_sse(
+          NativePortType port_,
+          PlatformGeneralizedUint8ListPtr ptr_,
+          int rust_vec_len_,
+          int data_len_);
+
+  external void
+      wire__crate__api__pseudo_manual__chrono_type_twin_sse__std_time_duration_twin_sse(
+          NativePortType port_,
+          PlatformGeneralizedUint8ListPtr ptr_,
+          int rust_vec_len_,
+          int data_len_);
+
+  external JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */
+      wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_duration_twin_sync(
+          JSAny d);
+
+  external JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartSse */
+      wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__std_time_duration_twin_sync_sse(
+          PlatformGeneralizedUint8ListPtr ptr_,
+          int rust_vec_len_,
+          int data_len_);
+
+  external void wire__crate__api__chrono_type__std_time_instant_twin_normal(
+      NativePortType port_, JSAny d);
+
+  external void
+      wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_instant_twin_rust_async(
+          NativePortType port_, JSAny d);
+
+  external void
+      wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__std_time_instant_twin_rust_async_sse(
+          NativePortType port_,
+          PlatformGeneralizedUint8ListPtr ptr_,
+          int rust_vec_len_,
+          int data_len_);
+
+  external void
+      wire__crate__api__pseudo_manual__chrono_type_twin_sse__std_time_instant_twin_sse(
+          NativePortType port_,
+          PlatformGeneralizedUint8ListPtr ptr_,
+          int rust_vec_len_,
+          int data_len_);
+
+  external JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */
+      wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_instant_twin_sync(
+          JSAny d);
+
+  external JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartSse */
+      wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__std_time_instant_twin_sync_sse(
+          PlatformGeneralizedUint8ListPtr ptr_,
+          int rust_vec_len_,
+          int data_len_);
+
+  external void wire__crate__api__chrono_type__std_time_system_time_twin_normal(
+      NativePortType port_, JSAny d);
+
+  external void
+      wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_system_time_twin_rust_async(
+          NativePortType port_, JSAny d);
+
+  external void
+      wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__std_time_system_time_twin_rust_async_sse(
+          NativePortType port_,
+          PlatformGeneralizedUint8ListPtr ptr_,
+          int rust_vec_len_,
+          int data_len_);
+
+  external void
+      wire__crate__api__pseudo_manual__chrono_type_twin_sse__std_time_system_time_twin_sse(
+          NativePortType port_,
+          PlatformGeneralizedUint8ListPtr ptr_,
+          int rust_vec_len_,
+          int data_len_);
+
+  external JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */
+      wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_system_time_twin_sync(
+          JSAny d);
+
+  external JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartSse */
+      wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__std_time_system_time_twin_sync_sse(
+          PlatformGeneralizedUint8ListPtr ptr_,
+          int rust_vec_len_,
+          int data_len_);
+
   external void
       wire__crate__api__stream_misc__stream_sink_dart_async_twin_normal(
           NativePortType port_, String sink);
@@ -79745,6 +80126,68 @@ extension type RustLibWasmModule._(JSObject _) implements JSObject {
 
   external JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartSse */
       wire__crate__api__pseudo_manual__exception_twin_sync_sse__throw_anyhow_twin_sync_sse(
+          PlatformGeneralizedUint8ListPtr ptr_,
+          int rust_vec_len_,
+          int data_len_);
+
+  external void wire__crate__api__chrono_type__tokio_time_duration_twin_normal(
+      NativePortType port_, JSAny d);
+
+  external void
+      wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__tokio_time_duration_twin_rust_async(
+          NativePortType port_, JSAny d);
+
+  external void
+      wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__tokio_time_duration_twin_rust_async_sse(
+          NativePortType port_,
+          PlatformGeneralizedUint8ListPtr ptr_,
+          int rust_vec_len_,
+          int data_len_);
+
+  external void
+      wire__crate__api__pseudo_manual__chrono_type_twin_sse__tokio_time_duration_twin_sse(
+          NativePortType port_,
+          PlatformGeneralizedUint8ListPtr ptr_,
+          int rust_vec_len_,
+          int data_len_);
+
+  external JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */
+      wire__crate__api__pseudo_manual__chrono_type_twin_sync__tokio_time_duration_twin_sync(
+          JSAny d);
+
+  external JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartSse */
+      wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__tokio_time_duration_twin_sync_sse(
+          PlatformGeneralizedUint8ListPtr ptr_,
+          int rust_vec_len_,
+          int data_len_);
+
+  external void wire__crate__api__chrono_type__tokio_time_instant_twin_normal(
+      NativePortType port_, JSAny d);
+
+  external void
+      wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__tokio_time_instant_twin_rust_async(
+          NativePortType port_, JSAny d);
+
+  external void
+      wire__crate__api__pseudo_manual__chrono_type_twin_rust_async_sse__tokio_time_instant_twin_rust_async_sse(
+          NativePortType port_,
+          PlatformGeneralizedUint8ListPtr ptr_,
+          int rust_vec_len_,
+          int data_len_);
+
+  external void
+      wire__crate__api__pseudo_manual__chrono_type_twin_sse__tokio_time_instant_twin_sse(
+          NativePortType port_,
+          PlatformGeneralizedUint8ListPtr ptr_,
+          int rust_vec_len_,
+          int data_len_);
+
+  external JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */
+      wire__crate__api__pseudo_manual__chrono_type_twin_sync__tokio_time_instant_twin_sync(
+          JSAny d);
+
+  external JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartSse */
+      wire__crate__api__pseudo_manual__chrono_type_twin_sync_sse__tokio_time_instant_twin_sync_sse(
           PlatformGeneralizedUint8ListPtr ptr_,
           int rust_vec_len_,
           int data_len_);

--- a/frb_example/pure_dart/rust/Cargo.toml
+++ b/frb_example/pure_dart/rust/Cargo.toml
@@ -22,7 +22,7 @@ futures = "0.3.29"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0" # Only used for comparison test
 protobuf = "=2.28.0" # Only used for comparison test
-tokio = { version = "1.34.0", features = ["rt"] }
+tokio = { version = "1.34.0", features = ["rt", "time"] }
 
 [features]
 internal_feature_for_testing = []

--- a/frb_example/pure_dart/rust/src/api/chrono_type.rs
+++ b/frb_example/pure_dart/rust/src/api/chrono_type.rs
@@ -58,6 +58,36 @@ pub fn duration_twin_normal(d: chrono::Duration) -> chrono::Duration {
     d
 }
 
+pub fn std_time_duration_twin_normal(d: std::time::Duration) -> std::time::Duration {
+    assert_eq!(d.as_secs(), 4 * 60 * 60);
+    d
+}
+
+pub fn std_time_system_time_twin_normal(d: std::time::SystemTime) -> std::time::SystemTime {
+    assert_eq!(
+        d.duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
+        1_631_297_333
+    );
+    d
+}
+
+pub fn std_time_instant_twin_normal(d: std::time::Instant) -> std::time::Instant {
+    assert!(d > std::time::Instant::now());
+    d
+}
+
+pub fn tokio_time_duration_twin_normal(d: tokio::time::Duration) -> tokio::time::Duration {
+    assert_eq!(d.as_secs(), 4 * 60 * 60);
+    d
+}
+
+pub fn tokio_time_instant_twin_normal(d: tokio::time::Instant) -> tokio::time::Instant {
+    assert!(d > tokio::time::Instant::now());
+    d
+}
+
 pub fn handle_timestamps_twin_normal(
     timestamps: Vec<chrono::NaiveDateTime>,
     epoch: chrono::NaiveDateTime,

--- a/frb_example/pure_dart/rust/src/api/chrono_type.rs
+++ b/frb_example/pure_dart/rust/src/api/chrono_type.rs
@@ -86,18 +86,8 @@ pub fn std_time_system_time_before_epoch_twin_normal(
     d
 }
 
-pub fn std_time_instant_twin_normal(d: std::time::Instant) -> std::time::Instant {
-    assert!(d > std::time::Instant::now());
-    d
-}
-
 pub fn tokio_time_duration_twin_normal(d: tokio::time::Duration) -> tokio::time::Duration {
     assert_eq!(d.as_secs(), 4 * 60 * 60);
-    d
-}
-
-pub fn tokio_time_instant_twin_normal(d: tokio::time::Instant) -> tokio::time::Instant {
-    assert!(d > tokio::time::Instant::now());
     d
 }
 

--- a/frb_example/pure_dart/rust/src/api/chrono_type.rs
+++ b/frb_example/pure_dart/rust/src/api/chrono_type.rs
@@ -73,6 +73,19 @@ pub fn std_time_system_time_twin_normal(d: std::time::SystemTime) -> std::time::
     d
 }
 
+pub fn std_time_system_time_before_epoch_twin_normal(
+    d: std::time::SystemTime,
+) -> std::time::SystemTime {
+    assert_eq!(
+        std::time::SystemTime::UNIX_EPOCH
+            .duration_since(d)
+            .unwrap()
+            .as_secs(),
+        1_000
+    );
+    d
+}
+
 pub fn std_time_instant_twin_normal(d: std::time::Instant) -> std::time::Instant {
     assert!(d > std::time::Instant::now());
     d

--- a/frb_example/pure_dart/rust/src/api/chrono_type.rs
+++ b/frb_example/pure_dart/rust/src/api/chrono_type.rs
@@ -54,12 +54,32 @@ pub fn optional_empty_datetime_utc_twin_normal(
 }
 
 pub fn duration_twin_normal(d: chrono::Duration) -> chrono::Duration {
-    assert_eq!(&d.num_hours(), &4);
+    let expected_micros: i64 = {
+        #[cfg(target_arch = "wasm32")]
+        {
+            14_403_002_000
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            14_403_002_001
+        }
+    };
+    assert_eq!(d.num_microseconds().unwrap(), expected_micros);
     d
 }
 
 pub fn std_time_duration_twin_normal(d: std::time::Duration) -> std::time::Duration {
-    assert_eq!(d.as_secs(), 4 * 60 * 60);
+    let expected_micros: i64 = {
+        #[cfg(target_arch = "wasm32")]
+        {
+            14_403_002_000
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            14_403_002_001
+        }
+    };
+    assert_eq!(d.as_micros(), expected_micros.try_into().unwrap());
     d
 }
 
@@ -87,7 +107,17 @@ pub fn std_time_system_time_before_epoch_twin_normal(
 }
 
 pub fn tokio_time_duration_twin_normal(d: tokio::time::Duration) -> tokio::time::Duration {
-    assert_eq!(d.as_secs(), 4 * 60 * 60);
+    let expected_micros: i64 = {
+        #[cfg(target_arch = "wasm32")]
+        {
+            14_403_002_000
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            14_403_002_001
+        }
+    };
+    assert_eq!(d.as_micros(), expected_micros.try_into().unwrap());
     d
 }
 

--- a/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_rust_async.rs
+++ b/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_rust_async.rs
@@ -60,12 +60,32 @@ pub async fn optional_empty_datetime_utc_twin_rust_async(
 }
 
 pub async fn duration_twin_rust_async(d: chrono::Duration) -> chrono::Duration {
-    assert_eq!(&d.num_hours(), &4);
+    let expected_micros: i64 = {
+        #[cfg(target_arch = "wasm32")]
+        {
+            14_403_002_000
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            14_403_002_001
+        }
+    };
+    assert_eq!(d.num_microseconds().unwrap(), expected_micros);
     d
 }
 
 pub async fn std_time_duration_twin_rust_async(d: std::time::Duration) -> std::time::Duration {
-    assert_eq!(d.as_secs(), 4 * 60 * 60);
+    let expected_micros: i64 = {
+        #[cfg(target_arch = "wasm32")]
+        {
+            14_403_002_000
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            14_403_002_001
+        }
+    };
+    assert_eq!(d.as_micros(), expected_micros.try_into().unwrap());
     d
 }
 
@@ -97,7 +117,17 @@ pub async fn std_time_system_time_before_epoch_twin_rust_async(
 pub async fn tokio_time_duration_twin_rust_async(
     d: tokio::time::Duration,
 ) -> tokio::time::Duration {
-    assert_eq!(d.as_secs(), 4 * 60 * 60);
+    let expected_micros: i64 = {
+        #[cfg(target_arch = "wasm32")]
+        {
+            14_403_002_000
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            14_403_002_001
+        }
+    };
+    assert_eq!(d.as_micros(), expected_micros.try_into().unwrap());
     d
 }
 

--- a/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_rust_async.rs
+++ b/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_rust_async.rs
@@ -64,6 +64,40 @@ pub async fn duration_twin_rust_async(d: chrono::Duration) -> chrono::Duration {
     d
 }
 
+pub async fn std_time_duration_twin_rust_async(d: std::time::Duration) -> std::time::Duration {
+    assert_eq!(d.as_secs(), 4 * 60 * 60);
+    d
+}
+
+pub async fn std_time_system_time_twin_rust_async(
+    d: std::time::SystemTime,
+) -> std::time::SystemTime {
+    assert_eq!(
+        d.duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
+        1_631_297_333
+    );
+    d
+}
+
+pub async fn std_time_instant_twin_rust_async(d: std::time::Instant) -> std::time::Instant {
+    assert!(d > std::time::Instant::now());
+    d
+}
+
+pub async fn tokio_time_duration_twin_rust_async(
+    d: tokio::time::Duration,
+) -> tokio::time::Duration {
+    assert_eq!(d.as_secs(), 4 * 60 * 60);
+    d
+}
+
+pub async fn tokio_time_instant_twin_rust_async(d: tokio::time::Instant) -> tokio::time::Instant {
+    assert!(d > tokio::time::Instant::now());
+    d
+}
+
 pub async fn handle_timestamps_twin_rust_async(
     timestamps: Vec<chrono::NaiveDateTime>,
     epoch: chrono::NaiveDateTime,

--- a/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_rust_async.rs
+++ b/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_rust_async.rs
@@ -81,6 +81,19 @@ pub async fn std_time_system_time_twin_rust_async(
     d
 }
 
+pub async fn std_time_system_time_before_epoch_twin_rust_async(
+    d: std::time::SystemTime,
+) -> std::time::SystemTime {
+    assert_eq!(
+        std::time::SystemTime::UNIX_EPOCH
+            .duration_since(d)
+            .unwrap()
+            .as_secs(),
+        1_000
+    );
+    d
+}
+
 pub async fn std_time_instant_twin_rust_async(d: std::time::Instant) -> std::time::Instant {
     assert!(d > std::time::Instant::now());
     d

--- a/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_rust_async.rs
+++ b/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_rust_async.rs
@@ -94,20 +94,10 @@ pub async fn std_time_system_time_before_epoch_twin_rust_async(
     d
 }
 
-pub async fn std_time_instant_twin_rust_async(d: std::time::Instant) -> std::time::Instant {
-    assert!(d > std::time::Instant::now());
-    d
-}
-
 pub async fn tokio_time_duration_twin_rust_async(
     d: tokio::time::Duration,
 ) -> tokio::time::Duration {
     assert_eq!(d.as_secs(), 4 * 60 * 60);
-    d
-}
-
-pub async fn tokio_time_instant_twin_rust_async(d: tokio::time::Instant) -> tokio::time::Instant {
-    assert!(d > tokio::time::Instant::now());
     d
 }
 

--- a/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_rust_async_sse.rs
+++ b/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_rust_async_sse.rs
@@ -71,6 +71,47 @@ pub async fn duration_twin_rust_async_sse(d: chrono::Duration) -> chrono::Durati
 }
 
 #[flutter_rust_bridge::frb(serialize)]
+pub async fn std_time_duration_twin_rust_async_sse(d: std::time::Duration) -> std::time::Duration {
+    assert_eq!(d.as_secs(), 4 * 60 * 60);
+    d
+}
+
+#[flutter_rust_bridge::frb(serialize)]
+pub async fn std_time_system_time_twin_rust_async_sse(
+    d: std::time::SystemTime,
+) -> std::time::SystemTime {
+    assert_eq!(
+        d.duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
+        1_631_297_333
+    );
+    d
+}
+
+#[flutter_rust_bridge::frb(serialize)]
+pub async fn std_time_instant_twin_rust_async_sse(d: std::time::Instant) -> std::time::Instant {
+    assert!(d > std::time::Instant::now());
+    d
+}
+
+#[flutter_rust_bridge::frb(serialize)]
+pub async fn tokio_time_duration_twin_rust_async_sse(
+    d: tokio::time::Duration,
+) -> tokio::time::Duration {
+    assert_eq!(d.as_secs(), 4 * 60 * 60);
+    d
+}
+
+#[flutter_rust_bridge::frb(serialize)]
+pub async fn tokio_time_instant_twin_rust_async_sse(
+    d: tokio::time::Instant,
+) -> tokio::time::Instant {
+    assert!(d > tokio::time::Instant::now());
+    d
+}
+
+#[flutter_rust_bridge::frb(serialize)]
 pub async fn handle_timestamps_twin_rust_async_sse(
     timestamps: Vec<chrono::NaiveDateTime>,
     epoch: chrono::NaiveDateTime,

--- a/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_rust_async_sse.rs
+++ b/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_rust_async_sse.rs
@@ -104,24 +104,10 @@ pub async fn std_time_system_time_before_epoch_twin_rust_async_sse(
 }
 
 #[flutter_rust_bridge::frb(serialize)]
-pub async fn std_time_instant_twin_rust_async_sse(d: std::time::Instant) -> std::time::Instant {
-    assert!(d > std::time::Instant::now());
-    d
-}
-
-#[flutter_rust_bridge::frb(serialize)]
 pub async fn tokio_time_duration_twin_rust_async_sse(
     d: tokio::time::Duration,
 ) -> tokio::time::Duration {
     assert_eq!(d.as_secs(), 4 * 60 * 60);
-    d
-}
-
-#[flutter_rust_bridge::frb(serialize)]
-pub async fn tokio_time_instant_twin_rust_async_sse(
-    d: tokio::time::Instant,
-) -> tokio::time::Instant {
-    assert!(d > tokio::time::Instant::now());
     d
 }
 

--- a/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_rust_async_sse.rs
+++ b/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_rust_async_sse.rs
@@ -66,13 +66,33 @@ pub async fn optional_empty_datetime_utc_twin_rust_async_sse(
 
 #[flutter_rust_bridge::frb(serialize)]
 pub async fn duration_twin_rust_async_sse(d: chrono::Duration) -> chrono::Duration {
-    assert_eq!(&d.num_hours(), &4);
+    let expected_micros: i64 = {
+        #[cfg(target_arch = "wasm32")]
+        {
+            14_403_002_000
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            14_403_002_001
+        }
+    };
+    assert_eq!(d.num_microseconds().unwrap(), expected_micros);
     d
 }
 
 #[flutter_rust_bridge::frb(serialize)]
 pub async fn std_time_duration_twin_rust_async_sse(d: std::time::Duration) -> std::time::Duration {
-    assert_eq!(d.as_secs(), 4 * 60 * 60);
+    let expected_micros: i64 = {
+        #[cfg(target_arch = "wasm32")]
+        {
+            14_403_002_000
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            14_403_002_001
+        }
+    };
+    assert_eq!(d.as_micros(), expected_micros.try_into().unwrap());
     d
 }
 
@@ -107,7 +127,17 @@ pub async fn std_time_system_time_before_epoch_twin_rust_async_sse(
 pub async fn tokio_time_duration_twin_rust_async_sse(
     d: tokio::time::Duration,
 ) -> tokio::time::Duration {
-    assert_eq!(d.as_secs(), 4 * 60 * 60);
+    let expected_micros: i64 = {
+        #[cfg(target_arch = "wasm32")]
+        {
+            14_403_002_000
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            14_403_002_001
+        }
+    };
+    assert_eq!(d.as_micros(), expected_micros.try_into().unwrap());
     d
 }
 

--- a/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_rust_async_sse.rs
+++ b/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_rust_async_sse.rs
@@ -90,6 +90,20 @@ pub async fn std_time_system_time_twin_rust_async_sse(
 }
 
 #[flutter_rust_bridge::frb(serialize)]
+pub async fn std_time_system_time_before_epoch_twin_rust_async_sse(
+    d: std::time::SystemTime,
+) -> std::time::SystemTime {
+    assert_eq!(
+        std::time::SystemTime::UNIX_EPOCH
+            .duration_since(d)
+            .unwrap()
+            .as_secs(),
+        1_000
+    );
+    d
+}
+
+#[flutter_rust_bridge::frb(serialize)]
 pub async fn std_time_instant_twin_rust_async_sse(d: std::time::Instant) -> std::time::Instant {
     assert!(d > std::time::Instant::now());
     d

--- a/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_sse.rs
+++ b/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_sse.rs
@@ -64,13 +64,33 @@ pub fn optional_empty_datetime_utc_twin_sse(
 
 #[flutter_rust_bridge::frb(serialize)]
 pub fn duration_twin_sse(d: chrono::Duration) -> chrono::Duration {
-    assert_eq!(&d.num_hours(), &4);
+    let expected_micros: i64 = {
+        #[cfg(target_arch = "wasm32")]
+        {
+            14_403_002_000
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            14_403_002_001
+        }
+    };
+    assert_eq!(d.num_microseconds().unwrap(), expected_micros);
     d
 }
 
 #[flutter_rust_bridge::frb(serialize)]
 pub fn std_time_duration_twin_sse(d: std::time::Duration) -> std::time::Duration {
-    assert_eq!(d.as_secs(), 4 * 60 * 60);
+    let expected_micros: i64 = {
+        #[cfg(target_arch = "wasm32")]
+        {
+            14_403_002_000
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            14_403_002_001
+        }
+    };
+    assert_eq!(d.as_micros(), expected_micros.try_into().unwrap());
     d
 }
 
@@ -101,7 +121,17 @@ pub fn std_time_system_time_before_epoch_twin_sse(
 
 #[flutter_rust_bridge::frb(serialize)]
 pub fn tokio_time_duration_twin_sse(d: tokio::time::Duration) -> tokio::time::Duration {
-    assert_eq!(d.as_secs(), 4 * 60 * 60);
+    let expected_micros: i64 = {
+        #[cfg(target_arch = "wasm32")]
+        {
+            14_403_002_000
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            14_403_002_001
+        }
+    };
+    assert_eq!(d.as_micros(), expected_micros.try_into().unwrap());
     d
 }
 

--- a/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_sse.rs
+++ b/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_sse.rs
@@ -69,6 +69,41 @@ pub fn duration_twin_sse(d: chrono::Duration) -> chrono::Duration {
 }
 
 #[flutter_rust_bridge::frb(serialize)]
+pub fn std_time_duration_twin_sse(d: std::time::Duration) -> std::time::Duration {
+    assert_eq!(d.as_secs(), 4 * 60 * 60);
+    d
+}
+
+#[flutter_rust_bridge::frb(serialize)]
+pub fn std_time_system_time_twin_sse(d: std::time::SystemTime) -> std::time::SystemTime {
+    assert_eq!(
+        d.duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
+        1_631_297_333
+    );
+    d
+}
+
+#[flutter_rust_bridge::frb(serialize)]
+pub fn std_time_instant_twin_sse(d: std::time::Instant) -> std::time::Instant {
+    assert!(d > std::time::Instant::now());
+    d
+}
+
+#[flutter_rust_bridge::frb(serialize)]
+pub fn tokio_time_duration_twin_sse(d: tokio::time::Duration) -> tokio::time::Duration {
+    assert_eq!(d.as_secs(), 4 * 60 * 60);
+    d
+}
+
+#[flutter_rust_bridge::frb(serialize)]
+pub fn tokio_time_instant_twin_sse(d: tokio::time::Instant) -> tokio::time::Instant {
+    assert!(d > tokio::time::Instant::now());
+    d
+}
+
+#[flutter_rust_bridge::frb(serialize)]
 pub fn handle_timestamps_twin_sse(
     timestamps: Vec<chrono::NaiveDateTime>,
     epoch: chrono::NaiveDateTime,

--- a/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_sse.rs
+++ b/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_sse.rs
@@ -100,20 +100,8 @@ pub fn std_time_system_time_before_epoch_twin_sse(
 }
 
 #[flutter_rust_bridge::frb(serialize)]
-pub fn std_time_instant_twin_sse(d: std::time::Instant) -> std::time::Instant {
-    assert!(d > std::time::Instant::now());
-    d
-}
-
-#[flutter_rust_bridge::frb(serialize)]
 pub fn tokio_time_duration_twin_sse(d: tokio::time::Duration) -> tokio::time::Duration {
     assert_eq!(d.as_secs(), 4 * 60 * 60);
-    d
-}
-
-#[flutter_rust_bridge::frb(serialize)]
-pub fn tokio_time_instant_twin_sse(d: tokio::time::Instant) -> tokio::time::Instant {
-    assert!(d > tokio::time::Instant::now());
     d
 }
 

--- a/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_sse.rs
+++ b/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_sse.rs
@@ -86,6 +86,20 @@ pub fn std_time_system_time_twin_sse(d: std::time::SystemTime) -> std::time::Sys
 }
 
 #[flutter_rust_bridge::frb(serialize)]
+pub fn std_time_system_time_before_epoch_twin_sse(
+    d: std::time::SystemTime,
+) -> std::time::SystemTime {
+    assert_eq!(
+        std::time::SystemTime::UNIX_EPOCH
+            .duration_since(d)
+            .unwrap()
+            .as_secs(),
+        1_000
+    );
+    d
+}
+
+#[flutter_rust_bridge::frb(serialize)]
 pub fn std_time_instant_twin_sse(d: std::time::Instant) -> std::time::Instant {
     assert!(d > std::time::Instant::now());
     d

--- a/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_sync.rs
+++ b/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_sync.rs
@@ -86,6 +86,20 @@ pub fn std_time_system_time_twin_sync(d: std::time::SystemTime) -> std::time::Sy
 }
 
 #[flutter_rust_bridge::frb(sync)]
+pub fn std_time_system_time_before_epoch_twin_sync(
+    d: std::time::SystemTime,
+) -> std::time::SystemTime {
+    assert_eq!(
+        std::time::SystemTime::UNIX_EPOCH
+            .duration_since(d)
+            .unwrap()
+            .as_secs(),
+        1_000
+    );
+    d
+}
+
+#[flutter_rust_bridge::frb(sync)]
 pub fn std_time_instant_twin_sync(d: std::time::Instant) -> std::time::Instant {
     assert!(d > std::time::Instant::now());
     d

--- a/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_sync.rs
+++ b/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_sync.rs
@@ -64,13 +64,33 @@ pub fn optional_empty_datetime_utc_twin_sync(
 
 #[flutter_rust_bridge::frb(sync)]
 pub fn duration_twin_sync(d: chrono::Duration) -> chrono::Duration {
-    assert_eq!(&d.num_hours(), &4);
+    let expected_micros: i64 = {
+        #[cfg(target_arch = "wasm32")]
+        {
+            14_403_002_000
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            14_403_002_001
+        }
+    };
+    assert_eq!(d.num_microseconds().unwrap(), expected_micros);
     d
 }
 
 #[flutter_rust_bridge::frb(sync)]
 pub fn std_time_duration_twin_sync(d: std::time::Duration) -> std::time::Duration {
-    assert_eq!(d.as_secs(), 4 * 60 * 60);
+    let expected_micros: i64 = {
+        #[cfg(target_arch = "wasm32")]
+        {
+            14_403_002_000
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            14_403_002_001
+        }
+    };
+    assert_eq!(d.as_micros(), expected_micros.try_into().unwrap());
     d
 }
 
@@ -101,7 +121,17 @@ pub fn std_time_system_time_before_epoch_twin_sync(
 
 #[flutter_rust_bridge::frb(sync)]
 pub fn tokio_time_duration_twin_sync(d: tokio::time::Duration) -> tokio::time::Duration {
-    assert_eq!(d.as_secs(), 4 * 60 * 60);
+    let expected_micros: i64 = {
+        #[cfg(target_arch = "wasm32")]
+        {
+            14_403_002_000
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            14_403_002_001
+        }
+    };
+    assert_eq!(d.as_micros(), expected_micros.try_into().unwrap());
     d
 }
 

--- a/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_sync.rs
+++ b/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_sync.rs
@@ -100,20 +100,8 @@ pub fn std_time_system_time_before_epoch_twin_sync(
 }
 
 #[flutter_rust_bridge::frb(sync)]
-pub fn std_time_instant_twin_sync(d: std::time::Instant) -> std::time::Instant {
-    assert!(d > std::time::Instant::now());
-    d
-}
-
-#[flutter_rust_bridge::frb(sync)]
 pub fn tokio_time_duration_twin_sync(d: tokio::time::Duration) -> tokio::time::Duration {
     assert_eq!(d.as_secs(), 4 * 60 * 60);
-    d
-}
-
-#[flutter_rust_bridge::frb(sync)]
-pub fn tokio_time_instant_twin_sync(d: tokio::time::Instant) -> tokio::time::Instant {
-    assert!(d > tokio::time::Instant::now());
     d
 }
 

--- a/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_sync.rs
+++ b/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_sync.rs
@@ -69,6 +69,41 @@ pub fn duration_twin_sync(d: chrono::Duration) -> chrono::Duration {
 }
 
 #[flutter_rust_bridge::frb(sync)]
+pub fn std_time_duration_twin_sync(d: std::time::Duration) -> std::time::Duration {
+    assert_eq!(d.as_secs(), 4 * 60 * 60);
+    d
+}
+
+#[flutter_rust_bridge::frb(sync)]
+pub fn std_time_system_time_twin_sync(d: std::time::SystemTime) -> std::time::SystemTime {
+    assert_eq!(
+        d.duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
+        1_631_297_333
+    );
+    d
+}
+
+#[flutter_rust_bridge::frb(sync)]
+pub fn std_time_instant_twin_sync(d: std::time::Instant) -> std::time::Instant {
+    assert!(d > std::time::Instant::now());
+    d
+}
+
+#[flutter_rust_bridge::frb(sync)]
+pub fn tokio_time_duration_twin_sync(d: tokio::time::Duration) -> tokio::time::Duration {
+    assert_eq!(d.as_secs(), 4 * 60 * 60);
+    d
+}
+
+#[flutter_rust_bridge::frb(sync)]
+pub fn tokio_time_instant_twin_sync(d: tokio::time::Instant) -> tokio::time::Instant {
+    assert!(d > tokio::time::Instant::now());
+    d
+}
+
+#[flutter_rust_bridge::frb(sync)]
 pub fn handle_timestamps_twin_sync(
     timestamps: Vec<chrono::NaiveDateTime>,
     epoch: chrono::NaiveDateTime,

--- a/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_sync_sse.rs
+++ b/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_sync_sse.rs
@@ -72,14 +72,34 @@ pub fn optional_empty_datetime_utc_twin_sync_sse(
 #[flutter_rust_bridge::frb(serialize)]
 #[flutter_rust_bridge::frb(sync)]
 pub fn duration_twin_sync_sse(d: chrono::Duration) -> chrono::Duration {
-    assert_eq!(&d.num_hours(), &4);
+    let expected_micros: i64 = {
+        #[cfg(target_arch = "wasm32")]
+        {
+            14_403_002_000
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            14_403_002_001
+        }
+    };
+    assert_eq!(d.num_microseconds().unwrap(), expected_micros);
     d
 }
 
 #[flutter_rust_bridge::frb(serialize)]
 #[flutter_rust_bridge::frb(sync)]
 pub fn std_time_duration_twin_sync_sse(d: std::time::Duration) -> std::time::Duration {
-    assert_eq!(d.as_secs(), 4 * 60 * 60);
+    let expected_micros: i64 = {
+        #[cfg(target_arch = "wasm32")]
+        {
+            14_403_002_000
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            14_403_002_001
+        }
+    };
+    assert_eq!(d.as_micros(), expected_micros.try_into().unwrap());
     d
 }
 
@@ -113,7 +133,17 @@ pub fn std_time_system_time_before_epoch_twin_sync_sse(
 #[flutter_rust_bridge::frb(serialize)]
 #[flutter_rust_bridge::frb(sync)]
 pub fn tokio_time_duration_twin_sync_sse(d: tokio::time::Duration) -> tokio::time::Duration {
-    assert_eq!(d.as_secs(), 4 * 60 * 60);
+    let expected_micros: i64 = {
+        #[cfg(target_arch = "wasm32")]
+        {
+            14_403_002_000
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            14_403_002_001
+        }
+    };
+    assert_eq!(d.as_micros(), expected_micros.try_into().unwrap());
     d
 }
 

--- a/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_sync_sse.rs
+++ b/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_sync_sse.rs
@@ -78,6 +78,46 @@ pub fn duration_twin_sync_sse(d: chrono::Duration) -> chrono::Duration {
 
 #[flutter_rust_bridge::frb(serialize)]
 #[flutter_rust_bridge::frb(sync)]
+pub fn std_time_duration_twin_sync_sse(d: std::time::Duration) -> std::time::Duration {
+    assert_eq!(d.as_secs(), 4 * 60 * 60);
+    d
+}
+
+#[flutter_rust_bridge::frb(serialize)]
+#[flutter_rust_bridge::frb(sync)]
+pub fn std_time_system_time_twin_sync_sse(d: std::time::SystemTime) -> std::time::SystemTime {
+    assert_eq!(
+        d.duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
+        1_631_297_333
+    );
+    d
+}
+
+#[flutter_rust_bridge::frb(serialize)]
+#[flutter_rust_bridge::frb(sync)]
+pub fn std_time_instant_twin_sync_sse(d: std::time::Instant) -> std::time::Instant {
+    assert!(d > std::time::Instant::now());
+    d
+}
+
+#[flutter_rust_bridge::frb(serialize)]
+#[flutter_rust_bridge::frb(sync)]
+pub fn tokio_time_duration_twin_sync_sse(d: tokio::time::Duration) -> tokio::time::Duration {
+    assert_eq!(d.as_secs(), 4 * 60 * 60);
+    d
+}
+
+#[flutter_rust_bridge::frb(serialize)]
+#[flutter_rust_bridge::frb(sync)]
+pub fn tokio_time_instant_twin_sync_sse(d: tokio::time::Instant) -> tokio::time::Instant {
+    assert!(d > tokio::time::Instant::now());
+    d
+}
+
+#[flutter_rust_bridge::frb(serialize)]
+#[flutter_rust_bridge::frb(sync)]
 pub fn handle_timestamps_twin_sync_sse(
     timestamps: Vec<chrono::NaiveDateTime>,
     epoch: chrono::NaiveDateTime,

--- a/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_sync_sse.rs
+++ b/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_sync_sse.rs
@@ -97,6 +97,21 @@ pub fn std_time_system_time_twin_sync_sse(d: std::time::SystemTime) -> std::time
 
 #[flutter_rust_bridge::frb(serialize)]
 #[flutter_rust_bridge::frb(sync)]
+pub fn std_time_system_time_before_epoch_twin_sync_sse(
+    d: std::time::SystemTime,
+) -> std::time::SystemTime {
+    assert_eq!(
+        std::time::SystemTime::UNIX_EPOCH
+            .duration_since(d)
+            .unwrap()
+            .as_secs(),
+        1_000
+    );
+    d
+}
+
+#[flutter_rust_bridge::frb(serialize)]
+#[flutter_rust_bridge::frb(sync)]
 pub fn std_time_instant_twin_sync_sse(d: std::time::Instant) -> std::time::Instant {
     assert!(d > std::time::Instant::now());
     d

--- a/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_sync_sse.rs
+++ b/frb_example/pure_dart/rust/src/api/pseudo_manual/chrono_type_twin_sync_sse.rs
@@ -112,22 +112,8 @@ pub fn std_time_system_time_before_epoch_twin_sync_sse(
 
 #[flutter_rust_bridge::frb(serialize)]
 #[flutter_rust_bridge::frb(sync)]
-pub fn std_time_instant_twin_sync_sse(d: std::time::Instant) -> std::time::Instant {
-    assert!(d > std::time::Instant::now());
-    d
-}
-
-#[flutter_rust_bridge::frb(serialize)]
-#[flutter_rust_bridge::frb(sync)]
 pub fn tokio_time_duration_twin_sync_sse(d: tokio::time::Duration) -> tokio::time::Duration {
     assert_eq!(d.as_secs(), 4 * 60 * 60);
-    d
-}
-
-#[flutter_rust_bridge::frb(serialize)]
-#[flutter_rust_bridge::frb(sync)]
-pub fn tokio_time_instant_twin_sync_sse(d: tokio::time::Instant) -> tokio::time::Instant {
-    assert!(d > tokio::time::Instant::now());
     d
 }
 

--- a/frb_example/pure_dart/test/api/chrono_type_test.dart
+++ b/frb_example/pure_dart/test/api/chrono_type_test.dart
@@ -85,6 +85,13 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp.millisecondsSinceEpoch, date.millisecondsSinceEpoch);
   });
 
+  test('std::time::SystemTime before UNIX epoch', () async {
+    final date = DateTime.fromMicrosecondsSinceEpoch(-1000000000, isUtc: true);
+    final resp = await stdTimeSystemTimeBeforeEpochTwinNormal(d: date);
+    expect(resp.isUtc, true);
+    expect(resp.microsecondsSinceEpoch, date.microsecondsSinceEpoch);
+  });
+
   test('std::time::Instant', () async {
     final date = DateTime.now().toUtc().add(Duration(seconds: 5));
     final resp = await stdTimeInstantTwinNormal(d: date);

--- a/frb_example/pure_dart/test/api/chrono_type_test.dart
+++ b/frb_example/pure_dart/test/api/chrono_type_test.dart
@@ -85,14 +85,17 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp.millisecondsSinceEpoch, date.millisecondsSinceEpoch);
   });
 
-  test('std::time::SystemTime before UNIX epoch', () async {
+  test('std::time::SystemTime before UNIX epoch',
+      skip: skipWeb('wasm SystemTime does not support pre-epoch values'),
+      () async {
     final date = DateTime.fromMicrosecondsSinceEpoch(-1000000000, isUtc: true);
     final resp = await stdTimeSystemTimeBeforeEpochTwinNormal(d: date);
     expect(resp.isUtc, true);
     expect(resp.microsecondsSinceEpoch, date.microsecondsSinceEpoch);
   });
 
-  test('std::time::Instant', () async {
+  test('std::time::Instant', skip: skipWeb('wasm Instant::now panics'),
+      () async {
     final date = DateTime.now().toUtc().add(Duration(seconds: 5));
     final resp = await stdTimeInstantTwinNormal(d: date);
     expect(resp.difference(date).abs() < Duration(seconds: 1), true);
@@ -104,7 +107,8 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp, d);
   });
 
-  test('tokio::time::Instant', () async {
+  test('tokio::time::Instant', skip: skipWeb('wasm Instant::now panics'),
+      () async {
     final date = DateTime.now().toUtc().add(Duration(seconds: 5));
     final resp = await tokioTimeInstantTwinNormal(d: date);
     expect(resp.difference(date).abs() < Duration(seconds: 1), true);

--- a/frb_example/pure_dart/test/api/chrono_type_test.dart
+++ b/frb_example/pure_dart/test/api/chrono_type_test.dart
@@ -71,6 +71,38 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp.inHours, d.inHours);
   });
 
+  test('std::time::Duration', () async {
+    final d = Duration(hours: 4);
+    final resp = await stdTimeDurationTwinNormal(d: d);
+    expect(resp, d);
+  });
+
+  test('std::time::SystemTime', () async {
+    final date =
+        DateTime.fromMillisecondsSinceEpoch(1631297333000, isUtc: true);
+    final resp = await stdTimeSystemTimeTwinNormal(d: date);
+    expect(resp.isUtc, true);
+    expect(resp.millisecondsSinceEpoch, date.millisecondsSinceEpoch);
+  });
+
+  test('std::time::Instant', () async {
+    final date = DateTime.now().toUtc().add(Duration(seconds: 5));
+    final resp = await stdTimeInstantTwinNormal(d: date);
+    expect(resp.difference(date).abs() < Duration(seconds: 1), true);
+  });
+
+  test('tokio::time::Duration', () async {
+    final d = Duration(hours: 4);
+    final resp = await tokioTimeDurationTwinNormal(d: d);
+    expect(resp, d);
+  });
+
+  test('tokio::time::Instant', () async {
+    final date = DateTime.now().toUtc().add(Duration(seconds: 5));
+    final resp = await tokioTimeInstantTwinNormal(d: date);
+    expect(resp.difference(date).abs() < Duration(seconds: 1), true);
+  });
+
   test('List<Duration>', () async {
     final expected = [
       Duration(days: 1),

--- a/frb_example/pure_dart/test/api/chrono_type_test.dart
+++ b/frb_example/pure_dart/test/api/chrono_type_test.dart
@@ -66,13 +66,13 @@ Future<void> main({bool skipRustLibInit = false}) async {
   });
 
   test('Duration', () async {
-    final d = Duration(hours: 4);
+    final d = preciseDuration();
     final resp = await durationTwinNormal(d: d);
-    expect(resp.inHours, d.inHours);
+    expect(resp, d);
   });
 
   test('std::time::Duration', () async {
-    final d = Duration(hours: 4);
+    final d = preciseDuration();
     final resp = await stdTimeDurationTwinNormal(d: d);
     expect(resp, d);
   });
@@ -95,7 +95,7 @@ Future<void> main({bool skipRustLibInit = false}) async {
   });
 
   test('tokio::time::Duration', () async {
-    final d = Duration(hours: 4);
+    final d = preciseDuration();
     final resp = await tokioTimeDurationTwinNormal(d: d);
     expect(resp, d);
   });
@@ -169,3 +169,10 @@ Future<void> main({bool skipRustLibInit = false}) async {
     debugPrint('$difference');
   });
 }
+
+Duration preciseDuration() => Duration(
+      hours: 4,
+      seconds: 3,
+      milliseconds: 2,
+      microseconds: kIsWeb ? 0 : 1,
+    );

--- a/frb_example/pure_dart/test/api/chrono_type_test.dart
+++ b/frb_example/pure_dart/test/api/chrono_type_test.dart
@@ -94,24 +94,10 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp.microsecondsSinceEpoch, date.microsecondsSinceEpoch);
   });
 
-  test('std::time::Instant', skip: skipWeb('wasm Instant::now panics'),
-      () async {
-    final date = DateTime.now().toUtc().add(Duration(seconds: 5));
-    final resp = await stdTimeInstantTwinNormal(d: date);
-    expect(resp.difference(date).abs() < Duration(seconds: 1), true);
-  });
-
   test('tokio::time::Duration', () async {
     final d = Duration(hours: 4);
     final resp = await tokioTimeDurationTwinNormal(d: d);
     expect(resp, d);
-  });
-
-  test('tokio::time::Instant', skip: skipWeb('wasm Instant::now panics'),
-      () async {
-    final date = DateTime.now().toUtc().add(Duration(seconds: 5));
-    final resp = await tokioTimeInstantTwinNormal(d: date);
-    expect(resp.difference(date).abs() < Duration(seconds: 1), true);
   });
 
   test('List<Duration>', () async {

--- a/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_rust_async_sse_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_rust_async_sse_test.dart
@@ -98,24 +98,10 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp.microsecondsSinceEpoch, date.microsecondsSinceEpoch);
   });
 
-  test('std::time::Instant', skip: skipWeb('wasm Instant::now panics'),
-      () async {
-    final date = DateTime.now().toUtc().add(Duration(seconds: 5));
-    final resp = await stdTimeInstantTwinRustAsyncSse(d: date);
-    expect(resp.difference(date).abs() < Duration(seconds: 1), true);
-  });
-
   test('tokio::time::Duration', () async {
     final d = Duration(hours: 4);
     final resp = await tokioTimeDurationTwinRustAsyncSse(d: d);
     expect(resp, d);
-  });
-
-  test('tokio::time::Instant', skip: skipWeb('wasm Instant::now panics'),
-      () async {
-    final date = DateTime.now().toUtc().add(Duration(seconds: 5));
-    final resp = await tokioTimeInstantTwinRustAsyncSse(d: date);
-    expect(resp.difference(date).abs() < Duration(seconds: 1), true);
   });
 
   test('List<Duration>', () async {

--- a/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_rust_async_sse_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_rust_async_sse_test.dart
@@ -89,14 +89,17 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp.millisecondsSinceEpoch, date.millisecondsSinceEpoch);
   });
 
-  test('std::time::SystemTime before UNIX epoch', () async {
+  test('std::time::SystemTime before UNIX epoch',
+      skip: skipWeb('wasm SystemTime does not support pre-epoch values'),
+      () async {
     final date = DateTime.fromMicrosecondsSinceEpoch(-1000000000, isUtc: true);
     final resp = await stdTimeSystemTimeBeforeEpochTwinRustAsyncSse(d: date);
     expect(resp.isUtc, true);
     expect(resp.microsecondsSinceEpoch, date.microsecondsSinceEpoch);
   });
 
-  test('std::time::Instant', () async {
+  test('std::time::Instant', skip: skipWeb('wasm Instant::now panics'),
+      () async {
     final date = DateTime.now().toUtc().add(Duration(seconds: 5));
     final resp = await stdTimeInstantTwinRustAsyncSse(d: date);
     expect(resp.difference(date).abs() < Duration(seconds: 1), true);
@@ -108,7 +111,8 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp, d);
   });
 
-  test('tokio::time::Instant', () async {
+  test('tokio::time::Instant', skip: skipWeb('wasm Instant::now panics'),
+      () async {
     final date = DateTime.now().toUtc().add(Duration(seconds: 5));
     final resp = await tokioTimeInstantTwinRustAsyncSse(d: date);
     expect(resp.difference(date).abs() < Duration(seconds: 1), true);

--- a/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_rust_async_sse_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_rust_async_sse_test.dart
@@ -70,13 +70,13 @@ Future<void> main({bool skipRustLibInit = false}) async {
   });
 
   test('Duration', () async {
-    final d = Duration(hours: 4);
+    final d = preciseDuration();
     final resp = await durationTwinRustAsyncSse(d: d);
-    expect(resp.inHours, d.inHours);
+    expect(resp, d);
   });
 
   test('std::time::Duration', () async {
-    final d = Duration(hours: 4);
+    final d = preciseDuration();
     final resp = await stdTimeDurationTwinRustAsyncSse(d: d);
     expect(resp, d);
   });
@@ -99,7 +99,7 @@ Future<void> main({bool skipRustLibInit = false}) async {
   });
 
   test('tokio::time::Duration', () async {
-    final d = Duration(hours: 4);
+    final d = preciseDuration();
     final resp = await tokioTimeDurationTwinRustAsyncSse(d: d);
     expect(resp, d);
   });
@@ -173,3 +173,10 @@ Future<void> main({bool skipRustLibInit = false}) async {
     debugPrint('$difference');
   });
 }
+
+Duration preciseDuration() => Duration(
+      hours: 4,
+      seconds: 3,
+      milliseconds: 2,
+      microseconds: kIsWeb ? 0 : 1,
+    );

--- a/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_rust_async_sse_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_rust_async_sse_test.dart
@@ -89,6 +89,13 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp.millisecondsSinceEpoch, date.millisecondsSinceEpoch);
   });
 
+  test('std::time::SystemTime before UNIX epoch', () async {
+    final date = DateTime.fromMicrosecondsSinceEpoch(-1000000000, isUtc: true);
+    final resp = await stdTimeSystemTimeBeforeEpochTwinRustAsyncSse(d: date);
+    expect(resp.isUtc, true);
+    expect(resp.microsecondsSinceEpoch, date.microsecondsSinceEpoch);
+  });
+
   test('std::time::Instant', () async {
     final date = DateTime.now().toUtc().add(Duration(seconds: 5));
     final resp = await stdTimeInstantTwinRustAsyncSse(d: date);

--- a/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_rust_async_sse_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_rust_async_sse_test.dart
@@ -75,6 +75,38 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp.inHours, d.inHours);
   });
 
+  test('std::time::Duration', () async {
+    final d = Duration(hours: 4);
+    final resp = await stdTimeDurationTwinRustAsyncSse(d: d);
+    expect(resp, d);
+  });
+
+  test('std::time::SystemTime', () async {
+    final date =
+        DateTime.fromMillisecondsSinceEpoch(1631297333000, isUtc: true);
+    final resp = await stdTimeSystemTimeTwinRustAsyncSse(d: date);
+    expect(resp.isUtc, true);
+    expect(resp.millisecondsSinceEpoch, date.millisecondsSinceEpoch);
+  });
+
+  test('std::time::Instant', () async {
+    final date = DateTime.now().toUtc().add(Duration(seconds: 5));
+    final resp = await stdTimeInstantTwinRustAsyncSse(d: date);
+    expect(resp.difference(date).abs() < Duration(seconds: 1), true);
+  });
+
+  test('tokio::time::Duration', () async {
+    final d = Duration(hours: 4);
+    final resp = await tokioTimeDurationTwinRustAsyncSse(d: d);
+    expect(resp, d);
+  });
+
+  test('tokio::time::Instant', () async {
+    final date = DateTime.now().toUtc().add(Duration(seconds: 5));
+    final resp = await tokioTimeInstantTwinRustAsyncSse(d: date);
+    expect(resp.difference(date).abs() < Duration(seconds: 1), true);
+  });
+
   test('List<Duration>', () async {
     final expected = [
       Duration(days: 1),

--- a/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_rust_async_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_rust_async_test.dart
@@ -98,24 +98,10 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp.microsecondsSinceEpoch, date.microsecondsSinceEpoch);
   });
 
-  test('std::time::Instant', skip: skipWeb('wasm Instant::now panics'),
-      () async {
-    final date = DateTime.now().toUtc().add(Duration(seconds: 5));
-    final resp = await stdTimeInstantTwinRustAsync(d: date);
-    expect(resp.difference(date).abs() < Duration(seconds: 1), true);
-  });
-
   test('tokio::time::Duration', () async {
     final d = Duration(hours: 4);
     final resp = await tokioTimeDurationTwinRustAsync(d: d);
     expect(resp, d);
-  });
-
-  test('tokio::time::Instant', skip: skipWeb('wasm Instant::now panics'),
-      () async {
-    final date = DateTime.now().toUtc().add(Duration(seconds: 5));
-    final resp = await tokioTimeInstantTwinRustAsync(d: date);
-    expect(resp.difference(date).abs() < Duration(seconds: 1), true);
   });
 
   test('List<Duration>', () async {

--- a/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_rust_async_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_rust_async_test.dart
@@ -70,13 +70,13 @@ Future<void> main({bool skipRustLibInit = false}) async {
   });
 
   test('Duration', () async {
-    final d = Duration(hours: 4);
+    final d = preciseDuration();
     final resp = await durationTwinRustAsync(d: d);
-    expect(resp.inHours, d.inHours);
+    expect(resp, d);
   });
 
   test('std::time::Duration', () async {
-    final d = Duration(hours: 4);
+    final d = preciseDuration();
     final resp = await stdTimeDurationTwinRustAsync(d: d);
     expect(resp, d);
   });
@@ -99,7 +99,7 @@ Future<void> main({bool skipRustLibInit = false}) async {
   });
 
   test('tokio::time::Duration', () async {
-    final d = Duration(hours: 4);
+    final d = preciseDuration();
     final resp = await tokioTimeDurationTwinRustAsync(d: d);
     expect(resp, d);
   });
@@ -173,3 +173,10 @@ Future<void> main({bool skipRustLibInit = false}) async {
     debugPrint('$difference');
   });
 }
+
+Duration preciseDuration() => Duration(
+      hours: 4,
+      seconds: 3,
+      milliseconds: 2,
+      microseconds: kIsWeb ? 0 : 1,
+    );

--- a/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_rust_async_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_rust_async_test.dart
@@ -89,6 +89,13 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp.millisecondsSinceEpoch, date.millisecondsSinceEpoch);
   });
 
+  test('std::time::SystemTime before UNIX epoch', () async {
+    final date = DateTime.fromMicrosecondsSinceEpoch(-1000000000, isUtc: true);
+    final resp = await stdTimeSystemTimeBeforeEpochTwinRustAsync(d: date);
+    expect(resp.isUtc, true);
+    expect(resp.microsecondsSinceEpoch, date.microsecondsSinceEpoch);
+  });
+
   test('std::time::Instant', () async {
     final date = DateTime.now().toUtc().add(Duration(seconds: 5));
     final resp = await stdTimeInstantTwinRustAsync(d: date);

--- a/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_rust_async_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_rust_async_test.dart
@@ -89,14 +89,17 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp.millisecondsSinceEpoch, date.millisecondsSinceEpoch);
   });
 
-  test('std::time::SystemTime before UNIX epoch', () async {
+  test('std::time::SystemTime before UNIX epoch',
+      skip: skipWeb('wasm SystemTime does not support pre-epoch values'),
+      () async {
     final date = DateTime.fromMicrosecondsSinceEpoch(-1000000000, isUtc: true);
     final resp = await stdTimeSystemTimeBeforeEpochTwinRustAsync(d: date);
     expect(resp.isUtc, true);
     expect(resp.microsecondsSinceEpoch, date.microsecondsSinceEpoch);
   });
 
-  test('std::time::Instant', () async {
+  test('std::time::Instant', skip: skipWeb('wasm Instant::now panics'),
+      () async {
     final date = DateTime.now().toUtc().add(Duration(seconds: 5));
     final resp = await stdTimeInstantTwinRustAsync(d: date);
     expect(resp.difference(date).abs() < Duration(seconds: 1), true);
@@ -108,7 +111,8 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp, d);
   });
 
-  test('tokio::time::Instant', () async {
+  test('tokio::time::Instant', skip: skipWeb('wasm Instant::now panics'),
+      () async {
     final date = DateTime.now().toUtc().add(Duration(seconds: 5));
     final resp = await tokioTimeInstantTwinRustAsync(d: date);
     expect(resp.difference(date).abs() < Duration(seconds: 1), true);

--- a/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_rust_async_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_rust_async_test.dart
@@ -75,6 +75,38 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp.inHours, d.inHours);
   });
 
+  test('std::time::Duration', () async {
+    final d = Duration(hours: 4);
+    final resp = await stdTimeDurationTwinRustAsync(d: d);
+    expect(resp, d);
+  });
+
+  test('std::time::SystemTime', () async {
+    final date =
+        DateTime.fromMillisecondsSinceEpoch(1631297333000, isUtc: true);
+    final resp = await stdTimeSystemTimeTwinRustAsync(d: date);
+    expect(resp.isUtc, true);
+    expect(resp.millisecondsSinceEpoch, date.millisecondsSinceEpoch);
+  });
+
+  test('std::time::Instant', () async {
+    final date = DateTime.now().toUtc().add(Duration(seconds: 5));
+    final resp = await stdTimeInstantTwinRustAsync(d: date);
+    expect(resp.difference(date).abs() < Duration(seconds: 1), true);
+  });
+
+  test('tokio::time::Duration', () async {
+    final d = Duration(hours: 4);
+    final resp = await tokioTimeDurationTwinRustAsync(d: d);
+    expect(resp, d);
+  });
+
+  test('tokio::time::Instant', () async {
+    final date = DateTime.now().toUtc().add(Duration(seconds: 5));
+    final resp = await tokioTimeInstantTwinRustAsync(d: date);
+    expect(resp.difference(date).abs() < Duration(seconds: 1), true);
+  });
+
   test('List<Duration>', () async {
     final expected = [
       Duration(days: 1),

--- a/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_sse_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_sse_test.dart
@@ -89,6 +89,13 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp.millisecondsSinceEpoch, date.millisecondsSinceEpoch);
   });
 
+  test('std::time::SystemTime before UNIX epoch', () async {
+    final date = DateTime.fromMicrosecondsSinceEpoch(-1000000000, isUtc: true);
+    final resp = await stdTimeSystemTimeBeforeEpochTwinSse(d: date);
+    expect(resp.isUtc, true);
+    expect(resp.microsecondsSinceEpoch, date.microsecondsSinceEpoch);
+  });
+
   test('std::time::Instant', () async {
     final date = DateTime.now().toUtc().add(Duration(seconds: 5));
     final resp = await stdTimeInstantTwinSse(d: date);

--- a/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_sse_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_sse_test.dart
@@ -89,14 +89,17 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp.millisecondsSinceEpoch, date.millisecondsSinceEpoch);
   });
 
-  test('std::time::SystemTime before UNIX epoch', () async {
+  test('std::time::SystemTime before UNIX epoch',
+      skip: skipWeb('wasm SystemTime does not support pre-epoch values'),
+      () async {
     final date = DateTime.fromMicrosecondsSinceEpoch(-1000000000, isUtc: true);
     final resp = await stdTimeSystemTimeBeforeEpochTwinSse(d: date);
     expect(resp.isUtc, true);
     expect(resp.microsecondsSinceEpoch, date.microsecondsSinceEpoch);
   });
 
-  test('std::time::Instant', () async {
+  test('std::time::Instant', skip: skipWeb('wasm Instant::now panics'),
+      () async {
     final date = DateTime.now().toUtc().add(Duration(seconds: 5));
     final resp = await stdTimeInstantTwinSse(d: date);
     expect(resp.difference(date).abs() < Duration(seconds: 1), true);
@@ -108,7 +111,8 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp, d);
   });
 
-  test('tokio::time::Instant', () async {
+  test('tokio::time::Instant', skip: skipWeb('wasm Instant::now panics'),
+      () async {
     final date = DateTime.now().toUtc().add(Duration(seconds: 5));
     final resp = await tokioTimeInstantTwinSse(d: date);
     expect(resp.difference(date).abs() < Duration(seconds: 1), true);

--- a/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_sse_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_sse_test.dart
@@ -70,13 +70,13 @@ Future<void> main({bool skipRustLibInit = false}) async {
   });
 
   test('Duration', () async {
-    final d = Duration(hours: 4);
+    final d = preciseDuration();
     final resp = await durationTwinSse(d: d);
-    expect(resp.inHours, d.inHours);
+    expect(resp, d);
   });
 
   test('std::time::Duration', () async {
-    final d = Duration(hours: 4);
+    final d = preciseDuration();
     final resp = await stdTimeDurationTwinSse(d: d);
     expect(resp, d);
   });
@@ -99,7 +99,7 @@ Future<void> main({bool skipRustLibInit = false}) async {
   });
 
   test('tokio::time::Duration', () async {
-    final d = Duration(hours: 4);
+    final d = preciseDuration();
     final resp = await tokioTimeDurationTwinSse(d: d);
     expect(resp, d);
   });
@@ -173,3 +173,10 @@ Future<void> main({bool skipRustLibInit = false}) async {
     debugPrint('$difference');
   });
 }
+
+Duration preciseDuration() => Duration(
+      hours: 4,
+      seconds: 3,
+      milliseconds: 2,
+      microseconds: kIsWeb ? 0 : 1,
+    );

--- a/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_sse_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_sse_test.dart
@@ -98,24 +98,10 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp.microsecondsSinceEpoch, date.microsecondsSinceEpoch);
   });
 
-  test('std::time::Instant', skip: skipWeb('wasm Instant::now panics'),
-      () async {
-    final date = DateTime.now().toUtc().add(Duration(seconds: 5));
-    final resp = await stdTimeInstantTwinSse(d: date);
-    expect(resp.difference(date).abs() < Duration(seconds: 1), true);
-  });
-
   test('tokio::time::Duration', () async {
     final d = Duration(hours: 4);
     final resp = await tokioTimeDurationTwinSse(d: d);
     expect(resp, d);
-  });
-
-  test('tokio::time::Instant', skip: skipWeb('wasm Instant::now panics'),
-      () async {
-    final date = DateTime.now().toUtc().add(Duration(seconds: 5));
-    final resp = await tokioTimeInstantTwinSse(d: date);
-    expect(resp.difference(date).abs() < Duration(seconds: 1), true);
   });
 
   test('List<Duration>', () async {

--- a/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_sse_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_sse_test.dart
@@ -75,6 +75,38 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp.inHours, d.inHours);
   });
 
+  test('std::time::Duration', () async {
+    final d = Duration(hours: 4);
+    final resp = await stdTimeDurationTwinSse(d: d);
+    expect(resp, d);
+  });
+
+  test('std::time::SystemTime', () async {
+    final date =
+        DateTime.fromMillisecondsSinceEpoch(1631297333000, isUtc: true);
+    final resp = await stdTimeSystemTimeTwinSse(d: date);
+    expect(resp.isUtc, true);
+    expect(resp.millisecondsSinceEpoch, date.millisecondsSinceEpoch);
+  });
+
+  test('std::time::Instant', () async {
+    final date = DateTime.now().toUtc().add(Duration(seconds: 5));
+    final resp = await stdTimeInstantTwinSse(d: date);
+    expect(resp.difference(date).abs() < Duration(seconds: 1), true);
+  });
+
+  test('tokio::time::Duration', () async {
+    final d = Duration(hours: 4);
+    final resp = await tokioTimeDurationTwinSse(d: d);
+    expect(resp, d);
+  });
+
+  test('tokio::time::Instant', () async {
+    final date = DateTime.now().toUtc().add(Duration(seconds: 5));
+    final resp = await tokioTimeInstantTwinSse(d: date);
+    expect(resp.difference(date).abs() < Duration(seconds: 1), true);
+  });
+
   test('List<Duration>', () async {
     final expected = [
       Duration(days: 1),

--- a/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_sync_sse_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_sync_sse_test.dart
@@ -89,14 +89,17 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp.millisecondsSinceEpoch, date.millisecondsSinceEpoch);
   });
 
-  test('std::time::SystemTime before UNIX epoch', () async {
+  test('std::time::SystemTime before UNIX epoch',
+      skip: skipWeb('wasm SystemTime does not support pre-epoch values'),
+      () async {
     final date = DateTime.fromMicrosecondsSinceEpoch(-1000000000, isUtc: true);
     final resp = await stdTimeSystemTimeBeforeEpochTwinSyncSse(d: date);
     expect(resp.isUtc, true);
     expect(resp.microsecondsSinceEpoch, date.microsecondsSinceEpoch);
   });
 
-  test('std::time::Instant', () async {
+  test('std::time::Instant', skip: skipWeb('wasm Instant::now panics'),
+      () async {
     final date = DateTime.now().toUtc().add(Duration(seconds: 5));
     final resp = await stdTimeInstantTwinSyncSse(d: date);
     expect(resp.difference(date).abs() < Duration(seconds: 1), true);
@@ -108,7 +111,8 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp, d);
   });
 
-  test('tokio::time::Instant', () async {
+  test('tokio::time::Instant', skip: skipWeb('wasm Instant::now panics'),
+      () async {
     final date = DateTime.now().toUtc().add(Duration(seconds: 5));
     final resp = await tokioTimeInstantTwinSyncSse(d: date);
     expect(resp.difference(date).abs() < Duration(seconds: 1), true);

--- a/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_sync_sse_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_sync_sse_test.dart
@@ -98,24 +98,10 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp.microsecondsSinceEpoch, date.microsecondsSinceEpoch);
   });
 
-  test('std::time::Instant', skip: skipWeb('wasm Instant::now panics'),
-      () async {
-    final date = DateTime.now().toUtc().add(Duration(seconds: 5));
-    final resp = await stdTimeInstantTwinSyncSse(d: date);
-    expect(resp.difference(date).abs() < Duration(seconds: 1), true);
-  });
-
   test('tokio::time::Duration', () async {
     final d = Duration(hours: 4);
     final resp = await tokioTimeDurationTwinSyncSse(d: d);
     expect(resp, d);
-  });
-
-  test('tokio::time::Instant', skip: skipWeb('wasm Instant::now panics'),
-      () async {
-    final date = DateTime.now().toUtc().add(Duration(seconds: 5));
-    final resp = await tokioTimeInstantTwinSyncSse(d: date);
-    expect(resp.difference(date).abs() < Duration(seconds: 1), true);
   });
 
   test('List<Duration>', () async {

--- a/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_sync_sse_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_sync_sse_test.dart
@@ -89,6 +89,13 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp.millisecondsSinceEpoch, date.millisecondsSinceEpoch);
   });
 
+  test('std::time::SystemTime before UNIX epoch', () async {
+    final date = DateTime.fromMicrosecondsSinceEpoch(-1000000000, isUtc: true);
+    final resp = await stdTimeSystemTimeBeforeEpochTwinSyncSse(d: date);
+    expect(resp.isUtc, true);
+    expect(resp.microsecondsSinceEpoch, date.microsecondsSinceEpoch);
+  });
+
   test('std::time::Instant', () async {
     final date = DateTime.now().toUtc().add(Duration(seconds: 5));
     final resp = await stdTimeInstantTwinSyncSse(d: date);

--- a/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_sync_sse_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_sync_sse_test.dart
@@ -70,13 +70,13 @@ Future<void> main({bool skipRustLibInit = false}) async {
   });
 
   test('Duration', () async {
-    final d = Duration(hours: 4);
+    final d = preciseDuration();
     final resp = await durationTwinSyncSse(d: d);
-    expect(resp.inHours, d.inHours);
+    expect(resp, d);
   });
 
   test('std::time::Duration', () async {
-    final d = Duration(hours: 4);
+    final d = preciseDuration();
     final resp = await stdTimeDurationTwinSyncSse(d: d);
     expect(resp, d);
   });
@@ -99,7 +99,7 @@ Future<void> main({bool skipRustLibInit = false}) async {
   });
 
   test('tokio::time::Duration', () async {
-    final d = Duration(hours: 4);
+    final d = preciseDuration();
     final resp = await tokioTimeDurationTwinSyncSse(d: d);
     expect(resp, d);
   });
@@ -173,3 +173,10 @@ Future<void> main({bool skipRustLibInit = false}) async {
     debugPrint('$difference');
   });
 }
+
+Duration preciseDuration() => Duration(
+      hours: 4,
+      seconds: 3,
+      milliseconds: 2,
+      microseconds: kIsWeb ? 0 : 1,
+    );

--- a/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_sync_sse_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_sync_sse_test.dart
@@ -75,6 +75,38 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp.inHours, d.inHours);
   });
 
+  test('std::time::Duration', () async {
+    final d = Duration(hours: 4);
+    final resp = await stdTimeDurationTwinSyncSse(d: d);
+    expect(resp, d);
+  });
+
+  test('std::time::SystemTime', () async {
+    final date =
+        DateTime.fromMillisecondsSinceEpoch(1631297333000, isUtc: true);
+    final resp = await stdTimeSystemTimeTwinSyncSse(d: date);
+    expect(resp.isUtc, true);
+    expect(resp.millisecondsSinceEpoch, date.millisecondsSinceEpoch);
+  });
+
+  test('std::time::Instant', () async {
+    final date = DateTime.now().toUtc().add(Duration(seconds: 5));
+    final resp = await stdTimeInstantTwinSyncSse(d: date);
+    expect(resp.difference(date).abs() < Duration(seconds: 1), true);
+  });
+
+  test('tokio::time::Duration', () async {
+    final d = Duration(hours: 4);
+    final resp = await tokioTimeDurationTwinSyncSse(d: d);
+    expect(resp, d);
+  });
+
+  test('tokio::time::Instant', () async {
+    final date = DateTime.now().toUtc().add(Duration(seconds: 5));
+    final resp = await tokioTimeInstantTwinSyncSse(d: date);
+    expect(resp.difference(date).abs() < Duration(seconds: 1), true);
+  });
+
   test('List<Duration>', () async {
     final expected = [
       Duration(days: 1),

--- a/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_sync_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_sync_test.dart
@@ -89,14 +89,17 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp.millisecondsSinceEpoch, date.millisecondsSinceEpoch);
   });
 
-  test('std::time::SystemTime before UNIX epoch', () async {
+  test('std::time::SystemTime before UNIX epoch',
+      skip: skipWeb('wasm SystemTime does not support pre-epoch values'),
+      () async {
     final date = DateTime.fromMicrosecondsSinceEpoch(-1000000000, isUtc: true);
     final resp = await stdTimeSystemTimeBeforeEpochTwinSync(d: date);
     expect(resp.isUtc, true);
     expect(resp.microsecondsSinceEpoch, date.microsecondsSinceEpoch);
   });
 
-  test('std::time::Instant', () async {
+  test('std::time::Instant', skip: skipWeb('wasm Instant::now panics'),
+      () async {
     final date = DateTime.now().toUtc().add(Duration(seconds: 5));
     final resp = await stdTimeInstantTwinSync(d: date);
     expect(resp.difference(date).abs() < Duration(seconds: 1), true);
@@ -108,7 +111,8 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp, d);
   });
 
-  test('tokio::time::Instant', () async {
+  test('tokio::time::Instant', skip: skipWeb('wasm Instant::now panics'),
+      () async {
     final date = DateTime.now().toUtc().add(Duration(seconds: 5));
     final resp = await tokioTimeInstantTwinSync(d: date);
     expect(resp.difference(date).abs() < Duration(seconds: 1), true);

--- a/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_sync_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_sync_test.dart
@@ -70,13 +70,13 @@ Future<void> main({bool skipRustLibInit = false}) async {
   });
 
   test('Duration', () async {
-    final d = Duration(hours: 4);
+    final d = preciseDuration();
     final resp = await durationTwinSync(d: d);
-    expect(resp.inHours, d.inHours);
+    expect(resp, d);
   });
 
   test('std::time::Duration', () async {
-    final d = Duration(hours: 4);
+    final d = preciseDuration();
     final resp = await stdTimeDurationTwinSync(d: d);
     expect(resp, d);
   });
@@ -99,7 +99,7 @@ Future<void> main({bool skipRustLibInit = false}) async {
   });
 
   test('tokio::time::Duration', () async {
-    final d = Duration(hours: 4);
+    final d = preciseDuration();
     final resp = await tokioTimeDurationTwinSync(d: d);
     expect(resp, d);
   });
@@ -173,3 +173,10 @@ Future<void> main({bool skipRustLibInit = false}) async {
     debugPrint('$difference');
   });
 }
+
+Duration preciseDuration() => Duration(
+      hours: 4,
+      seconds: 3,
+      milliseconds: 2,
+      microseconds: kIsWeb ? 0 : 1,
+    );

--- a/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_sync_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_sync_test.dart
@@ -98,24 +98,10 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp.microsecondsSinceEpoch, date.microsecondsSinceEpoch);
   });
 
-  test('std::time::Instant', skip: skipWeb('wasm Instant::now panics'),
-      () async {
-    final date = DateTime.now().toUtc().add(Duration(seconds: 5));
-    final resp = await stdTimeInstantTwinSync(d: date);
-    expect(resp.difference(date).abs() < Duration(seconds: 1), true);
-  });
-
   test('tokio::time::Duration', () async {
     final d = Duration(hours: 4);
     final resp = await tokioTimeDurationTwinSync(d: d);
     expect(resp, d);
-  });
-
-  test('tokio::time::Instant', skip: skipWeb('wasm Instant::now panics'),
-      () async {
-    final date = DateTime.now().toUtc().add(Duration(seconds: 5));
-    final resp = await tokioTimeInstantTwinSync(d: date);
-    expect(resp.difference(date).abs() < Duration(seconds: 1), true);
   });
 
   test('List<Duration>', () async {

--- a/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_sync_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_sync_test.dart
@@ -89,6 +89,13 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp.millisecondsSinceEpoch, date.millisecondsSinceEpoch);
   });
 
+  test('std::time::SystemTime before UNIX epoch', () async {
+    final date = DateTime.fromMicrosecondsSinceEpoch(-1000000000, isUtc: true);
+    final resp = await stdTimeSystemTimeBeforeEpochTwinSync(d: date);
+    expect(resp.isUtc, true);
+    expect(resp.microsecondsSinceEpoch, date.microsecondsSinceEpoch);
+  });
+
   test('std::time::Instant', () async {
     final date = DateTime.now().toUtc().add(Duration(seconds: 5));
     final resp = await stdTimeInstantTwinSync(d: date);

--- a/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_sync_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/chrono_type_twin_sync_test.dart
@@ -75,6 +75,38 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp.inHours, d.inHours);
   });
 
+  test('std::time::Duration', () async {
+    final d = Duration(hours: 4);
+    final resp = await stdTimeDurationTwinSync(d: d);
+    expect(resp, d);
+  });
+
+  test('std::time::SystemTime', () async {
+    final date =
+        DateTime.fromMillisecondsSinceEpoch(1631297333000, isUtc: true);
+    final resp = await stdTimeSystemTimeTwinSync(d: date);
+    expect(resp.isUtc, true);
+    expect(resp.millisecondsSinceEpoch, date.millisecondsSinceEpoch);
+  });
+
+  test('std::time::Instant', () async {
+    final date = DateTime.now().toUtc().add(Duration(seconds: 5));
+    final resp = await stdTimeInstantTwinSync(d: date);
+    expect(resp.difference(date).abs() < Duration(seconds: 1), true);
+  });
+
+  test('tokio::time::Duration', () async {
+    final d = Duration(hours: 4);
+    final resp = await tokioTimeDurationTwinSync(d: d);
+    expect(resp, d);
+  });
+
+  test('tokio::time::Instant', () async {
+    final date = DateTime.now().toUtc().add(Duration(seconds: 5));
+    final resp = await tokioTimeInstantTwinSync(d: date);
+    expect(resp.difference(date).abs() < Duration(seconds: 1), true);
+  });
+
   test('List<Duration>', () async {
     final expected = [
       Duration(days: 1),

--- a/frb_example/pure_dart_pde/lib/src/rust/api/chrono_type.dart
+++ b/frb_example/pure_dart_pde/lib/src/rust/api/chrono_type.dart
@@ -40,14 +40,8 @@ Future<DateTime> stdTimeSystemTimeBeforeEpochTwinNormal(
     RustLib.instance.api
         .crateApiChronoTypeStdTimeSystemTimeBeforeEpochTwinNormal(d: d);
 
-Future<DateTime> stdTimeInstantTwinNormal({required DateTime d}) =>
-    RustLib.instance.api.crateApiChronoTypeStdTimeInstantTwinNormal(d: d);
-
 Future<Duration> tokioTimeDurationTwinNormal({required Duration d}) =>
     RustLib.instance.api.crateApiChronoTypeTokioTimeDurationTwinNormal(d: d);
-
-Future<DateTime> tokioTimeInstantTwinNormal({required DateTime d}) =>
-    RustLib.instance.api.crateApiChronoTypeTokioTimeInstantTwinNormal(d: d);
 
 Future<List<Duration>> handleTimestampsTwinNormal(
         {required List<DateTime> timestamps, required DateTime epoch}) =>

--- a/frb_example/pure_dart_pde/lib/src/rust/api/chrono_type.dart
+++ b/frb_example/pure_dart_pde/lib/src/rust/api/chrono_type.dart
@@ -35,6 +35,11 @@ Future<Duration> stdTimeDurationTwinNormal({required Duration d}) =>
 Future<DateTime> stdTimeSystemTimeTwinNormal({required DateTime d}) =>
     RustLib.instance.api.crateApiChronoTypeStdTimeSystemTimeTwinNormal(d: d);
 
+Future<DateTime> stdTimeSystemTimeBeforeEpochTwinNormal(
+        {required DateTime d}) =>
+    RustLib.instance.api
+        .crateApiChronoTypeStdTimeSystemTimeBeforeEpochTwinNormal(d: d);
+
 Future<DateTime> stdTimeInstantTwinNormal({required DateTime d}) =>
     RustLib.instance.api.crateApiChronoTypeStdTimeInstantTwinNormal(d: d);
 

--- a/frb_example/pure_dart_pde/lib/src/rust/api/chrono_type.dart
+++ b/frb_example/pure_dart_pde/lib/src/rust/api/chrono_type.dart
@@ -29,6 +29,21 @@ Future<DateTime?> optionalEmptyDatetimeUtcTwinNormal({DateTime? d}) =>
 Future<Duration> durationTwinNormal({required Duration d}) =>
     RustLib.instance.api.crateApiChronoTypeDurationTwinNormal(d: d);
 
+Future<Duration> stdTimeDurationTwinNormal({required Duration d}) =>
+    RustLib.instance.api.crateApiChronoTypeStdTimeDurationTwinNormal(d: d);
+
+Future<DateTime> stdTimeSystemTimeTwinNormal({required DateTime d}) =>
+    RustLib.instance.api.crateApiChronoTypeStdTimeSystemTimeTwinNormal(d: d);
+
+Future<DateTime> stdTimeInstantTwinNormal({required DateTime d}) =>
+    RustLib.instance.api.crateApiChronoTypeStdTimeInstantTwinNormal(d: d);
+
+Future<Duration> tokioTimeDurationTwinNormal({required Duration d}) =>
+    RustLib.instance.api.crateApiChronoTypeTokioTimeDurationTwinNormal(d: d);
+
+Future<DateTime> tokioTimeInstantTwinNormal({required DateTime d}) =>
+    RustLib.instance.api.crateApiChronoTypeTokioTimeInstantTwinNormal(d: d);
+
 Future<List<Duration>> handleTimestampsTwinNormal(
         {required List<DateTime> timestamps, required DateTime epoch}) =>
     RustLib.instance.api.crateApiChronoTypeHandleTimestampsTwinNormal(

--- a/frb_example/pure_dart_pde/lib/src/rust/api/pseudo_manual/chrono_type_twin_rust_async.dart
+++ b/frb_example/pure_dart_pde/lib/src/rust/api/pseudo_manual/chrono_type_twin_rust_async.dart
@@ -53,19 +53,9 @@ Future<DateTime> stdTimeSystemTimeBeforeEpochTwinRustAsync(
         .crateApiPseudoManualChronoTypeTwinRustAsyncStdTimeSystemTimeBeforeEpochTwinRustAsync(
             d: d);
 
-Future<DateTime> stdTimeInstantTwinRustAsync({required DateTime d}) =>
-    RustLib.instance.api
-        .crateApiPseudoManualChronoTypeTwinRustAsyncStdTimeInstantTwinRustAsync(
-            d: d);
-
 Future<Duration> tokioTimeDurationTwinRustAsync({required Duration d}) => RustLib
     .instance.api
     .crateApiPseudoManualChronoTypeTwinRustAsyncTokioTimeDurationTwinRustAsync(
-        d: d);
-
-Future<DateTime> tokioTimeInstantTwinRustAsync({required DateTime d}) => RustLib
-    .instance.api
-    .crateApiPseudoManualChronoTypeTwinRustAsyncTokioTimeInstantTwinRustAsync(
         d: d);
 
 Future<List<Duration>> handleTimestampsTwinRustAsync(

--- a/frb_example/pure_dart_pde/lib/src/rust/api/pseudo_manual/chrono_type_twin_rust_async.dart
+++ b/frb_example/pure_dart_pde/lib/src/rust/api/pseudo_manual/chrono_type_twin_rust_async.dart
@@ -47,6 +47,12 @@ Future<DateTime> stdTimeSystemTimeTwinRustAsync({required DateTime d}) => RustLi
     .crateApiPseudoManualChronoTypeTwinRustAsyncStdTimeSystemTimeTwinRustAsync(
         d: d);
 
+Future<DateTime> stdTimeSystemTimeBeforeEpochTwinRustAsync(
+        {required DateTime d}) =>
+    RustLib.instance.api
+        .crateApiPseudoManualChronoTypeTwinRustAsyncStdTimeSystemTimeBeforeEpochTwinRustAsync(
+            d: d);
+
 Future<DateTime> stdTimeInstantTwinRustAsync({required DateTime d}) =>
     RustLib.instance.api
         .crateApiPseudoManualChronoTypeTwinRustAsyncStdTimeInstantTwinRustAsync(

--- a/frb_example/pure_dart_pde/lib/src/rust/api/pseudo_manual/chrono_type_twin_rust_async.dart
+++ b/frb_example/pure_dart_pde/lib/src/rust/api/pseudo_manual/chrono_type_twin_rust_async.dart
@@ -37,6 +37,31 @@ Future<Duration> durationTwinRustAsync({required Duration d}) =>
     RustLib.instance.api
         .crateApiPseudoManualChronoTypeTwinRustAsyncDurationTwinRustAsync(d: d);
 
+Future<Duration> stdTimeDurationTwinRustAsync({required Duration d}) => RustLib
+    .instance.api
+    .crateApiPseudoManualChronoTypeTwinRustAsyncStdTimeDurationTwinRustAsync(
+        d: d);
+
+Future<DateTime> stdTimeSystemTimeTwinRustAsync({required DateTime d}) => RustLib
+    .instance.api
+    .crateApiPseudoManualChronoTypeTwinRustAsyncStdTimeSystemTimeTwinRustAsync(
+        d: d);
+
+Future<DateTime> stdTimeInstantTwinRustAsync({required DateTime d}) =>
+    RustLib.instance.api
+        .crateApiPseudoManualChronoTypeTwinRustAsyncStdTimeInstantTwinRustAsync(
+            d: d);
+
+Future<Duration> tokioTimeDurationTwinRustAsync({required Duration d}) => RustLib
+    .instance.api
+    .crateApiPseudoManualChronoTypeTwinRustAsyncTokioTimeDurationTwinRustAsync(
+        d: d);
+
+Future<DateTime> tokioTimeInstantTwinRustAsync({required DateTime d}) => RustLib
+    .instance.api
+    .crateApiPseudoManualChronoTypeTwinRustAsyncTokioTimeInstantTwinRustAsync(
+        d: d);
+
 Future<List<Duration>> handleTimestampsTwinRustAsync(
         {required List<DateTime> timestamps, required DateTime epoch}) =>
     RustLib.instance.api

--- a/frb_example/pure_dart_pde/lib/src/rust/api/pseudo_manual/chrono_type_twin_sync.dart
+++ b/frb_example/pure_dart_pde/lib/src/rust/api/pseudo_manual/chrono_type_twin_sync.dart
@@ -42,15 +42,9 @@ DateTime stdTimeSystemTimeBeforeEpochTwinSync({required DateTime d}) => RustLib
     .crateApiPseudoManualChronoTypeTwinSyncStdTimeSystemTimeBeforeEpochTwinSync(
         d: d);
 
-DateTime stdTimeInstantTwinSync({required DateTime d}) => RustLib.instance.api
-    .crateApiPseudoManualChronoTypeTwinSyncStdTimeInstantTwinSync(d: d);
-
 Duration tokioTimeDurationTwinSync({required Duration d}) =>
     RustLib.instance.api
         .crateApiPseudoManualChronoTypeTwinSyncTokioTimeDurationTwinSync(d: d);
-
-DateTime tokioTimeInstantTwinSync({required DateTime d}) => RustLib.instance.api
-    .crateApiPseudoManualChronoTypeTwinSyncTokioTimeInstantTwinSync(d: d);
 
 List<Duration> handleTimestampsTwinSync(
         {required List<DateTime> timestamps, required DateTime epoch}) =>

--- a/frb_example/pure_dart_pde/lib/src/rust/api/pseudo_manual/chrono_type_twin_sync.dart
+++ b/frb_example/pure_dart_pde/lib/src/rust/api/pseudo_manual/chrono_type_twin_sync.dart
@@ -30,6 +30,23 @@ DateTime? optionalEmptyDatetimeUtcTwinSync({DateTime? d}) =>
 Duration durationTwinSync({required Duration d}) => RustLib.instance.api
     .crateApiPseudoManualChronoTypeTwinSyncDurationTwinSync(d: d);
 
+Duration stdTimeDurationTwinSync({required Duration d}) => RustLib.instance.api
+    .crateApiPseudoManualChronoTypeTwinSyncStdTimeDurationTwinSync(d: d);
+
+DateTime stdTimeSystemTimeTwinSync({required DateTime d}) =>
+    RustLib.instance.api
+        .crateApiPseudoManualChronoTypeTwinSyncStdTimeSystemTimeTwinSync(d: d);
+
+DateTime stdTimeInstantTwinSync({required DateTime d}) => RustLib.instance.api
+    .crateApiPseudoManualChronoTypeTwinSyncStdTimeInstantTwinSync(d: d);
+
+Duration tokioTimeDurationTwinSync({required Duration d}) =>
+    RustLib.instance.api
+        .crateApiPseudoManualChronoTypeTwinSyncTokioTimeDurationTwinSync(d: d);
+
+DateTime tokioTimeInstantTwinSync({required DateTime d}) => RustLib.instance.api
+    .crateApiPseudoManualChronoTypeTwinSyncTokioTimeInstantTwinSync(d: d);
+
 List<Duration> handleTimestampsTwinSync(
         {required List<DateTime> timestamps, required DateTime epoch}) =>
     RustLib.instance.api

--- a/frb_example/pure_dart_pde/lib/src/rust/api/pseudo_manual/chrono_type_twin_sync.dart
+++ b/frb_example/pure_dart_pde/lib/src/rust/api/pseudo_manual/chrono_type_twin_sync.dart
@@ -37,6 +37,11 @@ DateTime stdTimeSystemTimeTwinSync({required DateTime d}) =>
     RustLib.instance.api
         .crateApiPseudoManualChronoTypeTwinSyncStdTimeSystemTimeTwinSync(d: d);
 
+DateTime stdTimeSystemTimeBeforeEpochTwinSync({required DateTime d}) => RustLib
+    .instance.api
+    .crateApiPseudoManualChronoTypeTwinSyncStdTimeSystemTimeBeforeEpochTwinSync(
+        d: d);
+
 DateTime stdTimeInstantTwinSync({required DateTime d}) => RustLib.instance.api
     .crateApiPseudoManualChronoTypeTwinSyncStdTimeInstantTwinSync(d: d);
 

--- a/frb_example/pure_dart_pde/lib/src/rust/frb_generated.dart
+++ b/frb_example/pure_dart_pde/lib/src/rust/frb_generated.dart
@@ -240,7 +240,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => -1314015258;
+  int get rustContentHash => 231677322;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -4533,16 +4533,6 @@ abstract class RustLibApi extends BaseApi {
   Duration crateApiPseudoManualChronoTypeTwinSyncStdTimeDurationTwinSync(
       {required Duration d});
 
-  Future<DateTime> crateApiChronoTypeStdTimeInstantTwinNormal(
-      {required DateTime d});
-
-  Future<DateTime>
-      crateApiPseudoManualChronoTypeTwinRustAsyncStdTimeInstantTwinRustAsync(
-          {required DateTime d});
-
-  DateTime crateApiPseudoManualChronoTypeTwinSyncStdTimeInstantTwinSync(
-      {required DateTime d});
-
   Future<DateTime> crateApiChronoTypeStdTimeSystemTimeBeforeEpochTwinNormal(
       {required DateTime d});
 
@@ -4837,16 +4827,6 @@ abstract class RustLibApi extends BaseApi {
 
   Duration crateApiPseudoManualChronoTypeTwinSyncTokioTimeDurationTwinSync(
       {required Duration d});
-
-  Future<DateTime> crateApiChronoTypeTokioTimeInstantTwinNormal(
-      {required DateTime d});
-
-  Future<DateTime>
-      crateApiPseudoManualChronoTypeTwinRustAsyncTokioTimeInstantTwinRustAsync(
-          {required DateTime d});
-
-  DateTime crateApiPseudoManualChronoTypeTwinSyncTokioTimeInstantTwinSync(
-      {required DateTime d});
 
   Future<int>
       crateApiDartCodeTranslatableStructWithDartCodeTwinNormalNormalMethodTwinNormal(
@@ -40571,88 +40551,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           );
 
   @override
-  Future<DateTime> crateApiChronoTypeStdTimeInstantTwinNormal(
-      {required DateTime d}) {
-    return handler.executeNormal(NormalTask(
-      callFfi: (port_) {
-        final serializer = SseSerializer(generalizedFrbRustBinding);
-        sse_encode_StdTime_StdInstant(d, serializer);
-        pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1236, port: port_);
-      },
-      codec: SseCodec(
-        decodeSuccessData: sse_decode_StdTime_StdInstant,
-        decodeErrorData: null,
-      ),
-      constMeta: kCrateApiChronoTypeStdTimeInstantTwinNormalConstMeta,
-      argValues: [d],
-      apiImpl: this,
-    ));
-  }
-
-  TaskConstMeta get kCrateApiChronoTypeStdTimeInstantTwinNormalConstMeta =>
-      const TaskConstMeta(
-        debugName: "std_time_instant_twin_normal",
-        argNames: ["d"],
-      );
-
-  @override
-  Future<DateTime>
-      crateApiPseudoManualChronoTypeTwinRustAsyncStdTimeInstantTwinRustAsync(
-          {required DateTime d}) {
-    return handler.executeNormal(NormalTask(
-      callFfi: (port_) {
-        final serializer = SseSerializer(generalizedFrbRustBinding);
-        sse_encode_StdTime_StdInstant(d, serializer);
-        pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1237, port: port_);
-      },
-      codec: SseCodec(
-        decodeSuccessData: sse_decode_StdTime_StdInstant,
-        decodeErrorData: null,
-      ),
-      constMeta:
-          kCrateApiPseudoManualChronoTypeTwinRustAsyncStdTimeInstantTwinRustAsyncConstMeta,
-      argValues: [d],
-      apiImpl: this,
-    ));
-  }
-
-  TaskConstMeta
-      get kCrateApiPseudoManualChronoTypeTwinRustAsyncStdTimeInstantTwinRustAsyncConstMeta =>
-          const TaskConstMeta(
-            debugName: "std_time_instant_twin_rust_async",
-            argNames: ["d"],
-          );
-
-  @override
-  DateTime crateApiPseudoManualChronoTypeTwinSyncStdTimeInstantTwinSync(
-      {required DateTime d}) {
-    return handler.executeSync(SyncTask(
-      callFfi: () {
-        final serializer = SseSerializer(generalizedFrbRustBinding);
-        sse_encode_StdTime_StdInstant(d, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1238)!;
-      },
-      codec: SseCodec(
-        decodeSuccessData: sse_decode_StdTime_StdInstant,
-        decodeErrorData: null,
-      ),
-      constMeta:
-          kCrateApiPseudoManualChronoTypeTwinSyncStdTimeInstantTwinSyncConstMeta,
-      argValues: [d],
-      apiImpl: this,
-    ));
-  }
-
-  TaskConstMeta
-      get kCrateApiPseudoManualChronoTypeTwinSyncStdTimeInstantTwinSyncConstMeta =>
-          const TaskConstMeta(
-            debugName: "std_time_instant_twin_sync",
-            argNames: ["d"],
-          );
-
-  @override
   Future<DateTime> crateApiChronoTypeStdTimeSystemTimeBeforeEpochTwinNormal(
       {required DateTime d}) {
     return handler.executeNormal(NormalTask(
@@ -40660,7 +40558,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StdTime_StdSystemTime(d, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1239, port: port_);
+            funcId: 1236, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_StdTime_StdSystemTime,
@@ -40689,7 +40587,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StdTime_StdSystemTime(d, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1240, port: port_);
+            funcId: 1237, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_StdTime_StdSystemTime,
@@ -40717,7 +40615,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StdTime_StdSystemTime(d, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1241)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1238)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_StdTime_StdSystemTime,
@@ -40745,7 +40643,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StdTime_StdSystemTime(d, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1242, port: port_);
+            funcId: 1239, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_StdTime_StdSystemTime,
@@ -40772,7 +40670,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StdTime_StdSystemTime(d, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1243, port: port_);
+            funcId: 1240, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_StdTime_StdSystemTime,
@@ -40799,7 +40697,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StdTime_StdSystemTime(d, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1244)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1241)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_StdTime_StdSystemTime,
@@ -40827,7 +40725,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StreamSink_i_32_Sse(sink, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1245, port: port_);
+            funcId: 1242, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -40855,7 +40753,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StreamSink_u_8_array_2_Sse(sink, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1246, port: port_);
+            funcId: 1243, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -40885,7 +40783,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StreamSink_u_8_array_2_Sse(sink, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1247, port: port_);
+            funcId: 1244, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -40916,7 +40814,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_box_autoadd_my_struct_containing_stream_sink_twin_normal(
             arg, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1248, port: port_);
+            funcId: 1245, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -40944,7 +40842,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_box_autoadd_my_struct_containing_stream_sink_twin_rust_async(
             arg, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1249, port: port_);
+            funcId: 1246, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -40972,7 +40870,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_list_StreamSink_i_32_Sse(arg, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1250, port: port_);
+            funcId: 1247, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -40999,7 +40897,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_list_StreamSink_i_32_Sse(arg, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1251, port: port_);
+            funcId: 1248, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -41028,7 +40926,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StreamSink_String_Sse(sink, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1252, port: port_);
+            funcId: 1249, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -41057,7 +40955,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StreamSink_String_Sse(sink, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1253, port: port_);
+            funcId: 1250, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -41086,7 +40984,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StreamSink_String_Sse(sink, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1254)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1251)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -41117,7 +41015,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_box_autoadd_struct_with_comments_twin_normal(
             that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1255, port: port_);
+            funcId: 1252, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -41145,7 +41043,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1256, port: port_);
+            funcId: 1253, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -41176,7 +41074,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_box_autoadd_struct_with_comments_twin_rust_async(
             that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1257, port: port_);
+            funcId: 1254, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -41204,7 +41102,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1258, port: port_);
+            funcId: 1255, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -41233,7 +41131,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_struct_with_comments_twin_sync(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1259)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1256)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -41260,7 +41158,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1260)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1257)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -41289,7 +41187,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_struct_with_custom_name_method_twin_normal(
             that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1261)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1258)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -41319,7 +41217,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_box_autoadd_struct_with_impl_block_in_another_file_dependency(
             arg, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1262, port: port_);
+            funcId: 1259, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -41345,7 +41243,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1263, port: port_);
+            funcId: 1260, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -41372,7 +41270,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1264, port: port_);
+            funcId: 1261, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -41404,7 +41302,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_box_autoadd_struct_with_rust_auto_opaque_field_with_many_derive(
             that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1265, port: port_);
+            funcId: 1262, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -41434,7 +41332,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_box_autoadd_struct_with_rust_auto_opaque_with_non_clone_data(
             that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1266, port: port_);
+            funcId: 1263, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -41464,7 +41362,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_u_32(y, serializer);
         sse_encode_u_32(z, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1267, port: port_);
+            funcId: 1264, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_32,
@@ -41495,7 +41393,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_u_32(y, serializer);
         sse_encode_u_32(z, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1268, port: port_);
+            funcId: 1265, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_32,
@@ -41524,7 +41422,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_box_autoadd_sum_with_twin_sync(that, serializer);
         sse_encode_u_32(y, serializer);
         sse_encode_u_32(z, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1269)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1266)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_32,
@@ -41551,7 +41449,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_DartOpaque(opaque, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1270)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1267)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -41575,7 +41473,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1271)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1268)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_RustOpaque_NonCloneDataTwinNormal,
@@ -41599,7 +41497,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1272)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1269)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_RustOpaque_HideDataAnotherTwinNormal,
@@ -41625,7 +41523,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_DartOpaque(opaque, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1273)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1270)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_DartOpaque,
@@ -41650,7 +41548,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_DartOpaque(opaque, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1274)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1271)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_DartOpaque,
@@ -41675,7 +41573,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_opt_box_autoadd_DartOpaque(opaque, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1275)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1272)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_DartOpaque,
@@ -41700,7 +41598,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1276)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1273)!;
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -41728,7 +41626,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_abc_twin_normal(abc, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1277, port: port_);
+            funcId: 1274, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_abc_twin_normal,
@@ -41755,7 +41653,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_abc_twin_rust_async(abc, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1278, port: port_);
+            funcId: 1275, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_abc_twin_rust_async,
@@ -41782,7 +41680,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_abc_twin_sync(abc, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1279)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1276)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_abc_twin_sync,
@@ -41808,7 +41706,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1280, port: port_);
+            funcId: 1277, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_test_chrono_twin_normal,
@@ -41833,7 +41731,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1281, port: port_);
+            funcId: 1278, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_test_chrono_twin_rust_async,
@@ -41859,7 +41757,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1282)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1279)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_test_chrono_twin_sync,
@@ -41886,7 +41784,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1283, port: port_);
+            funcId: 1280, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_contains_mirrored_sub_struct_twin_normal,
@@ -41913,7 +41811,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1284, port: port_);
+            funcId: 1281, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -41940,7 +41838,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1285)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1282)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_contains_mirrored_sub_struct_twin_sync,
@@ -41969,7 +41867,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_struct_in_lower_level(s, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1286, port: port_);
+            funcId: 1283, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_struct_in_upper_level,
@@ -41996,7 +41894,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1287, port: port_);
+            funcId: 1284, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_raw_string_mirrored,
@@ -42023,7 +41921,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1288, port: port_);
+            funcId: 1285, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_raw_string_mirrored,
@@ -42049,7 +41947,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1289)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1286)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_raw_string_mirrored,
@@ -42076,7 +41974,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1290, port: port_);
+            funcId: 1287, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_struct_with_hash_map,
@@ -42102,7 +42000,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1291, port: port_);
+            funcId: 1288, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_struct_with_hash_map,
@@ -42128,7 +42026,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1292)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1289)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_struct_with_hash_map,
@@ -42155,7 +42053,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1293, port: port_);
+            funcId: 1290, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_raw_string_enum_mirrored,
@@ -42182,7 +42080,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1294, port: port_);
+            funcId: 1291, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_raw_string_enum_mirrored,
@@ -42208,7 +42106,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1295)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1292)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_raw_string_enum_mirrored,
@@ -42235,7 +42133,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1296, port: port_);
+            funcId: 1293, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_of_nested_raw_string_mirrored,
@@ -42262,7 +42160,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1297, port: port_);
+            funcId: 1294, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_of_nested_raw_string_mirrored,
@@ -42289,7 +42187,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1298)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1295)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_of_nested_raw_string_mirrored,
@@ -42316,7 +42214,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1299, port: port_);
+            funcId: 1296, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -42344,7 +42242,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1300, port: port_);
+            funcId: 1297, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -42372,7 +42270,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1301)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1298)!;
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -42400,7 +42298,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1302, port: port_);
+            funcId: 1299, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_nested_raw_string_mirrored,
@@ -42426,7 +42324,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1303, port: port_);
+            funcId: 1300, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_nested_raw_string_mirrored,
@@ -42452,7 +42350,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1304)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1301)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_nested_raw_string_mirrored,
@@ -42478,7 +42376,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1305, port: port_);
+            funcId: 1302, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_test_chrono_twin_normal,
@@ -42503,7 +42401,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1306, port: port_);
+            funcId: 1303, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_test_chrono_twin_rust_async,
@@ -42529,7 +42427,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1307)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1304)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_test_chrono_twin_sync,
@@ -42558,7 +42456,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_bool(nested, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1308, port: port_);
+            funcId: 1305, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_raw_string_enum_mirrored,
@@ -42586,7 +42484,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_bool(nested, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1309, port: port_);
+            funcId: 1306, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_raw_string_enum_mirrored,
@@ -42614,7 +42512,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_bool(nested, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1310)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1307)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_raw_string_enum_mirrored,
@@ -42641,7 +42539,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1311, port: port_);
+            funcId: 1308, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_raw_string_item_enum_twin_normal,
@@ -42667,7 +42565,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1312, port: port_);
+            funcId: 1309, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_raw_string_item_enum_twin_rust_async,
@@ -42693,7 +42591,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1313)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1310)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_raw_string_item_enum_twin_sync,
@@ -42720,7 +42618,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1314, port: port_);
+            funcId: 1311, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_raw_string_item_struct_twin_normal,
@@ -42746,7 +42644,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1315, port: port_);
+            funcId: 1312, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_raw_string_item_struct_twin_rust_async,
@@ -42772,7 +42670,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1316)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1313)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_raw_string_item_struct_twin_sync,
@@ -42798,7 +42696,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1317, port: port_);
+            funcId: 1314, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_raw_string_mirrored,
@@ -42823,7 +42721,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1318, port: port_);
+            funcId: 1315, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_raw_string_mirrored,
@@ -42849,7 +42747,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1319)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1316)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_raw_string_mirrored,
@@ -42878,7 +42776,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_struct_with_enum_twin_normal(se, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1320, port: port_);
+            funcId: 1317, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_struct_with_enum_twin_normal,
@@ -42905,7 +42803,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_struct_with_enum_twin_rust_async(se, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1321, port: port_);
+            funcId: 1318, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_struct_with_enum_twin_rust_async,
@@ -42933,7 +42831,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_struct_with_enum_twin_sync(se, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1322)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1319)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_struct_with_enum_twin_sync,
@@ -42961,7 +42859,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_list_record_string_i_32(value, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1323, port: port_);
+            funcId: 1320, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -42987,7 +42885,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_list_record_string_i_32(value, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1324, port: port_);
+            funcId: 1321, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -43014,7 +42912,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_list_record_string_i_32(value, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1325)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1322)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -43041,7 +42939,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_opt_box_autoadd_record_string_i_32(value, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1326, port: port_);
+            funcId: 1323, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_record_string_i_32,
@@ -43068,7 +42966,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_opt_box_autoadd_record_string_i_32(value, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1327, port: port_);
+            funcId: 1324, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_record_string_i_32,
@@ -43095,7 +42993,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_opt_box_autoadd_record_string_i_32(value, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1328)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1325)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_record_string_i_32,
@@ -43120,7 +43018,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1329, port: port_);
+            funcId: 1326, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -43145,7 +43043,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1330, port: port_);
+            funcId: 1327, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -43170,7 +43068,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1331)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1328)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -43198,7 +43096,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StdTime_StdDuration(d, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1332, port: port_);
+            funcId: 1329, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_StdTime_StdDuration,
@@ -43225,7 +43123,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StdTime_StdDuration(d, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1333, port: port_);
+            funcId: 1330, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_StdTime_StdDuration,
@@ -43252,7 +43150,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StdTime_StdDuration(d, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1334)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1331)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_StdTime_StdDuration,
@@ -43273,88 +43171,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           );
 
   @override
-  Future<DateTime> crateApiChronoTypeTokioTimeInstantTwinNormal(
-      {required DateTime d}) {
-    return handler.executeNormal(NormalTask(
-      callFfi: (port_) {
-        final serializer = SseSerializer(generalizedFrbRustBinding);
-        sse_encode_TokioTime_TokioInstant(d, serializer);
-        pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1335, port: port_);
-      },
-      codec: SseCodec(
-        decodeSuccessData: sse_decode_TokioTime_TokioInstant,
-        decodeErrorData: null,
-      ),
-      constMeta: kCrateApiChronoTypeTokioTimeInstantTwinNormalConstMeta,
-      argValues: [d],
-      apiImpl: this,
-    ));
-  }
-
-  TaskConstMeta get kCrateApiChronoTypeTokioTimeInstantTwinNormalConstMeta =>
-      const TaskConstMeta(
-        debugName: "tokio_time_instant_twin_normal",
-        argNames: ["d"],
-      );
-
-  @override
-  Future<DateTime>
-      crateApiPseudoManualChronoTypeTwinRustAsyncTokioTimeInstantTwinRustAsync(
-          {required DateTime d}) {
-    return handler.executeNormal(NormalTask(
-      callFfi: (port_) {
-        final serializer = SseSerializer(generalizedFrbRustBinding);
-        sse_encode_TokioTime_TokioInstant(d, serializer);
-        pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1336, port: port_);
-      },
-      codec: SseCodec(
-        decodeSuccessData: sse_decode_TokioTime_TokioInstant,
-        decodeErrorData: null,
-      ),
-      constMeta:
-          kCrateApiPseudoManualChronoTypeTwinRustAsyncTokioTimeInstantTwinRustAsyncConstMeta,
-      argValues: [d],
-      apiImpl: this,
-    ));
-  }
-
-  TaskConstMeta
-      get kCrateApiPseudoManualChronoTypeTwinRustAsyncTokioTimeInstantTwinRustAsyncConstMeta =>
-          const TaskConstMeta(
-            debugName: "tokio_time_instant_twin_rust_async",
-            argNames: ["d"],
-          );
-
-  @override
-  DateTime crateApiPseudoManualChronoTypeTwinSyncTokioTimeInstantTwinSync(
-      {required DateTime d}) {
-    return handler.executeSync(SyncTask(
-      callFfi: () {
-        final serializer = SseSerializer(generalizedFrbRustBinding);
-        sse_encode_TokioTime_TokioInstant(d, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1337)!;
-      },
-      codec: SseCodec(
-        decodeSuccessData: sse_decode_TokioTime_TokioInstant,
-        decodeErrorData: null,
-      ),
-      constMeta:
-          kCrateApiPseudoManualChronoTypeTwinSyncTokioTimeInstantTwinSyncConstMeta,
-      argValues: [d],
-      apiImpl: this,
-    ));
-  }
-
-  TaskConstMeta
-      get kCrateApiPseudoManualChronoTypeTwinSyncTokioTimeInstantTwinSyncConstMeta =>
-          const TaskConstMeta(
-            debugName: "tokio_time_instant_twin_sync",
-            argNames: ["d"],
-          );
-
-  @override
   Future<int>
       crateApiDartCodeTranslatableStructWithDartCodeTwinNormalNormalMethodTwinNormal(
           {required TranslatableStructWithDartCodeTwinNormal that}) {
@@ -43364,7 +43180,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_box_autoadd_translatable_struct_with_dart_code_twin_normal(
             that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1338, port: port_);
+            funcId: 1332, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_i_32,
@@ -43392,7 +43208,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_DartOpaque(opaque, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1339)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1333)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -43419,7 +43235,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_RustOpaque_HideDataTwinNormal(opaque, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1340, port: port_);
+            funcId: 1334, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -43446,7 +43262,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_RustOpaque_HideDataTwinRustAsync(opaque, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1341, port: port_);
+            funcId: 1335, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -43473,7 +43289,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_RustOpaque_HideDataTwinSync(opaque, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1342)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1336)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -43501,7 +43317,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_blob_twin_normal(blob, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1343, port: port_);
+            funcId: 1337, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_8_array_1600,
@@ -43528,7 +43344,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_blob_twin_rust_async(blob, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1344, port: port_);
+            funcId: 1338, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_8_array_1600,
@@ -43555,7 +43371,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_blob_twin_sync(blob, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1345)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1339)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_8_array_1600,
@@ -43583,7 +43399,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_my_enum(myEnum, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1346, port: port_);
+            funcId: 1340, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -43611,7 +43427,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_my_enum(myEnum, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1347, port: port_);
+            funcId: 1341, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -43638,7 +43454,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_my_enum(myEnum, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1348)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1342)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -43666,7 +43482,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_my_struct(myStruct, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1349, port: port_);
+            funcId: 1343, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -43695,7 +43511,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_my_struct(myStruct, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1350, port: port_);
+            funcId: 1344, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -43722,7 +43538,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_my_struct(myStruct, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1351)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1345)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -43750,7 +43566,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_message_id_twin_normal(id, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1352, port: port_);
+            funcId: 1346, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_8_array_32,
@@ -43776,7 +43592,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_message_id_twin_rust_async(id, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1353, port: port_);
+            funcId: 1347, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_8_array_32,
@@ -43803,7 +43619,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_message_id_twin_sync(id, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1354)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1348)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_8_array_32,
@@ -47660,12 +47476,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  DateTime dco_decode_StdTime_StdInstant(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    return dcoDecodeTimestamp(ts: dco_decode_i_64(raw).toInt(), isUtc: true);
-  }
-
-  @protected
   DateTime dco_decode_StdTime_StdSystemTime(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return dcoDecodeTimestamp(ts: dco_decode_i_64(raw).toInt(), isUtc: true);
@@ -47878,12 +47688,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   String dco_decode_String(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw as String;
-  }
-
-  @protected
-  DateTime dco_decode_TokioTime_TokioInstant(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    return dcoDecodeTimestamp(ts: dco_decode_i_64(raw).toInt(), isUtc: true);
   }
 
   @protected
@@ -59445,13 +59249,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  DateTime sse_decode_StdTime_StdInstant(SseDeserializer deserializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    var inner = sse_decode_i_64(deserializer);
-    return DateTime.fromMicrosecondsSinceEpoch(inner.toInt(), isUtc: true);
-  }
-
-  @protected
   DateTime sse_decode_StdTime_StdSystemTime(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var inner = sse_decode_i_64(deserializer);
@@ -59685,13 +59482,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var inner = sse_decode_list_prim_u_8_strict(deserializer);
     return utf8.decoder.convert(inner);
-  }
-
-  @protected
-  DateTime sse_decode_TokioTime_TokioInstant(SseDeserializer deserializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    var inner = sse_decode_i_64(deserializer);
-    return DateTime.fromMicrosecondsSinceEpoch(inner.toInt(), isUtc: true);
   }
 
   @protected
@@ -72173,13 +71963,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  void sse_encode_StdTime_StdInstant(DateTime self, SseSerializer serializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_i_64(
-        PlatformInt64Util.from(self.microsecondsSinceEpoch), serializer);
-  }
-
-  @protected
   void sse_encode_StdTime_StdSystemTime(
       DateTime self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -72584,14 +72367,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_String(String self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_list_prim_u_8_strict(utf8.encoder.convert(self), serializer);
-  }
-
-  @protected
-  void sse_encode_TokioTime_TokioInstant(
-      DateTime self, SseSerializer serializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_i_64(
-        PlatformInt64Util.from(self.microsecondsSinceEpoch), serializer);
   }
 
   @protected

--- a/frb_example/pure_dart_pde/lib/src/rust/frb_generated.dart
+++ b/frb_example/pure_dart_pde/lib/src/rust/frb_generated.dart
@@ -240,7 +240,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => -1020479450;
+  int get rustContentHash => 415027099;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -4523,6 +4523,36 @@ abstract class RustLibApi extends BaseApi {
   int crateApiPseudoManualMethodTwinSyncStaticOnlyTwinSyncStaticMethodTwinSync(
       {required int a});
 
+  Future<Duration> crateApiChronoTypeStdTimeDurationTwinNormal(
+      {required Duration d});
+
+  Future<Duration>
+      crateApiPseudoManualChronoTypeTwinRustAsyncStdTimeDurationTwinRustAsync(
+          {required Duration d});
+
+  Duration crateApiPseudoManualChronoTypeTwinSyncStdTimeDurationTwinSync(
+      {required Duration d});
+
+  Future<DateTime> crateApiChronoTypeStdTimeInstantTwinNormal(
+      {required DateTime d});
+
+  Future<DateTime>
+      crateApiPseudoManualChronoTypeTwinRustAsyncStdTimeInstantTwinRustAsync(
+          {required DateTime d});
+
+  DateTime crateApiPseudoManualChronoTypeTwinSyncStdTimeInstantTwinSync(
+      {required DateTime d});
+
+  Future<DateTime> crateApiChronoTypeStdTimeSystemTimeTwinNormal(
+      {required DateTime d});
+
+  Future<DateTime>
+      crateApiPseudoManualChronoTypeTwinRustAsyncStdTimeSystemTimeTwinRustAsync(
+          {required DateTime d});
+
+  DateTime crateApiPseudoManualChronoTypeTwinSyncStdTimeSystemTimeTwinSync(
+      {required DateTime d});
+
   Future<Stream<int>> crateApiStreamMiscStreamSinkDartAsyncTwinNormal();
 
   Stream<U8Array2> crateApiStreamStreamSinkFixedSizedPrimitiveArrayTwinNormal();
@@ -4786,6 +4816,26 @@ abstract class RustLibApi extends BaseApi {
       crateApiPseudoManualExceptionTwinRustAsyncThrowAnyhowTwinRustAsync();
 
   void crateApiPseudoManualExceptionTwinSyncThrowAnyhowTwinSync();
+
+  Future<Duration> crateApiChronoTypeTokioTimeDurationTwinNormal(
+      {required Duration d});
+
+  Future<Duration>
+      crateApiPseudoManualChronoTypeTwinRustAsyncTokioTimeDurationTwinRustAsync(
+          {required Duration d});
+
+  Duration crateApiPseudoManualChronoTypeTwinSyncTokioTimeDurationTwinSync(
+      {required Duration d});
+
+  Future<DateTime> crateApiChronoTypeTokioTimeInstantTwinNormal(
+      {required DateTime d});
+
+  Future<DateTime>
+      crateApiPseudoManualChronoTypeTwinRustAsyncTokioTimeInstantTwinRustAsync(
+          {required DateTime d});
+
+  DateTime crateApiPseudoManualChronoTypeTwinSyncTokioTimeInstantTwinSync(
+      {required DateTime d});
 
   Future<int>
       crateApiDartCodeTranslatableStructWithDartCodeTwinNormalNormalMethodTwinNormal(
@@ -40428,6 +40478,252 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           );
 
   @override
+  Future<Duration> crateApiChronoTypeStdTimeDurationTwinNormal(
+      {required Duration d}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_StdTime_StdDuration(d, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 1233, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_StdTime_StdDuration,
+        decodeErrorData: null,
+      ),
+      constMeta: kCrateApiChronoTypeStdTimeDurationTwinNormalConstMeta,
+      argValues: [d],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiChronoTypeStdTimeDurationTwinNormalConstMeta =>
+      const TaskConstMeta(
+        debugName: "std_time_duration_twin_normal",
+        argNames: ["d"],
+      );
+
+  @override
+  Future<Duration>
+      crateApiPseudoManualChronoTypeTwinRustAsyncStdTimeDurationTwinRustAsync(
+          {required Duration d}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_StdTime_StdDuration(d, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 1234, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_StdTime_StdDuration,
+        decodeErrorData: null,
+      ),
+      constMeta:
+          kCrateApiPseudoManualChronoTypeTwinRustAsyncStdTimeDurationTwinRustAsyncConstMeta,
+      argValues: [d],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta
+      get kCrateApiPseudoManualChronoTypeTwinRustAsyncStdTimeDurationTwinRustAsyncConstMeta =>
+          const TaskConstMeta(
+            debugName: "std_time_duration_twin_rust_async",
+            argNames: ["d"],
+          );
+
+  @override
+  Duration crateApiPseudoManualChronoTypeTwinSyncStdTimeDurationTwinSync(
+      {required Duration d}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_StdTime_StdDuration(d, serializer);
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1235)!;
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_StdTime_StdDuration,
+        decodeErrorData: null,
+      ),
+      constMeta:
+          kCrateApiPseudoManualChronoTypeTwinSyncStdTimeDurationTwinSyncConstMeta,
+      argValues: [d],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta
+      get kCrateApiPseudoManualChronoTypeTwinSyncStdTimeDurationTwinSyncConstMeta =>
+          const TaskConstMeta(
+            debugName: "std_time_duration_twin_sync",
+            argNames: ["d"],
+          );
+
+  @override
+  Future<DateTime> crateApiChronoTypeStdTimeInstantTwinNormal(
+      {required DateTime d}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_StdTime_StdInstant(d, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 1236, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_StdTime_StdInstant,
+        decodeErrorData: null,
+      ),
+      constMeta: kCrateApiChronoTypeStdTimeInstantTwinNormalConstMeta,
+      argValues: [d],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiChronoTypeStdTimeInstantTwinNormalConstMeta =>
+      const TaskConstMeta(
+        debugName: "std_time_instant_twin_normal",
+        argNames: ["d"],
+      );
+
+  @override
+  Future<DateTime>
+      crateApiPseudoManualChronoTypeTwinRustAsyncStdTimeInstantTwinRustAsync(
+          {required DateTime d}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_StdTime_StdInstant(d, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 1237, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_StdTime_StdInstant,
+        decodeErrorData: null,
+      ),
+      constMeta:
+          kCrateApiPseudoManualChronoTypeTwinRustAsyncStdTimeInstantTwinRustAsyncConstMeta,
+      argValues: [d],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta
+      get kCrateApiPseudoManualChronoTypeTwinRustAsyncStdTimeInstantTwinRustAsyncConstMeta =>
+          const TaskConstMeta(
+            debugName: "std_time_instant_twin_rust_async",
+            argNames: ["d"],
+          );
+
+  @override
+  DateTime crateApiPseudoManualChronoTypeTwinSyncStdTimeInstantTwinSync(
+      {required DateTime d}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_StdTime_StdInstant(d, serializer);
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1238)!;
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_StdTime_StdInstant,
+        decodeErrorData: null,
+      ),
+      constMeta:
+          kCrateApiPseudoManualChronoTypeTwinSyncStdTimeInstantTwinSyncConstMeta,
+      argValues: [d],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta
+      get kCrateApiPseudoManualChronoTypeTwinSyncStdTimeInstantTwinSyncConstMeta =>
+          const TaskConstMeta(
+            debugName: "std_time_instant_twin_sync",
+            argNames: ["d"],
+          );
+
+  @override
+  Future<DateTime> crateApiChronoTypeStdTimeSystemTimeTwinNormal(
+      {required DateTime d}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_StdTime_StdSystemTime(d, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 1239, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_StdTime_StdSystemTime,
+        decodeErrorData: null,
+      ),
+      constMeta: kCrateApiChronoTypeStdTimeSystemTimeTwinNormalConstMeta,
+      argValues: [d],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiChronoTypeStdTimeSystemTimeTwinNormalConstMeta =>
+      const TaskConstMeta(
+        debugName: "std_time_system_time_twin_normal",
+        argNames: ["d"],
+      );
+
+  @override
+  Future<DateTime>
+      crateApiPseudoManualChronoTypeTwinRustAsyncStdTimeSystemTimeTwinRustAsync(
+          {required DateTime d}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_StdTime_StdSystemTime(d, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 1240, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_StdTime_StdSystemTime,
+        decodeErrorData: null,
+      ),
+      constMeta:
+          kCrateApiPseudoManualChronoTypeTwinRustAsyncStdTimeSystemTimeTwinRustAsyncConstMeta,
+      argValues: [d],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta
+      get kCrateApiPseudoManualChronoTypeTwinRustAsyncStdTimeSystemTimeTwinRustAsyncConstMeta =>
+          const TaskConstMeta(
+            debugName: "std_time_system_time_twin_rust_async",
+            argNames: ["d"],
+          );
+
+  @override
+  DateTime crateApiPseudoManualChronoTypeTwinSyncStdTimeSystemTimeTwinSync(
+      {required DateTime d}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_StdTime_StdSystemTime(d, serializer);
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1241)!;
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_StdTime_StdSystemTime,
+        decodeErrorData: null,
+      ),
+      constMeta:
+          kCrateApiPseudoManualChronoTypeTwinSyncStdTimeSystemTimeTwinSyncConstMeta,
+      argValues: [d],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta
+      get kCrateApiPseudoManualChronoTypeTwinSyncStdTimeSystemTimeTwinSyncConstMeta =>
+          const TaskConstMeta(
+            debugName: "std_time_system_time_twin_sync",
+            argNames: ["d"],
+          );
+
+  @override
   Future<Stream<int>> crateApiStreamMiscStreamSinkDartAsyncTwinNormal() async {
     final sink = RustStreamSink<int>();
     await handler.executeNormal(NormalTask(
@@ -40435,7 +40731,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StreamSink_i_32_Sse(sink, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1233, port: port_);
+            funcId: 1242, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -40463,7 +40759,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StreamSink_u_8_array_2_Sse(sink, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1234, port: port_);
+            funcId: 1243, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -40493,7 +40789,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StreamSink_u_8_array_2_Sse(sink, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1235, port: port_);
+            funcId: 1244, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -40524,7 +40820,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_box_autoadd_my_struct_containing_stream_sink_twin_normal(
             arg, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1236, port: port_);
+            funcId: 1245, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -40552,7 +40848,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_box_autoadd_my_struct_containing_stream_sink_twin_rust_async(
             arg, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1237, port: port_);
+            funcId: 1246, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -40580,7 +40876,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_list_StreamSink_i_32_Sse(arg, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1238, port: port_);
+            funcId: 1247, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -40607,7 +40903,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_list_StreamSink_i_32_Sse(arg, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1239, port: port_);
+            funcId: 1248, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -40636,7 +40932,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StreamSink_String_Sse(sink, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1240, port: port_);
+            funcId: 1249, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -40665,7 +40961,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StreamSink_String_Sse(sink, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1241, port: port_);
+            funcId: 1250, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -40694,7 +40990,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StreamSink_String_Sse(sink, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1242)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1251)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -40725,7 +41021,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_box_autoadd_struct_with_comments_twin_normal(
             that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1243, port: port_);
+            funcId: 1252, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -40753,7 +41049,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1244, port: port_);
+            funcId: 1253, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -40784,7 +41080,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_box_autoadd_struct_with_comments_twin_rust_async(
             that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1245, port: port_);
+            funcId: 1254, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -40812,7 +41108,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1246, port: port_);
+            funcId: 1255, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -40841,7 +41137,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_struct_with_comments_twin_sync(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1247)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1256)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -40868,7 +41164,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1248)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1257)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -40897,7 +41193,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_struct_with_custom_name_method_twin_normal(
             that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1249)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1258)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -40927,7 +41223,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_box_autoadd_struct_with_impl_block_in_another_file_dependency(
             arg, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1250, port: port_);
+            funcId: 1259, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -40953,7 +41249,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1251, port: port_);
+            funcId: 1260, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -40980,7 +41276,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1252, port: port_);
+            funcId: 1261, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -41012,7 +41308,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_box_autoadd_struct_with_rust_auto_opaque_field_with_many_derive(
             that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1253, port: port_);
+            funcId: 1262, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -41042,7 +41338,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_box_autoadd_struct_with_rust_auto_opaque_with_non_clone_data(
             that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1254, port: port_);
+            funcId: 1263, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -41072,7 +41368,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_u_32(y, serializer);
         sse_encode_u_32(z, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1255, port: port_);
+            funcId: 1264, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_32,
@@ -41103,7 +41399,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_u_32(y, serializer);
         sse_encode_u_32(z, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1256, port: port_);
+            funcId: 1265, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_32,
@@ -41132,7 +41428,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_box_autoadd_sum_with_twin_sync(that, serializer);
         sse_encode_u_32(y, serializer);
         sse_encode_u_32(z, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1257)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1266)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_32,
@@ -41159,7 +41455,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_DartOpaque(opaque, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1258)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1267)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -41183,7 +41479,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1259)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1268)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_RustOpaque_NonCloneDataTwinNormal,
@@ -41207,7 +41503,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1260)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1269)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_RustOpaque_HideDataAnotherTwinNormal,
@@ -41233,7 +41529,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_DartOpaque(opaque, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1261)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1270)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_DartOpaque,
@@ -41258,7 +41554,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_DartOpaque(opaque, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1262)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1271)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_DartOpaque,
@@ -41283,7 +41579,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_opt_box_autoadd_DartOpaque(opaque, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1263)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1272)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_DartOpaque,
@@ -41308,7 +41604,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1264)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1273)!;
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -41336,7 +41632,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_abc_twin_normal(abc, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1265, port: port_);
+            funcId: 1274, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_abc_twin_normal,
@@ -41363,7 +41659,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_abc_twin_rust_async(abc, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1266, port: port_);
+            funcId: 1275, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_abc_twin_rust_async,
@@ -41390,7 +41686,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_abc_twin_sync(abc, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1267)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1276)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_abc_twin_sync,
@@ -41416,7 +41712,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1268, port: port_);
+            funcId: 1277, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_test_chrono_twin_normal,
@@ -41441,7 +41737,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1269, port: port_);
+            funcId: 1278, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_test_chrono_twin_rust_async,
@@ -41467,7 +41763,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1270)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1279)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_test_chrono_twin_sync,
@@ -41494,7 +41790,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1271, port: port_);
+            funcId: 1280, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_contains_mirrored_sub_struct_twin_normal,
@@ -41521,7 +41817,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1272, port: port_);
+            funcId: 1281, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -41548,7 +41844,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1273)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1282)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_contains_mirrored_sub_struct_twin_sync,
@@ -41577,7 +41873,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_struct_in_lower_level(s, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1274, port: port_);
+            funcId: 1283, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_struct_in_upper_level,
@@ -41604,7 +41900,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1275, port: port_);
+            funcId: 1284, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_raw_string_mirrored,
@@ -41631,7 +41927,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1276, port: port_);
+            funcId: 1285, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_raw_string_mirrored,
@@ -41657,7 +41953,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1277)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1286)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_raw_string_mirrored,
@@ -41684,7 +41980,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1278, port: port_);
+            funcId: 1287, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_struct_with_hash_map,
@@ -41710,7 +42006,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1279, port: port_);
+            funcId: 1288, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_struct_with_hash_map,
@@ -41736,7 +42032,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1280)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1289)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_struct_with_hash_map,
@@ -41763,7 +42059,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1281, port: port_);
+            funcId: 1290, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_raw_string_enum_mirrored,
@@ -41790,7 +42086,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1282, port: port_);
+            funcId: 1291, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_raw_string_enum_mirrored,
@@ -41816,7 +42112,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1283)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1292)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_raw_string_enum_mirrored,
@@ -41843,7 +42139,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1284, port: port_);
+            funcId: 1293, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_of_nested_raw_string_mirrored,
@@ -41870,7 +42166,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1285, port: port_);
+            funcId: 1294, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_of_nested_raw_string_mirrored,
@@ -41897,7 +42193,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1286)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1295)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_of_nested_raw_string_mirrored,
@@ -41924,7 +42220,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1287, port: port_);
+            funcId: 1296, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -41952,7 +42248,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1288, port: port_);
+            funcId: 1297, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -41980,7 +42276,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1289)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1298)!;
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -42008,7 +42304,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1290, port: port_);
+            funcId: 1299, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_nested_raw_string_mirrored,
@@ -42034,7 +42330,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1291, port: port_);
+            funcId: 1300, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_nested_raw_string_mirrored,
@@ -42060,7 +42356,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1292)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1301)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_nested_raw_string_mirrored,
@@ -42086,7 +42382,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1293, port: port_);
+            funcId: 1302, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_test_chrono_twin_normal,
@@ -42111,7 +42407,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1294, port: port_);
+            funcId: 1303, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_test_chrono_twin_rust_async,
@@ -42137,7 +42433,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1295)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1304)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_test_chrono_twin_sync,
@@ -42166,7 +42462,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_bool(nested, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1296, port: port_);
+            funcId: 1305, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_raw_string_enum_mirrored,
@@ -42194,7 +42490,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_bool(nested, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1297, port: port_);
+            funcId: 1306, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_raw_string_enum_mirrored,
@@ -42222,7 +42518,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_bool(nested, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1298)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1307)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_raw_string_enum_mirrored,
@@ -42249,7 +42545,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1299, port: port_);
+            funcId: 1308, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_raw_string_item_enum_twin_normal,
@@ -42275,7 +42571,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1300, port: port_);
+            funcId: 1309, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_raw_string_item_enum_twin_rust_async,
@@ -42301,7 +42597,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1301)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1310)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_raw_string_item_enum_twin_sync,
@@ -42328,7 +42624,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1302, port: port_);
+            funcId: 1311, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_raw_string_item_struct_twin_normal,
@@ -42354,7 +42650,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1303, port: port_);
+            funcId: 1312, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_raw_string_item_struct_twin_rust_async,
@@ -42380,7 +42676,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1304)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1313)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_raw_string_item_struct_twin_sync,
@@ -42406,7 +42702,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1305, port: port_);
+            funcId: 1314, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_raw_string_mirrored,
@@ -42431,7 +42727,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1306, port: port_);
+            funcId: 1315, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_raw_string_mirrored,
@@ -42457,7 +42753,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1307)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1316)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_raw_string_mirrored,
@@ -42486,7 +42782,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_struct_with_enum_twin_normal(se, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1308, port: port_);
+            funcId: 1317, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_struct_with_enum_twin_normal,
@@ -42513,7 +42809,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_struct_with_enum_twin_rust_async(se, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1309, port: port_);
+            funcId: 1318, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_struct_with_enum_twin_rust_async,
@@ -42541,7 +42837,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_struct_with_enum_twin_sync(se, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1310)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1319)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_struct_with_enum_twin_sync,
@@ -42569,7 +42865,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_list_record_string_i_32(value, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1311, port: port_);
+            funcId: 1320, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -42595,7 +42891,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_list_record_string_i_32(value, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1312, port: port_);
+            funcId: 1321, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -42622,7 +42918,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_list_record_string_i_32(value, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1313)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1322)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -42649,7 +42945,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_opt_box_autoadd_record_string_i_32(value, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1314, port: port_);
+            funcId: 1323, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_record_string_i_32,
@@ -42676,7 +42972,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_opt_box_autoadd_record_string_i_32(value, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1315, port: port_);
+            funcId: 1324, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_record_string_i_32,
@@ -42703,7 +42999,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_opt_box_autoadd_record_string_i_32(value, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1316)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1325)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_record_string_i_32,
@@ -42728,7 +43024,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1317, port: port_);
+            funcId: 1326, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -42753,7 +43049,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1318, port: port_);
+            funcId: 1327, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -42778,7 +43074,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1319)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1328)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -42799,6 +43095,170 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           );
 
   @override
+  Future<Duration> crateApiChronoTypeTokioTimeDurationTwinNormal(
+      {required Duration d}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_StdTime_StdDuration(d, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 1329, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_StdTime_StdDuration,
+        decodeErrorData: null,
+      ),
+      constMeta: kCrateApiChronoTypeTokioTimeDurationTwinNormalConstMeta,
+      argValues: [d],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiChronoTypeTokioTimeDurationTwinNormalConstMeta =>
+      const TaskConstMeta(
+        debugName: "tokio_time_duration_twin_normal",
+        argNames: ["d"],
+      );
+
+  @override
+  Future<Duration>
+      crateApiPseudoManualChronoTypeTwinRustAsyncTokioTimeDurationTwinRustAsync(
+          {required Duration d}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_StdTime_StdDuration(d, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 1330, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_StdTime_StdDuration,
+        decodeErrorData: null,
+      ),
+      constMeta:
+          kCrateApiPseudoManualChronoTypeTwinRustAsyncTokioTimeDurationTwinRustAsyncConstMeta,
+      argValues: [d],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta
+      get kCrateApiPseudoManualChronoTypeTwinRustAsyncTokioTimeDurationTwinRustAsyncConstMeta =>
+          const TaskConstMeta(
+            debugName: "tokio_time_duration_twin_rust_async",
+            argNames: ["d"],
+          );
+
+  @override
+  Duration crateApiPseudoManualChronoTypeTwinSyncTokioTimeDurationTwinSync(
+      {required Duration d}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_StdTime_StdDuration(d, serializer);
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1331)!;
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_StdTime_StdDuration,
+        decodeErrorData: null,
+      ),
+      constMeta:
+          kCrateApiPseudoManualChronoTypeTwinSyncTokioTimeDurationTwinSyncConstMeta,
+      argValues: [d],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta
+      get kCrateApiPseudoManualChronoTypeTwinSyncTokioTimeDurationTwinSyncConstMeta =>
+          const TaskConstMeta(
+            debugName: "tokio_time_duration_twin_sync",
+            argNames: ["d"],
+          );
+
+  @override
+  Future<DateTime> crateApiChronoTypeTokioTimeInstantTwinNormal(
+      {required DateTime d}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_TokioTime_TokioInstant(d, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 1332, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_TokioTime_TokioInstant,
+        decodeErrorData: null,
+      ),
+      constMeta: kCrateApiChronoTypeTokioTimeInstantTwinNormalConstMeta,
+      argValues: [d],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiChronoTypeTokioTimeInstantTwinNormalConstMeta =>
+      const TaskConstMeta(
+        debugName: "tokio_time_instant_twin_normal",
+        argNames: ["d"],
+      );
+
+  @override
+  Future<DateTime>
+      crateApiPseudoManualChronoTypeTwinRustAsyncTokioTimeInstantTwinRustAsync(
+          {required DateTime d}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_TokioTime_TokioInstant(d, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 1333, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_TokioTime_TokioInstant,
+        decodeErrorData: null,
+      ),
+      constMeta:
+          kCrateApiPseudoManualChronoTypeTwinRustAsyncTokioTimeInstantTwinRustAsyncConstMeta,
+      argValues: [d],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta
+      get kCrateApiPseudoManualChronoTypeTwinRustAsyncTokioTimeInstantTwinRustAsyncConstMeta =>
+          const TaskConstMeta(
+            debugName: "tokio_time_instant_twin_rust_async",
+            argNames: ["d"],
+          );
+
+  @override
+  DateTime crateApiPseudoManualChronoTypeTwinSyncTokioTimeInstantTwinSync(
+      {required DateTime d}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_TokioTime_TokioInstant(d, serializer);
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1334)!;
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_TokioTime_TokioInstant,
+        decodeErrorData: null,
+      ),
+      constMeta:
+          kCrateApiPseudoManualChronoTypeTwinSyncTokioTimeInstantTwinSyncConstMeta,
+      argValues: [d],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta
+      get kCrateApiPseudoManualChronoTypeTwinSyncTokioTimeInstantTwinSyncConstMeta =>
+          const TaskConstMeta(
+            debugName: "tokio_time_instant_twin_sync",
+            argNames: ["d"],
+          );
+
+  @override
   Future<int>
       crateApiDartCodeTranslatableStructWithDartCodeTwinNormalNormalMethodTwinNormal(
           {required TranslatableStructWithDartCodeTwinNormal that}) {
@@ -42808,7 +43268,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_box_autoadd_translatable_struct_with_dart_code_twin_normal(
             that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1320, port: port_);
+            funcId: 1335, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_i_32,
@@ -42836,7 +43296,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_DartOpaque(opaque, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1321)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1336)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -42863,7 +43323,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_RustOpaque_HideDataTwinNormal(opaque, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1322, port: port_);
+            funcId: 1337, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -42890,7 +43350,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_RustOpaque_HideDataTwinRustAsync(opaque, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1323, port: port_);
+            funcId: 1338, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -42917,7 +43377,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_RustOpaque_HideDataTwinSync(opaque, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1324)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1339)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -42945,7 +43405,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_blob_twin_normal(blob, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1325, port: port_);
+            funcId: 1340, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_8_array_1600,
@@ -42972,7 +43432,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_blob_twin_rust_async(blob, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1326, port: port_);
+            funcId: 1341, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_8_array_1600,
@@ -42999,7 +43459,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_blob_twin_sync(blob, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1327)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1342)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_8_array_1600,
@@ -43027,7 +43487,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_my_enum(myEnum, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1328, port: port_);
+            funcId: 1343, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -43055,7 +43515,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_my_enum(myEnum, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1329, port: port_);
+            funcId: 1344, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -43082,7 +43542,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_my_enum(myEnum, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1330)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1345)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -43110,7 +43570,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_my_struct(myStruct, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1331, port: port_);
+            funcId: 1346, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -43139,7 +43599,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_my_struct(myStruct, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1332, port: port_);
+            funcId: 1347, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -43166,7 +43626,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_my_struct(myStruct, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1333)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1348)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -43194,7 +43654,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_message_id_twin_normal(id, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1334, port: port_);
+            funcId: 1349, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_8_array_32,
@@ -43220,7 +43680,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_message_id_twin_rust_async(id, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1335, port: port_);
+            funcId: 1350, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_8_array_32,
@@ -43247,7 +43707,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_message_id_twin_sync(id, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1336)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1351)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_8_array_32,
@@ -47098,6 +47558,24 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  Duration dco_decode_StdTime_StdDuration(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dcoDecodeDuration(dco_decode_i_64(raw).toInt());
+  }
+
+  @protected
+  DateTime dco_decode_StdTime_StdInstant(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dcoDecodeTimestamp(ts: dco_decode_i_64(raw).toInt(), isUtc: true);
+  }
+
+  @protected
+  DateTime dco_decode_StdTime_StdSystemTime(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dcoDecodeTimestamp(ts: dco_decode_i_64(raw).toInt(), isUtc: true);
+  }
+
+  @protected
   RustStreamSink<NonCloneSimpleTwinNormal>
       dco_decode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinNormal_Sse(
           dynamic raw) {
@@ -47304,6 +47782,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   String dco_decode_String(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw as String;
+  }
+
+  @protected
+  DateTime dco_decode_TokioTime_TokioInstant(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dcoDecodeTimestamp(ts: dco_decode_i_64(raw).toInt(), isUtc: true);
   }
 
   @protected
@@ -58858,6 +59342,27 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  Duration sse_decode_StdTime_StdDuration(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var inner = sse_decode_i_64(deserializer);
+    return Duration(microseconds: inner.toInt());
+  }
+
+  @protected
+  DateTime sse_decode_StdTime_StdInstant(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var inner = sse_decode_i_64(deserializer);
+    return DateTime.fromMicrosecondsSinceEpoch(inner.toInt(), isUtc: true);
+  }
+
+  @protected
+  DateTime sse_decode_StdTime_StdSystemTime(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var inner = sse_decode_i_64(deserializer);
+    return DateTime.fromMicrosecondsSinceEpoch(inner.toInt(), isUtc: true);
+  }
+
+  @protected
   RustStreamSink<NonCloneSimpleTwinNormal>
       sse_decode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinNormal_Sse(
           SseDeserializer deserializer) {
@@ -59084,6 +59589,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var inner = sse_decode_list_prim_u_8_strict(deserializer);
     return utf8.decoder.convert(inner);
+  }
+
+  @protected
+  DateTime sse_decode_TokioTime_TokioInstant(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var inner = sse_decode_i_64(deserializer);
+    return DateTime.fromMicrosecondsSinceEpoch(inner.toInt(), isUtc: true);
   }
 
   @protected
@@ -71559,6 +72071,27 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_StdTime_StdDuration(Duration self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_64(PlatformInt64Util.from(self.inMicroseconds), serializer);
+  }
+
+  @protected
+  void sse_encode_StdTime_StdInstant(DateTime self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_64(
+        PlatformInt64Util.from(self.microsecondsSinceEpoch), serializer);
+  }
+
+  @protected
+  void sse_encode_StdTime_StdSystemTime(
+      DateTime self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_64(
+        PlatformInt64Util.from(self.microsecondsSinceEpoch), serializer);
+  }
+
+  @protected
   void
       sse_encode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinNormal_Sse(
           RustStreamSink<NonCloneSimpleTwinNormal> self,
@@ -71955,6 +72488,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_String(String self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_list_prim_u_8_strict(utf8.encoder.convert(self), serializer);
+  }
+
+  @protected
+  void sse_encode_TokioTime_TokioInstant(
+      DateTime self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_64(
+        PlatformInt64Util.from(self.microsecondsSinceEpoch), serializer);
   }
 
   @protected

--- a/frb_example/pure_dart_pde/lib/src/rust/frb_generated.dart
+++ b/frb_example/pure_dart_pde/lib/src/rust/frb_generated.dart
@@ -240,7 +240,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => 415027099;
+  int get rustContentHash => -1314015258;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -4542,6 +4542,17 @@ abstract class RustLibApi extends BaseApi {
 
   DateTime crateApiPseudoManualChronoTypeTwinSyncStdTimeInstantTwinSync(
       {required DateTime d});
+
+  Future<DateTime> crateApiChronoTypeStdTimeSystemTimeBeforeEpochTwinNormal(
+      {required DateTime d});
+
+  Future<DateTime>
+      crateApiPseudoManualChronoTypeTwinRustAsyncStdTimeSystemTimeBeforeEpochTwinRustAsync(
+          {required DateTime d});
+
+  DateTime
+      crateApiPseudoManualChronoTypeTwinSyncStdTimeSystemTimeBeforeEpochTwinSync(
+          {required DateTime d});
 
   Future<DateTime> crateApiChronoTypeStdTimeSystemTimeTwinNormal(
       {required DateTime d});
@@ -40642,7 +40653,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           );
 
   @override
-  Future<DateTime> crateApiChronoTypeStdTimeSystemTimeTwinNormal(
+  Future<DateTime> crateApiChronoTypeStdTimeSystemTimeBeforeEpochTwinNormal(
       {required DateTime d}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
@@ -40650,6 +40661,91 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_StdTime_StdSystemTime(d, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
             funcId: 1239, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_StdTime_StdSystemTime,
+        decodeErrorData: null,
+      ),
+      constMeta:
+          kCrateApiChronoTypeStdTimeSystemTimeBeforeEpochTwinNormalConstMeta,
+      argValues: [d],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta
+      get kCrateApiChronoTypeStdTimeSystemTimeBeforeEpochTwinNormalConstMeta =>
+          const TaskConstMeta(
+            debugName: "std_time_system_time_before_epoch_twin_normal",
+            argNames: ["d"],
+          );
+
+  @override
+  Future<DateTime>
+      crateApiPseudoManualChronoTypeTwinRustAsyncStdTimeSystemTimeBeforeEpochTwinRustAsync(
+          {required DateTime d}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_StdTime_StdSystemTime(d, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 1240, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_StdTime_StdSystemTime,
+        decodeErrorData: null,
+      ),
+      constMeta:
+          kCrateApiPseudoManualChronoTypeTwinRustAsyncStdTimeSystemTimeBeforeEpochTwinRustAsyncConstMeta,
+      argValues: [d],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta
+      get kCrateApiPseudoManualChronoTypeTwinRustAsyncStdTimeSystemTimeBeforeEpochTwinRustAsyncConstMeta =>
+          const TaskConstMeta(
+            debugName: "std_time_system_time_before_epoch_twin_rust_async",
+            argNames: ["d"],
+          );
+
+  @override
+  DateTime
+      crateApiPseudoManualChronoTypeTwinSyncStdTimeSystemTimeBeforeEpochTwinSync(
+          {required DateTime d}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_StdTime_StdSystemTime(d, serializer);
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1241)!;
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_StdTime_StdSystemTime,
+        decodeErrorData: null,
+      ),
+      constMeta:
+          kCrateApiPseudoManualChronoTypeTwinSyncStdTimeSystemTimeBeforeEpochTwinSyncConstMeta,
+      argValues: [d],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta
+      get kCrateApiPseudoManualChronoTypeTwinSyncStdTimeSystemTimeBeforeEpochTwinSyncConstMeta =>
+          const TaskConstMeta(
+            debugName: "std_time_system_time_before_epoch_twin_sync",
+            argNames: ["d"],
+          );
+
+  @override
+  Future<DateTime> crateApiChronoTypeStdTimeSystemTimeTwinNormal(
+      {required DateTime d}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_StdTime_StdSystemTime(d, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 1242, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_StdTime_StdSystemTime,
@@ -40676,7 +40772,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StdTime_StdSystemTime(d, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1240, port: port_);
+            funcId: 1243, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_StdTime_StdSystemTime,
@@ -40703,7 +40799,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StdTime_StdSystemTime(d, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1241)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1244)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_StdTime_StdSystemTime,
@@ -40731,7 +40827,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StreamSink_i_32_Sse(sink, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1242, port: port_);
+            funcId: 1245, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -40759,7 +40855,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StreamSink_u_8_array_2_Sse(sink, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1243, port: port_);
+            funcId: 1246, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -40789,7 +40885,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StreamSink_u_8_array_2_Sse(sink, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1244, port: port_);
+            funcId: 1247, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -40820,7 +40916,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_box_autoadd_my_struct_containing_stream_sink_twin_normal(
             arg, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1245, port: port_);
+            funcId: 1248, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -40848,7 +40944,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_box_autoadd_my_struct_containing_stream_sink_twin_rust_async(
             arg, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1246, port: port_);
+            funcId: 1249, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -40876,7 +40972,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_list_StreamSink_i_32_Sse(arg, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1247, port: port_);
+            funcId: 1250, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -40903,7 +40999,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_list_StreamSink_i_32_Sse(arg, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1248, port: port_);
+            funcId: 1251, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -40932,7 +41028,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StreamSink_String_Sse(sink, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1249, port: port_);
+            funcId: 1252, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -40961,7 +41057,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StreamSink_String_Sse(sink, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1250, port: port_);
+            funcId: 1253, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -40990,7 +41086,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StreamSink_String_Sse(sink, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1251)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1254)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -41021,7 +41117,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_box_autoadd_struct_with_comments_twin_normal(
             that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1252, port: port_);
+            funcId: 1255, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -41049,7 +41145,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1253, port: port_);
+            funcId: 1256, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -41080,7 +41176,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_box_autoadd_struct_with_comments_twin_rust_async(
             that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1254, port: port_);
+            funcId: 1257, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -41108,7 +41204,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1255, port: port_);
+            funcId: 1258, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -41137,7 +41233,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_struct_with_comments_twin_sync(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1256)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1259)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -41164,7 +41260,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1257)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1260)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -41193,7 +41289,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_struct_with_custom_name_method_twin_normal(
             that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1258)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1261)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -41223,7 +41319,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_box_autoadd_struct_with_impl_block_in_another_file_dependency(
             arg, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1259, port: port_);
+            funcId: 1262, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -41249,7 +41345,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1260, port: port_);
+            funcId: 1263, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -41276,7 +41372,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1261, port: port_);
+            funcId: 1264, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -41308,7 +41404,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_box_autoadd_struct_with_rust_auto_opaque_field_with_many_derive(
             that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1262, port: port_);
+            funcId: 1265, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -41338,7 +41434,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_box_autoadd_struct_with_rust_auto_opaque_with_non_clone_data(
             that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1263, port: port_);
+            funcId: 1266, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -41368,7 +41464,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_u_32(y, serializer);
         sse_encode_u_32(z, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1264, port: port_);
+            funcId: 1267, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_32,
@@ -41399,7 +41495,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_u_32(y, serializer);
         sse_encode_u_32(z, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1265, port: port_);
+            funcId: 1268, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_32,
@@ -41428,7 +41524,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_box_autoadd_sum_with_twin_sync(that, serializer);
         sse_encode_u_32(y, serializer);
         sse_encode_u_32(z, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1266)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1269)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_32,
@@ -41455,7 +41551,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_DartOpaque(opaque, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1267)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1270)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -41479,7 +41575,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1268)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1271)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_RustOpaque_NonCloneDataTwinNormal,
@@ -41503,7 +41599,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1269)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1272)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_RustOpaque_HideDataAnotherTwinNormal,
@@ -41529,7 +41625,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_DartOpaque(opaque, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1270)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1273)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_DartOpaque,
@@ -41554,7 +41650,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_DartOpaque(opaque, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1271)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1274)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_DartOpaque,
@@ -41579,7 +41675,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_opt_box_autoadd_DartOpaque(opaque, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1272)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1275)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_DartOpaque,
@@ -41604,7 +41700,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1273)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1276)!;
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -41632,7 +41728,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_abc_twin_normal(abc, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1274, port: port_);
+            funcId: 1277, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_abc_twin_normal,
@@ -41659,7 +41755,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_abc_twin_rust_async(abc, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1275, port: port_);
+            funcId: 1278, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_abc_twin_rust_async,
@@ -41686,7 +41782,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_abc_twin_sync(abc, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1276)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1279)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_abc_twin_sync,
@@ -41712,7 +41808,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1277, port: port_);
+            funcId: 1280, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_test_chrono_twin_normal,
@@ -41737,7 +41833,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1278, port: port_);
+            funcId: 1281, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_test_chrono_twin_rust_async,
@@ -41763,7 +41859,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1279)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1282)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_test_chrono_twin_sync,
@@ -41790,7 +41886,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1280, port: port_);
+            funcId: 1283, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_contains_mirrored_sub_struct_twin_normal,
@@ -41817,7 +41913,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1281, port: port_);
+            funcId: 1284, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -41844,7 +41940,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1282)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1285)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_contains_mirrored_sub_struct_twin_sync,
@@ -41873,7 +41969,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_struct_in_lower_level(s, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1283, port: port_);
+            funcId: 1286, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_struct_in_upper_level,
@@ -41900,7 +41996,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1284, port: port_);
+            funcId: 1287, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_raw_string_mirrored,
@@ -41927,7 +42023,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1285, port: port_);
+            funcId: 1288, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_raw_string_mirrored,
@@ -41953,7 +42049,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1286)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1289)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_raw_string_mirrored,
@@ -41980,7 +42076,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1287, port: port_);
+            funcId: 1290, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_struct_with_hash_map,
@@ -42006,7 +42102,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1288, port: port_);
+            funcId: 1291, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_struct_with_hash_map,
@@ -42032,7 +42128,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1289)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1292)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_struct_with_hash_map,
@@ -42059,7 +42155,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1290, port: port_);
+            funcId: 1293, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_raw_string_enum_mirrored,
@@ -42086,7 +42182,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1291, port: port_);
+            funcId: 1294, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_raw_string_enum_mirrored,
@@ -42112,7 +42208,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1292)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1295)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_raw_string_enum_mirrored,
@@ -42139,7 +42235,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1293, port: port_);
+            funcId: 1296, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_of_nested_raw_string_mirrored,
@@ -42166,7 +42262,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1294, port: port_);
+            funcId: 1297, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_of_nested_raw_string_mirrored,
@@ -42193,7 +42289,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1295)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1298)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_of_nested_raw_string_mirrored,
@@ -42220,7 +42316,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1296, port: port_);
+            funcId: 1299, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -42248,7 +42344,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1297, port: port_);
+            funcId: 1300, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -42276,7 +42372,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1298)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1301)!;
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -42304,7 +42400,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1299, port: port_);
+            funcId: 1302, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_nested_raw_string_mirrored,
@@ -42330,7 +42426,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1300, port: port_);
+            funcId: 1303, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_nested_raw_string_mirrored,
@@ -42356,7 +42452,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1301)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1304)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_nested_raw_string_mirrored,
@@ -42382,7 +42478,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1302, port: port_);
+            funcId: 1305, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_test_chrono_twin_normal,
@@ -42407,7 +42503,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1303, port: port_);
+            funcId: 1306, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_test_chrono_twin_rust_async,
@@ -42433,7 +42529,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1304)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1307)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_test_chrono_twin_sync,
@@ -42462,7 +42558,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_bool(nested, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1305, port: port_);
+            funcId: 1308, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_raw_string_enum_mirrored,
@@ -42490,7 +42586,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_bool(nested, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1306, port: port_);
+            funcId: 1309, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_raw_string_enum_mirrored,
@@ -42518,7 +42614,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_bool(nested, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1307)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1310)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_raw_string_enum_mirrored,
@@ -42545,7 +42641,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1308, port: port_);
+            funcId: 1311, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_raw_string_item_enum_twin_normal,
@@ -42571,7 +42667,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1309, port: port_);
+            funcId: 1312, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_raw_string_item_enum_twin_rust_async,
@@ -42597,7 +42693,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1310)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1313)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_raw_string_item_enum_twin_sync,
@@ -42624,7 +42720,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1311, port: port_);
+            funcId: 1314, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_raw_string_item_struct_twin_normal,
@@ -42650,7 +42746,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1312, port: port_);
+            funcId: 1315, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_raw_string_item_struct_twin_rust_async,
@@ -42676,7 +42772,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1313)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1316)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_raw_string_item_struct_twin_sync,
@@ -42702,7 +42798,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1314, port: port_);
+            funcId: 1317, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_raw_string_mirrored,
@@ -42727,7 +42823,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1315, port: port_);
+            funcId: 1318, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_raw_string_mirrored,
@@ -42753,7 +42849,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1316)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1319)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_raw_string_mirrored,
@@ -42782,7 +42878,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_struct_with_enum_twin_normal(se, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1317, port: port_);
+            funcId: 1320, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_struct_with_enum_twin_normal,
@@ -42809,7 +42905,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_struct_with_enum_twin_rust_async(se, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1318, port: port_);
+            funcId: 1321, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_struct_with_enum_twin_rust_async,
@@ -42837,7 +42933,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_struct_with_enum_twin_sync(se, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1319)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1322)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_struct_with_enum_twin_sync,
@@ -42865,7 +42961,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_list_record_string_i_32(value, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1320, port: port_);
+            funcId: 1323, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -42891,7 +42987,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_list_record_string_i_32(value, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1321, port: port_);
+            funcId: 1324, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -42918,7 +43014,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_list_record_string_i_32(value, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1322)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1325)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -42945,7 +43041,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_opt_box_autoadd_record_string_i_32(value, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1323, port: port_);
+            funcId: 1326, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_record_string_i_32,
@@ -42972,7 +43068,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_opt_box_autoadd_record_string_i_32(value, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1324, port: port_);
+            funcId: 1327, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_record_string_i_32,
@@ -42999,7 +43095,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_opt_box_autoadd_record_string_i_32(value, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1325)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1328)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_record_string_i_32,
@@ -43024,7 +43120,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1326, port: port_);
+            funcId: 1329, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -43049,7 +43145,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1327, port: port_);
+            funcId: 1330, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -43074,7 +43170,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1328)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1331)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -43102,7 +43198,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StdTime_StdDuration(d, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1329, port: port_);
+            funcId: 1332, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_StdTime_StdDuration,
@@ -43129,7 +43225,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StdTime_StdDuration(d, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1330, port: port_);
+            funcId: 1333, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_StdTime_StdDuration,
@@ -43156,7 +43252,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StdTime_StdDuration(d, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1331)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1334)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_StdTime_StdDuration,
@@ -43184,7 +43280,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_TokioTime_TokioInstant(d, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1332, port: port_);
+            funcId: 1335, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_TokioTime_TokioInstant,
@@ -43211,7 +43307,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_TokioTime_TokioInstant(d, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1333, port: port_);
+            funcId: 1336, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_TokioTime_TokioInstant,
@@ -43238,7 +43334,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_TokioTime_TokioInstant(d, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1334)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1337)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_TokioTime_TokioInstant,
@@ -43268,7 +43364,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_box_autoadd_translatable_struct_with_dart_code_twin_normal(
             that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1335, port: port_);
+            funcId: 1338, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_i_32,
@@ -43296,7 +43392,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_DartOpaque(opaque, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1336)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1339)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -43323,7 +43419,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_RustOpaque_HideDataTwinNormal(opaque, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1337, port: port_);
+            funcId: 1340, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -43350,7 +43446,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_RustOpaque_HideDataTwinRustAsync(opaque, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1338, port: port_);
+            funcId: 1341, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -43377,7 +43473,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_RustOpaque_HideDataTwinSync(opaque, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1339)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1342)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -43405,7 +43501,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_blob_twin_normal(blob, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1340, port: port_);
+            funcId: 1343, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_8_array_1600,
@@ -43432,7 +43528,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_blob_twin_rust_async(blob, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1341, port: port_);
+            funcId: 1344, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_8_array_1600,
@@ -43459,7 +43555,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_blob_twin_sync(blob, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1342)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1345)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_8_array_1600,
@@ -43487,7 +43583,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_my_enum(myEnum, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1343, port: port_);
+            funcId: 1346, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -43515,7 +43611,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_my_enum(myEnum, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1344, port: port_);
+            funcId: 1347, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -43542,7 +43638,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_my_enum(myEnum, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1345)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1348)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -43570,7 +43666,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_my_struct(myStruct, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1346, port: port_);
+            funcId: 1349, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -43599,7 +43695,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_my_struct(myStruct, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1347, port: port_);
+            funcId: 1350, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -43626,7 +43722,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_my_struct(myStruct, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1348)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1351)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -43654,7 +43750,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_message_id_twin_normal(id, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1349, port: port_);
+            funcId: 1352, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_8_array_32,
@@ -43680,7 +43776,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_message_id_twin_rust_async(id, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1350, port: port_);
+            funcId: 1353, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_8_array_32,
@@ -43707,7 +43803,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_message_id_twin_sync(id, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1351)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1354)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_8_array_32,

--- a/frb_example/pure_dart_pde/lib/src/rust/frb_generated.io.dart
+++ b/frb_example/pure_dart_pde/lib/src/rust/frb_generated.io.dart
@@ -2023,9 +2023,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   Duration dco_decode_StdTime_StdDuration(dynamic raw);
 
   @protected
-  DateTime dco_decode_StdTime_StdInstant(dynamic raw);
-
-  @protected
   DateTime dco_decode_StdTime_StdSystemTime(dynamic raw);
 
   @protected
@@ -2146,9 +2143,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   String dco_decode_String(dynamic raw);
-
-  @protected
-  DateTime dco_decode_TokioTime_TokioInstant(dynamic raw);
 
   @protected
   Issue2170Trait dco_decode_TraitDef_Issue2170Trait(dynamic raw);
@@ -6832,9 +6826,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   Duration sse_decode_StdTime_StdDuration(SseDeserializer deserializer);
 
   @protected
-  DateTime sse_decode_StdTime_StdInstant(SseDeserializer deserializer);
-
-  @protected
   DateTime sse_decode_StdTime_StdSystemTime(SseDeserializer deserializer);
 
   @protected
@@ -6974,9 +6965,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   String sse_decode_String(SseDeserializer deserializer);
-
-  @protected
-  DateTime sse_decode_TokioTime_TokioInstant(SseDeserializer deserializer);
 
   @protected
   BigInt sse_decode_U128(SseDeserializer deserializer);
@@ -12148,9 +12136,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_StdTime_StdDuration(Duration self, SseSerializer serializer);
 
   @protected
-  void sse_encode_StdTime_StdInstant(DateTime self, SseSerializer serializer);
-
-  @protected
   void sse_encode_StdTime_StdSystemTime(
       DateTime self, SseSerializer serializer);
 
@@ -12281,10 +12266,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_String(String self, SseSerializer serializer);
-
-  @protected
-  void sse_encode_TokioTime_TokioInstant(
-      DateTime self, SseSerializer serializer);
 
   @protected
   void sse_encode_U128(BigInt self, SseSerializer serializer);

--- a/frb_example/pure_dart_pde/lib/src/rust/frb_generated.io.dart
+++ b/frb_example/pure_dart_pde/lib/src/rust/frb_generated.io.dart
@@ -2020,6 +2020,15 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   Set<int> dco_decode_Set_i_32_None(dynamic raw);
 
   @protected
+  Duration dco_decode_StdTime_StdDuration(dynamic raw);
+
+  @protected
+  DateTime dco_decode_StdTime_StdInstant(dynamic raw);
+
+  @protected
+  DateTime dco_decode_StdTime_StdSystemTime(dynamic raw);
+
+  @protected
   RustStreamSink<NonCloneSimpleTwinNormal>
       dco_decode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinNormal_Sse(
           dynamic raw);
@@ -2137,6 +2146,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   String dco_decode_String(dynamic raw);
+
+  @protected
+  DateTime dco_decode_TokioTime_TokioInstant(dynamic raw);
 
   @protected
   Issue2170Trait dco_decode_TraitDef_Issue2170Trait(dynamic raw);
@@ -6817,6 +6829,15 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   Set<int> sse_decode_Set_i_32_None(SseDeserializer deserializer);
 
   @protected
+  Duration sse_decode_StdTime_StdDuration(SseDeserializer deserializer);
+
+  @protected
+  DateTime sse_decode_StdTime_StdInstant(SseDeserializer deserializer);
+
+  @protected
+  DateTime sse_decode_StdTime_StdSystemTime(SseDeserializer deserializer);
+
+  @protected
   RustStreamSink<NonCloneSimpleTwinNormal>
       sse_decode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinNormal_Sse(
           SseDeserializer deserializer);
@@ -6953,6 +6974,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   String sse_decode_String(SseDeserializer deserializer);
+
+  @protected
+  DateTime sse_decode_TokioTime_TokioInstant(SseDeserializer deserializer);
 
   @protected
   BigInt sse_decode_U128(SseDeserializer deserializer);
@@ -12121,6 +12145,16 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_Set_i_32_None(Set<int> self, SseSerializer serializer);
 
   @protected
+  void sse_encode_StdTime_StdDuration(Duration self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_StdTime_StdInstant(DateTime self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_StdTime_StdSystemTime(
+      DateTime self, SseSerializer serializer);
+
+  @protected
   void
       sse_encode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinNormal_Sse(
           RustStreamSink<NonCloneSimpleTwinNormal> self,
@@ -12247,6 +12281,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_String(String self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_TokioTime_TokioInstant(
+      DateTime self, SseSerializer serializer);
 
   @protected
   void sse_encode_U128(BigInt self, SseSerializer serializer);

--- a/frb_example/pure_dart_pde/lib/src/rust/frb_generated.web.dart
+++ b/frb_example/pure_dart_pde/lib/src/rust/frb_generated.web.dart
@@ -2025,9 +2025,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   Duration dco_decode_StdTime_StdDuration(dynamic raw);
 
   @protected
-  DateTime dco_decode_StdTime_StdInstant(dynamic raw);
-
-  @protected
   DateTime dco_decode_StdTime_StdSystemTime(dynamic raw);
 
   @protected
@@ -2148,9 +2145,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   String dco_decode_String(dynamic raw);
-
-  @protected
-  DateTime dco_decode_TokioTime_TokioInstant(dynamic raw);
 
   @protected
   Issue2170Trait dco_decode_TraitDef_Issue2170Trait(dynamic raw);
@@ -6834,9 +6828,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   Duration sse_decode_StdTime_StdDuration(SseDeserializer deserializer);
 
   @protected
-  DateTime sse_decode_StdTime_StdInstant(SseDeserializer deserializer);
-
-  @protected
   DateTime sse_decode_StdTime_StdSystemTime(SseDeserializer deserializer);
 
   @protected
@@ -6976,9 +6967,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   String sse_decode_String(SseDeserializer deserializer);
-
-  @protected
-  DateTime sse_decode_TokioTime_TokioInstant(SseDeserializer deserializer);
 
   @protected
   BigInt sse_decode_U128(SseDeserializer deserializer);
@@ -12150,9 +12138,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_StdTime_StdDuration(Duration self, SseSerializer serializer);
 
   @protected
-  void sse_encode_StdTime_StdInstant(DateTime self, SseSerializer serializer);
-
-  @protected
   void sse_encode_StdTime_StdSystemTime(
       DateTime self, SseSerializer serializer);
 
@@ -12283,10 +12268,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_String(String self, SseSerializer serializer);
-
-  @protected
-  void sse_encode_TokioTime_TokioInstant(
-      DateTime self, SseSerializer serializer);
 
   @protected
   void sse_encode_U128(BigInt self, SseSerializer serializer);

--- a/frb_example/pure_dart_pde/lib/src/rust/frb_generated.web.dart
+++ b/frb_example/pure_dart_pde/lib/src/rust/frb_generated.web.dart
@@ -2022,6 +2022,15 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   Set<int> dco_decode_Set_i_32_None(dynamic raw);
 
   @protected
+  Duration dco_decode_StdTime_StdDuration(dynamic raw);
+
+  @protected
+  DateTime dco_decode_StdTime_StdInstant(dynamic raw);
+
+  @protected
+  DateTime dco_decode_StdTime_StdSystemTime(dynamic raw);
+
+  @protected
   RustStreamSink<NonCloneSimpleTwinNormal>
       dco_decode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinNormal_Sse(
           dynamic raw);
@@ -2139,6 +2148,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   String dco_decode_String(dynamic raw);
+
+  @protected
+  DateTime dco_decode_TokioTime_TokioInstant(dynamic raw);
 
   @protected
   Issue2170Trait dco_decode_TraitDef_Issue2170Trait(dynamic raw);
@@ -6819,6 +6831,15 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   Set<int> sse_decode_Set_i_32_None(SseDeserializer deserializer);
 
   @protected
+  Duration sse_decode_StdTime_StdDuration(SseDeserializer deserializer);
+
+  @protected
+  DateTime sse_decode_StdTime_StdInstant(SseDeserializer deserializer);
+
+  @protected
+  DateTime sse_decode_StdTime_StdSystemTime(SseDeserializer deserializer);
+
+  @protected
   RustStreamSink<NonCloneSimpleTwinNormal>
       sse_decode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinNormal_Sse(
           SseDeserializer deserializer);
@@ -6955,6 +6976,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   String sse_decode_String(SseDeserializer deserializer);
+
+  @protected
+  DateTime sse_decode_TokioTime_TokioInstant(SseDeserializer deserializer);
 
   @protected
   BigInt sse_decode_U128(SseDeserializer deserializer);
@@ -12123,6 +12147,16 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_Set_i_32_None(Set<int> self, SseSerializer serializer);
 
   @protected
+  void sse_encode_StdTime_StdDuration(Duration self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_StdTime_StdInstant(DateTime self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_StdTime_StdSystemTime(
+      DateTime self, SseSerializer serializer);
+
+  @protected
   void
       sse_encode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinNormal_Sse(
           RustStreamSink<NonCloneSimpleTwinNormal> self,
@@ -12249,6 +12283,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_String(String self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_TokioTime_TokioInstant(
+      DateTime self, SseSerializer serializer);
 
   @protected
   void sse_encode_U128(BigInt self, SseSerializer serializer);

--- a/frb_example/pure_dart_pde/rust/Cargo.toml
+++ b/frb_example/pure_dart_pde/rust/Cargo.toml
@@ -22,7 +22,7 @@ futures = "0.3.29"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0" # Only used for comparison test
 protobuf = "=2.28.0" # Only used for comparison test
-tokio = { version = "1.34.0", features = ["rt"] }
+tokio = { version = "1.34.0", features = ["rt", "time"] }
 
 [features]
 internal_feature_for_testing = []

--- a/frb_example/pure_dart_pde/rust/src/api/chrono_type.rs
+++ b/frb_example/pure_dart_pde/rust/src/api/chrono_type.rs
@@ -56,12 +56,32 @@ pub fn optional_empty_datetime_utc_twin_normal(
 }
 
 pub fn duration_twin_normal(d: chrono::Duration) -> chrono::Duration {
-    assert_eq!(&d.num_hours(), &4);
+    let expected_micros: i64 = {
+        #[cfg(target_arch = "wasm32")]
+        {
+            14_403_002_000
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            14_403_002_001
+        }
+    };
+    assert_eq!(d.num_microseconds().unwrap(), expected_micros);
     d
 }
 
 pub fn std_time_duration_twin_normal(d: std::time::Duration) -> std::time::Duration {
-    assert_eq!(d.as_secs(), 4 * 60 * 60);
+    let expected_micros: i64 = {
+        #[cfg(target_arch = "wasm32")]
+        {
+            14_403_002_000
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            14_403_002_001
+        }
+    };
+    assert_eq!(d.as_micros(), expected_micros.try_into().unwrap());
     d
 }
 
@@ -89,7 +109,17 @@ pub fn std_time_system_time_before_epoch_twin_normal(
 }
 
 pub fn tokio_time_duration_twin_normal(d: tokio::time::Duration) -> tokio::time::Duration {
-    assert_eq!(d.as_secs(), 4 * 60 * 60);
+    let expected_micros: i64 = {
+        #[cfg(target_arch = "wasm32")]
+        {
+            14_403_002_000
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            14_403_002_001
+        }
+    };
+    assert_eq!(d.as_micros(), expected_micros.try_into().unwrap());
     d
 }
 

--- a/frb_example/pure_dart_pde/rust/src/api/chrono_type.rs
+++ b/frb_example/pure_dart_pde/rust/src/api/chrono_type.rs
@@ -88,18 +88,8 @@ pub fn std_time_system_time_before_epoch_twin_normal(
     d
 }
 
-pub fn std_time_instant_twin_normal(d: std::time::Instant) -> std::time::Instant {
-    assert!(d > std::time::Instant::now());
-    d
-}
-
 pub fn tokio_time_duration_twin_normal(d: tokio::time::Duration) -> tokio::time::Duration {
     assert_eq!(d.as_secs(), 4 * 60 * 60);
-    d
-}
-
-pub fn tokio_time_instant_twin_normal(d: tokio::time::Instant) -> tokio::time::Instant {
-    assert!(d > tokio::time::Instant::now());
     d
 }
 

--- a/frb_example/pure_dart_pde/rust/src/api/chrono_type.rs
+++ b/frb_example/pure_dart_pde/rust/src/api/chrono_type.rs
@@ -75,6 +75,19 @@ pub fn std_time_system_time_twin_normal(d: std::time::SystemTime) -> std::time::
     d
 }
 
+pub fn std_time_system_time_before_epoch_twin_normal(
+    d: std::time::SystemTime,
+) -> std::time::SystemTime {
+    assert_eq!(
+        std::time::SystemTime::UNIX_EPOCH
+            .duration_since(d)
+            .unwrap()
+            .as_secs(),
+        1_000
+    );
+    d
+}
+
 pub fn std_time_instant_twin_normal(d: std::time::Instant) -> std::time::Instant {
     assert!(d > std::time::Instant::now());
     d

--- a/frb_example/pure_dart_pde/rust/src/api/chrono_type.rs
+++ b/frb_example/pure_dart_pde/rust/src/api/chrono_type.rs
@@ -60,6 +60,36 @@ pub fn duration_twin_normal(d: chrono::Duration) -> chrono::Duration {
     d
 }
 
+pub fn std_time_duration_twin_normal(d: std::time::Duration) -> std::time::Duration {
+    assert_eq!(d.as_secs(), 4 * 60 * 60);
+    d
+}
+
+pub fn std_time_system_time_twin_normal(d: std::time::SystemTime) -> std::time::SystemTime {
+    assert_eq!(
+        d.duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
+        1_631_297_333
+    );
+    d
+}
+
+pub fn std_time_instant_twin_normal(d: std::time::Instant) -> std::time::Instant {
+    assert!(d > std::time::Instant::now());
+    d
+}
+
+pub fn tokio_time_duration_twin_normal(d: tokio::time::Duration) -> tokio::time::Duration {
+    assert_eq!(d.as_secs(), 4 * 60 * 60);
+    d
+}
+
+pub fn tokio_time_instant_twin_normal(d: tokio::time::Instant) -> tokio::time::Instant {
+    assert!(d > tokio::time::Instant::now());
+    d
+}
+
 pub fn handle_timestamps_twin_normal(
     timestamps: Vec<chrono::NaiveDateTime>,
     epoch: chrono::NaiveDateTime,

--- a/frb_example/pure_dart_pde/rust/src/api/pseudo_manual/chrono_type_twin_rust_async.rs
+++ b/frb_example/pure_dart_pde/rust/src/api/pseudo_manual/chrono_type_twin_rust_async.rs
@@ -66,6 +66,40 @@ pub async fn duration_twin_rust_async(d: chrono::Duration) -> chrono::Duration {
     d
 }
 
+pub async fn std_time_duration_twin_rust_async(d: std::time::Duration) -> std::time::Duration {
+    assert_eq!(d.as_secs(), 4 * 60 * 60);
+    d
+}
+
+pub async fn std_time_system_time_twin_rust_async(
+    d: std::time::SystemTime,
+) -> std::time::SystemTime {
+    assert_eq!(
+        d.duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
+        1_631_297_333
+    );
+    d
+}
+
+pub async fn std_time_instant_twin_rust_async(d: std::time::Instant) -> std::time::Instant {
+    assert!(d > std::time::Instant::now());
+    d
+}
+
+pub async fn tokio_time_duration_twin_rust_async(
+    d: tokio::time::Duration,
+) -> tokio::time::Duration {
+    assert_eq!(d.as_secs(), 4 * 60 * 60);
+    d
+}
+
+pub async fn tokio_time_instant_twin_rust_async(d: tokio::time::Instant) -> tokio::time::Instant {
+    assert!(d > tokio::time::Instant::now());
+    d
+}
+
 pub async fn handle_timestamps_twin_rust_async(
     timestamps: Vec<chrono::NaiveDateTime>,
     epoch: chrono::NaiveDateTime,

--- a/frb_example/pure_dart_pde/rust/src/api/pseudo_manual/chrono_type_twin_rust_async.rs
+++ b/frb_example/pure_dart_pde/rust/src/api/pseudo_manual/chrono_type_twin_rust_async.rs
@@ -96,20 +96,10 @@ pub async fn std_time_system_time_before_epoch_twin_rust_async(
     d
 }
 
-pub async fn std_time_instant_twin_rust_async(d: std::time::Instant) -> std::time::Instant {
-    assert!(d > std::time::Instant::now());
-    d
-}
-
 pub async fn tokio_time_duration_twin_rust_async(
     d: tokio::time::Duration,
 ) -> tokio::time::Duration {
     assert_eq!(d.as_secs(), 4 * 60 * 60);
-    d
-}
-
-pub async fn tokio_time_instant_twin_rust_async(d: tokio::time::Instant) -> tokio::time::Instant {
-    assert!(d > tokio::time::Instant::now());
     d
 }
 

--- a/frb_example/pure_dart_pde/rust/src/api/pseudo_manual/chrono_type_twin_rust_async.rs
+++ b/frb_example/pure_dart_pde/rust/src/api/pseudo_manual/chrono_type_twin_rust_async.rs
@@ -83,6 +83,19 @@ pub async fn std_time_system_time_twin_rust_async(
     d
 }
 
+pub async fn std_time_system_time_before_epoch_twin_rust_async(
+    d: std::time::SystemTime,
+) -> std::time::SystemTime {
+    assert_eq!(
+        std::time::SystemTime::UNIX_EPOCH
+            .duration_since(d)
+            .unwrap()
+            .as_secs(),
+        1_000
+    );
+    d
+}
+
 pub async fn std_time_instant_twin_rust_async(d: std::time::Instant) -> std::time::Instant {
     assert!(d > std::time::Instant::now());
     d

--- a/frb_example/pure_dart_pde/rust/src/api/pseudo_manual/chrono_type_twin_rust_async.rs
+++ b/frb_example/pure_dart_pde/rust/src/api/pseudo_manual/chrono_type_twin_rust_async.rs
@@ -62,12 +62,32 @@ pub async fn optional_empty_datetime_utc_twin_rust_async(
 }
 
 pub async fn duration_twin_rust_async(d: chrono::Duration) -> chrono::Duration {
-    assert_eq!(&d.num_hours(), &4);
+    let expected_micros: i64 = {
+        #[cfg(target_arch = "wasm32")]
+        {
+            14_403_002_000
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            14_403_002_001
+        }
+    };
+    assert_eq!(d.num_microseconds().unwrap(), expected_micros);
     d
 }
 
 pub async fn std_time_duration_twin_rust_async(d: std::time::Duration) -> std::time::Duration {
-    assert_eq!(d.as_secs(), 4 * 60 * 60);
+    let expected_micros: i64 = {
+        #[cfg(target_arch = "wasm32")]
+        {
+            14_403_002_000
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            14_403_002_001
+        }
+    };
+    assert_eq!(d.as_micros(), expected_micros.try_into().unwrap());
     d
 }
 
@@ -99,7 +119,17 @@ pub async fn std_time_system_time_before_epoch_twin_rust_async(
 pub async fn tokio_time_duration_twin_rust_async(
     d: tokio::time::Duration,
 ) -> tokio::time::Duration {
-    assert_eq!(d.as_secs(), 4 * 60 * 60);
+    let expected_micros: i64 = {
+        #[cfg(target_arch = "wasm32")]
+        {
+            14_403_002_000
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            14_403_002_001
+        }
+    };
+    assert_eq!(d.as_micros(), expected_micros.try_into().unwrap());
     d
 }
 

--- a/frb_example/pure_dart_pde/rust/src/api/pseudo_manual/chrono_type_twin_sync.rs
+++ b/frb_example/pure_dart_pde/rust/src/api/pseudo_manual/chrono_type_twin_sync.rs
@@ -71,6 +71,41 @@ pub fn duration_twin_sync(d: chrono::Duration) -> chrono::Duration {
 }
 
 #[flutter_rust_bridge::frb(sync)]
+pub fn std_time_duration_twin_sync(d: std::time::Duration) -> std::time::Duration {
+    assert_eq!(d.as_secs(), 4 * 60 * 60);
+    d
+}
+
+#[flutter_rust_bridge::frb(sync)]
+pub fn std_time_system_time_twin_sync(d: std::time::SystemTime) -> std::time::SystemTime {
+    assert_eq!(
+        d.duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
+        1_631_297_333
+    );
+    d
+}
+
+#[flutter_rust_bridge::frb(sync)]
+pub fn std_time_instant_twin_sync(d: std::time::Instant) -> std::time::Instant {
+    assert!(d > std::time::Instant::now());
+    d
+}
+
+#[flutter_rust_bridge::frb(sync)]
+pub fn tokio_time_duration_twin_sync(d: tokio::time::Duration) -> tokio::time::Duration {
+    assert_eq!(d.as_secs(), 4 * 60 * 60);
+    d
+}
+
+#[flutter_rust_bridge::frb(sync)]
+pub fn tokio_time_instant_twin_sync(d: tokio::time::Instant) -> tokio::time::Instant {
+    assert!(d > tokio::time::Instant::now());
+    d
+}
+
+#[flutter_rust_bridge::frb(sync)]
 pub fn handle_timestamps_twin_sync(
     timestamps: Vec<chrono::NaiveDateTime>,
     epoch: chrono::NaiveDateTime,

--- a/frb_example/pure_dart_pde/rust/src/api/pseudo_manual/chrono_type_twin_sync.rs
+++ b/frb_example/pure_dart_pde/rust/src/api/pseudo_manual/chrono_type_twin_sync.rs
@@ -66,13 +66,33 @@ pub fn optional_empty_datetime_utc_twin_sync(
 
 #[flutter_rust_bridge::frb(sync)]
 pub fn duration_twin_sync(d: chrono::Duration) -> chrono::Duration {
-    assert_eq!(&d.num_hours(), &4);
+    let expected_micros: i64 = {
+        #[cfg(target_arch = "wasm32")]
+        {
+            14_403_002_000
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            14_403_002_001
+        }
+    };
+    assert_eq!(d.num_microseconds().unwrap(), expected_micros);
     d
 }
 
 #[flutter_rust_bridge::frb(sync)]
 pub fn std_time_duration_twin_sync(d: std::time::Duration) -> std::time::Duration {
-    assert_eq!(d.as_secs(), 4 * 60 * 60);
+    let expected_micros: i64 = {
+        #[cfg(target_arch = "wasm32")]
+        {
+            14_403_002_000
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            14_403_002_001
+        }
+    };
+    assert_eq!(d.as_micros(), expected_micros.try_into().unwrap());
     d
 }
 
@@ -103,7 +123,17 @@ pub fn std_time_system_time_before_epoch_twin_sync(
 
 #[flutter_rust_bridge::frb(sync)]
 pub fn tokio_time_duration_twin_sync(d: tokio::time::Duration) -> tokio::time::Duration {
-    assert_eq!(d.as_secs(), 4 * 60 * 60);
+    let expected_micros: i64 = {
+        #[cfg(target_arch = "wasm32")]
+        {
+            14_403_002_000
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            14_403_002_001
+        }
+    };
+    assert_eq!(d.as_micros(), expected_micros.try_into().unwrap());
     d
 }
 

--- a/frb_example/pure_dart_pde/rust/src/api/pseudo_manual/chrono_type_twin_sync.rs
+++ b/frb_example/pure_dart_pde/rust/src/api/pseudo_manual/chrono_type_twin_sync.rs
@@ -88,6 +88,20 @@ pub fn std_time_system_time_twin_sync(d: std::time::SystemTime) -> std::time::Sy
 }
 
 #[flutter_rust_bridge::frb(sync)]
+pub fn std_time_system_time_before_epoch_twin_sync(
+    d: std::time::SystemTime,
+) -> std::time::SystemTime {
+    assert_eq!(
+        std::time::SystemTime::UNIX_EPOCH
+            .duration_since(d)
+            .unwrap()
+            .as_secs(),
+        1_000
+    );
+    d
+}
+
+#[flutter_rust_bridge::frb(sync)]
 pub fn std_time_instant_twin_sync(d: std::time::Instant) -> std::time::Instant {
     assert!(d > std::time::Instant::now());
     d

--- a/frb_example/pure_dart_pde/rust/src/api/pseudo_manual/chrono_type_twin_sync.rs
+++ b/frb_example/pure_dart_pde/rust/src/api/pseudo_manual/chrono_type_twin_sync.rs
@@ -102,20 +102,8 @@ pub fn std_time_system_time_before_epoch_twin_sync(
 }
 
 #[flutter_rust_bridge::frb(sync)]
-pub fn std_time_instant_twin_sync(d: std::time::Instant) -> std::time::Instant {
-    assert!(d > std::time::Instant::now());
-    d
-}
-
-#[flutter_rust_bridge::frb(sync)]
 pub fn tokio_time_duration_twin_sync(d: tokio::time::Duration) -> tokio::time::Duration {
     assert_eq!(d.as_secs(), 4 * 60 * 60);
-    d
-}
-
-#[flutter_rust_bridge::frb(sync)]
-pub fn tokio_time_instant_twin_sync(d: tokio::time::Instant) -> tokio::time::Instant {
-    assert!(d > tokio::time::Instant::now());
     d
 }
 

--- a/frb_example/pure_dart_pde/rust/src/frb_generated.rs
+++ b/frb_example/pure_dart_pde/rust/src/frb_generated.rs
@@ -46599,8 +46599,11 @@ impl flutter_rust_bridge::IntoDart for FrbWrapper<std::time::Instant> {
                     .as_micros()
                     .try_into()
                     .expect("cannot get microseconds from time"),
-                Err(error) => i64::try_from(-(error.duration().as_micros() as i128))
-                    .expect("cannot get microseconds from time"),
+                Err(error) => {
+                    let micros = i128::try_from(error.duration().as_micros())
+                        .expect("cannot get microseconds from time");
+                    i64::try_from(-micros).expect("cannot get microseconds from time")
+                }
             }
         };
         value.into_dart()
@@ -46623,8 +46626,11 @@ impl flutter_rust_bridge::IntoDart for FrbWrapper<std::time::SystemTime> {
                 .as_micros()
                 .try_into()
                 .expect("cannot get microseconds from time"),
-            Err(error) => i64::try_from(-(error.duration().as_micros() as i128))
-                .expect("cannot get microseconds from time"),
+            Err(error) => {
+                let micros = i128::try_from(error.duration().as_micros())
+                    .expect("cannot get microseconds from time");
+                i64::try_from(-micros).expect("cannot get microseconds from time")
+            }
         };
         value.into_dart()
     }
@@ -46661,8 +46667,11 @@ impl flutter_rust_bridge::IntoDart for FrbWrapper<tokio::time::Instant> {
                     .as_micros()
                     .try_into()
                     .expect("cannot get microseconds from time"),
-                Err(error) => i64::try_from(-(error.duration().as_micros() as i128))
-                    .expect("cannot get microseconds from time"),
+                Err(error) => {
+                    let micros = i128::try_from(error.duration().as_micros())
+                        .expect("cannot get microseconds from time");
+                    i64::try_from(-micros).expect("cannot get microseconds from time")
+                }
             }
         };
         value.into_dart()
@@ -56924,8 +56933,11 @@ impl SseEncode for std::time::Instant {
                         .as_micros()
                         .try_into()
                         .expect("cannot get microseconds from time"),
-                    Err(error) => i64::try_from(-(error.duration().as_micros() as i128))
-                        .expect("cannot get microseconds from time"),
+                    Err(error) => {
+                        let micros = i128::try_from(error.duration().as_micros())
+                            .expect("cannot get microseconds from time");
+                        i64::try_from(-micros).expect("cannot get microseconds from time")
+                    }
                 }
             },
             serializer,
@@ -56942,8 +56954,11 @@ impl SseEncode for std::time::SystemTime {
                     .as_micros()
                     .try_into()
                     .expect("cannot get microseconds from time"),
-                Err(error) => i64::try_from(-(error.duration().as_micros() as i128))
-                    .expect("cannot get microseconds from time"),
+                Err(error) => {
+                    let micros = i128::try_from(error.duration().as_micros())
+                        .expect("cannot get microseconds from time");
+                    i64::try_from(-micros).expect("cannot get microseconds from time")
+                }
             },
             serializer,
         );
@@ -57295,8 +57310,11 @@ impl SseEncode for tokio::time::Instant {
                         .as_micros()
                         .try_into()
                         .expect("cannot get microseconds from time"),
-                    Err(error) => i64::try_from(-(error.duration().as_micros() as i128))
-                        .expect("cannot get microseconds from time"),
+                    Err(error) => {
+                        let micros = i128::try_from(error.duration().as_micros())
+                            .expect("cannot get microseconds from time");
+                        i64::try_from(-micros).expect("cannot get microseconds from time")
+                    }
                 }
             },
             serializer,

--- a/frb_example/pure_dart_pde/rust/src/frb_generated.rs
+++ b/frb_example/pure_dart_pde/rust/src/frb_generated.rs
@@ -46561,11 +46561,22 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<MessageWithCustomSerializerTwi
 // Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for FrbWrapper<std::time::Duration> {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        let value: i64 = self
-            .0
-            .as_micros()
-            .try_into()
-            .expect("cannot get microseconds from time");
+        let value: i64 = {
+            #[cfg(target_arch = "wasm32")]
+            {
+                self.0
+                    .as_millis()
+                    .try_into()
+                    .expect("cannot get milliseconds from time")
+            }
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                self.0
+                    .as_micros()
+                    .try_into()
+                    .expect("cannot get microseconds from time")
+            }
+        };
         value.into_dart()
     }
 }
@@ -46594,15 +46605,34 @@ impl flutter_rust_bridge::IntoDart for FrbWrapper<std::time::Instant> {
                     .checked_sub(now_instant.duration_since(value))
                     .expect("instant out of range")
             };
-            match system_time.duration_since(std::time::SystemTime::UNIX_EPOCH) {
-                Ok(duration) => duration
-                    .as_micros()
-                    .try_into()
-                    .expect("cannot get microseconds from time"),
-                Err(error) => {
-                    let micros = i128::try_from(error.duration().as_micros())
-                        .expect("cannot get microseconds from time");
-                    i64::try_from(-micros).expect("cannot get microseconds from time")
+            {
+                #[cfg(target_arch = "wasm32")]
+                {
+                    match system_time.duration_since(std::time::SystemTime::UNIX_EPOCH) {
+                        Ok(duration) => duration
+                            .as_millis()
+                            .try_into()
+                            .expect("cannot get milliseconds from time"),
+                        Err(error) => {
+                            let millis = i128::try_from(error.duration().as_millis())
+                                .expect("cannot get milliseconds from time");
+                            i64::try_from(-millis).expect("cannot get milliseconds from time")
+                        }
+                    }
+                }
+                #[cfg(not(target_arch = "wasm32"))]
+                {
+                    match system_time.duration_since(std::time::SystemTime::UNIX_EPOCH) {
+                        Ok(duration) => duration
+                            .as_micros()
+                            .try_into()
+                            .expect("cannot get microseconds from time"),
+                        Err(error) => {
+                            let micros = i128::try_from(error.duration().as_micros())
+                                .expect("cannot get microseconds from time");
+                            i64::try_from(-micros).expect("cannot get microseconds from time")
+                        }
+                    }
                 }
             }
         };
@@ -46621,15 +46651,34 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<std::time::Instant>> for std::
 // Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for FrbWrapper<std::time::SystemTime> {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        let value: i64 = match self.0.duration_since(std::time::SystemTime::UNIX_EPOCH) {
-            Ok(duration) => duration
-                .as_micros()
-                .try_into()
-                .expect("cannot get microseconds from time"),
-            Err(error) => {
-                let micros = i128::try_from(error.duration().as_micros())
-                    .expect("cannot get microseconds from time");
-                i64::try_from(-micros).expect("cannot get microseconds from time")
+        let value: i64 = {
+            #[cfg(target_arch = "wasm32")]
+            {
+                match self.0.duration_since(std::time::SystemTime::UNIX_EPOCH) {
+                    Ok(duration) => duration
+                        .as_millis()
+                        .try_into()
+                        .expect("cannot get milliseconds from time"),
+                    Err(error) => {
+                        let millis = i128::try_from(error.duration().as_millis())
+                            .expect("cannot get milliseconds from time");
+                        i64::try_from(-millis).expect("cannot get milliseconds from time")
+                    }
+                }
+            }
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                match self.0.duration_since(std::time::SystemTime::UNIX_EPOCH) {
+                    Ok(duration) => duration
+                        .as_micros()
+                        .try_into()
+                        .expect("cannot get microseconds from time"),
+                    Err(error) => {
+                        let micros = i128::try_from(error.duration().as_micros())
+                            .expect("cannot get microseconds from time");
+                        i64::try_from(-micros).expect("cannot get microseconds from time")
+                    }
+                }
             }
         };
         value.into_dart()
@@ -46662,15 +46711,34 @@ impl flutter_rust_bridge::IntoDart for FrbWrapper<tokio::time::Instant> {
                     .checked_sub(now_instant.duration_since(value))
                     .expect("instant out of range")
             };
-            match system_time.duration_since(std::time::SystemTime::UNIX_EPOCH) {
-                Ok(duration) => duration
-                    .as_micros()
-                    .try_into()
-                    .expect("cannot get microseconds from time"),
-                Err(error) => {
-                    let micros = i128::try_from(error.duration().as_micros())
-                        .expect("cannot get microseconds from time");
-                    i64::try_from(-micros).expect("cannot get microseconds from time")
+            {
+                #[cfg(target_arch = "wasm32")]
+                {
+                    match system_time.duration_since(std::time::SystemTime::UNIX_EPOCH) {
+                        Ok(duration) => duration
+                            .as_millis()
+                            .try_into()
+                            .expect("cannot get milliseconds from time"),
+                        Err(error) => {
+                            let millis = i128::try_from(error.duration().as_millis())
+                                .expect("cannot get milliseconds from time");
+                            i64::try_from(-millis).expect("cannot get milliseconds from time")
+                        }
+                    }
+                }
+                #[cfg(not(target_arch = "wasm32"))]
+                {
+                    match system_time.duration_since(std::time::SystemTime::UNIX_EPOCH) {
+                        Ok(duration) => duration
+                            .as_micros()
+                            .try_into()
+                            .expect("cannot get microseconds from time"),
+                        Err(error) => {
+                            let micros = i128::try_from(error.duration().as_micros())
+                                .expect("cannot get microseconds from time");
+                            i64::try_from(-micros).expect("cannot get microseconds from time")
+                        }
+                    }
                 }
             }
         };

--- a/frb_example/pure_dart_pde/rust/src/frb_generated.rs
+++ b/frb_example/pure_dart_pde/rust/src/frb_generated.rs
@@ -35181,14 +35181,17 @@ impl SseDecode for std::time::Instant {
         return {
             let now_system_time = std::time::SystemTime::now();
             let now_instant = std::time::Instant::now();
-            let target_system_time = if inner >= 0 {
-                std::time::SystemTime::UNIX_EPOCH
-                    .checked_add(std::time::Duration::from_micros(inner.unsigned_abs()))
-                    .expect("timestamp out of range")
-            } else {
-                std::time::SystemTime::UNIX_EPOCH
-                    .checked_sub(std::time::Duration::from_micros(inner.unsigned_abs()))
-                    .expect("timestamp out of range")
+            let target_system_time = {
+                let value = inner;
+                if value >= 0 {
+                    std::time::SystemTime::UNIX_EPOCH
+                        .checked_add(std::time::Duration::from_micros(value.unsigned_abs()))
+                        .expect("timestamp out of range")
+                } else {
+                    std::time::SystemTime::UNIX_EPOCH
+                        .checked_sub(std::time::Duration::from_micros(value.unsigned_abs()))
+                        .expect("timestamp out of range")
+                }
             };
             if target_system_time >= now_system_time {
                 now_instant
@@ -35215,14 +35218,17 @@ impl SseDecode for std::time::SystemTime {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut inner = <i64>::sse_decode(deserializer);
-        return if inner >= 0 {
-            std::time::SystemTime::UNIX_EPOCH
-                .checked_add(std::time::Duration::from_micros(inner.unsigned_abs()))
-                .expect("timestamp out of range")
-        } else {
-            std::time::SystemTime::UNIX_EPOCH
-                .checked_sub(std::time::Duration::from_micros(inner.unsigned_abs()))
-                .expect("timestamp out of range")
+        return {
+            let value = inner;
+            if value >= 0 {
+                std::time::SystemTime::UNIX_EPOCH
+                    .checked_add(std::time::Duration::from_micros(value.unsigned_abs()))
+                    .expect("timestamp out of range")
+            } else {
+                std::time::SystemTime::UNIX_EPOCH
+                    .checked_sub(std::time::Duration::from_micros(value.unsigned_abs()))
+                    .expect("timestamp out of range")
+            }
         };
     }
 }
@@ -35587,14 +35593,17 @@ impl SseDecode for tokio::time::Instant {
         return tokio::time::Instant::from_std({
             let now_system_time = std::time::SystemTime::now();
             let now_instant = std::time::Instant::now();
-            let target_system_time = if inner >= 0 {
-                std::time::SystemTime::UNIX_EPOCH
-                    .checked_add(std::time::Duration::from_micros(inner.unsigned_abs()))
-                    .expect("timestamp out of range")
-            } else {
-                std::time::SystemTime::UNIX_EPOCH
-                    .checked_sub(std::time::Duration::from_micros(inner.unsigned_abs()))
-                    .expect("timestamp out of range")
+            let target_system_time = {
+                let value = inner;
+                if value >= 0 {
+                    std::time::SystemTime::UNIX_EPOCH
+                        .checked_add(std::time::Duration::from_micros(value.unsigned_abs()))
+                        .expect("timestamp out of range")
+                } else {
+                    std::time::SystemTime::UNIX_EPOCH
+                        .checked_sub(std::time::Duration::from_micros(value.unsigned_abs()))
+                        .expect("timestamp out of range")
+                }
             };
             if target_system_time >= now_system_time {
                 now_instant

--- a/frb_example/pure_dart_pde/rust/src/frb_generated.rs
+++ b/frb_example/pure_dart_pde/rust/src/frb_generated.rs
@@ -75,7 +75,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1314015258;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 231677322;
 
 // Section: executor
 
@@ -28804,90 +28804,6 @@ fn wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_duration_twi
         },
     )
 }
-fn wire__crate__api__chrono_type__std_time_instant_twin_normal_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "std_time_instant_twin_normal",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_d = <std::time::Instant>::sse_decode(&mut deserializer);
-            deserializer.end();
-            move |context| {
-                transform_result_sse::<_, ()>((move || {
-                    let output_ok = Result::<_, ()>::Ok(
-                        crate::api::chrono_type::std_time_instant_twin_normal(api_d),
-                    )?;
-                    Ok(output_ok)
-                })())
-            }
-        },
-    )
-}
-fn wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_instant_twin_rust_async_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec,_,_,_>(flutter_rust_bridge::for_generated::TaskInfo{ debug_name: "std_time_instant_twin_rust_async", port: Some(port_), mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal }, move || {
-            let message = unsafe { flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(ptr_, rust_vec_len_, data_len_) };
-            let mut deserializer = flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_d = <std::time::Instant>::sse_decode(&mut deserializer);deserializer.end(); move |context| async move {
-                    transform_result_sse::<_, ()>((move || async move {
-                         let output_ok = Result::<_,()>::Ok(crate::api::pseudo_manual::chrono_type_twin_rust_async::std_time_instant_twin_rust_async(api_d).await)?;   Ok(output_ok)
-                    })().await)
-                } })
-}
-fn wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_instant_twin_sync_impl(
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "std_time_instant_twin_sync",
-            port: None,
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_d = <std::time::Instant>::sse_decode(&mut deserializer);
-            deserializer.end();
-            transform_result_sse::<_, ()>((move || {
-                let output_ok = Result::<_, ()>::Ok(
-                    crate::api::pseudo_manual::chrono_type_twin_sync::std_time_instant_twin_sync(
-                        api_d,
-                    ),
-                )?;
-                Ok(output_ok)
-            })())
-        },
-    )
-}
 fn wire__crate__api__chrono_type__std_time_system_time_before_epoch_twin_normal_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -31148,90 +31064,6 @@ fn wire__crate__api__pseudo_manual__chrono_type_twin_sync__tokio_time_duration_t
             transform_result_sse::<_, ()>((move || {
                 let output_ok = Result::<_, ()>::Ok(
                     crate::api::pseudo_manual::chrono_type_twin_sync::tokio_time_duration_twin_sync(
-                        api_d,
-                    ),
-                )?;
-                Ok(output_ok)
-            })())
-        },
-    )
-}
-fn wire__crate__api__chrono_type__tokio_time_instant_twin_normal_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "tokio_time_instant_twin_normal",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_d = <tokio::time::Instant>::sse_decode(&mut deserializer);
-            deserializer.end();
-            move |context| {
-                transform_result_sse::<_, ()>((move || {
-                    let output_ok = Result::<_, ()>::Ok(
-                        crate::api::chrono_type::tokio_time_instant_twin_normal(api_d),
-                    )?;
-                    Ok(output_ok)
-                })())
-            }
-        },
-    )
-}
-fn wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__tokio_time_instant_twin_rust_async_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec,_,_,_>(flutter_rust_bridge::for_generated::TaskInfo{ debug_name: "tokio_time_instant_twin_rust_async", port: Some(port_), mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal }, move || {
-            let message = unsafe { flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(ptr_, rust_vec_len_, data_len_) };
-            let mut deserializer = flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_d = <tokio::time::Instant>::sse_decode(&mut deserializer);deserializer.end(); move |context| async move {
-                    transform_result_sse::<_, ()>((move || async move {
-                         let output_ok = Result::<_,()>::Ok(crate::api::pseudo_manual::chrono_type_twin_rust_async::tokio_time_instant_twin_rust_async(api_d).await)?;   Ok(output_ok)
-                    })().await)
-                } })
-}
-fn wire__crate__api__pseudo_manual__chrono_type_twin_sync__tokio_time_instant_twin_sync_impl(
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "tokio_time_instant_twin_sync",
-            port: None,
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_d = <tokio::time::Instant>::sse_decode(&mut deserializer);
-            deserializer.end();
-            transform_result_sse::<_, ()>((move || {
-                let output_ok = Result::<_, ()>::Ok(
-                    crate::api::pseudo_manual::chrono_type_twin_sync::tokio_time_instant_twin_sync(
                         api_d,
                     ),
                 )?;
@@ -35174,46 +35006,6 @@ impl SseDecode for std::time::Duration {
     }
 }
 
-impl SseDecode for std::time::Instant {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut inner = <i64>::sse_decode(deserializer);
-        return {
-            let now_system_time = std::time::SystemTime::now();
-            let now_instant = std::time::Instant::now();
-            let target_system_time = {
-                let value = inner;
-                if value >= 0 {
-                    std::time::SystemTime::UNIX_EPOCH
-                        .checked_add(std::time::Duration::from_micros(value.unsigned_abs()))
-                        .expect("timestamp out of range")
-                } else {
-                    std::time::SystemTime::UNIX_EPOCH
-                        .checked_sub(std::time::Duration::from_micros(value.unsigned_abs()))
-                        .expect("timestamp out of range")
-                }
-            };
-            if target_system_time >= now_system_time {
-                now_instant
-                    .checked_add(
-                        target_system_time
-                            .duration_since(now_system_time)
-                            .expect("invalid timestamp"),
-                    )
-                    .expect("instant out of range")
-            } else {
-                now_instant
-                    .checked_sub(
-                        now_system_time
-                            .duration_since(target_system_time)
-                            .expect("invalid timestamp"),
-                    )
-                    .expect("instant out of range")
-            }
-        };
-    }
-}
-
 impl SseDecode for std::time::SystemTime {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -35583,46 +35375,6 @@ impl SseDecode for String {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut inner = <Vec<u8>>::sse_decode(deserializer);
         return String::from_utf8(inner).unwrap();
-    }
-}
-
-impl SseDecode for tokio::time::Instant {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut inner = <i64>::sse_decode(deserializer);
-        return tokio::time::Instant::from_std({
-            let now_system_time = std::time::SystemTime::now();
-            let now_instant = std::time::Instant::now();
-            let target_system_time = {
-                let value = inner;
-                if value >= 0 {
-                    std::time::SystemTime::UNIX_EPOCH
-                        .checked_add(std::time::Duration::from_micros(value.unsigned_abs()))
-                        .expect("timestamp out of range")
-                } else {
-                    std::time::SystemTime::UNIX_EPOCH
-                        .checked_sub(std::time::Duration::from_micros(value.unsigned_abs()))
-                        .expect("timestamp out of range")
-                }
-            };
-            if target_system_time >= now_system_time {
-                now_instant
-                    .checked_add(
-                        target_system_time
-                            .duration_since(now_system_time)
-                            .expect("invalid timestamp"),
-                    )
-                    .expect("instant out of range")
-            } else {
-                now_instant
-                    .checked_sub(
-                        now_system_time
-                            .duration_since(target_system_time)
-                            .expect("invalid timestamp"),
-                    )
-                    .expect("instant out of range")
-            }
-        });
     }
 }
 
@@ -44784,84 +44536,80 @@ fn pde_ffi_dispatcher_primary_impl(
 1231 => wire__crate__api__pseudo_manual__method_twin_rust_async__static_only_twin_rust_async_static_method_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
 1233 => wire__crate__api__chrono_type__std_time_duration_twin_normal_impl(port, ptr, rust_vec_len, data_len),
 1234 => wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_duration_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1236 => wire__crate__api__chrono_type__std_time_instant_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1237 => wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_instant_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1239 => wire__crate__api__chrono_type__std_time_system_time_before_epoch_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1240 => wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_system_time_before_epoch_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1242 => wire__crate__api__chrono_type__std_time_system_time_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1243 => wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_system_time_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1245 => wire__crate__api__stream_misc__stream_sink_dart_async_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1246 => wire__crate__api__stream__stream_sink_fixed_sized_primitive_array_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1247 => wire__crate__api__pseudo_manual__stream_twin_rust_async__stream_sink_fixed_sized_primitive_array_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1248 => wire__crate__api__stream__stream_sink_inside_struct_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1249 => wire__crate__api__pseudo_manual__stream_twin_rust_async__stream_sink_inside_struct_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1250 => wire__crate__api__stream__stream_sink_inside_vec_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1251 => wire__crate__api__pseudo_manual__stream_twin_rust_async__stream_sink_inside_vec_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1252 => wire__crate__api__exception__stream_sink_throw_anyhow_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1253 => wire__crate__api__pseudo_manual__exception_twin_rust_async__stream_sink_throw_anyhow_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1255 => wire__crate__api__comment__struct_with_comments_twin_normal_instance_method_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1256 => wire__crate__api__comment__struct_with_comments_twin_normal_static_method_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1257 => wire__crate__api__pseudo_manual__comment_twin_rust_async__struct_with_comments_twin_rust_async_instance_method_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1258 => wire__crate__api__pseudo_manual__comment_twin_rust_async__struct_with_comments_twin_rust_async_static_method_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1262 => wire__crate__api__misc_no_twin_example_a__struct_with_impl_block_in_another_file_f_impl(port, ptr, rust_vec_len, data_len),
-1263 => wire__crate__api__misc_no_twin_example_a__struct_with_raw_name_field_dummy_function_impl(port, ptr, rust_vec_len, data_len),
-1264 => wire__crate__api__misc_no_twin_example_a__struct_with_rust_auto_opaque_field_with_many_derive_default_impl(port, ptr, rust_vec_len, data_len),
-1265 => wire__crate__api__misc_no_twin_example_a__struct_with_rust_auto_opaque_field_with_many_derive_f_impl(port, ptr, rust_vec_len, data_len),
-1266 => wire__crate__api__misc_no_twin_example_a__struct_with_rust_auto_opaque_with_non_clone_data_f_impl(port, ptr, rust_vec_len, data_len),
-1267 => wire__crate__api__method__sum_with_twin_normal_sum_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1268 => wire__crate__api__pseudo_manual__method_twin_rust_async__sum_with_twin_rust_async_sum_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1277 => wire__crate__api__misc_example__test_abc_enum_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1278 => wire__crate__api__pseudo_manual__misc_example_twin_rust_async__test_abc_enum_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1280 => wire__crate__api__chrono_type__test_chrono_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1281 => wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__test_chrono_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1283 => wire__crate__api__mirror__test_contains_mirrored_sub_struct_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1284 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_contains_mirrored_sub_struct_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1286 => wire__crate__api__deliberate_name_conflict__test_duplicated_module_names_impl(port, ptr, rust_vec_len, data_len),
-1287 => wire__crate__api__mirror__test_fallible_of_raw_string_mirrored_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1288 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_fallible_of_raw_string_mirrored_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1290 => wire__crate__api__mirror__test_hashmap_with_mirrored_value_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1291 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_hashmap_with_mirrored_value_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1293 => wire__crate__api__mirror__test_list_of_nested_enums_mirrored_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1294 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_list_of_nested_enums_mirrored_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1296 => wire__crate__api__mirror__test_list_of_raw_nested_string_mirrored_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1297 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_list_of_raw_nested_string_mirrored_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1299 => wire__crate__api__raw_string__test_more_than_just_one_raw_string_struct_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1300 => wire__crate__api__pseudo_manual__raw_string_twin_rust_async__test_more_than_just_one_raw_string_struct_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1302 => wire__crate__api__mirror__test_nested_raw_string_mirrored_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1303 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_nested_raw_string_mirrored_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1305 => wire__crate__api__chrono_type__test_precise_chrono_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1306 => wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__test_precise_chrono_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1308 => wire__crate__api__mirror__test_raw_string_enum_mirrored_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1309 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_raw_string_enum_mirrored_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1311 => wire__crate__api__raw_string__test_raw_string_item_enum_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1312 => wire__crate__api__pseudo_manual__raw_string_twin_rust_async__test_raw_string_item_enum_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1314 => wire__crate__api__raw_string__test_raw_string_item_struct_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1315 => wire__crate__api__pseudo_manual__raw_string_twin_rust_async__test_raw_string_item_struct_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1317 => wire__crate__api__mirror__test_raw_string_mirrored_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1318 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_raw_string_mirrored_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1320 => wire__crate__api__misc_example__test_struct_with_enum_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1321 => wire__crate__api__pseudo_manual__misc_example_twin_rust_async__test_struct_with_enum_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1323 => wire__crate__api__tuple__test_tuple_2_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1324 => wire__crate__api__pseudo_manual__tuple_twin_rust_async__test_tuple_2_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1326 => wire__crate__api__tuple__test_tuple_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1327 => wire__crate__api__pseudo_manual__tuple_twin_rust_async__test_tuple_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1329 => wire__crate__api__exception__throw_anyhow_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1330 => wire__crate__api__pseudo_manual__exception_twin_rust_async__throw_anyhow_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1332 => wire__crate__api__chrono_type__tokio_time_duration_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1333 => wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__tokio_time_duration_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1335 => wire__crate__api__chrono_type__tokio_time_instant_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1336 => wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__tokio_time_instant_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1338 => wire__crate__api__dart_code__translatable_struct_with_dart_code_twin_normal_normal_method_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1340 => wire__crate__api__rust_opaque__unwrap_rust_opaque_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1341 => wire__crate__api__pseudo_manual__rust_opaque_twin_rust_async__unwrap_rust_opaque_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1343 => wire__crate__api__array__use_boxed_blob_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1344 => wire__crate__api__pseudo_manual__array_twin_rust_async__use_boxed_blob_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1346 => wire__crate__api__external_type_in_crate__use_imported_enum_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1347 => wire__crate__api__pseudo_manual__external_type_in_crate_twin_rust_async__use_imported_enum_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1349 => wire__crate__api__external_type_in_crate__use_imported_struct_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1350 => wire__crate__api__pseudo_manual__external_type_in_crate_twin_rust_async__use_imported_struct_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1352 => wire__crate__api__array__use_msgid_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1353 => wire__crate__api__pseudo_manual__array_twin_rust_async__use_msgid_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1236 => wire__crate__api__chrono_type__std_time_system_time_before_epoch_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1237 => wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_system_time_before_epoch_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1239 => wire__crate__api__chrono_type__std_time_system_time_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1240 => wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_system_time_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1242 => wire__crate__api__stream_misc__stream_sink_dart_async_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1243 => wire__crate__api__stream__stream_sink_fixed_sized_primitive_array_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1244 => wire__crate__api__pseudo_manual__stream_twin_rust_async__stream_sink_fixed_sized_primitive_array_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1245 => wire__crate__api__stream__stream_sink_inside_struct_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1246 => wire__crate__api__pseudo_manual__stream_twin_rust_async__stream_sink_inside_struct_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1247 => wire__crate__api__stream__stream_sink_inside_vec_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1248 => wire__crate__api__pseudo_manual__stream_twin_rust_async__stream_sink_inside_vec_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1249 => wire__crate__api__exception__stream_sink_throw_anyhow_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1250 => wire__crate__api__pseudo_manual__exception_twin_rust_async__stream_sink_throw_anyhow_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1252 => wire__crate__api__comment__struct_with_comments_twin_normal_instance_method_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1253 => wire__crate__api__comment__struct_with_comments_twin_normal_static_method_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1254 => wire__crate__api__pseudo_manual__comment_twin_rust_async__struct_with_comments_twin_rust_async_instance_method_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1255 => wire__crate__api__pseudo_manual__comment_twin_rust_async__struct_with_comments_twin_rust_async_static_method_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1259 => wire__crate__api__misc_no_twin_example_a__struct_with_impl_block_in_another_file_f_impl(port, ptr, rust_vec_len, data_len),
+1260 => wire__crate__api__misc_no_twin_example_a__struct_with_raw_name_field_dummy_function_impl(port, ptr, rust_vec_len, data_len),
+1261 => wire__crate__api__misc_no_twin_example_a__struct_with_rust_auto_opaque_field_with_many_derive_default_impl(port, ptr, rust_vec_len, data_len),
+1262 => wire__crate__api__misc_no_twin_example_a__struct_with_rust_auto_opaque_field_with_many_derive_f_impl(port, ptr, rust_vec_len, data_len),
+1263 => wire__crate__api__misc_no_twin_example_a__struct_with_rust_auto_opaque_with_non_clone_data_f_impl(port, ptr, rust_vec_len, data_len),
+1264 => wire__crate__api__method__sum_with_twin_normal_sum_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1265 => wire__crate__api__pseudo_manual__method_twin_rust_async__sum_with_twin_rust_async_sum_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1274 => wire__crate__api__misc_example__test_abc_enum_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1275 => wire__crate__api__pseudo_manual__misc_example_twin_rust_async__test_abc_enum_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1277 => wire__crate__api__chrono_type__test_chrono_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1278 => wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__test_chrono_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1280 => wire__crate__api__mirror__test_contains_mirrored_sub_struct_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1281 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_contains_mirrored_sub_struct_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1283 => wire__crate__api__deliberate_name_conflict__test_duplicated_module_names_impl(port, ptr, rust_vec_len, data_len),
+1284 => wire__crate__api__mirror__test_fallible_of_raw_string_mirrored_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1285 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_fallible_of_raw_string_mirrored_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1287 => wire__crate__api__mirror__test_hashmap_with_mirrored_value_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1288 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_hashmap_with_mirrored_value_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1290 => wire__crate__api__mirror__test_list_of_nested_enums_mirrored_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1291 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_list_of_nested_enums_mirrored_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1293 => wire__crate__api__mirror__test_list_of_raw_nested_string_mirrored_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1294 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_list_of_raw_nested_string_mirrored_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1296 => wire__crate__api__raw_string__test_more_than_just_one_raw_string_struct_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1297 => wire__crate__api__pseudo_manual__raw_string_twin_rust_async__test_more_than_just_one_raw_string_struct_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1299 => wire__crate__api__mirror__test_nested_raw_string_mirrored_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1300 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_nested_raw_string_mirrored_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1302 => wire__crate__api__chrono_type__test_precise_chrono_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1303 => wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__test_precise_chrono_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1305 => wire__crate__api__mirror__test_raw_string_enum_mirrored_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1306 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_raw_string_enum_mirrored_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1308 => wire__crate__api__raw_string__test_raw_string_item_enum_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1309 => wire__crate__api__pseudo_manual__raw_string_twin_rust_async__test_raw_string_item_enum_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1311 => wire__crate__api__raw_string__test_raw_string_item_struct_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1312 => wire__crate__api__pseudo_manual__raw_string_twin_rust_async__test_raw_string_item_struct_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1314 => wire__crate__api__mirror__test_raw_string_mirrored_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1315 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_raw_string_mirrored_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1317 => wire__crate__api__misc_example__test_struct_with_enum_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1318 => wire__crate__api__pseudo_manual__misc_example_twin_rust_async__test_struct_with_enum_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1320 => wire__crate__api__tuple__test_tuple_2_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1321 => wire__crate__api__pseudo_manual__tuple_twin_rust_async__test_tuple_2_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1323 => wire__crate__api__tuple__test_tuple_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1324 => wire__crate__api__pseudo_manual__tuple_twin_rust_async__test_tuple_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1326 => wire__crate__api__exception__throw_anyhow_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1327 => wire__crate__api__pseudo_manual__exception_twin_rust_async__throw_anyhow_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1329 => wire__crate__api__chrono_type__tokio_time_duration_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1330 => wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__tokio_time_duration_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1332 => wire__crate__api__dart_code__translatable_struct_with_dart_code_twin_normal_normal_method_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1334 => wire__crate__api__rust_opaque__unwrap_rust_opaque_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1335 => wire__crate__api__pseudo_manual__rust_opaque_twin_rust_async__unwrap_rust_opaque_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1337 => wire__crate__api__array__use_boxed_blob_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1338 => wire__crate__api__pseudo_manual__array_twin_rust_async__use_boxed_blob_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1340 => wire__crate__api__external_type_in_crate__use_imported_enum_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1341 => wire__crate__api__pseudo_manual__external_type_in_crate_twin_rust_async__use_imported_enum_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1343 => wire__crate__api__external_type_in_crate__use_imported_struct_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1344 => wire__crate__api__pseudo_manual__external_type_in_crate_twin_rust_async__use_imported_struct_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1346 => wire__crate__api__array__use_msgid_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1347 => wire__crate__api__pseudo_manual__array_twin_rust_async__use_msgid_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -45276,47 +45024,45 @@ fn pde_ffi_dispatcher_sync_impl(
 1229 => wire__crate__api__pseudo_manual__exception_twin_sync__some_struct_twin_sync_static_return_ok_custom_error_twin_sync_impl(ptr, rust_vec_len, data_len),
 1232 => wire__crate__api__pseudo_manual__method_twin_sync__static_only_twin_sync_static_method_twin_sync_impl(ptr, rust_vec_len, data_len),
 1235 => wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_duration_twin_sync_impl(ptr, rust_vec_len, data_len),
-1238 => wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_instant_twin_sync_impl(ptr, rust_vec_len, data_len),
-1241 => wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_system_time_before_epoch_twin_sync_impl(ptr, rust_vec_len, data_len),
-1244 => wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_system_time_twin_sync_impl(ptr, rust_vec_len, data_len),
-1254 => wire__crate__api__pseudo_manual__exception_twin_sync__stream_sink_throw_anyhow_twin_sync_impl(ptr, rust_vec_len, data_len),
-1259 => wire__crate__api__pseudo_manual__comment_twin_sync__struct_with_comments_twin_sync_instance_method_twin_sync_impl(ptr, rust_vec_len, data_len),
-1260 => wire__crate__api__pseudo_manual__comment_twin_sync__struct_with_comments_twin_sync_static_method_twin_sync_impl(ptr, rust_vec_len, data_len),
-1261 => wire__crate__api__misc_no_twin_example_a__struct_with_custom_name_method_twin_normal_method_with_custom_name_twin_normal_impl(ptr, rust_vec_len, data_len),
-1269 => wire__crate__api__pseudo_manual__method_twin_sync__sum_with_twin_sync_sum_twin_sync_impl(ptr, rust_vec_len, data_len),
-1270 => wire__crate__api__dart_opaque_sync__sync_accept_dart_opaque_twin_normal_impl(ptr, rust_vec_len, data_len),
-1271 => wire__crate__api__rust_opaque_sync__sync_create_non_clone_twin_normal_impl(ptr, rust_vec_len, data_len),
-1272 => wire__crate__api__rust_opaque_sync__sync_create_opaque_twin_normal_impl(ptr, rust_vec_len, data_len),
-1273 => wire__crate__api__dart_opaque_sync__sync_loopback_twin_normal_impl(ptr, rust_vec_len, data_len),
-1274 => wire__crate__api__dart_opaque_sync__sync_option_dart_opaque_twin_normal_impl(ptr, rust_vec_len, data_len),
-1275 => wire__crate__api__dart_opaque_sync__sync_option_loopback_twin_normal_impl(ptr, rust_vec_len, data_len),
-1276 => wire__crate__api__rust_opaque_sync__sync_option_rust_opaque_twin_normal_impl(ptr, rust_vec_len, data_len),
-1279 => wire__crate__api__pseudo_manual__misc_example_twin_sync__test_abc_enum_twin_sync_impl(ptr, rust_vec_len, data_len),
-1282 => wire__crate__api__pseudo_manual__chrono_type_twin_sync__test_chrono_twin_sync_impl(ptr, rust_vec_len, data_len),
-1285 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_contains_mirrored_sub_struct_twin_sync_impl(ptr, rust_vec_len, data_len),
-1289 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_fallible_of_raw_string_mirrored_twin_sync_impl(ptr, rust_vec_len, data_len),
-1292 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_hashmap_with_mirrored_value_twin_sync_impl(ptr, rust_vec_len, data_len),
-1295 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_list_of_nested_enums_mirrored_twin_sync_impl(ptr, rust_vec_len, data_len),
-1298 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_list_of_raw_nested_string_mirrored_twin_sync_impl(ptr, rust_vec_len, data_len),
-1301 => wire__crate__api__pseudo_manual__raw_string_twin_sync__test_more_than_just_one_raw_string_struct_twin_sync_impl(ptr, rust_vec_len, data_len),
-1304 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_nested_raw_string_mirrored_twin_sync_impl(ptr, rust_vec_len, data_len),
-1307 => wire__crate__api__pseudo_manual__chrono_type_twin_sync__test_precise_chrono_twin_sync_impl(ptr, rust_vec_len, data_len),
-1310 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_raw_string_enum_mirrored_twin_sync_impl(ptr, rust_vec_len, data_len),
-1313 => wire__crate__api__pseudo_manual__raw_string_twin_sync__test_raw_string_item_enum_twin_sync_impl(ptr, rust_vec_len, data_len),
-1316 => wire__crate__api__pseudo_manual__raw_string_twin_sync__test_raw_string_item_struct_twin_sync_impl(ptr, rust_vec_len, data_len),
-1319 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_raw_string_mirrored_twin_sync_impl(ptr, rust_vec_len, data_len),
-1322 => wire__crate__api__pseudo_manual__misc_example_twin_sync__test_struct_with_enum_twin_sync_impl(ptr, rust_vec_len, data_len),
-1325 => wire__crate__api__pseudo_manual__tuple_twin_sync__test_tuple_2_twin_sync_impl(ptr, rust_vec_len, data_len),
-1328 => wire__crate__api__pseudo_manual__tuple_twin_sync__test_tuple_twin_sync_impl(ptr, rust_vec_len, data_len),
-1331 => wire__crate__api__pseudo_manual__exception_twin_sync__throw_anyhow_twin_sync_impl(ptr, rust_vec_len, data_len),
-1334 => wire__crate__api__pseudo_manual__chrono_type_twin_sync__tokio_time_duration_twin_sync_impl(ptr, rust_vec_len, data_len),
-1337 => wire__crate__api__pseudo_manual__chrono_type_twin_sync__tokio_time_instant_twin_sync_impl(ptr, rust_vec_len, data_len),
-1339 => wire__crate__api__dart_opaque_sync__unwrap_dart_opaque_twin_normal_impl(ptr, rust_vec_len, data_len),
-1342 => wire__crate__api__pseudo_manual__rust_opaque_twin_sync__unwrap_rust_opaque_twin_sync_impl(ptr, rust_vec_len, data_len),
-1345 => wire__crate__api__pseudo_manual__array_twin_sync__use_boxed_blob_twin_sync_impl(ptr, rust_vec_len, data_len),
-1348 => wire__crate__api__pseudo_manual__external_type_in_crate_twin_sync__use_imported_enum_twin_sync_impl(ptr, rust_vec_len, data_len),
-1351 => wire__crate__api__pseudo_manual__external_type_in_crate_twin_sync__use_imported_struct_twin_sync_impl(ptr, rust_vec_len, data_len),
-1354 => wire__crate__api__pseudo_manual__array_twin_sync__use_msgid_twin_sync_impl(ptr, rust_vec_len, data_len),
+1238 => wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_system_time_before_epoch_twin_sync_impl(ptr, rust_vec_len, data_len),
+1241 => wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_system_time_twin_sync_impl(ptr, rust_vec_len, data_len),
+1251 => wire__crate__api__pseudo_manual__exception_twin_sync__stream_sink_throw_anyhow_twin_sync_impl(ptr, rust_vec_len, data_len),
+1256 => wire__crate__api__pseudo_manual__comment_twin_sync__struct_with_comments_twin_sync_instance_method_twin_sync_impl(ptr, rust_vec_len, data_len),
+1257 => wire__crate__api__pseudo_manual__comment_twin_sync__struct_with_comments_twin_sync_static_method_twin_sync_impl(ptr, rust_vec_len, data_len),
+1258 => wire__crate__api__misc_no_twin_example_a__struct_with_custom_name_method_twin_normal_method_with_custom_name_twin_normal_impl(ptr, rust_vec_len, data_len),
+1266 => wire__crate__api__pseudo_manual__method_twin_sync__sum_with_twin_sync_sum_twin_sync_impl(ptr, rust_vec_len, data_len),
+1267 => wire__crate__api__dart_opaque_sync__sync_accept_dart_opaque_twin_normal_impl(ptr, rust_vec_len, data_len),
+1268 => wire__crate__api__rust_opaque_sync__sync_create_non_clone_twin_normal_impl(ptr, rust_vec_len, data_len),
+1269 => wire__crate__api__rust_opaque_sync__sync_create_opaque_twin_normal_impl(ptr, rust_vec_len, data_len),
+1270 => wire__crate__api__dart_opaque_sync__sync_loopback_twin_normal_impl(ptr, rust_vec_len, data_len),
+1271 => wire__crate__api__dart_opaque_sync__sync_option_dart_opaque_twin_normal_impl(ptr, rust_vec_len, data_len),
+1272 => wire__crate__api__dart_opaque_sync__sync_option_loopback_twin_normal_impl(ptr, rust_vec_len, data_len),
+1273 => wire__crate__api__rust_opaque_sync__sync_option_rust_opaque_twin_normal_impl(ptr, rust_vec_len, data_len),
+1276 => wire__crate__api__pseudo_manual__misc_example_twin_sync__test_abc_enum_twin_sync_impl(ptr, rust_vec_len, data_len),
+1279 => wire__crate__api__pseudo_manual__chrono_type_twin_sync__test_chrono_twin_sync_impl(ptr, rust_vec_len, data_len),
+1282 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_contains_mirrored_sub_struct_twin_sync_impl(ptr, rust_vec_len, data_len),
+1286 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_fallible_of_raw_string_mirrored_twin_sync_impl(ptr, rust_vec_len, data_len),
+1289 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_hashmap_with_mirrored_value_twin_sync_impl(ptr, rust_vec_len, data_len),
+1292 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_list_of_nested_enums_mirrored_twin_sync_impl(ptr, rust_vec_len, data_len),
+1295 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_list_of_raw_nested_string_mirrored_twin_sync_impl(ptr, rust_vec_len, data_len),
+1298 => wire__crate__api__pseudo_manual__raw_string_twin_sync__test_more_than_just_one_raw_string_struct_twin_sync_impl(ptr, rust_vec_len, data_len),
+1301 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_nested_raw_string_mirrored_twin_sync_impl(ptr, rust_vec_len, data_len),
+1304 => wire__crate__api__pseudo_manual__chrono_type_twin_sync__test_precise_chrono_twin_sync_impl(ptr, rust_vec_len, data_len),
+1307 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_raw_string_enum_mirrored_twin_sync_impl(ptr, rust_vec_len, data_len),
+1310 => wire__crate__api__pseudo_manual__raw_string_twin_sync__test_raw_string_item_enum_twin_sync_impl(ptr, rust_vec_len, data_len),
+1313 => wire__crate__api__pseudo_manual__raw_string_twin_sync__test_raw_string_item_struct_twin_sync_impl(ptr, rust_vec_len, data_len),
+1316 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_raw_string_mirrored_twin_sync_impl(ptr, rust_vec_len, data_len),
+1319 => wire__crate__api__pseudo_manual__misc_example_twin_sync__test_struct_with_enum_twin_sync_impl(ptr, rust_vec_len, data_len),
+1322 => wire__crate__api__pseudo_manual__tuple_twin_sync__test_tuple_2_twin_sync_impl(ptr, rust_vec_len, data_len),
+1325 => wire__crate__api__pseudo_manual__tuple_twin_sync__test_tuple_twin_sync_impl(ptr, rust_vec_len, data_len),
+1328 => wire__crate__api__pseudo_manual__exception_twin_sync__throw_anyhow_twin_sync_impl(ptr, rust_vec_len, data_len),
+1331 => wire__crate__api__pseudo_manual__chrono_type_twin_sync__tokio_time_duration_twin_sync_impl(ptr, rust_vec_len, data_len),
+1333 => wire__crate__api__dart_opaque_sync__unwrap_dart_opaque_twin_normal_impl(ptr, rust_vec_len, data_len),
+1336 => wire__crate__api__pseudo_manual__rust_opaque_twin_sync__unwrap_rust_opaque_twin_sync_impl(ptr, rust_vec_len, data_len),
+1339 => wire__crate__api__pseudo_manual__array_twin_sync__use_boxed_blob_twin_sync_impl(ptr, rust_vec_len, data_len),
+1342 => wire__crate__api__pseudo_manual__external_type_in_crate_twin_sync__use_imported_enum_twin_sync_impl(ptr, rust_vec_len, data_len),
+1345 => wire__crate__api__pseudo_manual__external_type_in_crate_twin_sync__use_imported_struct_twin_sync_impl(ptr, rust_vec_len, data_len),
+1348 => wire__crate__api__pseudo_manual__array_twin_sync__use_msgid_twin_sync_impl(ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -46590,65 +46336,6 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<std::time::Duration>> for std:
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
-impl flutter_rust_bridge::IntoDart for FrbWrapper<std::time::Instant> {
-    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        let value: i64 = {
-            let value = self.0.clone();
-            let now_instant = std::time::Instant::now();
-            let now_system_time = std::time::SystemTime::now();
-            let system_time = if value >= now_instant {
-                now_system_time
-                    .checked_add(value.duration_since(now_instant))
-                    .expect("instant out of range")
-            } else {
-                now_system_time
-                    .checked_sub(now_instant.duration_since(value))
-                    .expect("instant out of range")
-            };
-            {
-                #[cfg(target_arch = "wasm32")]
-                {
-                    match system_time.duration_since(std::time::SystemTime::UNIX_EPOCH) {
-                        Ok(duration) => duration
-                            .as_millis()
-                            .try_into()
-                            .expect("cannot get milliseconds from time"),
-                        Err(error) => {
-                            let millis = i128::try_from(error.duration().as_millis())
-                                .expect("cannot get milliseconds from time");
-                            i64::try_from(-millis).expect("cannot get milliseconds from time")
-                        }
-                    }
-                }
-                #[cfg(not(target_arch = "wasm32"))]
-                {
-                    match system_time.duration_since(std::time::SystemTime::UNIX_EPOCH) {
-                        Ok(duration) => duration
-                            .as_micros()
-                            .try_into()
-                            .expect("cannot get microseconds from time"),
-                        Err(error) => {
-                            let micros = i128::try_from(error.duration().as_micros())
-                                .expect("cannot get microseconds from time");
-                            i64::try_from(-micros).expect("cannot get microseconds from time")
-                        }
-                    }
-                }
-            }
-        };
-        value.into_dart()
-    }
-}
-impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
-    for FrbWrapper<std::time::Instant>
-{
-}
-impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<std::time::Instant>> for std::time::Instant {
-    fn into_into_dart(self) -> FrbWrapper<std::time::Instant> {
-        self.into()
-    }
-}
-// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for FrbWrapper<std::time::SystemTime> {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         let value: i64 = {
@@ -46692,65 +46379,6 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<std::time::SystemTime>>
     for std::time::SystemTime
 {
     fn into_into_dart(self) -> FrbWrapper<std::time::SystemTime> {
-        self.into()
-    }
-}
-// Codec=Dco (DartCObject based), see doc to use other codecs
-impl flutter_rust_bridge::IntoDart for FrbWrapper<tokio::time::Instant> {
-    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        let value: i64 = {
-            let value = self.0.into_std().clone();
-            let now_instant = std::time::Instant::now();
-            let now_system_time = std::time::SystemTime::now();
-            let system_time = if value >= now_instant {
-                now_system_time
-                    .checked_add(value.duration_since(now_instant))
-                    .expect("instant out of range")
-            } else {
-                now_system_time
-                    .checked_sub(now_instant.duration_since(value))
-                    .expect("instant out of range")
-            };
-            {
-                #[cfg(target_arch = "wasm32")]
-                {
-                    match system_time.duration_since(std::time::SystemTime::UNIX_EPOCH) {
-                        Ok(duration) => duration
-                            .as_millis()
-                            .try_into()
-                            .expect("cannot get milliseconds from time"),
-                        Err(error) => {
-                            let millis = i128::try_from(error.duration().as_millis())
-                                .expect("cannot get milliseconds from time");
-                            i64::try_from(-millis).expect("cannot get milliseconds from time")
-                        }
-                    }
-                }
-                #[cfg(not(target_arch = "wasm32"))]
-                {
-                    match system_time.duration_since(std::time::SystemTime::UNIX_EPOCH) {
-                        Ok(duration) => duration
-                            .as_micros()
-                            .try_into()
-                            .expect("cannot get microseconds from time"),
-                        Err(error) => {
-                            let micros = i128::try_from(error.duration().as_micros())
-                                .expect("cannot get microseconds from time");
-                            i64::try_from(-micros).expect("cannot get microseconds from time")
-                        }
-                    }
-                }
-            }
-        };
-        value.into_dart()
-    }
-}
-impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
-    for FrbWrapper<tokio::time::Instant>
-{
-}
-impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<tokio::time::Instant>> for tokio::time::Instant {
-    fn into_into_dart(self) -> FrbWrapper<tokio::time::Instant> {
         self.into()
     }
 }
@@ -56979,40 +56607,6 @@ impl SseEncode for std::time::Duration {
     }
 }
 
-impl SseEncode for std::time::Instant {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <i64>::sse_encode(
-            {
-                let value = self.clone();
-                let now_instant = std::time::Instant::now();
-                let now_system_time = std::time::SystemTime::now();
-                let system_time = if value >= now_instant {
-                    now_system_time
-                        .checked_add(value.duration_since(now_instant))
-                        .expect("instant out of range")
-                } else {
-                    now_system_time
-                        .checked_sub(now_instant.duration_since(value))
-                        .expect("instant out of range")
-                };
-                match system_time.duration_since(std::time::SystemTime::UNIX_EPOCH) {
-                    Ok(duration) => duration
-                        .as_micros()
-                        .try_into()
-                        .expect("cannot get microseconds from time"),
-                    Err(error) => {
-                        let micros = i128::try_from(error.duration().as_micros())
-                            .expect("cannot get microseconds from time");
-                        i64::try_from(-micros).expect("cannot get microseconds from time")
-                    }
-                }
-            },
-            serializer,
-        );
-    }
-}
-
 impl SseEncode for std::time::SystemTime {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -57353,40 +56947,6 @@ impl SseEncode for String {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <Vec<u8>>::sse_encode(self.into_bytes(), serializer);
-    }
-}
-
-impl SseEncode for tokio::time::Instant {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <i64>::sse_encode(
-            {
-                let value = self.into_std().clone();
-                let now_instant = std::time::Instant::now();
-                let now_system_time = std::time::SystemTime::now();
-                let system_time = if value >= now_instant {
-                    now_system_time
-                        .checked_add(value.duration_since(now_instant))
-                        .expect("instant out of range")
-                } else {
-                    now_system_time
-                        .checked_sub(now_instant.duration_since(value))
-                        .expect("instant out of range")
-                };
-                match system_time.duration_since(std::time::SystemTime::UNIX_EPOCH) {
-                    Ok(duration) => duration
-                        .as_micros()
-                        .try_into()
-                        .expect("cannot get microseconds from time"),
-                    Err(error) => {
-                        let micros = i128::try_from(error.duration().as_micros())
-                            .expect("cannot get microseconds from time");
-                        i64::try_from(-micros).expect("cannot get microseconds from time")
-                    }
-                }
-            },
-            serializer,
-        );
     }
 }
 

--- a/frb_example/pure_dart_pde/rust/src/frb_generated.rs
+++ b/frb_example/pure_dart_pde/rust/src/frb_generated.rs
@@ -75,7 +75,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 415027099;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1314015258;
 
 // Section: executor
 
@@ -28888,6 +28888,71 @@ fn wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_instant_twin
         },
     )
 }
+fn wire__crate__api__chrono_type__std_time_system_time_before_epoch_twin_normal_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "std_time_system_time_before_epoch_twin_normal",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_d = <std::time::SystemTime>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, ()>((move || {
+                    let output_ok = Result::<_, ()>::Ok(
+                        crate::api::chrono_type::std_time_system_time_before_epoch_twin_normal(
+                            api_d,
+                        ),
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_system_time_before_epoch_twin_rust_async_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec,_,_,_>(flutter_rust_bridge::for_generated::TaskInfo{ debug_name: "std_time_system_time_before_epoch_twin_rust_async", port: Some(port_), mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal }, move || {
+            let message = unsafe { flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(ptr_, rust_vec_len_, data_len_) };
+            let mut deserializer = flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_d = <std::time::SystemTime>::sse_decode(&mut deserializer);deserializer.end(); move |context| async move {
+                    transform_result_sse::<_, ()>((move || async move {
+                         let output_ok = Result::<_,()>::Ok(crate::api::pseudo_manual::chrono_type_twin_rust_async::std_time_system_time_before_epoch_twin_rust_async(api_d).await)?;   Ok(output_ok)
+                    })().await)
+                } })
+}
+fn wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_system_time_before_epoch_twin_sync_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec,_>(flutter_rust_bridge::for_generated::TaskInfo{ debug_name: "std_time_system_time_before_epoch_twin_sync", port: None, mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync }, move || {
+            let message = unsafe { flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(ptr_, rust_vec_len_, data_len_) };
+            let mut deserializer = flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_d = <std::time::SystemTime>::sse_decode(&mut deserializer);deserializer.end();
+                transform_result_sse::<_, ()>((move || {
+                     let output_ok = Result::<_,()>::Ok(crate::api::pseudo_manual::chrono_type_twin_sync::std_time_system_time_before_epoch_twin_sync(api_d))?;   Ok(output_ok)
+                })()) })
+}
 fn wire__crate__api__chrono_type__std_time_system_time_twin_normal_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -35118,9 +35183,7 @@ impl SseDecode for std::time::Instant {
             let now_instant = std::time::Instant::now();
             let target_system_time = if inner >= 0 {
                 std::time::SystemTime::UNIX_EPOCH
-                    .checked_add(std::time::Duration::from_micros(
-                        inner.try_into().expect("invalid timestamp"),
-                    ))
+                    .checked_add(std::time::Duration::from_micros(inner.unsigned_abs()))
                     .expect("timestamp out of range")
             } else {
                 std::time::SystemTime::UNIX_EPOCH
@@ -35154,9 +35217,7 @@ impl SseDecode for std::time::SystemTime {
         let mut inner = <i64>::sse_decode(deserializer);
         return if inner >= 0 {
             std::time::SystemTime::UNIX_EPOCH
-                .checked_add(std::time::Duration::from_micros(
-                    inner.try_into().expect("invalid timestamp"),
-                ))
+                .checked_add(std::time::Duration::from_micros(inner.unsigned_abs()))
                 .expect("timestamp out of range")
         } else {
             std::time::SystemTime::UNIX_EPOCH
@@ -35528,9 +35589,7 @@ impl SseDecode for tokio::time::Instant {
             let now_instant = std::time::Instant::now();
             let target_system_time = if inner >= 0 {
                 std::time::SystemTime::UNIX_EPOCH
-                    .checked_add(std::time::Duration::from_micros(
-                        inner.try_into().expect("invalid timestamp"),
-                    ))
+                    .checked_add(std::time::Duration::from_micros(inner.unsigned_abs()))
                     .expect("timestamp out of range")
             } else {
                 std::time::SystemTime::UNIX_EPOCH
@@ -44718,80 +44777,82 @@ fn pde_ffi_dispatcher_primary_impl(
 1234 => wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_duration_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
 1236 => wire__crate__api__chrono_type__std_time_instant_twin_normal_impl(port, ptr, rust_vec_len, data_len),
 1237 => wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_instant_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1239 => wire__crate__api__chrono_type__std_time_system_time_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1240 => wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_system_time_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1242 => wire__crate__api__stream_misc__stream_sink_dart_async_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1243 => wire__crate__api__stream__stream_sink_fixed_sized_primitive_array_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1244 => wire__crate__api__pseudo_manual__stream_twin_rust_async__stream_sink_fixed_sized_primitive_array_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1245 => wire__crate__api__stream__stream_sink_inside_struct_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1246 => wire__crate__api__pseudo_manual__stream_twin_rust_async__stream_sink_inside_struct_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1247 => wire__crate__api__stream__stream_sink_inside_vec_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1248 => wire__crate__api__pseudo_manual__stream_twin_rust_async__stream_sink_inside_vec_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1249 => wire__crate__api__exception__stream_sink_throw_anyhow_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1250 => wire__crate__api__pseudo_manual__exception_twin_rust_async__stream_sink_throw_anyhow_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1252 => wire__crate__api__comment__struct_with_comments_twin_normal_instance_method_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1253 => wire__crate__api__comment__struct_with_comments_twin_normal_static_method_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1254 => wire__crate__api__pseudo_manual__comment_twin_rust_async__struct_with_comments_twin_rust_async_instance_method_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1255 => wire__crate__api__pseudo_manual__comment_twin_rust_async__struct_with_comments_twin_rust_async_static_method_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1259 => wire__crate__api__misc_no_twin_example_a__struct_with_impl_block_in_another_file_f_impl(port, ptr, rust_vec_len, data_len),
-1260 => wire__crate__api__misc_no_twin_example_a__struct_with_raw_name_field_dummy_function_impl(port, ptr, rust_vec_len, data_len),
-1261 => wire__crate__api__misc_no_twin_example_a__struct_with_rust_auto_opaque_field_with_many_derive_default_impl(port, ptr, rust_vec_len, data_len),
-1262 => wire__crate__api__misc_no_twin_example_a__struct_with_rust_auto_opaque_field_with_many_derive_f_impl(port, ptr, rust_vec_len, data_len),
-1263 => wire__crate__api__misc_no_twin_example_a__struct_with_rust_auto_opaque_with_non_clone_data_f_impl(port, ptr, rust_vec_len, data_len),
-1264 => wire__crate__api__method__sum_with_twin_normal_sum_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1265 => wire__crate__api__pseudo_manual__method_twin_rust_async__sum_with_twin_rust_async_sum_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1274 => wire__crate__api__misc_example__test_abc_enum_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1275 => wire__crate__api__pseudo_manual__misc_example_twin_rust_async__test_abc_enum_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1277 => wire__crate__api__chrono_type__test_chrono_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1278 => wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__test_chrono_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1280 => wire__crate__api__mirror__test_contains_mirrored_sub_struct_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1281 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_contains_mirrored_sub_struct_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1283 => wire__crate__api__deliberate_name_conflict__test_duplicated_module_names_impl(port, ptr, rust_vec_len, data_len),
-1284 => wire__crate__api__mirror__test_fallible_of_raw_string_mirrored_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1285 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_fallible_of_raw_string_mirrored_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1287 => wire__crate__api__mirror__test_hashmap_with_mirrored_value_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1288 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_hashmap_with_mirrored_value_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1290 => wire__crate__api__mirror__test_list_of_nested_enums_mirrored_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1291 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_list_of_nested_enums_mirrored_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1293 => wire__crate__api__mirror__test_list_of_raw_nested_string_mirrored_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1294 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_list_of_raw_nested_string_mirrored_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1296 => wire__crate__api__raw_string__test_more_than_just_one_raw_string_struct_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1297 => wire__crate__api__pseudo_manual__raw_string_twin_rust_async__test_more_than_just_one_raw_string_struct_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1299 => wire__crate__api__mirror__test_nested_raw_string_mirrored_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1300 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_nested_raw_string_mirrored_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1302 => wire__crate__api__chrono_type__test_precise_chrono_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1303 => wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__test_precise_chrono_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1305 => wire__crate__api__mirror__test_raw_string_enum_mirrored_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1306 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_raw_string_enum_mirrored_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1308 => wire__crate__api__raw_string__test_raw_string_item_enum_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1309 => wire__crate__api__pseudo_manual__raw_string_twin_rust_async__test_raw_string_item_enum_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1311 => wire__crate__api__raw_string__test_raw_string_item_struct_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1312 => wire__crate__api__pseudo_manual__raw_string_twin_rust_async__test_raw_string_item_struct_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1314 => wire__crate__api__mirror__test_raw_string_mirrored_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1315 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_raw_string_mirrored_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1317 => wire__crate__api__misc_example__test_struct_with_enum_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1318 => wire__crate__api__pseudo_manual__misc_example_twin_rust_async__test_struct_with_enum_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1320 => wire__crate__api__tuple__test_tuple_2_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1321 => wire__crate__api__pseudo_manual__tuple_twin_rust_async__test_tuple_2_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1323 => wire__crate__api__tuple__test_tuple_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1324 => wire__crate__api__pseudo_manual__tuple_twin_rust_async__test_tuple_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1326 => wire__crate__api__exception__throw_anyhow_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1327 => wire__crate__api__pseudo_manual__exception_twin_rust_async__throw_anyhow_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1329 => wire__crate__api__chrono_type__tokio_time_duration_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1330 => wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__tokio_time_duration_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1332 => wire__crate__api__chrono_type__tokio_time_instant_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1333 => wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__tokio_time_instant_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1335 => wire__crate__api__dart_code__translatable_struct_with_dart_code_twin_normal_normal_method_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1337 => wire__crate__api__rust_opaque__unwrap_rust_opaque_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1338 => wire__crate__api__pseudo_manual__rust_opaque_twin_rust_async__unwrap_rust_opaque_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1340 => wire__crate__api__array__use_boxed_blob_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1341 => wire__crate__api__pseudo_manual__array_twin_rust_async__use_boxed_blob_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1343 => wire__crate__api__external_type_in_crate__use_imported_enum_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1344 => wire__crate__api__pseudo_manual__external_type_in_crate_twin_rust_async__use_imported_enum_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1346 => wire__crate__api__external_type_in_crate__use_imported_struct_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1347 => wire__crate__api__pseudo_manual__external_type_in_crate_twin_rust_async__use_imported_struct_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1349 => wire__crate__api__array__use_msgid_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1350 => wire__crate__api__pseudo_manual__array_twin_rust_async__use_msgid_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1239 => wire__crate__api__chrono_type__std_time_system_time_before_epoch_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1240 => wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_system_time_before_epoch_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1242 => wire__crate__api__chrono_type__std_time_system_time_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1243 => wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_system_time_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1245 => wire__crate__api__stream_misc__stream_sink_dart_async_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1246 => wire__crate__api__stream__stream_sink_fixed_sized_primitive_array_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1247 => wire__crate__api__pseudo_manual__stream_twin_rust_async__stream_sink_fixed_sized_primitive_array_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1248 => wire__crate__api__stream__stream_sink_inside_struct_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1249 => wire__crate__api__pseudo_manual__stream_twin_rust_async__stream_sink_inside_struct_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1250 => wire__crate__api__stream__stream_sink_inside_vec_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1251 => wire__crate__api__pseudo_manual__stream_twin_rust_async__stream_sink_inside_vec_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1252 => wire__crate__api__exception__stream_sink_throw_anyhow_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1253 => wire__crate__api__pseudo_manual__exception_twin_rust_async__stream_sink_throw_anyhow_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1255 => wire__crate__api__comment__struct_with_comments_twin_normal_instance_method_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1256 => wire__crate__api__comment__struct_with_comments_twin_normal_static_method_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1257 => wire__crate__api__pseudo_manual__comment_twin_rust_async__struct_with_comments_twin_rust_async_instance_method_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1258 => wire__crate__api__pseudo_manual__comment_twin_rust_async__struct_with_comments_twin_rust_async_static_method_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1262 => wire__crate__api__misc_no_twin_example_a__struct_with_impl_block_in_another_file_f_impl(port, ptr, rust_vec_len, data_len),
+1263 => wire__crate__api__misc_no_twin_example_a__struct_with_raw_name_field_dummy_function_impl(port, ptr, rust_vec_len, data_len),
+1264 => wire__crate__api__misc_no_twin_example_a__struct_with_rust_auto_opaque_field_with_many_derive_default_impl(port, ptr, rust_vec_len, data_len),
+1265 => wire__crate__api__misc_no_twin_example_a__struct_with_rust_auto_opaque_field_with_many_derive_f_impl(port, ptr, rust_vec_len, data_len),
+1266 => wire__crate__api__misc_no_twin_example_a__struct_with_rust_auto_opaque_with_non_clone_data_f_impl(port, ptr, rust_vec_len, data_len),
+1267 => wire__crate__api__method__sum_with_twin_normal_sum_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1268 => wire__crate__api__pseudo_manual__method_twin_rust_async__sum_with_twin_rust_async_sum_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1277 => wire__crate__api__misc_example__test_abc_enum_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1278 => wire__crate__api__pseudo_manual__misc_example_twin_rust_async__test_abc_enum_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1280 => wire__crate__api__chrono_type__test_chrono_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1281 => wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__test_chrono_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1283 => wire__crate__api__mirror__test_contains_mirrored_sub_struct_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1284 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_contains_mirrored_sub_struct_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1286 => wire__crate__api__deliberate_name_conflict__test_duplicated_module_names_impl(port, ptr, rust_vec_len, data_len),
+1287 => wire__crate__api__mirror__test_fallible_of_raw_string_mirrored_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1288 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_fallible_of_raw_string_mirrored_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1290 => wire__crate__api__mirror__test_hashmap_with_mirrored_value_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1291 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_hashmap_with_mirrored_value_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1293 => wire__crate__api__mirror__test_list_of_nested_enums_mirrored_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1294 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_list_of_nested_enums_mirrored_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1296 => wire__crate__api__mirror__test_list_of_raw_nested_string_mirrored_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1297 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_list_of_raw_nested_string_mirrored_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1299 => wire__crate__api__raw_string__test_more_than_just_one_raw_string_struct_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1300 => wire__crate__api__pseudo_manual__raw_string_twin_rust_async__test_more_than_just_one_raw_string_struct_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1302 => wire__crate__api__mirror__test_nested_raw_string_mirrored_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1303 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_nested_raw_string_mirrored_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1305 => wire__crate__api__chrono_type__test_precise_chrono_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1306 => wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__test_precise_chrono_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1308 => wire__crate__api__mirror__test_raw_string_enum_mirrored_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1309 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_raw_string_enum_mirrored_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1311 => wire__crate__api__raw_string__test_raw_string_item_enum_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1312 => wire__crate__api__pseudo_manual__raw_string_twin_rust_async__test_raw_string_item_enum_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1314 => wire__crate__api__raw_string__test_raw_string_item_struct_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1315 => wire__crate__api__pseudo_manual__raw_string_twin_rust_async__test_raw_string_item_struct_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1317 => wire__crate__api__mirror__test_raw_string_mirrored_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1318 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_raw_string_mirrored_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1320 => wire__crate__api__misc_example__test_struct_with_enum_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1321 => wire__crate__api__pseudo_manual__misc_example_twin_rust_async__test_struct_with_enum_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1323 => wire__crate__api__tuple__test_tuple_2_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1324 => wire__crate__api__pseudo_manual__tuple_twin_rust_async__test_tuple_2_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1326 => wire__crate__api__tuple__test_tuple_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1327 => wire__crate__api__pseudo_manual__tuple_twin_rust_async__test_tuple_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1329 => wire__crate__api__exception__throw_anyhow_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1330 => wire__crate__api__pseudo_manual__exception_twin_rust_async__throw_anyhow_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1332 => wire__crate__api__chrono_type__tokio_time_duration_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1333 => wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__tokio_time_duration_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1335 => wire__crate__api__chrono_type__tokio_time_instant_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1336 => wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__tokio_time_instant_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1338 => wire__crate__api__dart_code__translatable_struct_with_dart_code_twin_normal_normal_method_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1340 => wire__crate__api__rust_opaque__unwrap_rust_opaque_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1341 => wire__crate__api__pseudo_manual__rust_opaque_twin_rust_async__unwrap_rust_opaque_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1343 => wire__crate__api__array__use_boxed_blob_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1344 => wire__crate__api__pseudo_manual__array_twin_rust_async__use_boxed_blob_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1346 => wire__crate__api__external_type_in_crate__use_imported_enum_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1347 => wire__crate__api__pseudo_manual__external_type_in_crate_twin_rust_async__use_imported_enum_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1349 => wire__crate__api__external_type_in_crate__use_imported_struct_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1350 => wire__crate__api__pseudo_manual__external_type_in_crate_twin_rust_async__use_imported_struct_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1352 => wire__crate__api__array__use_msgid_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1353 => wire__crate__api__pseudo_manual__array_twin_rust_async__use_msgid_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -45207,45 +45268,46 @@ fn pde_ffi_dispatcher_sync_impl(
 1232 => wire__crate__api__pseudo_manual__method_twin_sync__static_only_twin_sync_static_method_twin_sync_impl(ptr, rust_vec_len, data_len),
 1235 => wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_duration_twin_sync_impl(ptr, rust_vec_len, data_len),
 1238 => wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_instant_twin_sync_impl(ptr, rust_vec_len, data_len),
-1241 => wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_system_time_twin_sync_impl(ptr, rust_vec_len, data_len),
-1251 => wire__crate__api__pseudo_manual__exception_twin_sync__stream_sink_throw_anyhow_twin_sync_impl(ptr, rust_vec_len, data_len),
-1256 => wire__crate__api__pseudo_manual__comment_twin_sync__struct_with_comments_twin_sync_instance_method_twin_sync_impl(ptr, rust_vec_len, data_len),
-1257 => wire__crate__api__pseudo_manual__comment_twin_sync__struct_with_comments_twin_sync_static_method_twin_sync_impl(ptr, rust_vec_len, data_len),
-1258 => wire__crate__api__misc_no_twin_example_a__struct_with_custom_name_method_twin_normal_method_with_custom_name_twin_normal_impl(ptr, rust_vec_len, data_len),
-1266 => wire__crate__api__pseudo_manual__method_twin_sync__sum_with_twin_sync_sum_twin_sync_impl(ptr, rust_vec_len, data_len),
-1267 => wire__crate__api__dart_opaque_sync__sync_accept_dart_opaque_twin_normal_impl(ptr, rust_vec_len, data_len),
-1268 => wire__crate__api__rust_opaque_sync__sync_create_non_clone_twin_normal_impl(ptr, rust_vec_len, data_len),
-1269 => wire__crate__api__rust_opaque_sync__sync_create_opaque_twin_normal_impl(ptr, rust_vec_len, data_len),
-1270 => wire__crate__api__dart_opaque_sync__sync_loopback_twin_normal_impl(ptr, rust_vec_len, data_len),
-1271 => wire__crate__api__dart_opaque_sync__sync_option_dart_opaque_twin_normal_impl(ptr, rust_vec_len, data_len),
-1272 => wire__crate__api__dart_opaque_sync__sync_option_loopback_twin_normal_impl(ptr, rust_vec_len, data_len),
-1273 => wire__crate__api__rust_opaque_sync__sync_option_rust_opaque_twin_normal_impl(ptr, rust_vec_len, data_len),
-1276 => wire__crate__api__pseudo_manual__misc_example_twin_sync__test_abc_enum_twin_sync_impl(ptr, rust_vec_len, data_len),
-1279 => wire__crate__api__pseudo_manual__chrono_type_twin_sync__test_chrono_twin_sync_impl(ptr, rust_vec_len, data_len),
-1282 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_contains_mirrored_sub_struct_twin_sync_impl(ptr, rust_vec_len, data_len),
-1286 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_fallible_of_raw_string_mirrored_twin_sync_impl(ptr, rust_vec_len, data_len),
-1289 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_hashmap_with_mirrored_value_twin_sync_impl(ptr, rust_vec_len, data_len),
-1292 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_list_of_nested_enums_mirrored_twin_sync_impl(ptr, rust_vec_len, data_len),
-1295 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_list_of_raw_nested_string_mirrored_twin_sync_impl(ptr, rust_vec_len, data_len),
-1298 => wire__crate__api__pseudo_manual__raw_string_twin_sync__test_more_than_just_one_raw_string_struct_twin_sync_impl(ptr, rust_vec_len, data_len),
-1301 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_nested_raw_string_mirrored_twin_sync_impl(ptr, rust_vec_len, data_len),
-1304 => wire__crate__api__pseudo_manual__chrono_type_twin_sync__test_precise_chrono_twin_sync_impl(ptr, rust_vec_len, data_len),
-1307 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_raw_string_enum_mirrored_twin_sync_impl(ptr, rust_vec_len, data_len),
-1310 => wire__crate__api__pseudo_manual__raw_string_twin_sync__test_raw_string_item_enum_twin_sync_impl(ptr, rust_vec_len, data_len),
-1313 => wire__crate__api__pseudo_manual__raw_string_twin_sync__test_raw_string_item_struct_twin_sync_impl(ptr, rust_vec_len, data_len),
-1316 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_raw_string_mirrored_twin_sync_impl(ptr, rust_vec_len, data_len),
-1319 => wire__crate__api__pseudo_manual__misc_example_twin_sync__test_struct_with_enum_twin_sync_impl(ptr, rust_vec_len, data_len),
-1322 => wire__crate__api__pseudo_manual__tuple_twin_sync__test_tuple_2_twin_sync_impl(ptr, rust_vec_len, data_len),
-1325 => wire__crate__api__pseudo_manual__tuple_twin_sync__test_tuple_twin_sync_impl(ptr, rust_vec_len, data_len),
-1328 => wire__crate__api__pseudo_manual__exception_twin_sync__throw_anyhow_twin_sync_impl(ptr, rust_vec_len, data_len),
-1331 => wire__crate__api__pseudo_manual__chrono_type_twin_sync__tokio_time_duration_twin_sync_impl(ptr, rust_vec_len, data_len),
-1334 => wire__crate__api__pseudo_manual__chrono_type_twin_sync__tokio_time_instant_twin_sync_impl(ptr, rust_vec_len, data_len),
-1336 => wire__crate__api__dart_opaque_sync__unwrap_dart_opaque_twin_normal_impl(ptr, rust_vec_len, data_len),
-1339 => wire__crate__api__pseudo_manual__rust_opaque_twin_sync__unwrap_rust_opaque_twin_sync_impl(ptr, rust_vec_len, data_len),
-1342 => wire__crate__api__pseudo_manual__array_twin_sync__use_boxed_blob_twin_sync_impl(ptr, rust_vec_len, data_len),
-1345 => wire__crate__api__pseudo_manual__external_type_in_crate_twin_sync__use_imported_enum_twin_sync_impl(ptr, rust_vec_len, data_len),
-1348 => wire__crate__api__pseudo_manual__external_type_in_crate_twin_sync__use_imported_struct_twin_sync_impl(ptr, rust_vec_len, data_len),
-1351 => wire__crate__api__pseudo_manual__array_twin_sync__use_msgid_twin_sync_impl(ptr, rust_vec_len, data_len),
+1241 => wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_system_time_before_epoch_twin_sync_impl(ptr, rust_vec_len, data_len),
+1244 => wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_system_time_twin_sync_impl(ptr, rust_vec_len, data_len),
+1254 => wire__crate__api__pseudo_manual__exception_twin_sync__stream_sink_throw_anyhow_twin_sync_impl(ptr, rust_vec_len, data_len),
+1259 => wire__crate__api__pseudo_manual__comment_twin_sync__struct_with_comments_twin_sync_instance_method_twin_sync_impl(ptr, rust_vec_len, data_len),
+1260 => wire__crate__api__pseudo_manual__comment_twin_sync__struct_with_comments_twin_sync_static_method_twin_sync_impl(ptr, rust_vec_len, data_len),
+1261 => wire__crate__api__misc_no_twin_example_a__struct_with_custom_name_method_twin_normal_method_with_custom_name_twin_normal_impl(ptr, rust_vec_len, data_len),
+1269 => wire__crate__api__pseudo_manual__method_twin_sync__sum_with_twin_sync_sum_twin_sync_impl(ptr, rust_vec_len, data_len),
+1270 => wire__crate__api__dart_opaque_sync__sync_accept_dart_opaque_twin_normal_impl(ptr, rust_vec_len, data_len),
+1271 => wire__crate__api__rust_opaque_sync__sync_create_non_clone_twin_normal_impl(ptr, rust_vec_len, data_len),
+1272 => wire__crate__api__rust_opaque_sync__sync_create_opaque_twin_normal_impl(ptr, rust_vec_len, data_len),
+1273 => wire__crate__api__dart_opaque_sync__sync_loopback_twin_normal_impl(ptr, rust_vec_len, data_len),
+1274 => wire__crate__api__dart_opaque_sync__sync_option_dart_opaque_twin_normal_impl(ptr, rust_vec_len, data_len),
+1275 => wire__crate__api__dart_opaque_sync__sync_option_loopback_twin_normal_impl(ptr, rust_vec_len, data_len),
+1276 => wire__crate__api__rust_opaque_sync__sync_option_rust_opaque_twin_normal_impl(ptr, rust_vec_len, data_len),
+1279 => wire__crate__api__pseudo_manual__misc_example_twin_sync__test_abc_enum_twin_sync_impl(ptr, rust_vec_len, data_len),
+1282 => wire__crate__api__pseudo_manual__chrono_type_twin_sync__test_chrono_twin_sync_impl(ptr, rust_vec_len, data_len),
+1285 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_contains_mirrored_sub_struct_twin_sync_impl(ptr, rust_vec_len, data_len),
+1289 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_fallible_of_raw_string_mirrored_twin_sync_impl(ptr, rust_vec_len, data_len),
+1292 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_hashmap_with_mirrored_value_twin_sync_impl(ptr, rust_vec_len, data_len),
+1295 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_list_of_nested_enums_mirrored_twin_sync_impl(ptr, rust_vec_len, data_len),
+1298 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_list_of_raw_nested_string_mirrored_twin_sync_impl(ptr, rust_vec_len, data_len),
+1301 => wire__crate__api__pseudo_manual__raw_string_twin_sync__test_more_than_just_one_raw_string_struct_twin_sync_impl(ptr, rust_vec_len, data_len),
+1304 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_nested_raw_string_mirrored_twin_sync_impl(ptr, rust_vec_len, data_len),
+1307 => wire__crate__api__pseudo_manual__chrono_type_twin_sync__test_precise_chrono_twin_sync_impl(ptr, rust_vec_len, data_len),
+1310 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_raw_string_enum_mirrored_twin_sync_impl(ptr, rust_vec_len, data_len),
+1313 => wire__crate__api__pseudo_manual__raw_string_twin_sync__test_raw_string_item_enum_twin_sync_impl(ptr, rust_vec_len, data_len),
+1316 => wire__crate__api__pseudo_manual__raw_string_twin_sync__test_raw_string_item_struct_twin_sync_impl(ptr, rust_vec_len, data_len),
+1319 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_raw_string_mirrored_twin_sync_impl(ptr, rust_vec_len, data_len),
+1322 => wire__crate__api__pseudo_manual__misc_example_twin_sync__test_struct_with_enum_twin_sync_impl(ptr, rust_vec_len, data_len),
+1325 => wire__crate__api__pseudo_manual__tuple_twin_sync__test_tuple_2_twin_sync_impl(ptr, rust_vec_len, data_len),
+1328 => wire__crate__api__pseudo_manual__tuple_twin_sync__test_tuple_twin_sync_impl(ptr, rust_vec_len, data_len),
+1331 => wire__crate__api__pseudo_manual__exception_twin_sync__throw_anyhow_twin_sync_impl(ptr, rust_vec_len, data_len),
+1334 => wire__crate__api__pseudo_manual__chrono_type_twin_sync__tokio_time_duration_twin_sync_impl(ptr, rust_vec_len, data_len),
+1337 => wire__crate__api__pseudo_manual__chrono_type_twin_sync__tokio_time_instant_twin_sync_impl(ptr, rust_vec_len, data_len),
+1339 => wire__crate__api__dart_opaque_sync__unwrap_dart_opaque_twin_normal_impl(ptr, rust_vec_len, data_len),
+1342 => wire__crate__api__pseudo_manual__rust_opaque_twin_sync__unwrap_rust_opaque_twin_sync_impl(ptr, rust_vec_len, data_len),
+1345 => wire__crate__api__pseudo_manual__array_twin_sync__use_boxed_blob_twin_sync_impl(ptr, rust_vec_len, data_len),
+1348 => wire__crate__api__pseudo_manual__external_type_in_crate_twin_sync__use_imported_enum_twin_sync_impl(ptr, rust_vec_len, data_len),
+1351 => wire__crate__api__pseudo_manual__external_type_in_crate_twin_sync__use_imported_struct_twin_sync_impl(ptr, rust_vec_len, data_len),
+1354 => wire__crate__api__pseudo_manual__array_twin_sync__use_msgid_twin_sync_impl(ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -46511,23 +46573,26 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<std::time::Duration>> for std:
 impl flutter_rust_bridge::IntoDart for FrbWrapper<std::time::Instant> {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         let value: i64 = {
+            let value = self.0;
             let now_instant = std::time::Instant::now();
             let now_system_time = std::time::SystemTime::now();
-            let system_time = if self.0 >= now_instant {
+            let system_time = if value >= now_instant {
                 now_system_time
-                    .checked_add(self.0.duration_since(now_instant))
+                    .checked_add(value.duration_since(now_instant))
                     .expect("instant out of range")
             } else {
                 now_system_time
-                    .checked_sub(now_instant.duration_since(self.0))
+                    .checked_sub(now_instant.duration_since(value))
                     .expect("instant out of range")
             };
-            system_time
-                .duration_since(std::time::SystemTime::UNIX_EPOCH)
-                .expect("time is before UNIX_EPOCH")
-                .as_micros()
-                .try_into()
-                .expect("cannot get microseconds from time")
+            match system_time.duration_since(std::time::SystemTime::UNIX_EPOCH) {
+                Ok(duration) => duration
+                    .as_micros()
+                    .try_into()
+                    .expect("cannot get microseconds from time"),
+                Err(error) => -i64::try_from(error.duration().as_micros())
+                    .expect("cannot get microseconds from time"),
+            }
         };
         value.into_dart()
     }
@@ -46544,13 +46609,14 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<std::time::Instant>> for std::
 // Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for FrbWrapper<std::time::SystemTime> {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        let value: i64 = self
-            .0
-            .duration_since(std::time::SystemTime::UNIX_EPOCH)
-            .expect("time is before UNIX_EPOCH")
-            .as_micros()
-            .try_into()
-            .expect("cannot get microseconds from time");
+        let value: i64 = match self.0.duration_since(std::time::SystemTime::UNIX_EPOCH) {
+            Ok(duration) => duration
+                .as_micros()
+                .try_into()
+                .expect("cannot get microseconds from time"),
+            Err(error) => -i64::try_from(error.duration().as_micros())
+                .expect("cannot get microseconds from time"),
+        };
         value.into_dart()
     }
 }
@@ -46569,23 +46635,26 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<std::time::SystemTime>>
 impl flutter_rust_bridge::IntoDart for FrbWrapper<tokio::time::Instant> {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         let value: i64 = {
+            let value = self.0.into_std();
             let now_instant = std::time::Instant::now();
             let now_system_time = std::time::SystemTime::now();
-            let system_time = if self.0.into_std() >= now_instant {
+            let system_time = if value >= now_instant {
                 now_system_time
-                    .checked_add(self.0.into_std().duration_since(now_instant))
+                    .checked_add(value.duration_since(now_instant))
                     .expect("instant out of range")
             } else {
                 now_system_time
-                    .checked_sub(now_instant.duration_since(self.0.into_std()))
+                    .checked_sub(now_instant.duration_since(value))
                     .expect("instant out of range")
             };
-            system_time
-                .duration_since(std::time::SystemTime::UNIX_EPOCH)
-                .expect("time is before UNIX_EPOCH")
-                .as_micros()
-                .try_into()
-                .expect("cannot get microseconds from time")
+            match system_time.duration_since(std::time::SystemTime::UNIX_EPOCH) {
+                Ok(duration) => duration
+                    .as_micros()
+                    .try_into()
+                    .expect("cannot get microseconds from time"),
+                Err(error) => -i64::try_from(error.duration().as_micros())
+                    .expect("cannot get microseconds from time"),
+            }
         };
         value.into_dart()
     }
@@ -56829,23 +56898,26 @@ impl SseEncode for std::time::Instant {
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <i64>::sse_encode(
             {
+                let value = self;
                 let now_instant = std::time::Instant::now();
                 let now_system_time = std::time::SystemTime::now();
-                let system_time = if self >= now_instant {
+                let system_time = if value >= now_instant {
                     now_system_time
-                        .checked_add(self.duration_since(now_instant))
+                        .checked_add(value.duration_since(now_instant))
                         .expect("instant out of range")
                 } else {
                     now_system_time
-                        .checked_sub(now_instant.duration_since(self))
+                        .checked_sub(now_instant.duration_since(value))
                         .expect("instant out of range")
                 };
-                system_time
-                    .duration_since(std::time::SystemTime::UNIX_EPOCH)
-                    .expect("time is before UNIX_EPOCH")
-                    .as_micros()
-                    .try_into()
-                    .expect("cannot get microseconds from time")
+                match system_time.duration_since(std::time::SystemTime::UNIX_EPOCH) {
+                    Ok(duration) => duration
+                        .as_micros()
+                        .try_into()
+                        .expect("cannot get microseconds from time"),
+                    Err(error) => -i64::try_from(error.duration().as_micros())
+                        .expect("cannot get microseconds from time"),
+                }
             },
             serializer,
         );
@@ -56856,11 +56928,14 @@ impl SseEncode for std::time::SystemTime {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <i64>::sse_encode(
-            self.duration_since(std::time::SystemTime::UNIX_EPOCH)
-                .expect("time is before UNIX_EPOCH")
-                .as_micros()
-                .try_into()
-                .expect("cannot get microseconds from time"),
+            match self.duration_since(std::time::SystemTime::UNIX_EPOCH) {
+                Ok(duration) => duration
+                    .as_micros()
+                    .try_into()
+                    .expect("cannot get microseconds from time"),
+                Err(error) => -i64::try_from(error.duration().as_micros())
+                    .expect("cannot get microseconds from time"),
+            },
             serializer,
         );
     }
@@ -57194,23 +57269,26 @@ impl SseEncode for tokio::time::Instant {
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <i64>::sse_encode(
             {
+                let value = self.into_std();
                 let now_instant = std::time::Instant::now();
                 let now_system_time = std::time::SystemTime::now();
-                let system_time = if self.into_std() >= now_instant {
+                let system_time = if value >= now_instant {
                     now_system_time
-                        .checked_add(self.into_std().duration_since(now_instant))
+                        .checked_add(value.duration_since(now_instant))
                         .expect("instant out of range")
                 } else {
                     now_system_time
-                        .checked_sub(now_instant.duration_since(self.into_std()))
+                        .checked_sub(now_instant.duration_since(value))
                         .expect("instant out of range")
                 };
-                system_time
-                    .duration_since(std::time::SystemTime::UNIX_EPOCH)
-                    .expect("time is before UNIX_EPOCH")
-                    .as_micros()
-                    .try_into()
-                    .expect("cannot get microseconds from time")
+                match system_time.duration_since(std::time::SystemTime::UNIX_EPOCH) {
+                    Ok(duration) => duration
+                        .as_micros()
+                        .try_into()
+                        .expect("cannot get microseconds from time"),
+                    Err(error) => -i64::try_from(error.duration().as_micros())
+                        .expect("cannot get microseconds from time"),
+                }
             },
             serializer,
         );

--- a/frb_example/pure_dart_pde/rust/src/frb_generated.rs
+++ b/frb_example/pure_dart_pde/rust/src/frb_generated.rs
@@ -75,7 +75,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1020479450;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 415027099;
 
 // Section: executor
 
@@ -28720,6 +28720,237 @@ fn wire__crate__api__pseudo_manual__method_twin_sync__static_only_twin_sync_stat
                      let output_ok = Result::<_,()>::Ok(crate::api::pseudo_manual::method_twin_sync::StaticOnlyTwinSync::static_method_twin_sync(api_a))?;   Ok(output_ok)
                 })()) })
 }
+fn wire__crate__api__chrono_type__std_time_duration_twin_normal_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "std_time_duration_twin_normal",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_d = <std::time::Duration>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, ()>((move || {
+                    let output_ok = Result::<_, ()>::Ok(
+                        crate::api::chrono_type::std_time_duration_twin_normal(api_d),
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_duration_twin_rust_async_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec,_,_,_>(flutter_rust_bridge::for_generated::TaskInfo{ debug_name: "std_time_duration_twin_rust_async", port: Some(port_), mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal }, move || {
+            let message = unsafe { flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(ptr_, rust_vec_len_, data_len_) };
+            let mut deserializer = flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_d = <std::time::Duration>::sse_decode(&mut deserializer);deserializer.end(); move |context| async move {
+                    transform_result_sse::<_, ()>((move || async move {
+                         let output_ok = Result::<_,()>::Ok(crate::api::pseudo_manual::chrono_type_twin_rust_async::std_time_duration_twin_rust_async(api_d).await)?;   Ok(output_ok)
+                    })().await)
+                } })
+}
+fn wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_duration_twin_sync_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "std_time_duration_twin_sync",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_d = <std::time::Duration>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok(
+                    crate::api::pseudo_manual::chrono_type_twin_sync::std_time_duration_twin_sync(
+                        api_d,
+                    ),
+                )?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__chrono_type__std_time_instant_twin_normal_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "std_time_instant_twin_normal",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_d = <std::time::Instant>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, ()>((move || {
+                    let output_ok = Result::<_, ()>::Ok(
+                        crate::api::chrono_type::std_time_instant_twin_normal(api_d),
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_instant_twin_rust_async_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec,_,_,_>(flutter_rust_bridge::for_generated::TaskInfo{ debug_name: "std_time_instant_twin_rust_async", port: Some(port_), mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal }, move || {
+            let message = unsafe { flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(ptr_, rust_vec_len_, data_len_) };
+            let mut deserializer = flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_d = <std::time::Instant>::sse_decode(&mut deserializer);deserializer.end(); move |context| async move {
+                    transform_result_sse::<_, ()>((move || async move {
+                         let output_ok = Result::<_,()>::Ok(crate::api::pseudo_manual::chrono_type_twin_rust_async::std_time_instant_twin_rust_async(api_d).await)?;   Ok(output_ok)
+                    })().await)
+                } })
+}
+fn wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_instant_twin_sync_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "std_time_instant_twin_sync",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_d = <std::time::Instant>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok(
+                    crate::api::pseudo_manual::chrono_type_twin_sync::std_time_instant_twin_sync(
+                        api_d,
+                    ),
+                )?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__chrono_type__std_time_system_time_twin_normal_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "std_time_system_time_twin_normal",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_d = <std::time::SystemTime>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, ()>((move || {
+                    let output_ok = Result::<_, ()>::Ok(
+                        crate::api::chrono_type::std_time_system_time_twin_normal(api_d),
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_system_time_twin_rust_async_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec,_,_,_>(flutter_rust_bridge::for_generated::TaskInfo{ debug_name: "std_time_system_time_twin_rust_async", port: Some(port_), mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal }, move || {
+            let message = unsafe { flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(ptr_, rust_vec_len_, data_len_) };
+            let mut deserializer = flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_d = <std::time::SystemTime>::sse_decode(&mut deserializer);deserializer.end(); move |context| async move {
+                    transform_result_sse::<_, ()>((move || async move {
+                         let output_ok = Result::<_,()>::Ok(crate::api::pseudo_manual::chrono_type_twin_rust_async::std_time_system_time_twin_rust_async(api_d).await)?;   Ok(output_ok)
+                    })().await)
+                } })
+}
+fn wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_system_time_twin_sync_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec,_>(flutter_rust_bridge::for_generated::TaskInfo{ debug_name: "std_time_system_time_twin_sync", port: None, mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync }, move || {
+            let message = unsafe { flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(ptr_, rust_vec_len_, data_len_) };
+            let mut deserializer = flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_d = <std::time::SystemTime>::sse_decode(&mut deserializer);deserializer.end();
+                transform_result_sse::<_, ()>((move || {
+                     let output_ok = Result::<_,()>::Ok(crate::api::pseudo_manual::chrono_type_twin_sync::std_time_system_time_twin_sync(api_d))?;   Ok(output_ok)
+                })()) })
+}
 fn wire__crate__api__stream_misc__stream_sink_dart_async_twin_normal_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -30773,6 +31004,174 @@ fn wire__crate__api__pseudo_manual__exception_twin_sync__throw_anyhow_twin_sync_
                     Ok(output_ok)
                 })(),
             )
+        },
+    )
+}
+fn wire__crate__api__chrono_type__tokio_time_duration_twin_normal_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "tokio_time_duration_twin_normal",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_d = <std::time::Duration>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, ()>((move || {
+                    let output_ok = Result::<_, ()>::Ok(
+                        crate::api::chrono_type::tokio_time_duration_twin_normal(api_d),
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__tokio_time_duration_twin_rust_async_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec,_,_,_>(flutter_rust_bridge::for_generated::TaskInfo{ debug_name: "tokio_time_duration_twin_rust_async", port: Some(port_), mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal }, move || {
+            let message = unsafe { flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(ptr_, rust_vec_len_, data_len_) };
+            let mut deserializer = flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_d = <std::time::Duration>::sse_decode(&mut deserializer);deserializer.end(); move |context| async move {
+                    transform_result_sse::<_, ()>((move || async move {
+                         let output_ok = Result::<_,()>::Ok(crate::api::pseudo_manual::chrono_type_twin_rust_async::tokio_time_duration_twin_rust_async(api_d).await)?;   Ok(output_ok)
+                    })().await)
+                } })
+}
+fn wire__crate__api__pseudo_manual__chrono_type_twin_sync__tokio_time_duration_twin_sync_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "tokio_time_duration_twin_sync",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_d = <std::time::Duration>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok(
+                    crate::api::pseudo_manual::chrono_type_twin_sync::tokio_time_duration_twin_sync(
+                        api_d,
+                    ),
+                )?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__chrono_type__tokio_time_instant_twin_normal_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "tokio_time_instant_twin_normal",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_d = <tokio::time::Instant>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, ()>((move || {
+                    let output_ok = Result::<_, ()>::Ok(
+                        crate::api::chrono_type::tokio_time_instant_twin_normal(api_d),
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__tokio_time_instant_twin_rust_async_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec,_,_,_>(flutter_rust_bridge::for_generated::TaskInfo{ debug_name: "tokio_time_instant_twin_rust_async", port: Some(port_), mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal }, move || {
+            let message = unsafe { flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(ptr_, rust_vec_len_, data_len_) };
+            let mut deserializer = flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_d = <tokio::time::Instant>::sse_decode(&mut deserializer);deserializer.end(); move |context| async move {
+                    transform_result_sse::<_, ()>((move || async move {
+                         let output_ok = Result::<_,()>::Ok(crate::api::pseudo_manual::chrono_type_twin_rust_async::tokio_time_instant_twin_rust_async(api_d).await)?;   Ok(output_ok)
+                    })().await)
+                } })
+}
+fn wire__crate__api__pseudo_manual__chrono_type_twin_sync__tokio_time_instant_twin_sync_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "tokio_time_instant_twin_sync",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_d = <tokio::time::Instant>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok(
+                    crate::api::pseudo_manual::chrono_type_twin_sync::tokio_time_instant_twin_sync(
+                        api_d,
+                    ),
+                )?;
+                Ok(output_ok)
+            })())
         },
     )
 }
@@ -34698,6 +35097,75 @@ impl SseDecode for std::collections::HashSet<i32> {
     }
 }
 
+impl SseDecode for std::time::Duration {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <i64>::sse_decode(deserializer);
+        return std::time::Duration::from_micros(
+            inner
+                .try_into()
+                .expect("negative duration is not valid for std::time::Duration"),
+        );
+    }
+}
+
+impl SseDecode for std::time::Instant {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <i64>::sse_decode(deserializer);
+        return {
+            let now_system_time = std::time::SystemTime::now();
+            let now_instant = std::time::Instant::now();
+            let target_system_time = if inner >= 0 {
+                std::time::SystemTime::UNIX_EPOCH
+                    .checked_add(std::time::Duration::from_micros(
+                        inner.try_into().expect("invalid timestamp"),
+                    ))
+                    .expect("timestamp out of range")
+            } else {
+                std::time::SystemTime::UNIX_EPOCH
+                    .checked_sub(std::time::Duration::from_micros(inner.unsigned_abs()))
+                    .expect("timestamp out of range")
+            };
+            if target_system_time >= now_system_time {
+                now_instant
+                    .checked_add(
+                        target_system_time
+                            .duration_since(now_system_time)
+                            .expect("invalid timestamp"),
+                    )
+                    .expect("instant out of range")
+            } else {
+                now_instant
+                    .checked_sub(
+                        now_system_time
+                            .duration_since(target_system_time)
+                            .expect("invalid timestamp"),
+                    )
+                    .expect("instant out of range")
+            }
+        };
+    }
+}
+
+impl SseDecode for std::time::SystemTime {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <i64>::sse_decode(deserializer);
+        return if inner >= 0 {
+            std::time::SystemTime::UNIX_EPOCH
+                .checked_add(std::time::Duration::from_micros(
+                    inner.try_into().expect("invalid timestamp"),
+                ))
+                .expect("timestamp out of range")
+        } else {
+            std::time::SystemTime::UNIX_EPOCH
+                .checked_sub(std::time::Duration::from_micros(inner.unsigned_abs()))
+                .expect("timestamp out of range")
+        };
+    }
+}
+
 impl SseDecode
     for StreamSink<NonCloneSimpleTwinNormal, flutter_rust_bridge::for_generated::SseCodec>
 {
@@ -35048,6 +35516,45 @@ impl SseDecode for String {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut inner = <Vec<u8>>::sse_decode(deserializer);
         return String::from_utf8(inner).unwrap();
+    }
+}
+
+impl SseDecode for tokio::time::Instant {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <i64>::sse_decode(deserializer);
+        return tokio::time::Instant::from_std({
+            let now_system_time = std::time::SystemTime::now();
+            let now_instant = std::time::Instant::now();
+            let target_system_time = if inner >= 0 {
+                std::time::SystemTime::UNIX_EPOCH
+                    .checked_add(std::time::Duration::from_micros(
+                        inner.try_into().expect("invalid timestamp"),
+                    ))
+                    .expect("timestamp out of range")
+            } else {
+                std::time::SystemTime::UNIX_EPOCH
+                    .checked_sub(std::time::Duration::from_micros(inner.unsigned_abs()))
+                    .expect("timestamp out of range")
+            };
+            if target_system_time >= now_system_time {
+                now_instant
+                    .checked_add(
+                        target_system_time
+                            .duration_since(now_system_time)
+                            .expect("invalid timestamp"),
+                    )
+                    .expect("instant out of range")
+            } else {
+                now_instant
+                    .checked_sub(
+                        now_system_time
+                            .duration_since(target_system_time)
+                            .expect("invalid timestamp"),
+                    )
+                    .expect("instant out of range")
+            }
+        });
     }
 }
 
@@ -44207,74 +44714,84 @@ fn pde_ffi_dispatcher_primary_impl(
 1224 => wire__crate__api__pseudo_manual__exception_twin_rust_async__some_struct_twin_rust_async_static_return_ok_custom_error_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
 1230 => wire__crate__api__method__static_only_twin_normal_static_method_twin_normal_impl(port, ptr, rust_vec_len, data_len),
 1231 => wire__crate__api__pseudo_manual__method_twin_rust_async__static_only_twin_rust_async_static_method_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1233 => wire__crate__api__stream_misc__stream_sink_dart_async_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1234 => wire__crate__api__stream__stream_sink_fixed_sized_primitive_array_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1235 => wire__crate__api__pseudo_manual__stream_twin_rust_async__stream_sink_fixed_sized_primitive_array_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1236 => wire__crate__api__stream__stream_sink_inside_struct_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1237 => wire__crate__api__pseudo_manual__stream_twin_rust_async__stream_sink_inside_struct_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1238 => wire__crate__api__stream__stream_sink_inside_vec_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1239 => wire__crate__api__pseudo_manual__stream_twin_rust_async__stream_sink_inside_vec_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1240 => wire__crate__api__exception__stream_sink_throw_anyhow_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1241 => wire__crate__api__pseudo_manual__exception_twin_rust_async__stream_sink_throw_anyhow_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1243 => wire__crate__api__comment__struct_with_comments_twin_normal_instance_method_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1244 => wire__crate__api__comment__struct_with_comments_twin_normal_static_method_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1245 => wire__crate__api__pseudo_manual__comment_twin_rust_async__struct_with_comments_twin_rust_async_instance_method_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1246 => wire__crate__api__pseudo_manual__comment_twin_rust_async__struct_with_comments_twin_rust_async_static_method_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1250 => wire__crate__api__misc_no_twin_example_a__struct_with_impl_block_in_another_file_f_impl(port, ptr, rust_vec_len, data_len),
-1251 => wire__crate__api__misc_no_twin_example_a__struct_with_raw_name_field_dummy_function_impl(port, ptr, rust_vec_len, data_len),
-1252 => wire__crate__api__misc_no_twin_example_a__struct_with_rust_auto_opaque_field_with_many_derive_default_impl(port, ptr, rust_vec_len, data_len),
-1253 => wire__crate__api__misc_no_twin_example_a__struct_with_rust_auto_opaque_field_with_many_derive_f_impl(port, ptr, rust_vec_len, data_len),
-1254 => wire__crate__api__misc_no_twin_example_a__struct_with_rust_auto_opaque_with_non_clone_data_f_impl(port, ptr, rust_vec_len, data_len),
-1255 => wire__crate__api__method__sum_with_twin_normal_sum_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1256 => wire__crate__api__pseudo_manual__method_twin_rust_async__sum_with_twin_rust_async_sum_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1265 => wire__crate__api__misc_example__test_abc_enum_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1266 => wire__crate__api__pseudo_manual__misc_example_twin_rust_async__test_abc_enum_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1268 => wire__crate__api__chrono_type__test_chrono_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1269 => wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__test_chrono_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1271 => wire__crate__api__mirror__test_contains_mirrored_sub_struct_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1272 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_contains_mirrored_sub_struct_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1274 => wire__crate__api__deliberate_name_conflict__test_duplicated_module_names_impl(port, ptr, rust_vec_len, data_len),
-1275 => wire__crate__api__mirror__test_fallible_of_raw_string_mirrored_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1276 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_fallible_of_raw_string_mirrored_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1278 => wire__crate__api__mirror__test_hashmap_with_mirrored_value_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1279 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_hashmap_with_mirrored_value_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1281 => wire__crate__api__mirror__test_list_of_nested_enums_mirrored_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1282 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_list_of_nested_enums_mirrored_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1284 => wire__crate__api__mirror__test_list_of_raw_nested_string_mirrored_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1285 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_list_of_raw_nested_string_mirrored_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1287 => wire__crate__api__raw_string__test_more_than_just_one_raw_string_struct_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1288 => wire__crate__api__pseudo_manual__raw_string_twin_rust_async__test_more_than_just_one_raw_string_struct_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1290 => wire__crate__api__mirror__test_nested_raw_string_mirrored_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1291 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_nested_raw_string_mirrored_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1293 => wire__crate__api__chrono_type__test_precise_chrono_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1294 => wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__test_precise_chrono_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1296 => wire__crate__api__mirror__test_raw_string_enum_mirrored_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1297 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_raw_string_enum_mirrored_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1299 => wire__crate__api__raw_string__test_raw_string_item_enum_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1300 => wire__crate__api__pseudo_manual__raw_string_twin_rust_async__test_raw_string_item_enum_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1302 => wire__crate__api__raw_string__test_raw_string_item_struct_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1303 => wire__crate__api__pseudo_manual__raw_string_twin_rust_async__test_raw_string_item_struct_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1305 => wire__crate__api__mirror__test_raw_string_mirrored_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1306 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_raw_string_mirrored_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1308 => wire__crate__api__misc_example__test_struct_with_enum_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1309 => wire__crate__api__pseudo_manual__misc_example_twin_rust_async__test_struct_with_enum_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1311 => wire__crate__api__tuple__test_tuple_2_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1312 => wire__crate__api__pseudo_manual__tuple_twin_rust_async__test_tuple_2_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1314 => wire__crate__api__tuple__test_tuple_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1315 => wire__crate__api__pseudo_manual__tuple_twin_rust_async__test_tuple_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1317 => wire__crate__api__exception__throw_anyhow_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1318 => wire__crate__api__pseudo_manual__exception_twin_rust_async__throw_anyhow_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1320 => wire__crate__api__dart_code__translatable_struct_with_dart_code_twin_normal_normal_method_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1322 => wire__crate__api__rust_opaque__unwrap_rust_opaque_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1323 => wire__crate__api__pseudo_manual__rust_opaque_twin_rust_async__unwrap_rust_opaque_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1325 => wire__crate__api__array__use_boxed_blob_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1326 => wire__crate__api__pseudo_manual__array_twin_rust_async__use_boxed_blob_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1328 => wire__crate__api__external_type_in_crate__use_imported_enum_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1329 => wire__crate__api__pseudo_manual__external_type_in_crate_twin_rust_async__use_imported_enum_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1331 => wire__crate__api__external_type_in_crate__use_imported_struct_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1332 => wire__crate__api__pseudo_manual__external_type_in_crate_twin_rust_async__use_imported_struct_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
-1334 => wire__crate__api__array__use_msgid_twin_normal_impl(port, ptr, rust_vec_len, data_len),
-1335 => wire__crate__api__pseudo_manual__array_twin_rust_async__use_msgid_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1233 => wire__crate__api__chrono_type__std_time_duration_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1234 => wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_duration_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1236 => wire__crate__api__chrono_type__std_time_instant_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1237 => wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_instant_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1239 => wire__crate__api__chrono_type__std_time_system_time_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1240 => wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__std_time_system_time_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1242 => wire__crate__api__stream_misc__stream_sink_dart_async_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1243 => wire__crate__api__stream__stream_sink_fixed_sized_primitive_array_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1244 => wire__crate__api__pseudo_manual__stream_twin_rust_async__stream_sink_fixed_sized_primitive_array_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1245 => wire__crate__api__stream__stream_sink_inside_struct_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1246 => wire__crate__api__pseudo_manual__stream_twin_rust_async__stream_sink_inside_struct_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1247 => wire__crate__api__stream__stream_sink_inside_vec_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1248 => wire__crate__api__pseudo_manual__stream_twin_rust_async__stream_sink_inside_vec_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1249 => wire__crate__api__exception__stream_sink_throw_anyhow_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1250 => wire__crate__api__pseudo_manual__exception_twin_rust_async__stream_sink_throw_anyhow_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1252 => wire__crate__api__comment__struct_with_comments_twin_normal_instance_method_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1253 => wire__crate__api__comment__struct_with_comments_twin_normal_static_method_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1254 => wire__crate__api__pseudo_manual__comment_twin_rust_async__struct_with_comments_twin_rust_async_instance_method_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1255 => wire__crate__api__pseudo_manual__comment_twin_rust_async__struct_with_comments_twin_rust_async_static_method_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1259 => wire__crate__api__misc_no_twin_example_a__struct_with_impl_block_in_another_file_f_impl(port, ptr, rust_vec_len, data_len),
+1260 => wire__crate__api__misc_no_twin_example_a__struct_with_raw_name_field_dummy_function_impl(port, ptr, rust_vec_len, data_len),
+1261 => wire__crate__api__misc_no_twin_example_a__struct_with_rust_auto_opaque_field_with_many_derive_default_impl(port, ptr, rust_vec_len, data_len),
+1262 => wire__crate__api__misc_no_twin_example_a__struct_with_rust_auto_opaque_field_with_many_derive_f_impl(port, ptr, rust_vec_len, data_len),
+1263 => wire__crate__api__misc_no_twin_example_a__struct_with_rust_auto_opaque_with_non_clone_data_f_impl(port, ptr, rust_vec_len, data_len),
+1264 => wire__crate__api__method__sum_with_twin_normal_sum_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1265 => wire__crate__api__pseudo_manual__method_twin_rust_async__sum_with_twin_rust_async_sum_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1274 => wire__crate__api__misc_example__test_abc_enum_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1275 => wire__crate__api__pseudo_manual__misc_example_twin_rust_async__test_abc_enum_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1277 => wire__crate__api__chrono_type__test_chrono_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1278 => wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__test_chrono_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1280 => wire__crate__api__mirror__test_contains_mirrored_sub_struct_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1281 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_contains_mirrored_sub_struct_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1283 => wire__crate__api__deliberate_name_conflict__test_duplicated_module_names_impl(port, ptr, rust_vec_len, data_len),
+1284 => wire__crate__api__mirror__test_fallible_of_raw_string_mirrored_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1285 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_fallible_of_raw_string_mirrored_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1287 => wire__crate__api__mirror__test_hashmap_with_mirrored_value_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1288 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_hashmap_with_mirrored_value_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1290 => wire__crate__api__mirror__test_list_of_nested_enums_mirrored_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1291 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_list_of_nested_enums_mirrored_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1293 => wire__crate__api__mirror__test_list_of_raw_nested_string_mirrored_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1294 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_list_of_raw_nested_string_mirrored_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1296 => wire__crate__api__raw_string__test_more_than_just_one_raw_string_struct_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1297 => wire__crate__api__pseudo_manual__raw_string_twin_rust_async__test_more_than_just_one_raw_string_struct_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1299 => wire__crate__api__mirror__test_nested_raw_string_mirrored_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1300 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_nested_raw_string_mirrored_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1302 => wire__crate__api__chrono_type__test_precise_chrono_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1303 => wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__test_precise_chrono_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1305 => wire__crate__api__mirror__test_raw_string_enum_mirrored_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1306 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_raw_string_enum_mirrored_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1308 => wire__crate__api__raw_string__test_raw_string_item_enum_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1309 => wire__crate__api__pseudo_manual__raw_string_twin_rust_async__test_raw_string_item_enum_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1311 => wire__crate__api__raw_string__test_raw_string_item_struct_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1312 => wire__crate__api__pseudo_manual__raw_string_twin_rust_async__test_raw_string_item_struct_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1314 => wire__crate__api__mirror__test_raw_string_mirrored_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1315 => wire__crate__api__pseudo_manual__mirror_twin_rust_async__test_raw_string_mirrored_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1317 => wire__crate__api__misc_example__test_struct_with_enum_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1318 => wire__crate__api__pseudo_manual__misc_example_twin_rust_async__test_struct_with_enum_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1320 => wire__crate__api__tuple__test_tuple_2_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1321 => wire__crate__api__pseudo_manual__tuple_twin_rust_async__test_tuple_2_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1323 => wire__crate__api__tuple__test_tuple_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1324 => wire__crate__api__pseudo_manual__tuple_twin_rust_async__test_tuple_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1326 => wire__crate__api__exception__throw_anyhow_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1327 => wire__crate__api__pseudo_manual__exception_twin_rust_async__throw_anyhow_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1329 => wire__crate__api__chrono_type__tokio_time_duration_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1330 => wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__tokio_time_duration_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1332 => wire__crate__api__chrono_type__tokio_time_instant_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1333 => wire__crate__api__pseudo_manual__chrono_type_twin_rust_async__tokio_time_instant_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1335 => wire__crate__api__dart_code__translatable_struct_with_dart_code_twin_normal_normal_method_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1337 => wire__crate__api__rust_opaque__unwrap_rust_opaque_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1338 => wire__crate__api__pseudo_manual__rust_opaque_twin_rust_async__unwrap_rust_opaque_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1340 => wire__crate__api__array__use_boxed_blob_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1341 => wire__crate__api__pseudo_manual__array_twin_rust_async__use_boxed_blob_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1343 => wire__crate__api__external_type_in_crate__use_imported_enum_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1344 => wire__crate__api__pseudo_manual__external_type_in_crate_twin_rust_async__use_imported_enum_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1346 => wire__crate__api__external_type_in_crate__use_imported_struct_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1347 => wire__crate__api__pseudo_manual__external_type_in_crate_twin_rust_async__use_imported_struct_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
+1349 => wire__crate__api__array__use_msgid_twin_normal_impl(port, ptr, rust_vec_len, data_len),
+1350 => wire__crate__api__pseudo_manual__array_twin_rust_async__use_msgid_twin_rust_async_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -44688,42 +45205,47 @@ fn pde_ffi_dispatcher_sync_impl(
 1228 => wire__crate__api__pseudo_manual__exception_twin_sync__some_struct_twin_sync_static_return_err_custom_error_twin_sync_impl(ptr, rust_vec_len, data_len),
 1229 => wire__crate__api__pseudo_manual__exception_twin_sync__some_struct_twin_sync_static_return_ok_custom_error_twin_sync_impl(ptr, rust_vec_len, data_len),
 1232 => wire__crate__api__pseudo_manual__method_twin_sync__static_only_twin_sync_static_method_twin_sync_impl(ptr, rust_vec_len, data_len),
-1242 => wire__crate__api__pseudo_manual__exception_twin_sync__stream_sink_throw_anyhow_twin_sync_impl(ptr, rust_vec_len, data_len),
-1247 => wire__crate__api__pseudo_manual__comment_twin_sync__struct_with_comments_twin_sync_instance_method_twin_sync_impl(ptr, rust_vec_len, data_len),
-1248 => wire__crate__api__pseudo_manual__comment_twin_sync__struct_with_comments_twin_sync_static_method_twin_sync_impl(ptr, rust_vec_len, data_len),
-1249 => wire__crate__api__misc_no_twin_example_a__struct_with_custom_name_method_twin_normal_method_with_custom_name_twin_normal_impl(ptr, rust_vec_len, data_len),
-1257 => wire__crate__api__pseudo_manual__method_twin_sync__sum_with_twin_sync_sum_twin_sync_impl(ptr, rust_vec_len, data_len),
-1258 => wire__crate__api__dart_opaque_sync__sync_accept_dart_opaque_twin_normal_impl(ptr, rust_vec_len, data_len),
-1259 => wire__crate__api__rust_opaque_sync__sync_create_non_clone_twin_normal_impl(ptr, rust_vec_len, data_len),
-1260 => wire__crate__api__rust_opaque_sync__sync_create_opaque_twin_normal_impl(ptr, rust_vec_len, data_len),
-1261 => wire__crate__api__dart_opaque_sync__sync_loopback_twin_normal_impl(ptr, rust_vec_len, data_len),
-1262 => wire__crate__api__dart_opaque_sync__sync_option_dart_opaque_twin_normal_impl(ptr, rust_vec_len, data_len),
-1263 => wire__crate__api__dart_opaque_sync__sync_option_loopback_twin_normal_impl(ptr, rust_vec_len, data_len),
-1264 => wire__crate__api__rust_opaque_sync__sync_option_rust_opaque_twin_normal_impl(ptr, rust_vec_len, data_len),
-1267 => wire__crate__api__pseudo_manual__misc_example_twin_sync__test_abc_enum_twin_sync_impl(ptr, rust_vec_len, data_len),
-1270 => wire__crate__api__pseudo_manual__chrono_type_twin_sync__test_chrono_twin_sync_impl(ptr, rust_vec_len, data_len),
-1273 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_contains_mirrored_sub_struct_twin_sync_impl(ptr, rust_vec_len, data_len),
-1277 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_fallible_of_raw_string_mirrored_twin_sync_impl(ptr, rust_vec_len, data_len),
-1280 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_hashmap_with_mirrored_value_twin_sync_impl(ptr, rust_vec_len, data_len),
-1283 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_list_of_nested_enums_mirrored_twin_sync_impl(ptr, rust_vec_len, data_len),
-1286 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_list_of_raw_nested_string_mirrored_twin_sync_impl(ptr, rust_vec_len, data_len),
-1289 => wire__crate__api__pseudo_manual__raw_string_twin_sync__test_more_than_just_one_raw_string_struct_twin_sync_impl(ptr, rust_vec_len, data_len),
-1292 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_nested_raw_string_mirrored_twin_sync_impl(ptr, rust_vec_len, data_len),
-1295 => wire__crate__api__pseudo_manual__chrono_type_twin_sync__test_precise_chrono_twin_sync_impl(ptr, rust_vec_len, data_len),
-1298 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_raw_string_enum_mirrored_twin_sync_impl(ptr, rust_vec_len, data_len),
-1301 => wire__crate__api__pseudo_manual__raw_string_twin_sync__test_raw_string_item_enum_twin_sync_impl(ptr, rust_vec_len, data_len),
-1304 => wire__crate__api__pseudo_manual__raw_string_twin_sync__test_raw_string_item_struct_twin_sync_impl(ptr, rust_vec_len, data_len),
-1307 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_raw_string_mirrored_twin_sync_impl(ptr, rust_vec_len, data_len),
-1310 => wire__crate__api__pseudo_manual__misc_example_twin_sync__test_struct_with_enum_twin_sync_impl(ptr, rust_vec_len, data_len),
-1313 => wire__crate__api__pseudo_manual__tuple_twin_sync__test_tuple_2_twin_sync_impl(ptr, rust_vec_len, data_len),
-1316 => wire__crate__api__pseudo_manual__tuple_twin_sync__test_tuple_twin_sync_impl(ptr, rust_vec_len, data_len),
-1319 => wire__crate__api__pseudo_manual__exception_twin_sync__throw_anyhow_twin_sync_impl(ptr, rust_vec_len, data_len),
-1321 => wire__crate__api__dart_opaque_sync__unwrap_dart_opaque_twin_normal_impl(ptr, rust_vec_len, data_len),
-1324 => wire__crate__api__pseudo_manual__rust_opaque_twin_sync__unwrap_rust_opaque_twin_sync_impl(ptr, rust_vec_len, data_len),
-1327 => wire__crate__api__pseudo_manual__array_twin_sync__use_boxed_blob_twin_sync_impl(ptr, rust_vec_len, data_len),
-1330 => wire__crate__api__pseudo_manual__external_type_in_crate_twin_sync__use_imported_enum_twin_sync_impl(ptr, rust_vec_len, data_len),
-1333 => wire__crate__api__pseudo_manual__external_type_in_crate_twin_sync__use_imported_struct_twin_sync_impl(ptr, rust_vec_len, data_len),
-1336 => wire__crate__api__pseudo_manual__array_twin_sync__use_msgid_twin_sync_impl(ptr, rust_vec_len, data_len),
+1235 => wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_duration_twin_sync_impl(ptr, rust_vec_len, data_len),
+1238 => wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_instant_twin_sync_impl(ptr, rust_vec_len, data_len),
+1241 => wire__crate__api__pseudo_manual__chrono_type_twin_sync__std_time_system_time_twin_sync_impl(ptr, rust_vec_len, data_len),
+1251 => wire__crate__api__pseudo_manual__exception_twin_sync__stream_sink_throw_anyhow_twin_sync_impl(ptr, rust_vec_len, data_len),
+1256 => wire__crate__api__pseudo_manual__comment_twin_sync__struct_with_comments_twin_sync_instance_method_twin_sync_impl(ptr, rust_vec_len, data_len),
+1257 => wire__crate__api__pseudo_manual__comment_twin_sync__struct_with_comments_twin_sync_static_method_twin_sync_impl(ptr, rust_vec_len, data_len),
+1258 => wire__crate__api__misc_no_twin_example_a__struct_with_custom_name_method_twin_normal_method_with_custom_name_twin_normal_impl(ptr, rust_vec_len, data_len),
+1266 => wire__crate__api__pseudo_manual__method_twin_sync__sum_with_twin_sync_sum_twin_sync_impl(ptr, rust_vec_len, data_len),
+1267 => wire__crate__api__dart_opaque_sync__sync_accept_dart_opaque_twin_normal_impl(ptr, rust_vec_len, data_len),
+1268 => wire__crate__api__rust_opaque_sync__sync_create_non_clone_twin_normal_impl(ptr, rust_vec_len, data_len),
+1269 => wire__crate__api__rust_opaque_sync__sync_create_opaque_twin_normal_impl(ptr, rust_vec_len, data_len),
+1270 => wire__crate__api__dart_opaque_sync__sync_loopback_twin_normal_impl(ptr, rust_vec_len, data_len),
+1271 => wire__crate__api__dart_opaque_sync__sync_option_dart_opaque_twin_normal_impl(ptr, rust_vec_len, data_len),
+1272 => wire__crate__api__dart_opaque_sync__sync_option_loopback_twin_normal_impl(ptr, rust_vec_len, data_len),
+1273 => wire__crate__api__rust_opaque_sync__sync_option_rust_opaque_twin_normal_impl(ptr, rust_vec_len, data_len),
+1276 => wire__crate__api__pseudo_manual__misc_example_twin_sync__test_abc_enum_twin_sync_impl(ptr, rust_vec_len, data_len),
+1279 => wire__crate__api__pseudo_manual__chrono_type_twin_sync__test_chrono_twin_sync_impl(ptr, rust_vec_len, data_len),
+1282 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_contains_mirrored_sub_struct_twin_sync_impl(ptr, rust_vec_len, data_len),
+1286 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_fallible_of_raw_string_mirrored_twin_sync_impl(ptr, rust_vec_len, data_len),
+1289 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_hashmap_with_mirrored_value_twin_sync_impl(ptr, rust_vec_len, data_len),
+1292 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_list_of_nested_enums_mirrored_twin_sync_impl(ptr, rust_vec_len, data_len),
+1295 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_list_of_raw_nested_string_mirrored_twin_sync_impl(ptr, rust_vec_len, data_len),
+1298 => wire__crate__api__pseudo_manual__raw_string_twin_sync__test_more_than_just_one_raw_string_struct_twin_sync_impl(ptr, rust_vec_len, data_len),
+1301 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_nested_raw_string_mirrored_twin_sync_impl(ptr, rust_vec_len, data_len),
+1304 => wire__crate__api__pseudo_manual__chrono_type_twin_sync__test_precise_chrono_twin_sync_impl(ptr, rust_vec_len, data_len),
+1307 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_raw_string_enum_mirrored_twin_sync_impl(ptr, rust_vec_len, data_len),
+1310 => wire__crate__api__pseudo_manual__raw_string_twin_sync__test_raw_string_item_enum_twin_sync_impl(ptr, rust_vec_len, data_len),
+1313 => wire__crate__api__pseudo_manual__raw_string_twin_sync__test_raw_string_item_struct_twin_sync_impl(ptr, rust_vec_len, data_len),
+1316 => wire__crate__api__pseudo_manual__mirror_twin_sync__test_raw_string_mirrored_twin_sync_impl(ptr, rust_vec_len, data_len),
+1319 => wire__crate__api__pseudo_manual__misc_example_twin_sync__test_struct_with_enum_twin_sync_impl(ptr, rust_vec_len, data_len),
+1322 => wire__crate__api__pseudo_manual__tuple_twin_sync__test_tuple_2_twin_sync_impl(ptr, rust_vec_len, data_len),
+1325 => wire__crate__api__pseudo_manual__tuple_twin_sync__test_tuple_twin_sync_impl(ptr, rust_vec_len, data_len),
+1328 => wire__crate__api__pseudo_manual__exception_twin_sync__throw_anyhow_twin_sync_impl(ptr, rust_vec_len, data_len),
+1331 => wire__crate__api__pseudo_manual__chrono_type_twin_sync__tokio_time_duration_twin_sync_impl(ptr, rust_vec_len, data_len),
+1334 => wire__crate__api__pseudo_manual__chrono_type_twin_sync__tokio_time_instant_twin_sync_impl(ptr, rust_vec_len, data_len),
+1336 => wire__crate__api__dart_opaque_sync__unwrap_dart_opaque_twin_normal_impl(ptr, rust_vec_len, data_len),
+1339 => wire__crate__api__pseudo_manual__rust_opaque_twin_sync__unwrap_rust_opaque_twin_sync_impl(ptr, rust_vec_len, data_len),
+1342 => wire__crate__api__pseudo_manual__array_twin_sync__use_boxed_blob_twin_sync_impl(ptr, rust_vec_len, data_len),
+1345 => wire__crate__api__pseudo_manual__external_type_in_crate_twin_sync__use_imported_enum_twin_sync_impl(ptr, rust_vec_len, data_len),
+1348 => wire__crate__api__pseudo_manual__external_type_in_crate_twin_sync__use_imported_struct_twin_sync_impl(ptr, rust_vec_len, data_len),
+1351 => wire__crate__api__pseudo_manual__array_twin_sync__use_msgid_twin_sync_impl(ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -45962,6 +46484,118 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<MessageWithCustomSerializerTwi
     for MessageWithCustomSerializerTwinNormal
 {
     fn into_into_dart(self) -> FrbWrapper<MessageWithCustomSerializerTwinNormal> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<std::time::Duration> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        let value: i64 = self
+            .0
+            .as_micros()
+            .try_into()
+            .expect("cannot get microseconds from time");
+        value.into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<std::time::Duration>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<std::time::Duration>> for std::time::Duration {
+    fn into_into_dart(self) -> FrbWrapper<std::time::Duration> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<std::time::Instant> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        let value: i64 = {
+            let now_instant = std::time::Instant::now();
+            let now_system_time = std::time::SystemTime::now();
+            let system_time = if self.0 >= now_instant {
+                now_system_time
+                    .checked_add(self.0.duration_since(now_instant))
+                    .expect("instant out of range")
+            } else {
+                now_system_time
+                    .checked_sub(now_instant.duration_since(self.0))
+                    .expect("instant out of range")
+            };
+            system_time
+                .duration_since(std::time::SystemTime::UNIX_EPOCH)
+                .expect("time is before UNIX_EPOCH")
+                .as_micros()
+                .try_into()
+                .expect("cannot get microseconds from time")
+        };
+        value.into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<std::time::Instant>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<std::time::Instant>> for std::time::Instant {
+    fn into_into_dart(self) -> FrbWrapper<std::time::Instant> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<std::time::SystemTime> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        let value: i64 = self
+            .0
+            .duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .expect("time is before UNIX_EPOCH")
+            .as_micros()
+            .try_into()
+            .expect("cannot get microseconds from time");
+        value.into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<std::time::SystemTime>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<std::time::SystemTime>>
+    for std::time::SystemTime
+{
+    fn into_into_dart(self) -> FrbWrapper<std::time::SystemTime> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<tokio::time::Instant> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        let value: i64 = {
+            let now_instant = std::time::Instant::now();
+            let now_system_time = std::time::SystemTime::now();
+            let system_time = if self.0.into_std() >= now_instant {
+                now_system_time
+                    .checked_add(self.0.into_std().duration_since(now_instant))
+                    .expect("instant out of range")
+            } else {
+                now_system_time
+                    .checked_sub(now_instant.duration_since(self.0.into_std()))
+                    .expect("instant out of range")
+            };
+            system_time
+                .duration_since(std::time::SystemTime::UNIX_EPOCH)
+                .expect("time is before UNIX_EPOCH")
+                .as_micros()
+                .try_into()
+                .expect("cannot get microseconds from time")
+        };
+        value.into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<tokio::time::Instant>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<tokio::time::Instant>> for tokio::time::Instant {
+    fn into_into_dart(self) -> FrbWrapper<tokio::time::Instant> {
         self.into()
     }
 }
@@ -56178,6 +56812,60 @@ impl SseEncode for std::collections::HashSet<i32> {
     }
 }
 
+impl SseEncode for std::time::Duration {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i64>::sse_encode(
+            self.as_micros()
+                .try_into()
+                .expect("cannot get microseconds from time"),
+            serializer,
+        );
+    }
+}
+
+impl SseEncode for std::time::Instant {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i64>::sse_encode(
+            {
+                let now_instant = std::time::Instant::now();
+                let now_system_time = std::time::SystemTime::now();
+                let system_time = if self >= now_instant {
+                    now_system_time
+                        .checked_add(self.duration_since(now_instant))
+                        .expect("instant out of range")
+                } else {
+                    now_system_time
+                        .checked_sub(now_instant.duration_since(self))
+                        .expect("instant out of range")
+                };
+                system_time
+                    .duration_since(std::time::SystemTime::UNIX_EPOCH)
+                    .expect("time is before UNIX_EPOCH")
+                    .as_micros()
+                    .try_into()
+                    .expect("cannot get microseconds from time")
+            },
+            serializer,
+        );
+    }
+}
+
+impl SseEncode for std::time::SystemTime {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i64>::sse_encode(
+            self.duration_since(std::time::SystemTime::UNIX_EPOCH)
+                .expect("time is before UNIX_EPOCH")
+                .as_micros()
+                .try_into()
+                .expect("cannot get microseconds from time"),
+            serializer,
+        );
+    }
+}
+
 impl SseEncode
     for StreamSink<NonCloneSimpleTwinNormal, flutter_rust_bridge::for_generated::SseCodec>
 {
@@ -56498,6 +57186,34 @@ impl SseEncode for String {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <Vec<u8>>::sse_encode(self.into_bytes(), serializer);
+    }
+}
+
+impl SseEncode for tokio::time::Instant {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i64>::sse_encode(
+            {
+                let now_instant = std::time::Instant::now();
+                let now_system_time = std::time::SystemTime::now();
+                let system_time = if self.into_std() >= now_instant {
+                    now_system_time
+                        .checked_add(self.into_std().duration_since(now_instant))
+                        .expect("instant out of range")
+                } else {
+                    now_system_time
+                        .checked_sub(now_instant.duration_since(self.into_std()))
+                        .expect("instant out of range")
+                };
+                system_time
+                    .duration_since(std::time::SystemTime::UNIX_EPOCH)
+                    .expect("time is before UNIX_EPOCH")
+                    .as_micros()
+                    .try_into()
+                    .expect("cannot get microseconds from time")
+            },
+            serializer,
+        );
     }
 }
 

--- a/frb_example/pure_dart_pde/rust/src/frb_generated.rs
+++ b/frb_example/pure_dart_pde/rust/src/frb_generated.rs
@@ -46599,7 +46599,7 @@ impl flutter_rust_bridge::IntoDart for FrbWrapper<std::time::Instant> {
                     .as_micros()
                     .try_into()
                     .expect("cannot get microseconds from time"),
-                Err(error) => -i64::try_from(error.duration().as_micros())
+                Err(error) => i64::try_from(-(error.duration().as_micros() as i128))
                     .expect("cannot get microseconds from time"),
             }
         };
@@ -46623,7 +46623,7 @@ impl flutter_rust_bridge::IntoDart for FrbWrapper<std::time::SystemTime> {
                 .as_micros()
                 .try_into()
                 .expect("cannot get microseconds from time"),
-            Err(error) => -i64::try_from(error.duration().as_micros())
+            Err(error) => i64::try_from(-(error.duration().as_micros() as i128))
                 .expect("cannot get microseconds from time"),
         };
         value.into_dart()
@@ -46661,7 +46661,7 @@ impl flutter_rust_bridge::IntoDart for FrbWrapper<tokio::time::Instant> {
                     .as_micros()
                     .try_into()
                     .expect("cannot get microseconds from time"),
-                Err(error) => -i64::try_from(error.duration().as_micros())
+                Err(error) => i64::try_from(-(error.duration().as_micros() as i128))
                     .expect("cannot get microseconds from time"),
             }
         };
@@ -56924,7 +56924,7 @@ impl SseEncode for std::time::Instant {
                         .as_micros()
                         .try_into()
                         .expect("cannot get microseconds from time"),
-                    Err(error) => -i64::try_from(error.duration().as_micros())
+                    Err(error) => i64::try_from(-(error.duration().as_micros() as i128))
                         .expect("cannot get microseconds from time"),
                 }
             },
@@ -56942,7 +56942,7 @@ impl SseEncode for std::time::SystemTime {
                     .as_micros()
                     .try_into()
                     .expect("cannot get microseconds from time"),
-                Err(error) => -i64::try_from(error.duration().as_micros())
+                Err(error) => i64::try_from(-(error.duration().as_micros() as i128))
                     .expect("cannot get microseconds from time"),
             },
             serializer,
@@ -57295,7 +57295,7 @@ impl SseEncode for tokio::time::Instant {
                         .as_micros()
                         .try_into()
                         .expect("cannot get microseconds from time"),
-                    Err(error) => -i64::try_from(error.duration().as_micros())
+                    Err(error) => i64::try_from(-(error.duration().as_micros() as i128))
                         .expect("cannot get microseconds from time"),
                 }
             },

--- a/frb_example/pure_dart_pde/rust/src/frb_generated.rs
+++ b/frb_example/pure_dart_pde/rust/src/frb_generated.rs
@@ -46582,7 +46582,7 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<std::time::Duration>> for std:
 impl flutter_rust_bridge::IntoDart for FrbWrapper<std::time::Instant> {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         let value: i64 = {
-            let value = self.0;
+            let value = self.0.clone();
             let now_instant = std::time::Instant::now();
             let now_system_time = std::time::SystemTime::now();
             let system_time = if value >= now_instant {
@@ -46644,7 +46644,7 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<std::time::SystemTime>>
 impl flutter_rust_bridge::IntoDart for FrbWrapper<tokio::time::Instant> {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         let value: i64 = {
-            let value = self.0.into_std();
+            let value = self.0.into_std().clone();
             let now_instant = std::time::Instant::now();
             let now_system_time = std::time::SystemTime::now();
             let system_time = if value >= now_instant {
@@ -56907,7 +56907,7 @@ impl SseEncode for std::time::Instant {
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <i64>::sse_encode(
             {
-                let value = self;
+                let value = self.clone();
                 let now_instant = std::time::Instant::now();
                 let now_system_time = std::time::SystemTime::now();
                 let system_time = if value >= now_instant {
@@ -57278,7 +57278,7 @@ impl SseEncode for tokio::time::Instant {
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <i64>::sse_encode(
             {
-                let value = self.into_std();
+                let value = self.into_std().clone();
                 let now_instant = std::time::Instant::now();
                 let now_system_time = std::time::SystemTime::now();
                 let system_time = if value >= now_instant {

--- a/frb_example/pure_dart_pde/test/api/chrono_type_test.dart
+++ b/frb_example/pure_dart_pde/test/api/chrono_type_test.dart
@@ -73,6 +73,38 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp.inHours, d.inHours);
   });
 
+  test('std::time::Duration', () async {
+    final d = Duration(hours: 4);
+    final resp = await stdTimeDurationTwinNormal(d: d);
+    expect(resp, d);
+  });
+
+  test('std::time::SystemTime', () async {
+    final date =
+        DateTime.fromMillisecondsSinceEpoch(1631297333000, isUtc: true);
+    final resp = await stdTimeSystemTimeTwinNormal(d: date);
+    expect(resp.isUtc, true);
+    expect(resp.millisecondsSinceEpoch, date.millisecondsSinceEpoch);
+  });
+
+  test('std::time::Instant', () async {
+    final date = DateTime.now().toUtc().add(Duration(seconds: 5));
+    final resp = await stdTimeInstantTwinNormal(d: date);
+    expect(resp.difference(date).abs() < Duration(seconds: 1), true);
+  });
+
+  test('tokio::time::Duration', () async {
+    final d = Duration(hours: 4);
+    final resp = await tokioTimeDurationTwinNormal(d: d);
+    expect(resp, d);
+  });
+
+  test('tokio::time::Instant', () async {
+    final date = DateTime.now().toUtc().add(Duration(seconds: 5));
+    final resp = await tokioTimeInstantTwinNormal(d: date);
+    expect(resp.difference(date).abs() < Duration(seconds: 1), true);
+  });
+
   test('List<Duration>', () async {
     final expected = [
       Duration(days: 1),

--- a/frb_example/pure_dart_pde/test/api/chrono_type_test.dart
+++ b/frb_example/pure_dart_pde/test/api/chrono_type_test.dart
@@ -96,24 +96,10 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp.microsecondsSinceEpoch, date.microsecondsSinceEpoch);
   });
 
-  test('std::time::Instant', skip: skipWeb('wasm Instant::now panics'),
-      () async {
-    final date = DateTime.now().toUtc().add(Duration(seconds: 5));
-    final resp = await stdTimeInstantTwinNormal(d: date);
-    expect(resp.difference(date).abs() < Duration(seconds: 1), true);
-  });
-
   test('tokio::time::Duration', () async {
     final d = Duration(hours: 4);
     final resp = await tokioTimeDurationTwinNormal(d: d);
     expect(resp, d);
-  });
-
-  test('tokio::time::Instant', skip: skipWeb('wasm Instant::now panics'),
-      () async {
-    final date = DateTime.now().toUtc().add(Duration(seconds: 5));
-    final resp = await tokioTimeInstantTwinNormal(d: date);
-    expect(resp.difference(date).abs() < Duration(seconds: 1), true);
   });
 
   test('List<Duration>', () async {

--- a/frb_example/pure_dart_pde/test/api/chrono_type_test.dart
+++ b/frb_example/pure_dart_pde/test/api/chrono_type_test.dart
@@ -87,14 +87,17 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp.millisecondsSinceEpoch, date.millisecondsSinceEpoch);
   });
 
-  test('std::time::SystemTime before UNIX epoch', () async {
+  test('std::time::SystemTime before UNIX epoch',
+      skip: skipWeb('wasm SystemTime does not support pre-epoch values'),
+      () async {
     final date = DateTime.fromMicrosecondsSinceEpoch(-1000000000, isUtc: true);
     final resp = await stdTimeSystemTimeBeforeEpochTwinNormal(d: date);
     expect(resp.isUtc, true);
     expect(resp.microsecondsSinceEpoch, date.microsecondsSinceEpoch);
   });
 
-  test('std::time::Instant', () async {
+  test('std::time::Instant', skip: skipWeb('wasm Instant::now panics'),
+      () async {
     final date = DateTime.now().toUtc().add(Duration(seconds: 5));
     final resp = await stdTimeInstantTwinNormal(d: date);
     expect(resp.difference(date).abs() < Duration(seconds: 1), true);
@@ -106,7 +109,8 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp, d);
   });
 
-  test('tokio::time::Instant', () async {
+  test('tokio::time::Instant', skip: skipWeb('wasm Instant::now panics'),
+      () async {
     final date = DateTime.now().toUtc().add(Duration(seconds: 5));
     final resp = await tokioTimeInstantTwinNormal(d: date);
     expect(resp.difference(date).abs() < Duration(seconds: 1), true);

--- a/frb_example/pure_dart_pde/test/api/chrono_type_test.dart
+++ b/frb_example/pure_dart_pde/test/api/chrono_type_test.dart
@@ -68,13 +68,13 @@ Future<void> main({bool skipRustLibInit = false}) async {
   });
 
   test('Duration', () async {
-    final d = Duration(hours: 4);
+    final d = preciseDuration();
     final resp = await durationTwinNormal(d: d);
-    expect(resp.inHours, d.inHours);
+    expect(resp, d);
   });
 
   test('std::time::Duration', () async {
-    final d = Duration(hours: 4);
+    final d = preciseDuration();
     final resp = await stdTimeDurationTwinNormal(d: d);
     expect(resp, d);
   });
@@ -97,7 +97,7 @@ Future<void> main({bool skipRustLibInit = false}) async {
   });
 
   test('tokio::time::Duration', () async {
-    final d = Duration(hours: 4);
+    final d = preciseDuration();
     final resp = await tokioTimeDurationTwinNormal(d: d);
     expect(resp, d);
   });
@@ -171,3 +171,10 @@ Future<void> main({bool skipRustLibInit = false}) async {
     debugPrint('$difference');
   });
 }
+
+Duration preciseDuration() => Duration(
+      hours: 4,
+      seconds: 3,
+      milliseconds: 2,
+      microseconds: kIsWeb ? 0 : 1,
+    );

--- a/frb_example/pure_dart_pde/test/api/chrono_type_test.dart
+++ b/frb_example/pure_dart_pde/test/api/chrono_type_test.dart
@@ -87,6 +87,13 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp.millisecondsSinceEpoch, date.millisecondsSinceEpoch);
   });
 
+  test('std::time::SystemTime before UNIX epoch', () async {
+    final date = DateTime.fromMicrosecondsSinceEpoch(-1000000000, isUtc: true);
+    final resp = await stdTimeSystemTimeBeforeEpochTwinNormal(d: date);
+    expect(resp.isUtc, true);
+    expect(resp.microsecondsSinceEpoch, date.microsecondsSinceEpoch);
+  });
+
   test('std::time::Instant', () async {
     final date = DateTime.now().toUtc().add(Duration(seconds: 5));
     final resp = await stdTimeInstantTwinNormal(d: date);

--- a/frb_example/pure_dart_pde/test/api/pseudo_manual/chrono_type_twin_rust_async_test.dart
+++ b/frb_example/pure_dart_pde/test/api/pseudo_manual/chrono_type_twin_rust_async_test.dart
@@ -100,24 +100,10 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp.microsecondsSinceEpoch, date.microsecondsSinceEpoch);
   });
 
-  test('std::time::Instant', skip: skipWeb('wasm Instant::now panics'),
-      () async {
-    final date = DateTime.now().toUtc().add(Duration(seconds: 5));
-    final resp = await stdTimeInstantTwinRustAsync(d: date);
-    expect(resp.difference(date).abs() < Duration(seconds: 1), true);
-  });
-
   test('tokio::time::Duration', () async {
     final d = Duration(hours: 4);
     final resp = await tokioTimeDurationTwinRustAsync(d: d);
     expect(resp, d);
-  });
-
-  test('tokio::time::Instant', skip: skipWeb('wasm Instant::now panics'),
-      () async {
-    final date = DateTime.now().toUtc().add(Duration(seconds: 5));
-    final resp = await tokioTimeInstantTwinRustAsync(d: date);
-    expect(resp.difference(date).abs() < Duration(seconds: 1), true);
   });
 
   test('List<Duration>', () async {

--- a/frb_example/pure_dart_pde/test/api/pseudo_manual/chrono_type_twin_rust_async_test.dart
+++ b/frb_example/pure_dart_pde/test/api/pseudo_manual/chrono_type_twin_rust_async_test.dart
@@ -91,14 +91,17 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp.millisecondsSinceEpoch, date.millisecondsSinceEpoch);
   });
 
-  test('std::time::SystemTime before UNIX epoch', () async {
+  test('std::time::SystemTime before UNIX epoch',
+      skip: skipWeb('wasm SystemTime does not support pre-epoch values'),
+      () async {
     final date = DateTime.fromMicrosecondsSinceEpoch(-1000000000, isUtc: true);
     final resp = await stdTimeSystemTimeBeforeEpochTwinRustAsync(d: date);
     expect(resp.isUtc, true);
     expect(resp.microsecondsSinceEpoch, date.microsecondsSinceEpoch);
   });
 
-  test('std::time::Instant', () async {
+  test('std::time::Instant', skip: skipWeb('wasm Instant::now panics'),
+      () async {
     final date = DateTime.now().toUtc().add(Duration(seconds: 5));
     final resp = await stdTimeInstantTwinRustAsync(d: date);
     expect(resp.difference(date).abs() < Duration(seconds: 1), true);
@@ -110,7 +113,8 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp, d);
   });
 
-  test('tokio::time::Instant', () async {
+  test('tokio::time::Instant', skip: skipWeb('wasm Instant::now panics'),
+      () async {
     final date = DateTime.now().toUtc().add(Duration(seconds: 5));
     final resp = await tokioTimeInstantTwinRustAsync(d: date);
     expect(resp.difference(date).abs() < Duration(seconds: 1), true);

--- a/frb_example/pure_dart_pde/test/api/pseudo_manual/chrono_type_twin_rust_async_test.dart
+++ b/frb_example/pure_dart_pde/test/api/pseudo_manual/chrono_type_twin_rust_async_test.dart
@@ -91,6 +91,13 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp.millisecondsSinceEpoch, date.millisecondsSinceEpoch);
   });
 
+  test('std::time::SystemTime before UNIX epoch', () async {
+    final date = DateTime.fromMicrosecondsSinceEpoch(-1000000000, isUtc: true);
+    final resp = await stdTimeSystemTimeBeforeEpochTwinRustAsync(d: date);
+    expect(resp.isUtc, true);
+    expect(resp.microsecondsSinceEpoch, date.microsecondsSinceEpoch);
+  });
+
   test('std::time::Instant', () async {
     final date = DateTime.now().toUtc().add(Duration(seconds: 5));
     final resp = await stdTimeInstantTwinRustAsync(d: date);

--- a/frb_example/pure_dart_pde/test/api/pseudo_manual/chrono_type_twin_rust_async_test.dart
+++ b/frb_example/pure_dart_pde/test/api/pseudo_manual/chrono_type_twin_rust_async_test.dart
@@ -77,6 +77,38 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp.inHours, d.inHours);
   });
 
+  test('std::time::Duration', () async {
+    final d = Duration(hours: 4);
+    final resp = await stdTimeDurationTwinRustAsync(d: d);
+    expect(resp, d);
+  });
+
+  test('std::time::SystemTime', () async {
+    final date =
+        DateTime.fromMillisecondsSinceEpoch(1631297333000, isUtc: true);
+    final resp = await stdTimeSystemTimeTwinRustAsync(d: date);
+    expect(resp.isUtc, true);
+    expect(resp.millisecondsSinceEpoch, date.millisecondsSinceEpoch);
+  });
+
+  test('std::time::Instant', () async {
+    final date = DateTime.now().toUtc().add(Duration(seconds: 5));
+    final resp = await stdTimeInstantTwinRustAsync(d: date);
+    expect(resp.difference(date).abs() < Duration(seconds: 1), true);
+  });
+
+  test('tokio::time::Duration', () async {
+    final d = Duration(hours: 4);
+    final resp = await tokioTimeDurationTwinRustAsync(d: d);
+    expect(resp, d);
+  });
+
+  test('tokio::time::Instant', () async {
+    final date = DateTime.now().toUtc().add(Duration(seconds: 5));
+    final resp = await tokioTimeInstantTwinRustAsync(d: date);
+    expect(resp.difference(date).abs() < Duration(seconds: 1), true);
+  });
+
   test('List<Duration>', () async {
     final expected = [
       Duration(days: 1),

--- a/frb_example/pure_dart_pde/test/api/pseudo_manual/chrono_type_twin_rust_async_test.dart
+++ b/frb_example/pure_dart_pde/test/api/pseudo_manual/chrono_type_twin_rust_async_test.dart
@@ -72,13 +72,13 @@ Future<void> main({bool skipRustLibInit = false}) async {
   });
 
   test('Duration', () async {
-    final d = Duration(hours: 4);
+    final d = preciseDuration();
     final resp = await durationTwinRustAsync(d: d);
-    expect(resp.inHours, d.inHours);
+    expect(resp, d);
   });
 
   test('std::time::Duration', () async {
-    final d = Duration(hours: 4);
+    final d = preciseDuration();
     final resp = await stdTimeDurationTwinRustAsync(d: d);
     expect(resp, d);
   });
@@ -101,7 +101,7 @@ Future<void> main({bool skipRustLibInit = false}) async {
   });
 
   test('tokio::time::Duration', () async {
-    final d = Duration(hours: 4);
+    final d = preciseDuration();
     final resp = await tokioTimeDurationTwinRustAsync(d: d);
     expect(resp, d);
   });
@@ -175,3 +175,10 @@ Future<void> main({bool skipRustLibInit = false}) async {
     debugPrint('$difference');
   });
 }
+
+Duration preciseDuration() => Duration(
+      hours: 4,
+      seconds: 3,
+      milliseconds: 2,
+      microseconds: kIsWeb ? 0 : 1,
+    );

--- a/frb_example/pure_dart_pde/test/api/pseudo_manual/chrono_type_twin_sync_test.dart
+++ b/frb_example/pure_dart_pde/test/api/pseudo_manual/chrono_type_twin_sync_test.dart
@@ -91,6 +91,13 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp.millisecondsSinceEpoch, date.millisecondsSinceEpoch);
   });
 
+  test('std::time::SystemTime before UNIX epoch', () async {
+    final date = DateTime.fromMicrosecondsSinceEpoch(-1000000000, isUtc: true);
+    final resp = await stdTimeSystemTimeBeforeEpochTwinSync(d: date);
+    expect(resp.isUtc, true);
+    expect(resp.microsecondsSinceEpoch, date.microsecondsSinceEpoch);
+  });
+
   test('std::time::Instant', () async {
     final date = DateTime.now().toUtc().add(Duration(seconds: 5));
     final resp = await stdTimeInstantTwinSync(d: date);

--- a/frb_example/pure_dart_pde/test/api/pseudo_manual/chrono_type_twin_sync_test.dart
+++ b/frb_example/pure_dart_pde/test/api/pseudo_manual/chrono_type_twin_sync_test.dart
@@ -72,13 +72,13 @@ Future<void> main({bool skipRustLibInit = false}) async {
   });
 
   test('Duration', () async {
-    final d = Duration(hours: 4);
+    final d = preciseDuration();
     final resp = await durationTwinSync(d: d);
-    expect(resp.inHours, d.inHours);
+    expect(resp, d);
   });
 
   test('std::time::Duration', () async {
-    final d = Duration(hours: 4);
+    final d = preciseDuration();
     final resp = await stdTimeDurationTwinSync(d: d);
     expect(resp, d);
   });
@@ -101,7 +101,7 @@ Future<void> main({bool skipRustLibInit = false}) async {
   });
 
   test('tokio::time::Duration', () async {
-    final d = Duration(hours: 4);
+    final d = preciseDuration();
     final resp = await tokioTimeDurationTwinSync(d: d);
     expect(resp, d);
   });
@@ -175,3 +175,10 @@ Future<void> main({bool skipRustLibInit = false}) async {
     debugPrint('$difference');
   });
 }
+
+Duration preciseDuration() => Duration(
+      hours: 4,
+      seconds: 3,
+      milliseconds: 2,
+      microseconds: kIsWeb ? 0 : 1,
+    );

--- a/frb_example/pure_dart_pde/test/api/pseudo_manual/chrono_type_twin_sync_test.dart
+++ b/frb_example/pure_dart_pde/test/api/pseudo_manual/chrono_type_twin_sync_test.dart
@@ -91,14 +91,17 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp.millisecondsSinceEpoch, date.millisecondsSinceEpoch);
   });
 
-  test('std::time::SystemTime before UNIX epoch', () async {
+  test('std::time::SystemTime before UNIX epoch',
+      skip: skipWeb('wasm SystemTime does not support pre-epoch values'),
+      () async {
     final date = DateTime.fromMicrosecondsSinceEpoch(-1000000000, isUtc: true);
     final resp = await stdTimeSystemTimeBeforeEpochTwinSync(d: date);
     expect(resp.isUtc, true);
     expect(resp.microsecondsSinceEpoch, date.microsecondsSinceEpoch);
   });
 
-  test('std::time::Instant', () async {
+  test('std::time::Instant', skip: skipWeb('wasm Instant::now panics'),
+      () async {
     final date = DateTime.now().toUtc().add(Duration(seconds: 5));
     final resp = await stdTimeInstantTwinSync(d: date);
     expect(resp.difference(date).abs() < Duration(seconds: 1), true);
@@ -110,7 +113,8 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp, d);
   });
 
-  test('tokio::time::Instant', () async {
+  test('tokio::time::Instant', skip: skipWeb('wasm Instant::now panics'),
+      () async {
     final date = DateTime.now().toUtc().add(Duration(seconds: 5));
     final resp = await tokioTimeInstantTwinSync(d: date);
     expect(resp.difference(date).abs() < Duration(seconds: 1), true);

--- a/frb_example/pure_dart_pde/test/api/pseudo_manual/chrono_type_twin_sync_test.dart
+++ b/frb_example/pure_dart_pde/test/api/pseudo_manual/chrono_type_twin_sync_test.dart
@@ -100,24 +100,10 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp.microsecondsSinceEpoch, date.microsecondsSinceEpoch);
   });
 
-  test('std::time::Instant', skip: skipWeb('wasm Instant::now panics'),
-      () async {
-    final date = DateTime.now().toUtc().add(Duration(seconds: 5));
-    final resp = await stdTimeInstantTwinSync(d: date);
-    expect(resp.difference(date).abs() < Duration(seconds: 1), true);
-  });
-
   test('tokio::time::Duration', () async {
     final d = Duration(hours: 4);
     final resp = await tokioTimeDurationTwinSync(d: d);
     expect(resp, d);
-  });
-
-  test('tokio::time::Instant', skip: skipWeb('wasm Instant::now panics'),
-      () async {
-    final date = DateTime.now().toUtc().add(Duration(seconds: 5));
-    final resp = await tokioTimeInstantTwinSync(d: date);
-    expect(resp.difference(date).abs() < Duration(seconds: 1), true);
   });
 
   test('List<Duration>', () async {

--- a/frb_example/pure_dart_pde/test/api/pseudo_manual/chrono_type_twin_sync_test.dart
+++ b/frb_example/pure_dart_pde/test/api/pseudo_manual/chrono_type_twin_sync_test.dart
@@ -77,6 +77,38 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(resp.inHours, d.inHours);
   });
 
+  test('std::time::Duration', () async {
+    final d = Duration(hours: 4);
+    final resp = await stdTimeDurationTwinSync(d: d);
+    expect(resp, d);
+  });
+
+  test('std::time::SystemTime', () async {
+    final date =
+        DateTime.fromMillisecondsSinceEpoch(1631297333000, isUtc: true);
+    final resp = await stdTimeSystemTimeTwinSync(d: date);
+    expect(resp.isUtc, true);
+    expect(resp.millisecondsSinceEpoch, date.millisecondsSinceEpoch);
+  });
+
+  test('std::time::Instant', () async {
+    final date = DateTime.now().toUtc().add(Duration(seconds: 5));
+    final resp = await stdTimeInstantTwinSync(d: date);
+    expect(resp.difference(date).abs() < Duration(seconds: 1), true);
+  });
+
+  test('tokio::time::Duration', () async {
+    final d = Duration(hours: 4);
+    final resp = await tokioTimeDurationTwinSync(d: d);
+    expect(resp, d);
+  });
+
+  test('tokio::time::Instant', () async {
+    final date = DateTime.now().toUtc().add(Duration(seconds: 5));
+    final resp = await tokioTimeInstantTwinSync(d: date);
+    expect(resp.difference(date).abs() < Duration(seconds: 1), true);
+  });
+
   test('List<Duration>', () async {
     final expected = [
       Duration(days: 1),

--- a/website/docs/guides/types/translatable/detailed/chrono.md
+++ b/website/docs/guides/types/translatable/detailed/chrono.md
@@ -1,6 +1,6 @@
-# DateTime (Chrono)
+# DateTime and Duration
 
-Codegen optionally support [chrono crate](https://docs.rs/chrono) with feature `chrono`.
+Codegen optionally supports [chrono crate](https://docs.rs/chrono) with feature `chrono`.
 
 | :crab: Rust       | :dart: Dart                   |
 | -----------       | -----------                   |
@@ -8,6 +8,18 @@ Codegen optionally support [chrono crate](https://docs.rs/chrono) with feature `
 | `DateTime<Local>` | `DateTime` *local timezone*   |
 | `NaiveDateTime`   | `DateTime` *utc assumed*      |
 | `Duration`        | `Duration`                    |
+
+Codegen also supports these time types from the Rust standard library and Tokio:
+
+| :crab: Rust              | :dart: Dart      |
+| -----------              | -----------      |
+| `std::time::SystemTime`  | `DateTime` *utc* |
+| `std::time::Instant`     | `DateTime` *utc* |
+| `std::time::Duration`    | `Duration`       |
+| `tokio::time::Instant`   | `DateTime` *utc* |
+| `tokio::time::Duration`  | `Duration`       |
+
+For Tokio types, enable Tokio's `time` feature in your Rust crate.
 
 You can also use nullable values through `Option`, for example: `Option<NaiveDateTime>`.
 
@@ -19,3 +31,5 @@ You can also use nullable values through `Option`, for example: `Option<NaiveDat
 :bulb: Also a `DateTime<Local>` will always be translated into local time of the device, which might not be what you want if you expect them to be sent *as-is*.
 
 > In that case, you could implement it in your codebase by sending a `u32` (timezone offset) alongside the `i64` (timestamp) over the wire, or open a issue / PR here to further discuss it. The reason why this choice was originally made is to have all `DateTime<Utc>`, `DateTime<Local>` and `NaiveDateTime` been represented by a single `i64`.
+
+:bulb: `Instant` does not carry an absolute timestamp in Rust, so it is translated relative to the current time when crossing the bridge.

--- a/website/docs/guides/types/translatable/detailed/chrono.md
+++ b/website/docs/guides/types/translatable/detailed/chrono.md
@@ -14,9 +14,7 @@ Codegen also supports these time types from the Rust standard library and Tokio:
 | :crab: Rust              | :dart: Dart      |
 | -----------              | -----------      |
 | `std::time::SystemTime`  | `DateTime` *utc* |
-| `std::time::Instant`     | `DateTime` *utc* |
 | `std::time::Duration`    | `Duration`       |
-| `tokio::time::Instant`   | `DateTime` *utc* |
 | `tokio::time::Duration`  | `Duration`       |
 
 For Tokio types, enable Tokio's `time` feature in your Rust crate.
@@ -31,5 +29,3 @@ You can also use nullable values through `Option`, for example: `Option<NaiveDat
 :bulb: Also a `DateTime<Local>` will always be translated into local time of the device, which might not be what you want if you expect them to be sent *as-is*.
 
 > In that case, you could implement it in your codebase by sending a `u32` (timezone offset) alongside the `i64` (timestamp) over the wire, or open a issue / PR here to further discuss it. The reason why this choice was originally made is to have all `DateTime<Utc>`, `DateTime<Local>` and `NaiveDateTime` been represented by a single `i64`.
-
-:bulb: `Instant` does not carry an absolute timestamp in Rust, so it is translated relative to the current time when crossing the bridge.


### PR DESCRIPTION
Close #3119.

Reproduction report:

- Baseline: `03a1cbb36e3fb012c4dab4a272e0b0ff5a01bf38`.
- Steps: add APIs using `std::time::{Duration, SystemTime, Instant}` and `tokio::time::{Duration, Instant}` to a Dart example and run FRB generation/tests in Docker.
- Observed before fix: these types were parsed as opaque Rust types instead of Dart-native time types, so the generated Dart API did not expose `DateTime` / `Duration`.
- Expected: `SystemTime` and `Instant` map to Dart `DateTime`; `Duration` maps to Dart `Duration`; `tokio::time::Duration` follows its std alias while `tokio::time::Instant` is supported explicitly.

Local verification:

- `cargo fmt --manifest-path frb_codegen/Cargo.toml && cargo check --manifest-path frb_codegen/Cargo.toml`
- `UPDATE_GOLDEN=1 cargo test --manifest-path frb_codegen/Cargo.toml codegen::parser::tests::test_qualified_names --lib`
- `cargo test --manifest-path frb_codegen/Cargo.toml codegen::parser::tests::test_qualified_names --lib`
- `./frb_internal precommit-generate`
- `./frb_internal lint` reached all Rust/native+wasm clippy successfully; first Dart format pass failed only because ignored `rust/target/frb_dump` artifacts from local generation were reformatted.
- After removing ignored `frb_dump` build artifacts: `./frb_internal lint-dart`
- `cd frb_example/pure_dart && dart test test/api/chrono_type_test.dart`
- `cd frb_example/pure_dart_pde && dart test test/api/chrono_type_test.dart`
