### PR TITLE
Add precommit autofix devcontainer fallback

### DIFF
--- a/.github/workflows/precommit_autofix.yaml
+++ b/.github/workflows/precommit_autofix.yaml
@@ -42,7 +42,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          ./frb_internal precommit-autofix-in-dev-container --mode slow
+          ./frb_internal precommit-autofix-in-dev-container --mode slow --build-if-missing
 
       - name: Upload patch artifact
         if: ${{ steps.autofix.outputs.has_patch == 'true' }}

--- a/tools/frb_internal/lib/src/makefile_dart/precommit_autofix_in_dev_container.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/precommit_autofix_in_dev_container.dart
@@ -17,7 +17,7 @@ class PrecommitAutofixInDevContainerCommand extends Command<void> {
 
   @override
   final String description =
-      'Run precommit-autofix inside the published dev Docker image';
+      'Run precommit-autofix inside the dev Docker image';
 
   PrecommitAutofixInDevContainerCommand({
     required this.commandRunner,
@@ -69,6 +69,12 @@ class PrecommitAutofixInDevContainerCommand extends Command<void> {
         'github-notice',
         defaultsTo: false,
         help: 'Emit a ::notice:: line when a patch is produced.',
+      )
+      ..addFlag(
+        'build-if-missing',
+        defaultsTo: false,
+        help:
+            'Build the dev Docker image locally if pulling the published tag fails.',
       );
   }
 
@@ -113,6 +119,7 @@ class PrecommitAutofixInDevContainerCommand extends Command<void> {
             mode: argResults!['mode'] as String,
             outputPath: outputPath,
             artifactName: argResults!['artifact-name'] as String,
+            buildIfMissing: argResults!['build-if-missing'] as bool,
             githubHeadSha: githubHeadSha,
             githubRunId: githubRunId,
             githubOutputPath: githubOutputPath,
@@ -127,6 +134,7 @@ class PrecommitAutofixInDevContainerCommand extends Command<void> {
 
 class PrecommitAutofixInDevContainerConfig {
   final String artifactName;
+  final bool buildIfMissing;
   final String dockerfilePath;
   final String? githubHeadSha;
   final String? githubRunId;
@@ -139,6 +147,7 @@ class PrecommitAutofixInDevContainerConfig {
 
   const PrecommitAutofixInDevContainerConfig({
     required this.artifactName,
+    required this.buildIfMissing,
     required this.dockerfilePath,
     required this.githubHeadSha,
     required this.githubRunId,
@@ -211,7 +220,12 @@ class PrecommitAutofixInDevContainerService {
       outputPath: containerPatchPath,
     );
 
-    await commandRunner('docker pull ${shellEscape(imageRef)}');
+    await ensurePrecommitAutofixImage(
+      buildIfMissing: config.buildIfMissing,
+      commandRunner: commandRunner,
+      dockerfilePath: dockerfilePath,
+      imageRef: imageRef,
+    );
 
     await commandRunner(
       'docker run --rm '
@@ -281,6 +295,29 @@ class PrecommitAutofixInDevContainerService {
       hasPatch: hasPatch,
       imageRef: imageRef,
       outputPath: outputPath,
+    );
+  }
+}
+
+@visibleForTesting
+Future<void> ensurePrecommitAutofixImage({
+  required bool buildIfMissing,
+  required DevDockerWorkflowCommandRunner commandRunner,
+  required String dockerfilePath,
+  required String imageRef,
+}) async {
+  try {
+    await commandRunner('docker pull ${shellEscape(imageRef)}');
+  } on Object {
+    if (!buildIfMissing) {
+      rethrow;
+    }
+
+    await commandRunner(
+      'docker build '
+      '-f ${shellEscape(dockerfilePath)} '
+      '-t ${shellEscape(imageRef)} '
+      '${shellEscape(path.dirname(dockerfilePath))}',
     );
   }
 }

--- a/tools/frb_internal/lib/src/makefile_dart/precommit_autofix_in_dev_container.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/precommit_autofix_in_dev_container.dart
@@ -308,7 +308,7 @@ Future<void> ensurePrecommitAutofixImage({
 }) async {
   try {
     await commandRunner('docker pull ${shellEscape(imageRef)}');
-  } on Object {
+  } on Exception {
     if (!buildIfMissing) {
       rethrow;
     }

--- a/tools/frb_internal/test/src/makefile_dart/test_precommit_autofix_in_dev_container.dart
+++ b/tools/frb_internal/test/src/makefile_dart/test_precommit_autofix_in_dev_container.dart
@@ -4,6 +4,42 @@ import 'package:test/test.dart';
 
 void main() {
   test(
+    'ensurePrecommitAutofixImage builds local image when published tag is missing',
+    () async {
+      final commands = <String>[];
+
+      await ensurePrecommitAutofixImage(
+        buildIfMissing: true,
+        commandRunner:
+            (
+              cmd, {
+              String? relativePwd,
+              Map<String, String>? extraEnv,
+              bool? checkExitCode,
+            }) async {
+              commands.add(cmd);
+              if (cmd.startsWith('docker pull ')) {
+                throw Exception('missing image');
+              }
+              return const RunCommandOutput(
+                stdout: '',
+                stderr: '',
+                exitCode: 0,
+              );
+            },
+        dockerfilePath: '/repo/.devcontainer/Dockerfile',
+        imageRef:
+            'fzyzcjy/flutter_rust_bridge_dev:flutter-3.41.2-rust-1.93.1-nightly-2025-02-01',
+      );
+
+      expect(commands, [
+        "docker pull 'fzyzcjy/flutter_rust_bridge_dev:flutter-3.41.2-rust-1.93.1-nightly-2025-02-01'",
+        "docker build -f '/repo/.devcontainer/Dockerfile' -t 'fzyzcjy/flutter_rust_bridge_dev:flutter-3.41.2-rust-1.93.1-nightly-2025-02-01' '/repo/.devcontainer'",
+      ]);
+    },
+  );
+
+  test(
     'validatePrecommitAutofixPatch runs git apply check in repo root',
     () async {
       String? command;


### PR DESCRIPTION
## Summary

- Add a `--build-if-missing` option to `frb_internal precommit-autofix-in-dev-container`.
- Keep the default behavior unchanged: without the flag, a missing published dev image still fails after `docker pull`.
- Use the new flag in the Precommit Autofix workflow so PRs for freshly bumped dev image tags can still produce autofix patches before the image is published.

## Rationale

The precommit autofix workflow runs inside the versioned FRB dev Docker image. During version/image-transition PRs, the Dockerfile may point at a new image tag that has not been published yet. In that case the workflow fails at `docker pull` before it can run the autofix command.

This PR makes the GitHub workflow resilient by building the same dev image locally only when pulling the published tag fails. The fallback is opt-in through the workflow flag, so local/manual callers keep the stricter existing behavior unless they explicitly request the fallback.

## Verification

- `dart format tools/frb_internal/lib/src/makefile_dart/precommit_autofix_in_dev_container.dart tools/frb_internal/test/src/makefile_dart/test_precommit_autofix_in_dev_container.dart`
- `cd tools/frb_internal && dart test test/src/makefile_dart/test_precommit_autofix_in_dev_container.dart`