### PR TITLE
Add coverage tests for existing helpers

### DIFF
--- a/frb_codegen/src/library/codegen/polisher/auto_upgrade.rs
+++ b/frb_codegen/src/library/codegen/polisher/auto_upgrade.rs
@@ -132,3 +132,58 @@ impl Upgrader for RustUpgrader<'_> {
         cargo_add(&args, self.base_dir)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::RustUpgrader;
+    use cargo_toml::Manifest;
+
+    fn parse_manifest(text: &str) -> Manifest {
+        toml::from_str(text).unwrap()
+    }
+
+    #[test]
+    fn test_get_dependency_from_target_specific_dependencies() {
+        let manifest = parse_manifest(
+            r#"
+                [package]
+                name = "demo"
+                version = "0.1.0"
+                edition = "2021"
+
+                [target.x86_64-unknown-linux-gnu.dependencies]
+                flutter_rust_bridge = "=1.0.0"
+            "#,
+        );
+
+        let (target_name, dependency) =
+            RustUpgrader::get_dependency(manifest, "flutter_rust_bridge").unwrap();
+
+        assert_eq!(target_name.as_deref(), Some("x86_64-unknown-linux-gnu"));
+        assert_eq!(dependency.req(), "=1.0.0");
+    }
+
+    #[test]
+    fn test_get_dependency_prefers_root_dependencies() {
+        let manifest = parse_manifest(
+            r#"
+                [package]
+                name = "demo"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                flutter_rust_bridge = "=2.0.0"
+
+                [target.x86_64-unknown-linux-gnu.dependencies]
+                flutter_rust_bridge = "=1.0.0"
+            "#,
+        );
+
+        let (target_name, dependency) =
+            RustUpgrader::get_dependency(manifest, "flutter_rust_bridge").unwrap();
+
+        assert_eq!(target_name, None);
+        assert_eq!(dependency.req(), "=2.0.0");
+    }
+}

--- a/frb_codegen/src/library/integration/creator.rs
+++ b/frb_codegen/src/library/integration/creator.rs
@@ -141,3 +141,22 @@ fn remove_files_in_dir(dir: &Path) -> anyhow::Result<()> {
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::remove_files_in_dir;
+    use std::fs;
+
+    #[test]
+    fn test_remove_files_in_dir_rejects_nested_directories() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let root = temp_dir.path().join("root");
+        fs::create_dir_all(root.join("nested")).unwrap();
+        fs::write(root.join("top.txt"), "x").unwrap();
+        fs::write(root.join("nested").join("child.txt"), "x").unwrap();
+
+        let err = remove_files_in_dir(&root).unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("expected to contain only files"));
+    }
+}

--- a/frb_codegen/src/library/integration/integrator.rs
+++ b/frb_codegen/src/library/integration/integrator.rs
@@ -242,8 +242,8 @@ fn set_permission_executable(path: &Path) -> Result<()> {
 #[cfg(all(test, unix))]
 mod tests {
     use super::{
-        refresh_cargo_lock_ordering, set_permission_executable, should_refresh_cargo_lock_ordering,
-        REFRESH_CARGO_LOCK_ORDERING_ENV_VAR,
+        maybe_refresh_cargo_lock_ordering, refresh_cargo_lock_ordering, set_permission_executable,
+        should_refresh_cargo_lock_ordering, REFRESH_CARGO_LOCK_ORDERING_ENV_VAR,
     };
     use serial_test::serial;
     use std::fs;
@@ -302,6 +302,20 @@ mod tests {
 
         std::env::set_var(REFRESH_CARGO_LOCK_ORDERING_ENV_VAR, "1");
         assert!(should_refresh_cargo_lock_ordering());
+
+        std::env::remove_var(REFRESH_CARGO_LOCK_ORDERING_ENV_VAR);
+    }
+
+    #[test]
+    #[serial]
+    fn test_maybe_refresh_cargo_lock_ordering_skips_when_env_var_is_not_one() {
+        std::env::remove_var(REFRESH_CARGO_LOCK_ORDERING_ENV_VAR);
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        maybe_refresh_cargo_lock_ordering(temp_dir.path(), "does-not-need-to-exist").unwrap();
+
+        std::env::set_var(REFRESH_CARGO_LOCK_ORDERING_ENV_VAR, "0");
+        maybe_refresh_cargo_lock_ordering(temp_dir.path(), "still-not-used").unwrap();
 
         std::env::remove_var(REFRESH_CARGO_LOCK_ORDERING_ENV_VAR);
     }


### PR DESCRIPTION
Extracts coverage-only tests from #3065 so the HarmonyOS PR can stay focused on HarmonyOS changes. These tests were originally contributed in #3065 by its author, not as new feature work in this branch.