### PR TITLE
Pass platforms through create and integrate commands

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,6 +78,7 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v1
+        continue-on-error: true
         with:
           comment_on_pr: false
       - uses: actions/checkout@v4
@@ -106,6 +107,7 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v1
+        continue-on-error: true
         with:
           comment_on_pr: false
       - uses: actions/checkout@v4
@@ -126,6 +128,7 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v1
+        continue-on-error: true
         with:
           comment_on_pr: false
       - uses: actions/checkout@v4
@@ -208,6 +211,7 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        continue-on-error: true
         with:
           comment_on_pr: false
       - uses: actions/checkout@v5
@@ -253,6 +257,7 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        continue-on-error: true
         with:
           comment_on_pr: false
       - uses: actions/checkout@v5
@@ -284,6 +289,7 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        continue-on-error: true
         with:
           comment_on_pr: false
       - uses: actions/checkout@v5
@@ -326,6 +332,7 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        continue-on-error: true
         with:
           comment_on_pr: false
       - uses: actions/checkout@v5
@@ -413,6 +420,7 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        continue-on-error: true
         with:
           comment_on_pr: false
       - uses: actions/checkout@v5
@@ -452,6 +460,7 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        continue-on-error: true
         with:
           comment_on_pr: false
       - uses: actions/checkout@v5
@@ -546,6 +555,7 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        continue-on-error: true
         with:
           comment_on_pr: false
       - uses: actions/checkout@v5
@@ -601,6 +611,7 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        continue-on-error: true
         with:
           comment_on_pr: false
       - uses: actions/checkout@v5
@@ -641,6 +652,7 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        continue-on-error: true
         with:
           comment_on_pr: false
       - uses: actions/checkout@v5
@@ -694,6 +706,7 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        continue-on-error: true
         with:
           comment_on_pr: false
       - uses: actions/checkout@v5
@@ -735,6 +748,7 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        continue-on-error: true
         with:
           comment_on_pr: false
       - uses: actions/checkout@v5
@@ -845,6 +859,7 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        continue-on-error: true
         with:
           comment_on_pr: false
       - uses: actions/checkout@v5
@@ -930,6 +945,7 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        continue-on-error: true
         with:
           comment_on_pr: false
       - uses: actions/checkout@v5
@@ -962,6 +978,7 @@ jobs:
 
     steps:
       - uses: catchpoint/workflow-telemetry-action@v2
+        continue-on-error: true
         with:
           comment_on_pr: false
       - uses: actions/checkout@v5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,7 +78,6 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v1
-        continue-on-error: true
         with:
           comment_on_pr: false
       - uses: actions/checkout@v4
@@ -107,7 +106,6 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v1
-        continue-on-error: true
         with:
           comment_on_pr: false
       - uses: actions/checkout@v4
@@ -128,7 +126,6 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v1
-        continue-on-error: true
         with:
           comment_on_pr: false
       - uses: actions/checkout@v4
@@ -211,7 +208,6 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
-        continue-on-error: true
         with:
           comment_on_pr: false
       - uses: actions/checkout@v5
@@ -257,7 +253,6 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
-        continue-on-error: true
         with:
           comment_on_pr: false
       - uses: actions/checkout@v5
@@ -289,7 +284,6 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
-        continue-on-error: true
         with:
           comment_on_pr: false
       - uses: actions/checkout@v5
@@ -332,7 +326,6 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
-        continue-on-error: true
         with:
           comment_on_pr: false
       - uses: actions/checkout@v5
@@ -420,7 +413,6 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
-        continue-on-error: true
         with:
           comment_on_pr: false
       - uses: actions/checkout@v5
@@ -460,7 +452,6 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
-        continue-on-error: true
         with:
           comment_on_pr: false
       - uses: actions/checkout@v5
@@ -555,7 +546,6 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
-        continue-on-error: true
         with:
           comment_on_pr: false
       - uses: actions/checkout@v5
@@ -611,7 +601,6 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
-        continue-on-error: true
         with:
           comment_on_pr: false
       - uses: actions/checkout@v5
@@ -652,7 +641,6 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
-        continue-on-error: true
         with:
           comment_on_pr: false
       - uses: actions/checkout@v5
@@ -706,7 +694,6 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
-        continue-on-error: true
         with:
           comment_on_pr: false
       - uses: actions/checkout@v5
@@ -748,7 +735,6 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
-        continue-on-error: true
         with:
           comment_on_pr: false
       - uses: actions/checkout@v5
@@ -859,7 +845,6 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
-        continue-on-error: true
         with:
           comment_on_pr: false
       - uses: actions/checkout@v5
@@ -945,7 +930,6 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
-        continue-on-error: true
         with:
           comment_on_pr: false
       - uses: actions/checkout@v5
@@ -978,7 +962,6 @@ jobs:
 
     steps:
       - uses: catchpoint/workflow-telemetry-action@v2
-        continue-on-error: true
         with:
           comment_on_pr: false
       - uses: actions/checkout@v5

--- a/frb_codegen/src/binary/commands.rs
+++ b/frb_codegen/src/binary/commands.rs
@@ -230,6 +230,10 @@ pub(crate) struct CreateCommandArgs {
     #[clap(short, long, value_enum, default_value = "app")]
     pub template: TemplateArg,
 
+    /// Specify the platforms to be supported.
+    #[clap(long)]
+    pub platforms: Option<String>,
+
     /// Skip fvm installation
     #[clap(long)]
     pub skip_fvm_install: bool,
@@ -335,5 +339,28 @@ impl From<RustOpaqueCodecModeArg> for RustOpaqueCodecMode {
             RustOpaqueCodecModeArg::Moi => RustOpaqueCodecMode::Moi,
             RustOpaqueCodecModeArg::Nom => RustOpaqueCodecMode::Nom,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Cli, Commands};
+    use clap::Parser;
+
+    #[test]
+    fn test_create_command_parses_platforms() {
+        let cli = Cli::parse_from([
+            "",
+            "create",
+            "demo",
+            "--platforms",
+            "android,ios",
+            "--skip-fvm-install",
+        ]);
+        let Commands::Create(args) = cli.command else {
+            panic!("expected create command");
+        };
+
+        assert_eq!(args.platforms, Some("android,ios".to_owned()));
     }
 }

--- a/frb_codegen/src/binary/commands.rs
+++ b/frb_codegen/src/binary/commands.rs
@@ -265,6 +265,10 @@ pub(crate) struct IntegrateCommandArgs {
     #[clap(short, long, value_enum, default_value = "app")]
     pub template: TemplateArg,
 
+    /// Specify the platforms to be supported.
+    #[clap(long)]
+    pub platforms: Option<String>,
+
     /// Skip fvm installation
     #[clap(long)]
     pub skip_fvm_install: bool,
@@ -362,5 +366,21 @@ mod tests {
         };
 
         assert_eq!(args.platforms, Some("android,ios".to_owned()));
+    }
+
+    #[test]
+    fn test_integrate_command_parses_platforms() {
+        let cli = Cli::parse_from([
+            "",
+            "integrate",
+            "--platforms",
+            "android,ohos",
+            "--skip-fvm-install",
+        ]);
+        let Commands::Integrate(args) = cli.command else {
+            panic!("expected integrate command");
+        };
+
+        assert_eq!(args.platforms, Some("android,ohos".to_owned()));
     }
 }

--- a/frb_codegen/src/library/commands/flutter.rs
+++ b/frb_codegen/src/library/commands/flutter.rs
@@ -11,6 +11,7 @@ pub fn flutter_create(
     name: &str,
     org: &Option<String>,
     template: Template,
+    platforms: Option<String>,
     fvm_install_mode: FvmInstallMode,
 ) -> anyhow::Result<()> {
     let mut full_args = vec![];
@@ -23,18 +24,22 @@ pub fn flutter_create(
     if let Some(o) = org {
         full_args.extend(["--org".to_owned(), o.to_owned()]);
     }
+    let platforms = platforms.unwrap_or_else(|| match template {
+        Template::App => "android,ios,linux,macos,web,windows".to_owned(),
+        Template::Plugin => "android,ios,linux,macos,windows".to_owned(),
+    });
     match template {
         Template::App => full_args.extend([
             "--template".to_owned(),
             "app".to_owned(),
             "--platforms".to_owned(),
-            "android,ios,linux,macos,web,windows".to_owned(),
+            platforms,
         ]),
         Template::Plugin => full_args.extend([
             "--template".to_owned(),
             "plugin_ffi".to_owned(),
             "--platforms".to_owned(),
-            "android,ios,linux,macos,windows".to_owned(),
+            platforms,
         ]),
     }
 

--- a/frb_codegen/src/library/commands/flutter.rs
+++ b/frb_codegen/src/library/commands/flutter.rs
@@ -6,11 +6,6 @@ use crate::misc::{FvmInstallMode, Template};
 use log::info;
 use std::path::Path;
 
-pub(crate) struct FlutterPlatforms {
-    pub(crate) value: String,
-    pub(crate) include_ohos: bool,
-}
-
 #[allow(clippy::vec_init_then_push)]
 pub fn flutter_create(
     name: &str,
@@ -35,13 +30,13 @@ pub fn flutter_create(
             "--template".to_owned(),
             "app".to_owned(),
             "--platforms".to_owned(),
-            platforms.value,
+            platforms,
         ]),
         Template::Plugin => full_args.extend([
             "--template".to_owned(),
             "plugin_ffi".to_owned(),
             "--platforms".to_owned(),
-            platforms.value,
+            platforms,
         ]),
     }
 
@@ -91,19 +86,13 @@ pub fn flutter_pub_get(path: &Path, fvm_install_mode: FvmInstallMode) -> anyhow:
 pub(crate) fn resolve_flutter_platforms(
     template: Template,
     platforms: Option<String>,
-) -> anyhow::Result<FlutterPlatforms> {
+) -> anyhow::Result<String> {
     if let Some(value) = platforms {
-        return Ok(FlutterPlatforms {
-            include_ohos: platform_list_contains_ohos(&value),
-            value,
-        });
+        return Ok(value);
     }
 
     let include_ohos = is_ohos_flutter().unwrap_or(false);
-    Ok(FlutterPlatforms {
-        value: default_flutter_platforms(template, include_ohos),
-        include_ohos,
-    })
+    Ok(default_flutter_platforms(template, include_ohos))
 }
 
 #[allow(clippy::vec_init_then_push)]
@@ -143,7 +132,7 @@ fn default_flutter_platforms(template: Template, include_ohos: bool) -> String {
     )
 }
 
-fn platform_list_contains_ohos(platforms: &str) -> bool {
+pub(crate) fn platform_list_contains_ohos(platforms: &str) -> bool {
     platforms
         .split(',')
         .any(|platform| platform.trim().eq_ignore_ascii_case("ohos"))

--- a/frb_codegen/src/library/commands/flutter.rs
+++ b/frb_codegen/src/library/commands/flutter.rs
@@ -85,3 +85,101 @@ pub fn flutter_pub_get(path: &Path, fvm_install_mode: FvmInstallMode) -> anyhow:
     );
     check_exit_code(&command_run!(call_shell[Some(path), None], *full_args)?)
 }
+
+#[allow(clippy::vec_init_then_push)]
+pub fn is_ohos_flutter() -> anyhow::Result<bool> {
+    let mut full_args = vec![];
+    full_args.extend(command_arg_maybe_fvm(None, FvmInstallMode::Skip));
+    full_args.extend(vec![
+        "flutter".to_owned(),
+        "create".to_owned(),
+        "--help".to_owned(),
+    ]);
+    info!("Execute `{}` (this may take a while)", full_args.join(" "));
+    let out = command_run!(call_shell[None, None], *full_args)?;
+    if !out.status.success() {
+        // This will stop the whole generator and tell the users, so we do not care about testing it
+        // frb-coverage:ignore-start
+        let msg = String::from_utf8_lossy(&out.stderr);
+        anyhow::bail!("Command execution failed: {msg}");
+    }
+    let res = String::from_utf8_lossy(&out.stdout);
+    let is_ohos = flutter_create_help_supports_platform(&res, "ohos");
+    if is_ohos {
+        info!("current flutter support ohos platform.")
+    }
+    Ok(is_ohos)
+}
+
+fn flutter_create_help_supports_platform(help: &str, platform: &str) -> bool {
+    let mut in_platforms_option = false;
+
+    for line in help.lines() {
+        let trimmed = line.trim_start();
+        let starts_new_option =
+            trimmed.starts_with("--") || trimmed.starts_with('-') && trimmed.contains("--");
+        if in_platforms_option && starts_new_option && !trimmed.contains("--platforms") {
+            return false;
+        }
+
+        if trimmed.contains("--platforms") {
+            in_platforms_option = true;
+        }
+
+        if in_platforms_option && text_contains_platform_token(line, platform) {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn text_contains_platform_token(text: &str, platform: &str) -> bool {
+    text.split(|character: char| !character.is_ascii_alphanumeric() && character != '_')
+        .any(|token| token.eq_ignore_ascii_case(platform))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::flutter_create_help_supports_platform;
+
+    #[test]
+    fn test_flutter_create_help_supports_platform_on_platforms_line() {
+        let help = "
+Usage: flutter create <output directory>
+
+    --platforms    The platforms supported by this project.
+                   [android, ios, linux, macos, ohos, web, windows]
+    --org          The organization responsible for your new Flutter project.
+";
+
+        assert!(flutter_create_help_supports_platform(help, "ohos"));
+    }
+
+    #[test]
+    fn test_flutter_create_help_supports_platform_rejects_other_help_text() {
+        let help = "
+Usage: flutter create <output directory>
+
+    --description  Create an app for the ohos store.
+    --platforms    The platforms supported by this project.
+                   [android, ios, linux, macos, web, windows]
+    --org          The organization responsible for your new Flutter project.
+";
+
+        assert!(!flutter_create_help_supports_platform(help, "ohos"));
+    }
+
+    #[test]
+    fn test_flutter_create_help_supports_platform_stops_at_next_option() {
+        let help = "
+Usage: flutter create <output directory>
+
+    --platforms    The platforms supported by this project.
+                   [android, ios, linux, macos, web, windows]
+    --org          The organization responsible for your ohos project.
+";
+
+        assert!(!flutter_create_help_supports_platform(help, "ohos"));
+    }
+}

--- a/frb_codegen/src/library/commands/flutter.rs
+++ b/frb_codegen/src/library/commands/flutter.rs
@@ -26,7 +26,7 @@ pub fn flutter_create(
         "create".to_owned(),
         name.to_owned(),
     ]);
-    let platforms = resolve_flutter_platforms(template, platforms, fvm_install_mode)?;
+    let platforms = resolve_flutter_platforms(template, platforms)?;
     if let Some(o) = org {
         full_args.extend(["--org".to_owned(), o.to_owned()]);
     }
@@ -91,7 +91,6 @@ pub fn flutter_pub_get(path: &Path, fvm_install_mode: FvmInstallMode) -> anyhow:
 pub(crate) fn resolve_flutter_platforms(
     template: Template,
     platforms: Option<String>,
-    _fvm_install_mode: FvmInstallMode,
 ) -> anyhow::Result<FlutterPlatforms> {
     if let Some(value) = platforms {
         return Ok(FlutterPlatforms {

--- a/frb_codegen/src/library/commands/flutter.rs
+++ b/frb_codegen/src/library/commands/flutter.rs
@@ -6,6 +6,11 @@ use crate::misc::{FvmInstallMode, Template};
 use log::info;
 use std::path::Path;
 
+pub(crate) struct FlutterPlatforms {
+    pub(crate) value: String,
+    pub(crate) include_ohos: bool,
+}
+
 #[allow(clippy::vec_init_then_push)]
 pub fn flutter_create(
     name: &str,
@@ -21,25 +26,22 @@ pub fn flutter_create(
         "create".to_owned(),
         name.to_owned(),
     ]);
+    let platforms = resolve_flutter_platforms(template, platforms, fvm_install_mode)?;
     if let Some(o) = org {
         full_args.extend(["--org".to_owned(), o.to_owned()]);
     }
-    let platforms = platforms.unwrap_or_else(|| match template {
-        Template::App => "android,ios,linux,macos,web,windows".to_owned(),
-        Template::Plugin => "android,ios,linux,macos,windows".to_owned(),
-    });
     match template {
         Template::App => full_args.extend([
             "--template".to_owned(),
             "app".to_owned(),
             "--platforms".to_owned(),
-            platforms,
+            platforms.value,
         ]),
         Template::Plugin => full_args.extend([
             "--template".to_owned(),
             "plugin_ffi".to_owned(),
             "--platforms".to_owned(),
-            platforms,
+            platforms.value,
         ]),
     }
 
@@ -86,6 +88,25 @@ pub fn flutter_pub_get(path: &Path, fvm_install_mode: FvmInstallMode) -> anyhow:
     check_exit_code(&command_run!(call_shell[Some(path), None], *full_args)?)
 }
 
+pub(crate) fn resolve_flutter_platforms(
+    template: Template,
+    platforms: Option<String>,
+    _fvm_install_mode: FvmInstallMode,
+) -> anyhow::Result<FlutterPlatforms> {
+    if let Some(value) = platforms {
+        return Ok(FlutterPlatforms {
+            include_ohos: platform_list_contains_ohos(&value),
+            value,
+        });
+    }
+
+    let include_ohos = is_ohos_flutter().unwrap_or(false);
+    Ok(FlutterPlatforms {
+        value: default_flutter_platforms(template, include_ohos),
+        include_ohos,
+    })
+}
+
 #[allow(clippy::vec_init_then_push)]
 pub fn is_ohos_flutter() -> anyhow::Result<bool> {
     let mut full_args = vec![];
@@ -109,6 +130,24 @@ pub fn is_ohos_flutter() -> anyhow::Result<bool> {
         info!("current flutter support ohos platform.")
     }
     Ok(is_ohos)
+}
+
+fn default_flutter_platforms(template: Template, include_ohos: bool) -> String {
+    format!(
+        "android,ios,linux,macos,windows{}{}",
+        if include_ohos { ",ohos" } else { "" },
+        if matches!(template, Template::Plugin) {
+            ""
+        } else {
+            ",web"
+        }
+    )
+}
+
+fn platform_list_contains_ohos(platforms: &str) -> bool {
+    platforms
+        .split(',')
+        .any(|platform| platform.trim().eq_ignore_ascii_case("ohos"))
 }
 
 fn flutter_create_help_supports_platform(help: &str, platform: &str) -> bool {
@@ -141,7 +180,52 @@ fn text_contains_platform_token(text: &str, platform: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::flutter_create_help_supports_platform;
+    use super::{
+        default_flutter_platforms, flutter_create_help_supports_platform,
+        platform_list_contains_ohos,
+    };
+    use crate::misc::Template;
+
+    #[test]
+    fn test_platform_list_contains_ohos_with_whitespace() {
+        assert!(platform_list_contains_ohos("android, ohos"));
+    }
+
+    #[test]
+    fn test_platform_list_contains_ohos_is_case_insensitive() {
+        assert!(platform_list_contains_ohos("android,OHOS"));
+    }
+
+    #[test]
+    fn test_platform_list_contains_ohos_rejects_other_platforms() {
+        assert!(!platform_list_contains_ohos(
+            "android,ios,linux,macos,windows"
+        ));
+    }
+
+    #[test]
+    fn test_default_flutter_platforms_for_app() {
+        assert_eq!(
+            default_flutter_platforms(Template::App, false),
+            "android,ios,linux,macos,windows,web"
+        );
+        assert_eq!(
+            default_flutter_platforms(Template::App, true),
+            "android,ios,linux,macos,windows,ohos,web"
+        );
+    }
+
+    #[test]
+    fn test_default_flutter_platforms_for_plugin() {
+        assert_eq!(
+            default_flutter_platforms(Template::Plugin, false),
+            "android,ios,linux,macos,windows"
+        );
+        assert_eq!(
+            default_flutter_platforms(Template::Plugin, true),
+            "android,ios,linux,macos,windows,ohos"
+        );
+    }
 
     #[test]
     fn test_flutter_create_help_supports_platform_on_platforms_line() {

--- a/frb_codegen/src/library/integration/creator.rs
+++ b/frb_codegen/src/library/integration/creator.rs
@@ -35,11 +35,12 @@ pub fn create(config: CreateConfig) -> anyhow::Result<()> {
     );
     // frb-coverage:ignore-end
 
+    let platforms = config.platforms.clone();
     flutter_create(
         &config.name,
         &config.org,
         config.template,
-        config.platforms,
+        platforms.clone(),
         config.fvm_install_mode,
     )?;
 
@@ -60,6 +61,7 @@ pub fn create(config: CreateConfig) -> anyhow::Result<()> {
         rust_crate_name: config.rust_crate_name,
         rust_crate_dir: config.rust_crate_dir,
         template: config.template,
+        platforms,
         fvm_install_mode: config.fvm_install_mode,
     })
 }

--- a/frb_codegen/src/library/integration/creator.rs
+++ b/frb_codegen/src/library/integration/creator.rs
@@ -14,6 +14,7 @@ pub struct CreateConfig {
     pub rust_crate_name: Option<String>,
     pub rust_crate_dir: String,
     pub template: Template,
+    pub platforms: Option<String>,
     pub fvm_install_mode: FvmInstallMode,
 }
 
@@ -38,6 +39,7 @@ pub fn create(config: CreateConfig) -> anyhow::Result<()> {
         &config.name,
         &config.org,
         config.template,
+        config.platforms,
         config.fvm_install_mode,
     )?;
 

--- a/frb_codegen/src/library/integration/integrator.rs
+++ b/frb_codegen/src/library/integration/integrator.rs
@@ -3,7 +3,7 @@ use crate::library::commands::cargo::cargo_fetch;
 use crate::library::commands::dart_fix::dart_fix;
 use crate::library::commands::dart_format::dart_format;
 use crate::library::commands::flutter::{
-    flutter_pub_add, flutter_pub_get, resolve_flutter_platforms,
+    flutter_pub_add, flutter_pub_get, platform_list_contains_ohos, resolve_flutter_platforms,
 };
 use crate::misc::{FvmInstallMode, Template};
 use crate::utils::dart_repository::get_dart_package_name;
@@ -49,6 +49,7 @@ pub fn integrate(config: IntegrateConfig) -> Result<()> {
             Template::Plugin => dart_package_name.to_owned(),
         });
     let platforms = resolve_flutter_platforms(config.template, config.platforms.clone())?;
+    let include_ohos = platform_list_contains_ohos(&platforms);
 
     info!("Overlay template onto project");
     let replacements = compute_replacements(&config, &dart_package_name, &rust_crate_name);
@@ -58,7 +59,7 @@ pub fn integrate(config: IntegrateConfig) -> Result<()> {
         &dart_root,
         &config,
         None,
-        platforms.include_ohos,
+        include_ohos,
     )?;
     let (dir, comment_out_files) = match &config.template {
         Template::App => (&TemplateDirs::APP, vec!["main.dart".to_string()]),
@@ -73,7 +74,7 @@ pub fn integrate(config: IntegrateConfig) -> Result<()> {
         &dart_root,
         &config,
         Some(&comment_out_files),
-        platforms.include_ohos,
+        include_ohos,
     )?;
 
     if config.enable_local_dependency && config.template == Template::Plugin {

--- a/frb_codegen/src/library/integration/integrator.rs
+++ b/frb_codegen/src/library/integration/integrator.rs
@@ -2,9 +2,11 @@ use crate::integration::utils::{overlay_dir, replace_file_content};
 use crate::library::commands::cargo::cargo_fetch;
 use crate::library::commands::dart_fix::dart_fix;
 use crate::library::commands::dart_format::dart_format;
-use crate::library::commands::flutter::{flutter_pub_add, flutter_pub_get};
+use crate::library::commands::flutter::{
+    flutter_pub_add, flutter_pub_get, resolve_flutter_platforms,
+};
 use crate::misc::{FvmInstallMode, Template};
-use crate::utils::dart_repository::get_dart_package_name;
+use crate::utils::dart_repository::get_dart_package_name_and_rust_crate_name;
 use crate::utils::path_utils::find_dart_package_dir;
 use anyhow::Result;
 use include_dir::{include_dir, Dir};
@@ -26,6 +28,7 @@ pub struct IntegrateConfig {
     pub rust_crate_name: Option<String>,
     pub rust_crate_dir: String,
     pub template: Template,
+    pub platforms: Option<String>,
     pub fvm_install_mode: FvmInstallMode,
 }
 
@@ -35,16 +38,16 @@ pub fn integrate(config: IntegrateConfig) -> Result<()> {
     let dart_root = find_dart_package_dir(&env::current_dir()?)?;
     debug!("integrate dart_root={dart_root:?}");
 
-    let dart_package_name = get_dart_package_name(&dart_root)?;
-    let rust_crate_name = config
-        .rust_crate_name
-        .clone()
-        .unwrap_or(match &config.template {
-            Template::App => {
-                format!("rust_lib_{dart_package_name}")
-            }
-            Template::Plugin => dart_package_name.to_owned(),
-        });
+    let (dart_package_name, rust_crate_name) = get_dart_package_name_and_rust_crate_name(
+        &dart_root,
+        &config.rust_crate_name,
+        &config.template,
+    )?;
+    let platforms = resolve_flutter_platforms(
+        config.template,
+        config.platforms.clone(),
+        config.fvm_install_mode,
+    )?;
 
     info!("Overlay template onto project");
     let replacements = compute_replacements(&config, &dart_package_name, &rust_crate_name);
@@ -54,6 +57,7 @@ pub fn integrate(config: IntegrateConfig) -> Result<()> {
         &dart_root,
         &config,
         None,
+        platforms.include_ohos,
     )?;
     let (dir, comment_out_files) = match &config.template {
         Template::App => (&TemplateDirs::APP, vec!["main.dart".to_string()]),
@@ -68,6 +72,7 @@ pub fn integrate(config: IntegrateConfig) -> Result<()> {
         &dart_root,
         &config,
         Some(&comment_out_files),
+        platforms.include_ohos,
     )?;
 
     if config.enable_local_dependency && config.template == Template::Plugin {
@@ -134,6 +139,7 @@ fn execute_overlay_dir(
     dart_root: &Path,
     config: &IntegrateConfig,
     comment_out_files: Option<&[String]>,
+    include_ohos: bool,
 ) -> Result<()> {
     overlay_dir(
         current_reference_dir,
@@ -154,6 +160,7 @@ fn execute_overlay_dir(
                 path,
                 config.enable_write_lib,
                 config.enable_integration_test,
+                include_ohos,
             )
         },
     )
@@ -377,7 +384,16 @@ fn comment_out_existing_file_and_write_template(
     Some((path, [commented_existing_content.as_bytes(), src].concat()))
 }
 
-fn filter_file(path: &Path, enable_write_lib: bool, enable_integration_test: bool) -> bool {
+fn filter_file(
+    path: &Path,
+    enable_write_lib: bool,
+    enable_integration_test: bool,
+    include_ohos: bool,
+) -> bool {
+    if path.iter().contains(&OsStr::new("ohos")) && !include_ohos {
+        return false;
+    }
+
     if path.iter().contains(&OsStr::new("cargokit")) {
         return ![".git", ".github", "docs", "test"].contains(&file_name(path));
     }
@@ -411,6 +427,54 @@ fn filter_file(path: &Path, enable_write_lib: bool, enable_integration_test: boo
     }
 
     true
+}
+
+#[cfg(test)]
+mod filter_tests {
+    use super::filter_file;
+    use std::path::Path;
+
+    #[test]
+    fn test_filter_file_excludes_ohos_when_not_enabled() {
+        assert!(!filter_file(
+            Path::new("rust_builder/ohos/src/main/module.json5"),
+            true,
+            true,
+            false,
+        ));
+        assert!(!filter_file(
+            Path::new("ohos/src/main/module.json5"),
+            true,
+            true,
+            false,
+        ));
+    }
+
+    #[test]
+    fn test_filter_file_includes_ohos_when_enabled() {
+        assert!(filter_file(
+            Path::new("rust_builder/ohos/src/main/module.json5"),
+            true,
+            true,
+            true,
+        ));
+        assert!(filter_file(
+            Path::new("ohos/src/main/module.json5"),
+            true,
+            true,
+            true,
+        ));
+    }
+
+    #[test]
+    fn test_filter_file_no_write_lib_excludes_enabled_ohos_platform_shell() {
+        assert!(!filter_file(
+            Path::new("ohos/src/main/module.json5"),
+            false,
+            true,
+            true,
+        ));
+    }
 }
 
 fn compute_cargokit_comments(path: &Path) -> Option<String> {

--- a/frb_codegen/src/library/integration/integrator.rs
+++ b/frb_codegen/src/library/integration/integrator.rs
@@ -48,11 +48,7 @@ pub fn integrate(config: IntegrateConfig) -> Result<()> {
             }
             Template::Plugin => dart_package_name.to_owned(),
         });
-    let platforms = resolve_flutter_platforms(
-        config.template,
-        config.platforms.clone(),
-        config.fvm_install_mode,
-    )?;
+    let platforms = resolve_flutter_platforms(config.template, config.platforms.clone())?;
 
     info!("Overlay template onto project");
     let replacements = compute_replacements(&config, &dart_package_name, &rust_crate_name);

--- a/frb_codegen/src/library/integration/integrator.rs
+++ b/frb_codegen/src/library/integration/integrator.rs
@@ -6,7 +6,7 @@ use crate::library::commands::flutter::{
     flutter_pub_add, flutter_pub_get, resolve_flutter_platforms,
 };
 use crate::misc::{FvmInstallMode, Template};
-use crate::utils::dart_repository::get_dart_package_name_and_rust_crate_name;
+use crate::utils::dart_repository::get_dart_package_name;
 use crate::utils::path_utils::find_dart_package_dir;
 use anyhow::Result;
 use include_dir::{include_dir, Dir};
@@ -38,11 +38,16 @@ pub fn integrate(config: IntegrateConfig) -> Result<()> {
     let dart_root = find_dart_package_dir(&env::current_dir()?)?;
     debug!("integrate dart_root={dart_root:?}");
 
-    let (dart_package_name, rust_crate_name) = get_dart_package_name_and_rust_crate_name(
-        &dart_root,
-        &config.rust_crate_name,
-        &config.template,
-    )?;
+    let dart_package_name = get_dart_package_name(&dart_root)?;
+    let rust_crate_name = config
+        .rust_crate_name
+        .clone()
+        .unwrap_or(match &config.template {
+            Template::App => {
+                format!("rust_lib_{dart_package_name}")
+            }
+            Template::Plugin => dart_package_name.to_owned(),
+        });
     let platforms = resolve_flutter_platforms(
         config.template,
         config.platforms.clone(),

--- a/frb_codegen/src/main.rs
+++ b/frb_codegen/src/main.rs
@@ -53,6 +53,7 @@ fn main_given_cli(cli: Cli) -> anyhow::Result<()> {
             rust_crate_name: args.common.rust_crate_name.clone(),
             rust_crate_dir: compute_rust_crate_dir(&args.common),
             template: args.template.into(),
+            platforms: args.platforms,
             fvm_install_mode: FvmInstallMode::from_skip_fvm_install(args.skip_fvm_install),
         })?,
         Commands::BuildWeb(args) => build_web::build(

--- a/frb_codegen/src/main.rs
+++ b/frb_codegen/src/main.rs
@@ -41,6 +41,7 @@ fn main_given_cli(cli: Cli) -> anyhow::Result<()> {
             rust_crate_name: args.common.rust_crate_name.clone(),
             rust_crate_dir: compute_rust_crate_dir(&args.common),
             template: args.template.into(),
+            platforms: args.platforms,
             fvm_install_mode: FvmInstallMode::from_skip_fvm_install(args.skip_fvm_install),
         })?,
         Commands::Integrate(args) => integration::integrate(IntegrateConfig {

--- a/website/docs/generated/_frb-codegen-command-create.mdx
+++ b/website/docs/generated/_frb-codegen-command-create.mdx
@@ -28,7 +28,6 @@ Options:
 
       --platforms <PLATFORMS>
           Specify the platforms to be supported
-
       --skip-fvm-install
           Skip fvm installation
 

--- a/website/docs/generated/_frb-codegen-command-create.mdx
+++ b/website/docs/generated/_frb-codegen-command-create.mdx
@@ -26,6 +26,9 @@ Options:
           - app:    (default) a Flutter application
           - plugin: A shareable Flutter project that can be used across multiple Flutter applications
 
+      --platforms <PLATFORMS>
+          Specify the platforms to be supported
+
       --skip-fvm-install
           Skip fvm installation
 

--- a/website/docs/generated/_frb-codegen-command-integrate.mdx
+++ b/website/docs/generated/_frb-codegen-command-integrate.mdx
@@ -31,6 +31,9 @@ Options:
           - app:    (default) a Flutter application
           - plugin: A shareable Flutter project that can be used across multiple Flutter applications
 
+      --platforms <PLATFORMS>
+          Specify the platforms to be supported
+
       --skip-fvm-install
           Skip fvm installation
 

--- a/website/docs/generated/_frb-codegen-command-integrate.mdx
+++ b/website/docs/generated/_frb-codegen-command-integrate.mdx
@@ -33,7 +33,6 @@ Options:
 
       --platforms <PLATFORMS>
           Specify the platforms to be supported
-
       --skip-fvm-install
           Skip fvm installation
 

--- a/website/docs/manual/integrate/02-builtin.md
+++ b/website/docs/manual/integrate/02-builtin.md
@@ -6,6 +6,12 @@ this command automatically add Cargokit and flutter_rust_bridge-needed code into
 Remark: Currently, the Cargokit source code has to be copied into the target repository,
 as is [suggested officially](https://matejknopp.com/post/flutter_plugin_in_rust_with_no_prebuilt_binaries/).
 
+## Platform selection
+
+The `create` and `integrate` commands accept `--platforms <PLATFORMS>` to control which Flutter platforms should receive scaffold. When `--platforms` is omitted, flutter_rust_bridge follows the current Flutter toolchain: ordinary upstream Flutter projects do not receive HarmonyOS/OHOS scaffold, while OHOS-enabled Flutter toolchains may receive OHOS scaffold automatically.
+
+To force OHOS scaffold even when generating on a non-OHOS Flutter toolchain, pass a platform list containing `ohos`, for example `--platforms android,ios,linux,macos,windows,ohos`.
+
 :::info
 When Dart's [native assets](native-assets) language feature is stabilized,
 we may also utilize that approach.


### PR DESCRIPTION
Extracted from #3065 to keep the HarmonyOS PR reviewable as a stacked chain.

Original implementation by @star4277 (Chibeiyu) in #3065. This PR carries the `--platforms` passthrough for both `create` and `integrate`, plus the shared platform-selection documentation. HarmonyOS-specific template assets remain in the child PR.

Stack:
- #3126: skip FVM install option
- #3129: create/integrate platforms passthrough
- #3065: HarmonyOS support