### PR TITLE
Add Packer workflow for Tart iOS test base VM

### DIFF
--- a/.claude/skills/frb-dev-env/SKILL.md
+++ b/.claude/skills/frb-dev-env/SKILL.md
@@ -90,7 +90,7 @@ frb-tart-<worktree-root-sha256-prefix-12>
 
 By default, `create` clones from a prepared local base VM named `frb-tart-base`. Override it with `FRB_TART_BASE_VM` or `--base-vm`.
 
-Read `frb-tart-prepare` before creating or changing the base VM. The base VM should be cloned directly from a pinned OCI artifact and treated as immutable; do not boot it and manually install tools into it.
+Read `frb-tart-prepare` before creating or changing the base VM. The base VM should be built by the checked-in Packer template from a pinned Tart OCI artifact and treated as immutable; do not boot it and manually install tools into it.
 
 For linked git worktrees, the Tart helper shares both the canonical worktree root and the git common root into the VM, then mounts them at host-like absolute paths with `mount_virtiofs`. This keeps worktree `.git` files and submodule gitdir references valid inside the VM.
 

--- a/.claude/skills/frb-tart-prepare/SKILL.md
+++ b/.claude/skills/frb-tart-prepare/SKILL.md
@@ -156,7 +156,7 @@ packer build \
   .
 ```
 
-The Packer template clones the raw source VM, boots it as `admin/admin`, runs `scripts/provision-frb-tart-base.sh`, and leaves a stopped local VM named by `target_vm`. The current provision step initializes Xcode, uses the Flutter SDK already present in the source Tart image, installs CocoaPods with Homebrew, installs Rust matching the devcontainer, adds the `aarch64-apple-ios-sim` Rust target, and pre-caches Flutter iOS artifacts. It also verifies the image contains Xcode and simulator tooling.
+The Packer template clones the raw source VM, boots it as `admin/admin`, runs `scripts/provision-frb-tart-base.sh`, and leaves a stopped local VM named by `target_vm`. The current provision step initializes Xcode, uses the Flutter SDK already present in the source Tart image, installs CocoaPods with Homebrew, installs Rust matching the devcontainer, adds the `aarch64-apple-ios-sim` and `x86_64-apple-ios` Rust targets, and pre-caches Flutter iOS artifacts. It also verifies the image contains Xcode and simulator tooling.
 
 Verify the candidate:
 
@@ -171,7 +171,7 @@ Do not boot and mutate `frb-tart-base` during verification. If you need to inspe
 tart clone frb-tart-base-candidate frb-tart-probe
 tart run --no-graphics frb-tart-probe
 tart ip frb-tart-probe --wait 180
-tart exec frb-tart-probe /bin/zsh -lc 'sw_vers && xcodebuild -version && flutter --version && pod --version && rustc --version && cargo --version && rustup target list --installed | grep aarch64-apple-ios-sim'
+tart exec frb-tart-probe /bin/zsh -lc 'sw_vers && xcodebuild -version && flutter --version && pod --version && rustc --version && cargo --version && rustup target list --installed | grep aarch64-apple-ios-sim && rustup target list --installed | grep x86_64-apple-ios'
 tart stop frb-tart-probe
 tart delete frb-tart-probe
 ```

--- a/.claude/skills/frb-tart-prepare/SKILL.md
+++ b/.claude/skills/frb-tart-prepare/SKILL.md
@@ -156,7 +156,7 @@ packer build \
   .
 ```
 
-The Packer template clones the raw source VM, boots it as `admin/admin`, runs `scripts/provision-frb-tart-base.sh`, and leaves a stopped local VM named by `target_vm`. The current provision step initializes Xcode, uses the Flutter SDK already present in the source Tart image, installs CocoaPods with Homebrew, installs Rust matching the devcontainer, adds the `aarch64-apple-ios-sim` and `x86_64-apple-ios` Rust targets, and pre-caches Flutter iOS artifacts. It also verifies the image contains Xcode and simulator tooling.
+The Packer template clones the raw source VM, boots it as `admin/admin`, runs `scripts/provision-frb-tart-base.sh`, and leaves a stopped local VM named by `target_vm`. The current provision step initializes Xcode, uses the Flutter SDK already present in the source Tart image, installs CocoaPods with Homebrew, installs Rust matching the devcontainer, adds the `aarch64-apple-ios-sim` and `x86_64-apple-ios` Rust targets for both the pinned toolchain and the `stable-aarch64-apple-darwin` toolchain used by CargoKit, and pre-caches Flutter iOS artifacts. It also verifies the image contains Xcode and simulator tooling.
 
 Verify the candidate:
 
@@ -171,7 +171,7 @@ Do not boot and mutate `frb-tart-base` during verification. If you need to inspe
 tart clone frb-tart-base-candidate frb-tart-probe
 tart run --no-graphics frb-tart-probe
 tart ip frb-tart-probe --wait 180
-tart exec frb-tart-probe /bin/zsh -lc 'sw_vers && xcodebuild -version && flutter --version && pod --version && rustc --version && cargo --version && rustup target list --installed | grep aarch64-apple-ios-sim && rustup target list --installed | grep x86_64-apple-ios'
+tart exec frb-tart-probe /bin/zsh -lc 'sw_vers && xcodebuild -version && flutter --version && pod --version && rustc --version && cargo --version && rustup target list --installed | grep aarch64-apple-ios-sim && rustup target list --installed | grep x86_64-apple-ios && rustup target list --toolchain stable-aarch64-apple-darwin --installed | grep aarch64-apple-ios-sim && rustup target list --toolchain stable-aarch64-apple-darwin --installed | grep x86_64-apple-ios'
 tart stop frb-tart-probe
 tart delete frb-tart-probe
 ```

--- a/.claude/skills/frb-tart-prepare/SKILL.md
+++ b/.claude/skills/frb-tart-prepare/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frb-tart-prepare
-description: Use when preparing or explaining the FRB Tart base VM for iOS Simulator validation, including local OCI registry mirroring, direct OCI clone, and base VM hygiene.
+description: Use when preparing or explaining the FRB Tart base VM for iOS Simulator validation, including local OCI registry mirroring, Packer provisioning, and base VM hygiene.
 ---
 
 # FRB Tart Base VM Preparation
@@ -9,22 +9,24 @@ Use this skill when preparing the reusable Tart base VM used by `frb-dev-env tar
 
 ## Model
 
-The reusable base VM is a clean local VM cloned directly from a pinned OCI artifact:
+The reusable base VM is a clean local VM built by Packer from a pinned Tart OCI artifact:
 
 ```text
 ghcr.io/cirruslabs/macos-sonoma-xcode:16.1
   -> optional local OCI registry mirror
-  -> tart clone ... frb-tart-base
+  -> packer build ... frb-tart-base-candidate
+  -> smoke test candidate
+  -> promote candidate to frb-tart-base
   -> tart clone frb-tart-base frb-tart-<worktree-hash>
 ```
 
-`frb-tart-base` is the base image. Do not use it for development, do not run tests in it, and do not manually install tools into it. Treat it as immutable after creation. Per-worktree VMs are cloned from it via APFS copy-on-write and can be dirtied, stopped, deleted, and recreated.
+`frb-tart-base` is the prepared base image. Do not use it for development, do not run tests in it, and do not manually install tools into it. Treat it as immutable after creation. Per-worktree VMs are cloned from it via APFS copy-on-write and can be dirtied, stopped, deleted, and recreated.
 
 ## Why Not Mutate the Base VM
 
 Do not boot `frb-tart-base` and manually install Flutter, Android SDK packages, CocoaPods updates, Rust targets, or other dependencies into it.
 
-Manual changes make the base hard to reproduce and hard to audit. If the base needs different tools, choose or build a new pinned OCI image, document the exact source, and recreate `frb-tart-base` from that artifact. The base VM should answer the question "which OCI artifact did this come from?", not "what did someone install by hand last week?".
+Manual changes make the base hard to reproduce and hard to audit. If the base needs different tools, update the Packer template or provision script next to this skill, document the exact source, rebuild a candidate, smoke test it, and then promote it to `frb-tart-base`. The base VM should answer both questions: "which OCI artifact did this come from?" and "which provision script changed it?"
 
 ## Source Image
 
@@ -38,13 +40,19 @@ Avoid `latest` tags. Avoid broad multi-Xcode runner images unless there is a spe
 
 ## Fast Path When Network Is Good
 
-If network access to GHCR is reliable enough, create the base VM directly:
+If network access to GHCR is reliable enough, Packer can clone the raw source image directly:
 
 ```bash
-tart clone ghcr.io/cirruslabs/macos-sonoma-xcode:16.1 frb-tart-base
+cd .claude/skills/frb-tart-prepare/packer
+packer init .
+packer build \
+  -var 'source_vm=ghcr.io/cirruslabs/macos-sonoma-xcode:16.1' \
+  -var 'target_vm=frb-tart-base-candidate' \
+  -var 'allow_insecure=false' \
+  .
 ```
 
-Use this only when the direct download path is acceptable. `tart clone` uses macOS networking, so shell proxy environment variables may not control it the way they control CLI tools like `curl` or `crane`.
+Use this only when the direct download path is acceptable. Packer delegates the source VM clone to Tart, so shell proxy environment variables may not control it the way they control CLI tools like `curl` or `crane`.
 
 ## Controlled Local Registry Path
 
@@ -52,7 +60,9 @@ Use this path when direct `tart clone ghcr.io/...` is slow, unreliable, or hard 
 
 1. Run a local OCI registry on `127.0.0.1:5000`.
 2. Use `crane copy` with explicit proxy environment variables to mirror the remote Tart OCI artifact into the local registry.
-3. Run `tart clone --insecure` from the local registry to create `frb-tart-base`.
+3. Run Packer with `allow_insecure=true` and `source_vm=127.0.0.1:5000/...` to create `frb-tart-base-candidate`.
+4. Smoke test the candidate.
+5. Promote it to `frb-tart-base`.
 
 ### Start Local Registry
 
@@ -132,33 +142,49 @@ Known digest for the current source image:
 sha256:f181b76eede9acd7a6db76438a4cf73e76550c3f9e8104aed16347122e132184
 ```
 
-## Create Base VM
+## Build Base VM With Packer
 
-Create `frb-tart-base` from the local registry:
+Build a candidate base VM from the local registry:
 
 ```bash
-tart clone --insecure \
-  127.0.0.1:5000/cirruslabs/macos-sonoma-xcode:16.1 \
-  frb-tart-base
+cd .claude/skills/frb-tart-prepare/packer
+packer init .
+packer build \
+  -var 'source_vm=127.0.0.1:5000/cirruslabs/macos-sonoma-xcode:16.1' \
+  -var 'target_vm=frb-tart-base-candidate' \
+  -var 'allow_insecure=true' \
+  .
 ```
 
-Verify:
+The Packer template clones the raw source VM, boots it as `admin/admin`, runs `scripts/provision-frb-tart-base.sh`, and leaves a stopped local VM named by `target_vm`. The current provision step initializes Xcode, uses the Flutter SDK already present in the source Tart image, installs CocoaPods with Homebrew, installs Rust matching the devcontainer, adds the `aarch64-apple-ios-sim` Rust target, and pre-caches Flutter iOS artifacts. It also verifies the image contains Xcode and simulator tooling.
+
+Verify the candidate:
 
 ```bash
 tart list
-tart get frb-tart-base --format json
+tart get frb-tart-base-candidate --format json
 ```
 
-Do not boot and mutate `frb-tart-base` during verification. If you need to inspect runtime state, clone a disposable probe VM from it:
+Do not boot and mutate `frb-tart-base` during verification. If you need to inspect runtime state, clone a disposable probe VM from the candidate:
 
 ```bash
-tart clone frb-tart-base frb-tart-probe
+tart clone frb-tart-base-candidate frb-tart-probe
 tart run --no-graphics frb-tart-probe
 tart ip frb-tart-probe --wait 180
-tart exec frb-tart-probe sw_vers
+tart exec frb-tart-probe /bin/zsh -lc 'sw_vers && xcodebuild -version && flutter --version && pod --version && rustc --version && cargo --version && rustup target list --installed | grep aarch64-apple-ios-sim'
 tart stop frb-tart-probe
 tart delete frb-tart-probe
 ```
+
+After the candidate passes smoke, promote it by moving the old base out of the way and renaming the candidate:
+
+```bash
+stamp=$(date +%Y%m%d-%H%M%S)
+tart rename frb-tart-base "frb-tart-base-before-packer-$stamp"
+tart rename frb-tart-base-candidate frb-tart-base
+```
+
+If there is no existing `frb-tart-base`, only the second rename is needed.
 
 ## Cost Notes
 

--- a/.claude/skills/frb-tart-prepare/packer/frb-tart-base.pkr.hcl
+++ b/.claude/skills/frb-tart-prepare/packer/frb-tart-base.pkr.hcl
@@ -1,0 +1,50 @@
+packer {
+  required_plugins {
+    tart = {
+      source  = "github.com/cirruslabs/tart"
+      version = ">= 1.20.0"
+    }
+  }
+}
+
+variable "source_vm" {
+  type        = string
+  description = "Pinned upstream or locally mirrored Tart OCI VM used as the raw source."
+  default     = "127.0.0.1:5000/cirruslabs/macos-sonoma-xcode:16.1"
+}
+
+variable "target_vm" {
+  type        = string
+  description = "Local Tart VM name to create. Use frb-tart-base-candidate first, then promote after smoke."
+  default     = "frb-tart-base-candidate"
+}
+
+variable "allow_insecure" {
+  type        = bool
+  description = "Allow cloning from a local HTTP OCI registry such as 127.0.0.1:5000."
+  default     = true
+}
+
+source "tart-cli" "frb_tart_base" {
+  vm_base_name   = var.source_vm
+  vm_name        = var.target_vm
+  allow_insecure = var.allow_insecure
+
+  cpu_count    = 4
+  memory_gb    = 8
+  disk_size_gb = 140
+
+  ssh_username = "admin"
+  ssh_password = "admin"
+  ssh_timeout  = "20m"
+}
+
+build {
+  name    = "frb-tart-base"
+  sources = ["source.tart-cli.frb_tart_base"]
+
+  provisioner "shell" {
+    script          = "scripts/provision-frb-tart-base.sh"
+    execute_command = "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}"
+  }
+}

--- a/.claude/skills/frb-tart-prepare/packer/frb-tart-base.pkr.hcl
+++ b/.claude/skills/frb-tart-prepare/packer/frb-tart-base.pkr.hcl
@@ -31,7 +31,7 @@ source "tart-cli" "frb_tart_base" {
   allow_insecure = var.allow_insecure
 
   cpu_count    = 4
-  memory_gb    = 8
+  memory_gb    = 16
   disk_size_gb = 140
 
   ssh_username = "admin"

--- a/.claude/skills/frb-tart-prepare/packer/scripts/provision-frb-tart-base.sh
+++ b/.claude/skills/frb-tart-prepare/packer/scripts/provision-frb-tart-base.sh
@@ -1,0 +1,116 @@
+#!/bin/zsh
+set -euo pipefail
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:$HOME/.cargo/bin:$PATH"
+export LANG="en_US.UTF-8"
+
+RUST_VERSION="1.93.1"
+
+log() {
+  printf '[frb-tart-base] %s\n' "$*"
+}
+
+require_command() {
+  local name="$1"
+  if ! command -v "$name" >/dev/null 2>&1; then
+    printf 'Required command not found in base image: %s\n' "$name" >&2
+    exit 1
+  fi
+}
+
+install_rustup_if_needed() {
+  if command -v rustup >/dev/null 2>&1; then
+    return
+  fi
+
+  log "Installing rustup"
+  curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable
+  export PATH="$HOME/.cargo/bin:$PATH"
+}
+
+configure_xcode() {
+  if [ -d /Applications/Xcode.app/Contents/Developer ]; then
+    sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+  fi
+
+  sudo xcodebuild -license accept
+  sudo xcodebuild -runFirstLaunch
+}
+
+install_flutter_if_needed() {
+  if command -v flutter >/dev/null 2>&1; then
+    return
+  fi
+
+  if [ -x "$HOME/flutter/bin/flutter" ]; then
+    export PATH="$HOME/flutter/bin:$PATH"
+    return
+  fi
+
+  printf 'Flutter was not found in the source Tart image. Use a source image with Flutter preinstalled, or extend this Packer template with a fast local Flutter archive upload.\n' >&2
+  exit 1
+}
+
+install_cocoapods_if_needed() {
+  if command -v pod >/dev/null 2>&1; then
+    return
+  fi
+
+  require_command brew
+
+  log "Installing CocoaPods"
+  HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_CLEANUP=1 brew install cocoapods
+}
+
+persist_shell_path() {
+  local profile="$HOME/.zprofile"
+  local marker="# FRB Tart base PATH"
+
+  if [ -f "$profile" ] && grep -F "$marker" "$profile" >/dev/null 2>&1; then
+    return
+  fi
+
+  {
+    printf '\n%s\n' "$marker"
+    printf 'export PATH="$HOME/flutter/bin:$HOME/.cargo/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"\n'
+    printf 'export LANG="en_US.UTF-8"\n'
+  } >> "$profile"
+}
+
+log "Checking source image tools"
+require_command xcodebuild
+require_command xcrun
+require_command curl
+
+configure_xcode
+install_flutter_if_needed
+install_cocoapods_if_needed
+install_rustup_if_needed
+persist_shell_path
+
+require_command flutter
+require_command pod
+require_command rustup
+
+log "Installing Rust ${RUST_VERSION} and iOS Simulator target"
+rustup toolchain install "$RUST_VERSION" --profile minimal
+rustup default "$RUST_VERSION"
+rustup target add aarch64-apple-ios-sim
+
+log "Pre-caching Flutter iOS artifacts"
+flutter config --no-analytics
+flutter precache --ios
+
+log "Disabling Spotlight indexing inside the VM"
+sudo mdutil -a -i off
+
+log "Printing tool versions"
+sw_vers
+xcodebuild -version
+flutter --version
+pod --version
+rustc --version
+cargo --version
+rustup target list --installed | grep '^aarch64-apple-ios-sim$'
+
+log "Provisioning complete"

--- a/.claude/skills/frb-tart-prepare/packer/scripts/provision-frb-tart-base.sh
+++ b/.claude/skills/frb-tart-prepare/packer/scripts/provision-frb-tart-base.sh
@@ -97,6 +97,8 @@ rustup toolchain install "$RUST_VERSION" --profile minimal
 rustup default "$RUST_VERSION"
 rustup target add aarch64-apple-ios-sim
 rustup target add x86_64-apple-ios
+rustup target add --toolchain stable-aarch64-apple-darwin aarch64-apple-ios-sim
+rustup target add --toolchain stable-aarch64-apple-darwin x86_64-apple-ios
 
 log "Pre-caching Flutter iOS artifacts"
 flutter config --no-analytics
@@ -114,5 +116,7 @@ rustc --version
 cargo --version
 rustup target list --installed | grep '^aarch64-apple-ios-sim$'
 rustup target list --installed | grep '^x86_64-apple-ios$'
+rustup target list --toolchain stable-aarch64-apple-darwin --installed | grep '^aarch64-apple-ios-sim$'
+rustup target list --toolchain stable-aarch64-apple-darwin --installed | grep '^x86_64-apple-ios$'
 
 log "Provisioning complete"

--- a/.claude/skills/frb-tart-prepare/packer/scripts/provision-frb-tart-base.sh
+++ b/.claude/skills/frb-tart-prepare/packer/scripts/provision-frb-tart-base.sh
@@ -92,10 +92,11 @@ require_command flutter
 require_command pod
 require_command rustup
 
-log "Installing Rust ${RUST_VERSION} and iOS Simulator target"
+log "Installing Rust ${RUST_VERSION} and iOS targets"
 rustup toolchain install "$RUST_VERSION" --profile minimal
 rustup default "$RUST_VERSION"
 rustup target add aarch64-apple-ios-sim
+rustup target add x86_64-apple-ios
 
 log "Pre-caching Flutter iOS artifacts"
 flutter config --no-analytics
@@ -112,5 +113,6 @@ pod --version
 rustc --version
 cargo --version
 rustup target list --installed | grep '^aarch64-apple-ios-sim$'
+rustup target list --installed | grep '^x86_64-apple-ios$'
 
 log "Provisioning complete"


### PR DESCRIPTION
## Summary

- add a Packer Tart template for building `frb-tart-base-candidate` from the pinned Cirrus macOS/Xcode OCI source, including local registry support via `allow_insecure`
- add a provision script that initializes Xcode, reuses the source image Flutter SDK, installs CocoaPods via Homebrew, installs Rust 1.93.1 plus iOS simulator Rust targets, and pre-caches Flutter iOS artifacts
- preinstall the `stable-aarch64-apple-darwin` iOS targets used by CargoKit so the first iOS build does not spend time downloading targets
- update the Tart preparation skill and FRB dev environment skill to describe the Packer candidate/smoke/promote workflow

## Validation

- `packer init .`
- `packer validate .`
- `crane --insecure digest 127.0.0.1:5000/cirruslabs/macos-sonoma-xcode:16.1` returned `sha256:f181b76eede9acd7a6db76438a4cf73e76550c3f9e8104aed16347122e132184`
- after `~/.tart` was cleared locally, rebuilt from the local registry with:

```bash
packer build \
  -var source_vm=127.0.0.1:5000/cirruslabs/macos-sonoma-xcode:16.1 \
  -var target_vm=frb-tart-base-candidate \
  -var allow_insecure=true \
  .
```

- the rebuild completed successfully in about 12m32s and produced `frb-tart-base-candidate`
- promoted the candidate to local `frb-tart-base`, created the per-worktree VM with `frb_dev_env.py tart create`, and verified macOS 14.8.3, Xcode 16.1, Flutter 3.41.6, CocoaPods 1.16.2, Rust/Cargo 1.93.1, and both pinned/stable iOS Rust targets
- ran a real iOS Simulator test in the Tart VM local disk copy of the repo:

```bash
./frb_internal test-flutter-native \
  --package frb_example--flutter_via_create \
  --flutter-test-args "--device-id 826DC3E8-2073-42A9-A6DB-05C1926DC82A"
```

Result: `BUILD SUCCEEDED`, `All tests passed!`, and `test package returned with exit code 0`. The Xcode build took about 726.9s and the full Flutter test took about 758.9s.

## Notes

The test used an in-VM local copy of the repo rather than writing Xcode build artifacts through the virtiofs mount. Earlier mounted-worktree attempts made progress but the VM process stopped during heavy Xcode build output/artifact churn. The helper still mounts the host worktree and git common root for source access; the local-copy run is the current safer pattern for the heavy iOS build/test phase.

The source Tart image currently provides Flutter 3.41.6. I tried forcing Flutter 3.41.2 from the repository `.fvmrc`, but downloading the 2GB Flutter archive from inside the VM or host proxy was too slow for the default workflow. This PR keeps Flutter as part of the pinned source image and makes the FRB-specific additions reproducible in Packer.

One validation wrapper used `status=$?` under zsh after the Flutter command had already finished; `status` is read-only in zsh, so the wrapper process itself exited non-zero after printing the log. The FRB/Flutter log immediately before that shows `test package returned with exit code 0`.

`flutter doctor` still reports Chrome missing and a `maven.google.com` network timeout in this VM. Neither blocked the iOS Simulator test above.

`pre-commit run --all-files` was attempted, but this repository does not have `.pre-commit-config.yaml`.
