### PR TITLE
Add FRB PR review gate

### DIFF
--- a/.claude/skills/frb-issue-to-green-pr/SKILL.md
+++ b/.claude/skills/frb-issue-to-green-pr/SKILL.md
@@ -50,6 +50,7 @@ Read these when entering the matching phase:
 5. Prepare and open the PR.
    - Follow `frb-prepare-pr`.
    - Re-check that no final regression or feature coverage remains only in `frb_example/dart_minimal`. If it does, stop PR preparation and migrate it to `frb_example/pure_dart` first.
+   - Before treating the PR as ready, have a subagent run the test-weakening gate described in `sdev-pass-test` and address any unjustified weakening.
    - Push with upstream tracking.
    - Before drafting a PR title, inspect the user's recent PR titles and mimic the repo style.
    - Create the PR according to the active PR workflow and repository/user PR body rules.

--- a/.claude/skills/frb-issue-to-green-pr/SKILL.md
+++ b/.claude/skills/frb-issue-to-green-pr/SKILL.md
@@ -22,6 +22,7 @@ Read these when entering the matching phase:
 - `frb-test` before running local tests.
 - `frb-lint` before lint or format checks.
 - `frb-prepare-pr` before pushing or opening the PR.
+- `frb-pr-review` before treating a non-trivial PR as ready.
 - `frb-fix-ci` before diagnosing any CI failure.
 - `gh-actions-live-logs` before reading GitHub Actions logs.
 - `frb-debugging` when generated code is surprising or codegen behavior is unclear.
@@ -50,13 +51,13 @@ Read these when entering the matching phase:
 5. Prepare and open the PR.
    - Follow `frb-prepare-pr`.
    - Re-check that no final regression or feature coverage remains only in `frb_example/dart_minimal`. If it does, stop PR preparation and migrate it to `frb_example/pure_dart` first.
-   - Before treating the PR as ready, have a subagent run the test-weakening gate described in `sdev-pass-test` and address any unjustified weakening.
    - Push with upstream tracking.
    - Before drafting a PR title, inspect the user's recent PR titles and mimic the repo style.
    - Create the PR according to the active PR workflow and repository/user PR body rules.
    - If the work comes from a GitHub issue, ensure the PR body includes the appropriate closing keyword such as `Close #1234`, unless the active PR workflow explicitly requires an empty body.
 
 6. Handle Gemini review.
+   - Follow `frb-pr-review` for the full PR review gate, including correctness review, test-weakening review, and Gemini.
    - After pushing the PR and once you believe the code is reasonably ready, post a PR comment containing exactly `/gemini review` to request a Gemini pass; do not wait for CI to be green before requesting this first self-initiated review.
    - Wait for Gemini's GitHub review or comments if the repository automation posts them.
    - Treat actionable Gemini feedback like review comments: inspect, fix if valid, commit, push, and reply or otherwise make the resolution visible.

--- a/.claude/skills/frb-pr-review/SKILL.md
+++ b/.claude/skills/frb-pr-review/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: frb-pr-review
+description: Review a flutter_rust_bridge PR before treating it as ready, including subagent checks for correctness and test weakening plus Gemini review.
+---
+
+# FRB PR Review
+
+Use this before treating a non-trivial `flutter_rust_bridge` PR as ready, especially after CI-driven fixes, Flutter upgrades, generated drift, test changes, workflow changes, or broad merge conflict resolution.
+
+## Review Gate
+
+Run independent review before final readiness:
+
+1. Spawn a subagent to review correctness.
+   - Ask it to inspect the PR diff against the PR base.
+   - Focus on real behavior bugs, stale generated output, incorrect CI workarounds, coverage-only changes, and unrelated drift.
+   - Require findings with file paths, line numbers, impact, and suggested fix.
+
+2. Spawn a subagent to review test weakening.
+   - Use the test-weakening gate described in `sdev-pass-test` as the source of truth.
+   - Do not duplicate that workflow here; read `sdev-pass-test` for detection, classification, and restoration details.
+   - Treat unjustified skipped tests, weaker assertions, broader ignores, fake timeouts, and coverage hiding as blockers.
+
+3. Ask Gemini for an external review.
+   - Post `/gemini review` when the PR is reasonably ready.
+   - Inspect Gemini's review/comments.
+   - Fix valid feedback, commit, push, and explain invalid feedback in a concise PR comment.
+   - Request another Gemini pass after substantial follow-up fixes.
+
+4. Write a concise review conclusion.
+   - Put the conclusion in the PR description or an agent-context draft when the user asks for a Markdown artifact.
+   - Include the subagents used, Gemini status, accepted findings, dismissed findings, fixes made, and remaining risks.
+
+## Stop Condition
+
+Do not call the PR ready until:
+
+- Correctness review has no unresolved actionable findings.
+- Test-weakening review has no unjustified weakening.
+- Gemini has no unresolved actionable feedback after the latest requested pass.
+- CI status is green, or remaining non-green checks are clearly unrelated and explained.

--- a/.claude/skills/frb-prepare-pr/SKILL.md
+++ b/.claude/skills/frb-prepare-pr/SKILL.md
@@ -9,7 +9,7 @@ description: Use when about to create a PR or push changes in flutter_rust_bridg
 
 ## Overview
 
-Before creating a PR, ensure generated code is up to date, lint passes, and bug fixes have a concrete reproduction report in the PR description.
+Before creating a PR, ensure generated code is up to date, lint passes, and bug fixes have a concrete reproduction report in the PR description. Before treating a non-trivial PR as ready, run `frb-pr-review`.
 
 **Core principle:** Generate → Lint → Commit → PR.
 
@@ -28,11 +28,13 @@ Before creating a PR, ensure generated code is up to date, lint passes, and bug 
    |
    +-- 4. (Optional) Read frb-test skill --> Run relevant tests
    |
-   +-- 5. For bug fixes, add the reproduction report to the PR description
+   +-- 5. For non-trivial PRs, read frb-pr-review --> Run review gate
    |
-   +-- 6. Commit all changes
+   +-- 6. For bug fixes, add the reproduction report to the PR description
    |
-   +-- 7. Create PR (use creating-pull-requests skill)
+   +-- 7. Commit all changes
+   |
+   +-- 8. Create PR (use creating-pull-requests skill)
 ```
 
 ## Quick Checklist
@@ -41,9 +43,10 @@ Before creating a PR, ensure generated code is up to date, lint passes, and bug 
 2. [ ] **REQUIRED for integrate output diffs:** If the PR changes Flutter integrate example outputs, platform scaffolds, or copied `cargokit` files under `frb_example/**`, confirm whether `frb_codegen/assets/integration_template/` is the source that should change, then run `./frb_internal precommit-integrate`
 3. [ ] **REQUIRED:** Read `frb-lint` skill, run `./frb_internal lint --fix`
 4. [ ] (Optional) Read `frb-test` skill, run relevant tests
-5. [ ] **REQUIRED for bug fixes:** PR description includes the reproduction report from `frb-develop-feature`, including baseline commit, mechanical steps, observed failure, and expected behavior
-6. [ ] Commit all changes
-7. [ ] Push and create PR
+5. [ ] **REQUIRED for non-trivial PRs:** Read `frb-pr-review`, run the review gate before final readiness
+6. [ ] **REQUIRED for bug fixes:** PR description includes the reproduction report from `frb-develop-feature`, including baseline commit, mechanical steps, observed failure, and expected behavior
+7. [ ] Commit all changes
+8. [ ] Push and create PR
 
 ## What CI Will Do
 
@@ -63,4 +66,5 @@ If the PR changes integrate-generated example output but not `frb_codegen/assets
 - `frb-code-generation` - Determines which generation commands to run
 - `frb-lint` - Lint and format checks
 - `frb-test` - For local debugging when CI fails
+- `frb-pr-review` - PR readiness review gate
 - `creating-pull-requests` - Standard PR creation process

--- a/.claude/skills/frb-test/SKILL.md
+++ b/.claude/skills/frb-test/SKILL.md
@@ -60,3 +60,5 @@ Choose tests by blast radius:
 - Codegen changes: run generation and the affected example tests
 
 After pushing to a PR branch, monitor GitHub Actions until the run reaches a terminal state. If CI fails, inspect the failing job logs and either fix the issue or clearly report why it is unrelated or flaky. Do not leave a PR in an unknown queued or in-progress state when the user asked for CI validation.
+
+Before treating a non-trivial PR as ready, run the review gate in `frb-pr-review`; local tests alone do not check correctness review, test weakening, or Gemini feedback.

--- a/.claude/skills/frb-upgrade-flutter/SKILL.md
+++ b/.claude/skills/frb-upgrade-flutter/SKILL.md
@@ -16,6 +16,7 @@ Use this as the single-file workflow for Flutter stable bumps in `flutter_rust_b
    - `frb-docker` before changing `.devcontainer/**` or publishing the dev image.
    - `frb-code-generation` before accepting generated or scaffold drift.
    - `frb-cargokit` or `frb-cargokit-dev` before changing copied `cargokit` files.
+   - `frb-pr-review` before treating the upgrade PR as ready.
    - `frb-fix-ci` when CI starts failing.
 
 ## Non-Negotiables
@@ -192,8 +193,7 @@ Recommended minimum validation:
 For CI or Docker plumbing-only changes, dev image dry-run and focused metadata tests may be enough
 before opening the PR. Let CI cover the full matrix.
 
-Before treating the upgrade PR as ready, have a subagent run the test-weakening gate described in
-`sdev-pass-test` and address any unjustified weakening.
+Before treating the upgrade PR as ready, run the review gate in `frb-pr-review`.
 
 ### Step 8: Triage CI in Dependency Order
 

--- a/.claude/skills/frb-upgrade-flutter/SKILL.md
+++ b/.claude/skills/frb-upgrade-flutter/SKILL.md
@@ -192,6 +192,9 @@ Recommended minimum validation:
 For CI or Docker plumbing-only changes, dev image dry-run and focused metadata tests may be enough
 before opening the PR. Let CI cover the full matrix.
 
+Before treating the upgrade PR as ready, have a subagent run the test-weakening gate described in
+`sdev-pass-test` and address any unjustified weakening.
+
 ### Step 8: Triage CI in Dependency Order
 
 Read `frb-fix-ci` before deep debugging.


### PR DESCRIPTION
## Summary

- Add a new `frb-pr-review` skill for PR readiness review.
- Include independent subagent checks for correctness and test weakening.
- Include Gemini review as part of the same review gate.
- Point `frb-issue-to-green-pr`, `frb-upgrade-flutter`, `frb-prepare-pr`, and `frb-test` at the new skill instead of duplicating review details.

## Rationale

`frb-pr-review` keeps FRB-specific PR review expectations in one place. Test-weakening details remain owned by `sdev-pass-test`; this skill references that source of truth and adds broader correctness and Gemini review coverage.

## Verification

- `git diff --check`