### PR TITLE
Make workflow telemetry optional

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,9 +77,13 @@ jobs:
 
     steps:
       # setup
-      - uses: catchpoint/workflow-telemetry-action@v1
+      - uses: catchpoint/workflow-telemetry-action@v2
+        continue-on-error: true
+        env:
+          WORKFLOW_TELEMETRY_SERVER_PORT: 7778
         with:
           comment_on_pr: false
+          job_summary: false
       - uses: actions/checkout@v4
         with:
           submodules: recursive
@@ -105,9 +109,13 @@ jobs:
 
     steps:
       # setup
-      - uses: catchpoint/workflow-telemetry-action@v1
+      - uses: catchpoint/workflow-telemetry-action@v2
+        continue-on-error: true
+        env:
+          WORKFLOW_TELEMETRY_SERVER_PORT: 7778
         with:
           comment_on_pr: false
+          job_summary: false
       - uses: actions/checkout@v4
         with:
           submodules: recursive
@@ -125,9 +133,13 @@ jobs:
 
     steps:
       # setup
-      - uses: catchpoint/workflow-telemetry-action@v1
+      - uses: catchpoint/workflow-telemetry-action@v2
+        continue-on-error: true
+        env:
+          WORKFLOW_TELEMETRY_SERVER_PORT: 7778
         with:
           comment_on_pr: false
+          job_summary: false
       - uses: actions/checkout@v4
         with:
           submodules: recursive
@@ -208,8 +220,12 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        continue-on-error: true
+        env:
+          WORKFLOW_TELEMETRY_SERVER_PORT: 7778
         with:
           comment_on_pr: false
+          job_summary: false
       - uses: actions/checkout@v5
         with:
           submodules: recursive
@@ -253,8 +269,12 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        continue-on-error: true
+        env:
+          WORKFLOW_TELEMETRY_SERVER_PORT: 7778
         with:
           comment_on_pr: false
+          job_summary: false
       - uses: actions/checkout@v5
         with:
           submodules: recursive
@@ -284,8 +304,12 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        continue-on-error: true
+        env:
+          WORKFLOW_TELEMETRY_SERVER_PORT: 7778
         with:
           comment_on_pr: false
+          job_summary: false
       - uses: actions/checkout@v5
         with:
           submodules: recursive
@@ -326,8 +350,12 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        continue-on-error: true
+        env:
+          WORKFLOW_TELEMETRY_SERVER_PORT: 7778
         with:
           comment_on_pr: false
+          job_summary: false
       - uses: actions/checkout@v5
         with:
           submodules: recursive
@@ -413,8 +441,12 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        continue-on-error: true
+        env:
+          WORKFLOW_TELEMETRY_SERVER_PORT: 7778
         with:
           comment_on_pr: false
+          job_summary: false
       - uses: actions/checkout@v5
         with:
           submodules: recursive
@@ -452,8 +484,12 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        continue-on-error: true
+        env:
+          WORKFLOW_TELEMETRY_SERVER_PORT: 7778
         with:
           comment_on_pr: false
+          job_summary: false
       - uses: actions/checkout@v5
         with:
           submodules: recursive
@@ -546,8 +582,12 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        continue-on-error: true
+        env:
+          WORKFLOW_TELEMETRY_SERVER_PORT: 7778
         with:
           comment_on_pr: false
+          job_summary: false
       - uses: actions/checkout@v5
         with:
           submodules: recursive
@@ -601,8 +641,12 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        continue-on-error: true
+        env:
+          WORKFLOW_TELEMETRY_SERVER_PORT: 7778
         with:
           comment_on_pr: false
+          job_summary: false
       - uses: actions/checkout@v5
         with:
           submodules: recursive
@@ -641,8 +685,12 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        continue-on-error: true
+        env:
+          WORKFLOW_TELEMETRY_SERVER_PORT: 7778
         with:
           comment_on_pr: false
+          job_summary: false
       - uses: actions/checkout@v5
         with:
           submodules: recursive
@@ -694,8 +742,12 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        continue-on-error: true
+        env:
+          WORKFLOW_TELEMETRY_SERVER_PORT: 7778
         with:
           comment_on_pr: false
+          job_summary: false
       - uses: actions/checkout@v5
         with:
           submodules: recursive
@@ -735,8 +787,12 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        continue-on-error: true
+        env:
+          WORKFLOW_TELEMETRY_SERVER_PORT: 7778
         with:
           comment_on_pr: false
+          job_summary: false
       - uses: actions/checkout@v5
         with:
           submodules: recursive
@@ -845,8 +901,12 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        continue-on-error: true
+        env:
+          WORKFLOW_TELEMETRY_SERVER_PORT: 7778
         with:
           comment_on_pr: false
+          job_summary: false
       - uses: actions/checkout@v5
         with:
           submodules: recursive
@@ -930,8 +990,12 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        continue-on-error: true
+        env:
+          WORKFLOW_TELEMETRY_SERVER_PORT: 7778
         with:
           comment_on_pr: false
+          job_summary: false
       - uses: actions/checkout@v5
         with:
           submodules: recursive
@@ -962,8 +1026,12 @@ jobs:
 
     steps:
       - uses: catchpoint/workflow-telemetry-action@v2
+        continue-on-error: true
+        env:
+          WORKFLOW_TELEMETRY_SERVER_PORT: 7778
         with:
           comment_on_pr: false
+          job_summary: false
       - uses: actions/checkout@v5
         with:
           submodules: recursive

--- a/.github/workflows/post_release.yaml
+++ b/.github/workflows/post_release.yaml
@@ -42,8 +42,12 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        continue-on-error: true
+        env:
+          WORKFLOW_TELEMETRY_SERVER_PORT: 7778
         with:
           comment_on_pr: false
+          job_summary: false
       - uses: actions/checkout@v5
         with:
           submodules: recursive


### PR DESCRIPTION
Make workflow telemetry non-blocking across CI and post-release jobs.

## Why

Telemetry is useful for diagnosing slow or flaky workflow behavior, but it should never be able to fail an otherwise valid CI job. The previous setup mixed older `workflow-telemetry-action@v1` steps with v2 steps, and recent attempts to use telemetry showed that the action can fail in its publishing/post-processing path. This PR keeps telemetry enabled while making it explicitly best-effort.

## Changes

- Upgrade the remaining live `catchpoint/workflow-telemetry-action@v1` steps in CI to `@v2`.
  - Reason: the workflow already had several v2 telemetry steps, so using v2 everywhere keeps behavior consistent.
  - Scope: only active workflow steps are changed; commented-out legacy examples are left alone.

- Add `continue-on-error: true` to telemetry steps.
  - Reason: telemetry collection is observational. A telemetry outage, publishing error, or action-side failure should not block lint, build, test, or release validation.

- Keep `comment_on_pr: false`.
  - Reason: telemetry should not add noisy automated PR comments to ordinary development PRs.

- Add `job_summary: false`.
  - Reason: the telemetry action's summary/publication path has previously failed independently from the job being measured. Disabling summaries keeps telemetry from affecting job results while preserving collection.

- Set `WORKFLOW_TELEMETRY_SERVER_PORT: 7778`.
  - Reason: moving the telemetry worker off the default metrics/post-action path avoids port/path collisions observed when the action tries to publish charts.

## Validation

- `git diff --check origin/master...HEAD`
