### PR TITLE
Support Tart local code uploads

### DIFF
--- a/.claude/skills/frb-dev-env/SKILL.md
+++ b/.claude/skills/frb-dev-env/SKILL.md
@@ -104,12 +104,21 @@ Typical usage:
 .claude/skills/frb-dev-env/frb_dev_env.py tart exec -- sw_vers
 ```
 
+For heavy iOS build/test commands, prefer uploading the current worktree to a VM-local copy and running there. This avoids writing Xcode build artifacts through the virtiofs host mount:
+
+```bash
+.claude/skills/frb-dev-env/frb_dev_env.py tart upload
+.claude/skills/frb-dev-env/frb_dev_env.py tart exec --sync-code -- ./frb_internal test-flutter-native --flutter-test-args '--device-id <UDID>' --package <package>
+```
+
+The uploaded copy lives under `/Users/admin/frb-dev-env-local-copies/<worktree-hash>` inside the VM. The upload excludes `.git`, `.dart_tool`, `build`, `.idea`, and `.vscode`, and uses rsync delete semantics so stale generated files from previous uploads do not survive.
+
 Run iOS Simulator tests by starting the worktree VM, booting an iOS simulator inside it, then running the existing FRB test command inside the VM:
 
 ```bash
 .claude/skills/frb-dev-env/frb_dev_env.py tart exec -- xcrun simctl boot <UDID>
 .claude/skills/frb-dev-env/frb_dev_env.py tart exec -- xcrun simctl bootstatus <UDID> -b
-.claude/skills/frb-dev-env/frb_dev_env.py tart exec -- ./frb_internal test-flutter-native --flutter-test-args '--device-id <UDID>' --package <package>
+.claude/skills/frb-dev-env/frb_dev_env.py tart exec --sync-code -- ./frb_internal test-flutter-native --flutter-test-args '--device-id <UDID>' --package <package>
 ```
 
 Delete the worktree VM when it is no longer needed:

--- a/.claude/skills/frb-dev-env/SKILL.md
+++ b/.claude/skills/frb-dev-env/SKILL.md
@@ -111,7 +111,7 @@ For heavy iOS build/test commands, prefer uploading the current worktree to a VM
 .claude/skills/frb-dev-env/frb_dev_env.py tart exec --sync-code -- ./frb_internal test-flutter-native --flutter-test-args '--device-id <UDID>' --package <package>
 ```
 
-`tart upload` and `tart exec --sync-code` both first ensure the worktree VM is running and the host-like worktree mount exists. They then run `rsync` inside the VM from the mounted host worktree to a VM-local copy under `/Users/admin/frb-dev-env-local-copies/<worktree-hash>`. The upload excludes `.git`, `.dart_tool`, `build`, `.idea`, and `.vscode`, and uses rsync delete semantics so stale generated files from previous uploads do not survive.
+`tart upload` and `tart exec --sync-code` both first ensure the worktree VM is running and the host-like worktree mount exists. They then run `rsync` inside the VM from the mounted host worktree to a VM-local copy under `/Users/admin/frb-dev-env-local-copies/<worktree-hash>`. The upload excludes `.git`, `.dart_tool`, `build`, `target`, `.idea`, and `.vscode`. It uses rsync delete semantics for tracked source paths, but preserves excluded VM-local build caches for faster repeated runs.
 
 Use plain `tart exec` for light commands that should see the mounted host checkout exactly, such as `git status`, `flutter --version`, `xcrun simctl list`, and simulator boot commands. Use `tart exec --sync-code` for heavy build/test commands that create many artifacts, especially iOS Flutter/Xcode tests. Commands run with `--sync-code` start from the VM-local uploaded copy, not from the host-mounted path.
 

--- a/.claude/skills/frb-dev-env/SKILL.md
+++ b/.claude/skills/frb-dev-env/SKILL.md
@@ -111,14 +111,37 @@ For heavy iOS build/test commands, prefer uploading the current worktree to a VM
 .claude/skills/frb-dev-env/frb_dev_env.py tart exec --sync-code -- ./frb_internal test-flutter-native --flutter-test-args '--device-id <UDID>' --package <package>
 ```
 
-The uploaded copy lives under `/Users/admin/frb-dev-env-local-copies/<worktree-hash>` inside the VM. The upload excludes `.git`, `.dart_tool`, `build`, `.idea`, and `.vscode`, and uses rsync delete semantics so stale generated files from previous uploads do not survive.
+`tart upload` and `tart exec --sync-code` both first ensure the worktree VM is running and the host-like worktree mount exists. They then run `rsync` inside the VM from the mounted host worktree to a VM-local copy under `/Users/admin/frb-dev-env-local-copies/<worktree-hash>`. The upload excludes `.git`, `.dart_tool`, `build`, `.idea`, and `.vscode`, and uses rsync delete semantics so stale generated files from previous uploads do not survive.
 
-Run iOS Simulator tests by starting the worktree VM, booting an iOS simulator inside it, then running the existing FRB test command inside the VM:
+Use plain `tart exec` for light commands that should see the mounted host checkout exactly, such as `git status`, `flutter --version`, `xcrun simctl list`, and simulator boot commands. Use `tart exec --sync-code` for heavy build/test commands that create many artifacts, especially iOS Flutter/Xcode tests. Commands run with `--sync-code` start from the VM-local uploaded copy, not from the host-mounted path.
+
+Examples:
 
 ```bash
+# Show the VM-local path after uploading the current worktree.
+.claude/skills/frb-dev-env/frb_dev_env.py tart upload
+
+# Run a light command from the mounted host worktree.
+.claude/skills/frb-dev-env/frb_dev_env.py tart exec -- git status --short
+
+# Run a heavy command from the uploaded VM-local copy.
+.claude/skills/frb-dev-env/frb_dev_env.py tart exec --sync-code -- ./frb_internal test-flutter-native --package frb_example--flutter_via_create --flutter-test-args '--device-id <UDID>'
+```
+
+Run iOS Simulator tests by starting the worktree VM, choosing and booting an iOS simulator inside it, then running the existing FRB test command from the VM-local uploaded copy:
+
+```bash
+.claude/skills/frb-dev-env/frb_dev_env.py tart start --wait 300
+.claude/skills/frb-dev-env/frb_dev_env.py tart exec -- xcrun simctl list devices available
 .claude/skills/frb-dev-env/frb_dev_env.py tart exec -- xcrun simctl boot <UDID>
 .claude/skills/frb-dev-env/frb_dev_env.py tart exec -- xcrun simctl bootstatus <UDID> -b
-.claude/skills/frb-dev-env/frb_dev_env.py tart exec --sync-code -- ./frb_internal test-flutter-native --flutter-test-args '--device-id <UDID>' --package <package>
+.claude/skills/frb-dev-env/frb_dev_env.py tart exec --sync-code -- ./frb_internal test-flutter-native --package frb_example--flutter_via_create --flutter-test-args '--device-id <UDID>'
+```
+
+For example, when an iOS 18.1 `iPhone 16 Pro Max` simulator with UDID `826DC3E8-2073-42A9-A6DB-05C1926DC82A` is available:
+
+```bash
+.claude/skills/frb-dev-env/frb_dev_env.py tart exec --sync-code -- ./frb_internal test-flutter-native --package frb_example--flutter_via_create --flutter-test-args '--device-id 826DC3E8-2073-42A9-A6DB-05C1926DC82A'
 ```
 
 Delete the worktree VM when it is no longer needed:

--- a/.claude/skills/frb-dev-env/SKILL.md
+++ b/.claude/skills/frb-dev-env/SKILL.md
@@ -111,7 +111,7 @@ For heavy iOS build/test commands, prefer uploading the current worktree to a VM
 .claude/skills/frb-dev-env/frb_dev_env.py tart exec --sync-code -- ./frb_internal test-flutter-native --flutter-test-args '--device-id <UDID>' --package <package>
 ```
 
-`tart upload` and `tart exec --sync-code` both first ensure the worktree VM is running and the host-like worktree mount exists. They then run `rsync` inside the VM from the mounted host worktree to a VM-local copy under `/Users/admin/frb-dev-env-local-copies/<worktree-hash>`. The upload excludes `.git`, `.dart_tool`, `build`, `target`, `.idea`, and `.vscode`. It uses rsync delete semantics for tracked source paths, but preserves excluded VM-local build caches for faster repeated runs.
+`tart upload` and `tart exec --sync-code` both first ensure the worktree VM is running and the host-like worktree mount exists. They then run `rsync` inside the VM from the mounted host worktree to a VM-local copy under `/Users/admin/frb-dev-env-local-copies/<worktree-hash>`. The upload excludes `.git`, `.dart_tool`, `build`, `target`, `.idea`, and `.vscode`. It does not delete existing files in the VM-local copy, so build caches survive repeated runs.
 
 Use plain `tart exec` for light commands that should see the mounted host checkout exactly, such as `git status`, `flutter --version`, `xcrun simctl list`, and simulator boot commands. Use `tart exec --sync-code` for heavy build/test commands that create many artifacts, especially iOS Flutter/Xcode tests. Commands run with `--sync-code` start from the VM-local uploaded copy, not from the host-mounted path.
 

--- a/.claude/skills/frb-dev-env/frb_dev_env.py
+++ b/.claude/skills/frb-dev-env/frb_dev_env.py
@@ -34,6 +34,14 @@ REPO_LABEL_VALUE = "flutter_rust_bridge"
 LAYOUT_VERSION_VALUE = "3"
 TART_WORKSPACE_SHARE_NAME = "workspace"
 TART_HOST_MAIN_SHARE_NAME = "main"
+TART_LOCAL_COPY_ROOT = Path("/Users/admin/frb-dev-env-local-copies")
+TART_LOCAL_COPY_EXCLUDES = [
+    ".dart_tool",
+    ".git",
+    ".idea",
+    ".vscode",
+    "build",
+]
 
 
 # ========== Common ==========
@@ -122,8 +130,22 @@ def get_image(image: str | None) -> str:
 
 
 def tart_vm_name_for_worktree(worktree_root: Path) -> str:
-    digest = hashlib.sha256(str(worktree_root).encode()).hexdigest()[:12]
-    return f"frb-tart-{digest}"
+    return f"frb-tart-{tart_worktree_digest(worktree_root=worktree_root)}"
+
+
+def tart_worktree_digest(worktree_root: Path) -> str:
+    return hashlib.sha256(str(worktree_root).encode()).hexdigest()[:12]
+
+
+def tart_local_copy_path_for_worktree(worktree_root: Path) -> Path:
+    return TART_LOCAL_COPY_ROOT / tart_worktree_digest(worktree_root=worktree_root)
+
+
+def validate_tart_local_copy_root(local_copy_root: Path) -> Path:
+    if not local_copy_root.is_absolute():
+        raise CommandError(f"Tart local copy root must be an absolute VM path: {local_copy_root}")
+
+    return local_copy_root
 
 
 def tart_storage_root() -> Path:
@@ -218,6 +240,8 @@ def build_tart_info(*, worktree_root: Path, base_vm: str, min_free_gb: int) -> d
         "details": details,
         "base_exists": base_details is not None,
         "base_details": base_details,
+        "local_copy_path": str(tart_local_copy_path_for_worktree(worktree_root=worktree_root)),
+        "local_copy_excludes": TART_LOCAL_COPY_EXCLUDES,
     }
 
 
@@ -334,6 +358,64 @@ def wait_for_tart_running(*, vm_name: str, wait_seconds: int) -> None:
         time.sleep(1)
 
     raise CommandError(f'Tart VM "{vm_name}" did not become running within {wait_seconds}s')
+
+
+def ensure_tart_vm_running(
+    *,
+    worktree_root: Path,
+    base_vm: str,
+    min_free_gb: int,
+    log_path: Path | None,
+    wait: int,
+) -> str:
+    vm_name = ensure_tart_vm(
+        worktree_root=worktree_root,
+        base_vm=base_vm,
+        min_free_gb=min_free_gb,
+    )
+    if not tart_vm_is_running(vm_name=vm_name):
+        start_tart_vm(
+            vm_name=vm_name,
+            worktree_root=worktree_root,
+            log_path=log_path,
+        )
+        wait_for_tart_running(vm_name=vm_name, wait_seconds=wait)
+        wait_for_tart_ip(vm_name=vm_name, wait_seconds=wait)
+    ensure_tart_host_path_links(vm_name=vm_name, worktree_root=worktree_root)
+
+    return vm_name
+
+
+def upload_tart_local_copy(
+    *,
+    vm_name: str,
+    worktree_root: Path,
+    local_copy_root: Path,
+) -> Path:
+    local_copy_path = local_copy_root / tart_worktree_digest(worktree_root=worktree_root)
+    exclude_args = " ".join(
+        f"--exclude {shlex.quote(exclude)}"
+        for exclude in TART_LOCAL_COPY_EXCLUDES
+    )
+    upload_command = "\n".join(
+        [
+            "set -euo pipefail",
+            f"source_dir={shlex.quote(str(worktree_root))}",
+            f"copy_root={shlex.quote(str(local_copy_root))}",
+            f"copy_dir={shlex.quote(str(local_copy_path))}",
+            'if [ -e "$copy_dir" ] && [ ! -d "$copy_dir" ]; then',
+            '  archive_root="${TMPDIR:-/tmp}/frb-dev-env-replaced-local-copies"',
+            '  archive_name="$(date +%Y%m%d-%H%M%S)-$(basename "$copy_dir")"',
+            '  mkdir -p "$archive_root"',
+            '  mv "$copy_dir" "$archive_root/$archive_name"',
+            "fi",
+            'mkdir -p "$copy_root" "$copy_dir"',
+            f'rsync -a --delete --delete-excluded {exclude_args} "$source_dir/" "$copy_dir/"',
+        ]
+    )
+    exec_command(["tart", "exec", vm_name, "/bin/zsh", "-lc", upload_command])
+
+    return local_copy_path
 
 
 # ========== Docker ==========
@@ -773,6 +855,51 @@ def tart_delete(
     typer.echo(vm_name)
 
 
+@tart_app.command(name="upload")
+def tart_upload(
+    worktree_root: Annotated[
+        Path | None,
+        typer.Option("--worktree-root", help="FRB worktree root. Defaults to git root."),
+    ] = None,
+    base_vm: Annotated[
+        str | None,
+        typer.Option("--base-vm", help="Prepared Tart base VM. Defaults to FRB_TART_BASE_VM or frb-tart-base."),
+    ] = None,
+    min_free_gb: Annotated[
+        int,
+        typer.Option("--min-free-gb", help="Minimum free space required before creating a Tart VM."),
+    ] = MIN_TART_FREE_GB,
+    log_path: Annotated[
+        Path | None,
+        typer.Option("--log-path", help="Where to write tart run output if the VM needs to start."),
+    ] = None,
+    wait: Annotated[
+        int,
+        typer.Option("--wait", help="Seconds to wait for the VM IP if the VM needs to start."),
+    ] = 180,
+    local_copy_root: Annotated[
+        Path,
+        typer.Option("--local-copy-root", help="VM-local root for uploaded worktree copies."),
+    ] = TART_LOCAL_COPY_ROOT,
+) -> None:
+    """Upload the current worktree into a VM-local copy for heavy build/test commands."""
+
+    resolved_worktree_root = resolve_worktree_root(worktree_root=worktree_root)
+    vm_name = ensure_tart_vm_running(
+        worktree_root=resolved_worktree_root,
+        base_vm=get_tart_base_vm(base_vm=base_vm),
+        min_free_gb=min_free_gb,
+        log_path=log_path,
+        wait=wait,
+    )
+    local_copy_path = upload_tart_local_copy(
+        vm_name=vm_name,
+        worktree_root=resolved_worktree_root,
+        local_copy_root=validate_tart_local_copy_root(local_copy_root=local_copy_root),
+    )
+    typer.echo(local_copy_path)
+
+
 @tart_app.command(name="exec")
 def tart_exec(
     command: Annotated[
@@ -799,6 +926,14 @@ def tart_exec(
         int,
         typer.Option("--wait", help="Seconds to wait for the VM IP if the VM needs to start."),
     ] = 180,
+    sync_code: Annotated[
+        bool,
+        typer.Option("--sync-code", help="Upload the worktree to a VM-local copy before executing."),
+    ] = False,
+    local_copy_root: Annotated[
+        Path,
+        typer.Option("--local-copy-root", help="VM-local root for uploaded worktree copies."),
+    ] = TART_LOCAL_COPY_ROOT,
 ) -> None:
     """Ensure the Tart VM is running, then execute a command inside it."""
 
@@ -806,27 +941,27 @@ def tart_exec(
         raise typer.BadParameter("exec requires a command, for example: exec -- sw_vers")
 
     resolved_worktree_root = resolve_worktree_root(worktree_root=worktree_root)
-    vm_name = ensure_tart_vm(
+    vm_name = ensure_tart_vm_running(
         worktree_root=resolved_worktree_root,
         base_vm=get_tart_base_vm(base_vm=base_vm),
         min_free_gb=min_free_gb,
+        log_path=log_path,
+        wait=wait,
     )
-    if not tart_vm_is_running(vm_name=vm_name):
-        start_tart_vm(
+    command_worktree_root = resolved_worktree_root
+    if sync_code:
+        command_worktree_root = upload_tart_local_copy(
             vm_name=vm_name,
             worktree_root=resolved_worktree_root,
-            log_path=log_path,
+            local_copy_root=validate_tart_local_copy_root(local_copy_root=local_copy_root),
         )
-        wait_for_tart_running(vm_name=vm_name, wait_seconds=wait)
-        wait_for_tart_ip(vm_name=vm_name, wait_seconds=wait)
-    ensure_tart_host_path_links(vm_name=vm_name, worktree_root=resolved_worktree_root)
 
     exec_command(
         [
             "tart",
             "exec",
             vm_name,
-            *tart_shell_command(command, worktree_root=resolved_worktree_root),
+            *tart_shell_command(command, worktree_root=command_worktree_root),
         ]
     )
 

--- a/.claude/skills/frb-dev-env/frb_dev_env.py
+++ b/.claude/skills/frb-dev-env/frb_dev_env.py
@@ -411,7 +411,7 @@ def upload_tart_local_copy(
             '  mv "$copy_dir" "$archive_root/$archive_name"',
             "fi",
             'mkdir -p "$copy_root" "$copy_dir"',
-            f'rsync -a --delete {exclude_args} "$source_dir/" "$copy_dir/"',
+            f'rsync -a {exclude_args} "$source_dir/" "$copy_dir/"',
         ]
     )
     exec_command(["tart", "exec", vm_name, "/bin/zsh", "-lc", upload_command])

--- a/.claude/skills/frb-dev-env/frb_dev_env.py
+++ b/.claude/skills/frb-dev-env/frb_dev_env.py
@@ -41,6 +41,7 @@ TART_LOCAL_COPY_EXCLUDES = [
     ".idea",
     ".vscode",
     "build",
+    "target",
 ]
 
 
@@ -410,7 +411,7 @@ def upload_tart_local_copy(
             '  mv "$copy_dir" "$archive_root/$archive_name"',
             "fi",
             'mkdir -p "$copy_root" "$copy_dir"',
-            f'rsync -a --delete --delete-excluded {exclude_args} "$source_dir/" "$copy_dir/"',
+            f'rsync -a --delete {exclude_args} "$source_dir/" "$copy_dir/"',
         ]
     )
     exec_command(["tart", "exec", vm_name, "/bin/zsh", "-lc", upload_command])


### PR DESCRIPTION
## Summary

- add `frb_dev_env.py tart upload` to sync the current worktree into a VM-local copy under `/Users/admin/frb-dev-env-local-copies/<worktree-hash>`
- add `frb_dev_env.py tart exec --sync-code` to upload first, then run the command from that VM-local copy
- document when to use mounted `tart exec` versus `--sync-code`, and add a concrete iOS Simulator test example

## Validation

- `uv run python -m py_compile .claude/skills/frb-dev-env/frb_dev_env.py`
- `.claude/skills/frb-dev-env/frb_dev_env.py tart exec --help`
- `git diff --check`
- `pre-commit run --all-files` was attempted, but this repository does not have `.pre-commit-config.yaml`
- followed the documented Tart flow:

```bash
.claude/skills/frb-dev-env/frb_dev_env.py tart start --wait 300 --log-path /private/tmp/frb-tart-local-copy-pr-start.log
.claude/skills/frb-dev-env/frb_dev_env.py tart exec -- xcrun simctl list devices available
.claude/skills/frb-dev-env/frb_dev_env.py tart upload
.claude/skills/frb-dev-env/frb_dev_env.py tart exec -- /bin/zsh -lc 'xcrun simctl boot 826DC3E8-2073-42A9-A6DB-05C1926DC82A || true; xcrun simctl bootstatus 826DC3E8-2073-42A9-A6DB-05C1926DC82A -b'
.claude/skills/frb-dev-env/frb_dev_env.py tart exec --sync-code -- /bin/zsh -lc 'set +e; ./frb_internal test-flutter-native --package frb_example--flutter_via_create --flutter-test-args "--device-id 826DC3E8-2073-42A9-A6DB-05C1926DC82A" > /tmp/frb-tart-sync-code-ios-test-rerun.log 2>&1; exit_code=$?; tail -260 /tmp/frb-tart-sync-code-ios-test-rerun.log; exit $exit_code'
```

The passing run used Tart VM `frb-tart-35d2c17b68cc`, iOS 18.1 `iPhone 16 Pro Max` simulator `826DC3E8-2073-42A9-A6DB-05C1926DC82A`, and VM-local copy `/Users/admin/frb-dev-env-local-copies/35d2c17b68cc`.

Result: `All tests passed!`, `test package returned with exit code 0`, and `"flutter test" took 46,397ms`.

## Notes

The first test attempt reached app launch but stayed at `Waiting for VM Service port to be available...`. I terminated that stuck attempt, restarted the same simulator, and reran the documented `--sync-code` command successfully. I left this as validation context rather than adding simulator lifecycle automation in this PR.
