### PR TITLE
Skip workflow telemetry on Windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,6 +78,7 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        if: runner.os != 'Windows'
         continue-on-error: true
         env:
           WORKFLOW_TELEMETRY_SERVER_PORT: 7778
@@ -110,6 +111,7 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        if: runner.os != 'Windows'
         continue-on-error: true
         env:
           WORKFLOW_TELEMETRY_SERVER_PORT: 7778
@@ -134,6 +136,7 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        if: runner.os != 'Windows'
         continue-on-error: true
         env:
           WORKFLOW_TELEMETRY_SERVER_PORT: 7778
@@ -220,6 +223,7 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        if: runner.os != 'Windows'
         continue-on-error: true
         env:
           WORKFLOW_TELEMETRY_SERVER_PORT: 7778
@@ -269,6 +273,7 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        if: runner.os != 'Windows'
         continue-on-error: true
         env:
           WORKFLOW_TELEMETRY_SERVER_PORT: 7778
@@ -304,6 +309,7 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        if: runner.os != 'Windows'
         continue-on-error: true
         env:
           WORKFLOW_TELEMETRY_SERVER_PORT: 7778
@@ -350,6 +356,7 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        if: runner.os != 'Windows'
         continue-on-error: true
         env:
           WORKFLOW_TELEMETRY_SERVER_PORT: 7778
@@ -441,6 +448,7 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        if: runner.os != 'Windows'
         continue-on-error: true
         env:
           WORKFLOW_TELEMETRY_SERVER_PORT: 7778
@@ -484,6 +492,7 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        if: runner.os != 'Windows'
         continue-on-error: true
         env:
           WORKFLOW_TELEMETRY_SERVER_PORT: 7778
@@ -582,6 +591,7 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        if: runner.os != 'Windows'
         continue-on-error: true
         env:
           WORKFLOW_TELEMETRY_SERVER_PORT: 7778
@@ -641,6 +651,7 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        if: runner.os != 'Windows'
         continue-on-error: true
         env:
           WORKFLOW_TELEMETRY_SERVER_PORT: 7778
@@ -685,6 +696,7 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        if: runner.os != 'Windows'
         continue-on-error: true
         env:
           WORKFLOW_TELEMETRY_SERVER_PORT: 7778
@@ -742,6 +754,7 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        if: runner.os != 'Windows'
         continue-on-error: true
         env:
           WORKFLOW_TELEMETRY_SERVER_PORT: 7778
@@ -787,6 +800,7 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        if: runner.os != 'Windows'
         continue-on-error: true
         env:
           WORKFLOW_TELEMETRY_SERVER_PORT: 7778
@@ -834,6 +848,7 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        if: runner.os != 'Windows'
         continue-on-error: true
         with:
           comment_on_pr: false
@@ -902,6 +917,7 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        if: runner.os != 'Windows'
         continue-on-error: true
         env:
           WORKFLOW_TELEMETRY_SERVER_PORT: 7778
@@ -991,6 +1007,7 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        if: runner.os != 'Windows'
         continue-on-error: true
         env:
           WORKFLOW_TELEMETRY_SERVER_PORT: 7778
@@ -1027,6 +1044,7 @@ jobs:
 
     steps:
       - uses: catchpoint/workflow-telemetry-action@v2
+        if: runner.os != 'Windows'
         continue-on-error: true
         env:
           WORKFLOW_TELEMETRY_SERVER_PORT: 7778

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -834,6 +834,7 @@ jobs:
     steps:
       # setup
       - uses: catchpoint/workflow-telemetry-action@v2
+        continue-on-error: true
         with:
           comment_on_pr: false
       - uses: actions/checkout@v5


### PR DESCRIPTION
The telemetry action can fail in CI independently of the tested command. One Android job missed continue-on-error, and a Windows generate job also failed during the action's post-cleanup/stat collector phase even with continue-on-error enabled. This keeps telemetry on Linux/macOS, skips it on Windows where the action reports unsupported process tracing and can fail during cleanup, and makes the Android telemetry step non-blocking for consistency.