### PR TITLE
Sync generated Cargokit copies

### DIFF
--- a/frb_example/gallery/rust_builder/cargokit/build_tool/lib/src/build_gradle.dart
+++ b/frb_example/gallery/rust_builder/cargokit/build_tool/lib/src/build_gradle.dart
@@ -27,7 +27,7 @@ class BuildGradle {
             "Unknown darwin target or platform: $arch, ${Environment.darwinPlatformName}");
       }
       return target;
-    }).toList();
+    }).toSet().toList();
 
     final environment = BuildEnvironment.fromEnvironment(isAndroid: true);
     final provider =

--- a/frb_example/gallery/rust_builder/cargokit/build_tool/lib/src/builder.dart
+++ b/frb_example/gallery/rust_builder/cargokit/build_tool/lib/src/builder.dart
@@ -1,6 +1,8 @@
 /// This is copied from Cargokit (which is the official way to use it currently)
 /// Details: https://fzyzcjy.github.io/flutter_rust_bridge/manual/integrate/builtin
 
+import 'dart:io';
+
 import 'package:collection/collection.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
@@ -53,6 +55,7 @@ class BuildEnvironment {
   final String? androidNdkVersion;
   final int? androidMinSdkVersion;
   final String? javaHome;
+  final String? ohosSdkHome;
 
   final String? glibcVersion;
 
@@ -68,6 +71,7 @@ class BuildEnvironment {
     this.androidMinSdkVersion,
     this.javaHome,
     this.glibcVersion,
+    this.ohosSdkHome,
   });
 
   static BuildConfiguration parseBuildConfiguration(String value) {
@@ -105,6 +109,7 @@ class BuildEnvironment {
       androidMinSdkVersion:
           isAndroid ? int.parse(Environment.minSdkVersion) : null,
       javaHome: isAndroid ? Environment.javaHome : null,
+      ohosSdkHome: Environment.ohosSdkHome,
     );
   }
 }
@@ -112,7 +117,6 @@ class BuildEnvironment {
 class RustBuilder {
   final Target target;
   final BuildEnvironment environment;
-  String? _resolvedToolchain;
 
   RustBuilder({
     required this.target,
@@ -123,28 +127,24 @@ class RustBuilder {
     Rustup rustup,
   ) {
     final toolchain = _toolchain;
-    var resolvedToolchain = rustup.resolveToolchain(toolchain);
     if (rustup.installedTargets(toolchain) == null) {
       rustup.installToolchain(toolchain);
-      resolvedToolchain = rustup.resolveToolchain(toolchain);
     }
     if (toolchain == 'nightly') {
-      rustup.installRustSrcForNightly(toolchain: resolvedToolchain);
+      rustup.installRustSrcForNightly();
     }
     if (!rustup.installedTargets(toolchain)!.contains(target.rust)) {
-      rustup.installTarget(target.rust, toolchain: resolvedToolchain);
+      rustup.installTarget(target.rust, toolchain: toolchain);
     }
     if (environment.glibcVersion != null) {
-      rustup.installZigBuild(resolvedToolchain);
+      rustup.installZigBuild(toolchain);
     }
-    _resolvedToolchain = resolvedToolchain;
   }
 
   CargoBuildOptions? get _buildOptions =>
       environment.crateOptions.cargo[environment.configuration];
 
   String get _toolchain => _buildOptions?.toolchain.name ?? 'stable';
-  String get _effectiveToolchain => _resolvedToolchain ?? _toolchain;
 
   /// Returns the path of directory containing build artifacts.
   Future<String> build() async {
@@ -154,7 +154,7 @@ class RustBuilder {
       'rustup',
       [
         'run',
-        _effectiveToolchain,
+        _toolchain,
         'cargo',
         (target.android == null && environment.glibcVersion != null)
             ? 'zigbuild'
@@ -183,32 +183,75 @@ class RustBuilder {
   }
 
   Future<Map<String, String>> _buildEnvironment() async {
-    if (target.android == null) {
-      return {};
-    } else {
-      final sdkPath = environment.androidSdkPath;
-      final ndkVersion = environment.androidNdkVersion;
-      final minSdkVersion = environment.androidMinSdkVersion;
-      if (sdkPath == null) {
-        throw BuildException('androidSdkPath is not set');
-      }
-      if (ndkVersion == null) {
-        throw BuildException('androidNdkVersion is not set');
-      }
-      if (minSdkVersion == null) {
-        throw BuildException('androidMinSdkVersion is not set');
-      }
-      final env = AndroidEnvironment(
-        sdkPath: sdkPath,
-        ndkVersion: ndkVersion,
-        minSdkVersion: minSdkVersion,
-        targetTempDir: environment.targetTempDir,
-        target: target,
-      );
-      if (!env.ndkIsInstalled() && environment.javaHome != null) {
-        env.installNdk(javaHome: environment.javaHome!);
-      }
-      return env.buildEnvironment();
+    if (target.ohos != null) {
+      return _buildOhosEnv();
     }
+    if (target.android != null) {
+      return _buildAndroidEnv();
+    }
+    return {};
+  }
+
+  Future<Map<String, String>> _buildAndroidEnv() {
+    final sdkPath = environment.androidSdkPath;
+    final ndkVersion = environment.androidNdkVersion;
+    final minSdkVersion = environment.androidMinSdkVersion;
+    if (sdkPath == null) {
+      throw BuildException('androidSdkPath is not set');
+    }
+    if (ndkVersion == null) {
+      throw BuildException('androidNdkVersion is not set');
+    }
+    if (minSdkVersion == null) {
+      throw BuildException('androidMinSdkVersion is not set');
+    }
+    final env = AndroidEnvironment(
+      sdkPath: sdkPath,
+      ndkVersion: ndkVersion,
+      minSdkVersion: minSdkVersion,
+      targetTempDir: environment.targetTempDir,
+      target: target,
+    );
+    if (!env.ndkIsInstalled() && environment.javaHome != null) {
+      env.installNdk(javaHome: environment.javaHome!);
+    }
+    return env.buildEnvironment();
+  }
+
+  Map<String, String> _buildOhosEnv() {
+    final sdkPath = environment.ohosSdkHome;
+    if (sdkPath == null) {
+      throw BuildException('OHOS SDK native path is not set');
+    }
+    final exe = Platform.isWindows ? '.exe' : '';
+    final clangPath = path.join(sdkPath, 'llvm', 'bin', 'clang$exe');
+    final sysroot = path.join(sdkPath, 'sysroot');
+    String clangTarget;
+    switch (target.ohos) {
+      case 'arm64-v8a':
+        clangTarget = 'aarch64-linux-ohos';
+        break;
+      case 'armeabi-v7a':
+        clangTarget = 'arm-linux-ohos';
+        break;
+      case 'x86_64':
+        clangTarget = 'x86_64-linux-ohos';
+        break;
+      default:
+        clangTarget = 'aarch64-linux-ohos';
+    }
+    final targetEnvName = target.rust.toUpperCase().replaceAll('-', '_');
+    final linkerEnvVar = 'CARGO_TARGET_${targetEnvName}_LINKER';
+    final rustFlagsEnvVar = 'CARGO_TARGET_${targetEnvName}_RUSTFLAGS';
+    final rustFlags = '-C link-arg=--target=$clangTarget '
+        '-C link-arg=-fuse-ld=lld '
+        '-C link-arg=--sysroot=$sysroot '
+        '-C link-arg=-D__MUSL__';
+    return {
+      rustFlagsEnvVar: rustFlags,
+      linkerEnvVar: clangPath,
+      'CC_${target.rust}': clangPath,
+      'AR_${target.rust}': path.join(sdkPath, 'llvm', 'bin', 'llvm-ar$exe'),
+    };
   }
 }

--- a/frb_example/gallery/rust_builder/cargokit/build_tool/lib/src/environment.dart
+++ b/frb_example/gallery/rust_builder/cargokit/build_tool/lib/src/environment.dart
@@ -46,6 +46,8 @@ class Environment {
   static List<String> get targetPlatforms =>
       _getEnv("CARGOKIT_TARGET_PLATFORMS").split(',');
 
+  static String? get ohosSdkHome => _getEnvOptional("CARGOKIT_OHOS_SDK_HOME");
+
   // CMAKE
   static String get targetPlatform => _getEnv("CARGOKIT_TARGET_PLATFORM");
 
@@ -64,5 +66,9 @@ class Environment {
     } else {
       return res;
     }
+  }
+
+  static String? _getEnvOptional(String key) {
+    return Platform.environment[key];
   }
 }

--- a/frb_example/gallery/rust_builder/cargokit/build_tool/lib/src/rustup.dart
+++ b/frb_example/gallery/rust_builder/cargokit/build_tool/lib/src/rustup.dart
@@ -24,17 +24,6 @@ class Rustup {
     return targets != null ? List.unmodifiable(targets) : null;
   }
 
-  String resolveToolchain(String toolchain) =>
-      _installedToolchains
-          .firstWhereOrNull(
-            (e) => _matchesRequestedToolchain(
-              installedName: e.name,
-              requestedToolchain: toolchain,
-            ),
-          )
-          ?.name ??
-      toolchain;
-
   void installToolchain(String toolchain) {
     log.info("Installing Rust toolchain: $toolchain");
     runCommand("rustup", ['toolchain', 'install', toolchain]);
@@ -74,20 +63,9 @@ class Rustup {
 
   Rustup() : _installedToolchains = _getInstalledToolchains();
 
-  bool _matchesRequestedToolchain({
-    required String installedName,
-    required String requestedToolchain,
-  }) =>
-      installedName == requestedToolchain ||
-      installedName.startsWith('$requestedToolchain-');
-
   List<String>? _installedTargets(String toolchain) => _installedToolchains
       .firstWhereOrNull(
-        (e) => _matchesRequestedToolchain(
-          installedName: e.name,
-          requestedToolchain: toolchain,
-        ),
-      )
+          (e) => e.name == toolchain || e.name.startsWith('$toolchain-'))
       ?.targets;
 
   static List<_Toolchain> _getInstalledToolchains() {
@@ -101,11 +79,11 @@ class Rustup {
 
     // To list all non-custom toolchains, we need to filter out lines that
     // don't start with "stable", "beta", or "nightly".
-    final nonCustom = RegExp(r'^(stable|beta|nightly)');
+    Pattern nonCustom = RegExp(r"^(stable|beta|nightly)");
     final lines = res.stdout
         .toString()
         .split('\n')
-        .where((e) => e.isNotEmpty && nonCustom.hasMatch(e))
+        .where((e) => e.isNotEmpty && e.startsWith(nonCustom))
         .map(extractToolchainName)
         .toList(growable: true);
 
@@ -137,14 +115,14 @@ class Rustup {
 
   bool _didInstallRustSrcForNightly = false;
 
-  void installRustSrcForNightly({String toolchain = 'nightly'}) {
+  void installRustSrcForNightly() {
     if (_didInstallRustSrcForNightly) {
       return;
     }
     // Useful for -Z build-std
     runCommand(
       "rustup",
-      ['component', 'add', 'rust-src', '--toolchain', toolchain],
+      ['component', 'add', 'rust-src', '--toolchain', 'nightly'],
     );
     _didInstallRustSrcForNightly = true;
   }

--- a/frb_example/gallery/rust_builder/cargokit/build_tool/lib/src/target.dart
+++ b/frb_example/gallery/rust_builder/cargokit/build_tool/lib/src/target.dart
@@ -15,6 +15,7 @@ class Target {
     this.androidMinSdkVersion,
     this.darwinPlatform,
     this.darwinArch,
+    this.ohos,
   });
 
   static final all = [
@@ -84,6 +85,21 @@ class Target {
       darwinPlatform: 'iphonesimulator',
       darwinArch: 'x86_64',
     ),
+    Target(
+      rust: 'aarch64-unknown-linux-ohos',
+      flutter: 'ohos-arm64',
+      ohos: 'arm64-v8a',
+    ),
+    Target(
+      rust: 'armv7-unknown-linux-ohos',
+      flutter: 'ohos-arm',
+      ohos: 'armeabi-v7a',
+    ),
+    Target(
+      rust: 'x86_64-unknown-linux-ohos',
+      flutter: 'ohos-x64',
+      ohos: 'x86_64',
+    ),
   ];
 
   static Target? forFlutterName(String flutterName) {
@@ -109,8 +125,22 @@ class Target {
         .toList(growable: false);
   }
 
+  static List<Target> ohosTargets() {
+    return all.where((element) => element.ohos != null).toList(growable: false);
+  }
+
   /// Returns buildable targets on current host platform ignoring Android targets.
   static List<Target> buildableTargets() {
+    if (Platform.operatingSystem == 'ohos') {
+      final arch = (runCommand('arch', []).stdout as String).trim();
+      if (arch.trim() == 'aarch64') {
+        return [Target.forRustTriple('aarch64-unknown-linux-ohos')!];
+      }
+      if (arch == 'armv7') {
+        return [Target.forRustTriple('armv7-unknown-linux-ohos')!];
+      }
+      return [Target.forRustTriple('x86_64-unknown-linux-ohos')!];
+    }
     if (Platform.isLinux) {
       // Right now we don't support cross-compiling on Linux. So we just return
       // the host target.
@@ -144,4 +174,5 @@ class Target {
   final int? androidMinSdkVersion;
   final String? darwinPlatform;
   final String? darwinArch;
+  final String? ohos;
 }

--- a/frb_example/gallery/rust_builder/cargokit/cmake/cargokit.cmake
+++ b/frb_example/gallery/rust_builder/cargokit/cmake/cargokit.cmake
@@ -32,6 +32,7 @@ function(apply_cargokit target manifest_dir lib_name any_symbol_name)
     else()
         set(CARGOKIT_TARGET_PLATFORM "windows-x64")
     endif()
+    set(CARGOKIT_OHOS_SDK_HOME $ENV{OHOS_SDK_HOME})
 
     set(CARGOKIT_ENV
         "CARGOKIT_CMAKE=${CMAKE_COMMAND}"
@@ -42,11 +43,22 @@ function(apply_cargokit target manifest_dir lib_name any_symbol_name)
         "CARGOKIT_TARGET_PLATFORM=${CARGOKIT_TARGET_PLATFORM}"
         "CARGOKIT_TOOL_TEMP_DIR=${CARGOKIT_TEMP_DIR}/tool"
         "CARGOKIT_ROOT_PROJECT_DIR=${CMAKE_SOURCE_DIR}"
+        "CARGOKIT_OHOS_SDK_HOME=${CARGOKIT_OHOS_SDK_HOME}"
     )
 
     if (WIN32)
         set(SCRIPT_EXTENSION ".cmd")
         set(IMPORT_LIB_EXTENSION ".lib")
+    elseif (CARGOKIT_TARGET_PLATFORM STREQUAL "ohos-arm64"
+         OR CARGOKIT_TARGET_PLATFORM STREQUAL "ohos-arm"
+         OR CARGOKIT_TARGET_PLATFORM STREQUAL "ohos-x64")
+                if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
+                    set(SCRIPT_EXTENSION ".cmd")
+                else()
+                    set(SCRIPT_EXTENSION ".sh")
+                    execute_process(COMMAND chmod +x "${cargokit_cmake_root}/run_build_tool${SCRIPT_EXTENSION}")
+                endif()
+                set(IMPORT_LIB_EXTENSION "")
     else()
         set(SCRIPT_EXTENSION ".sh")
         set(IMPORT_LIB_EXTENSION "")
@@ -65,6 +77,21 @@ function(apply_cargokit target manifest_dir lib_name any_symbol_name)
                 VERBATIM
             )
         endforeach()
+    elseif (CARGOKIT_TARGET_PLATFORM STREQUAL "ohos-arm64"
+             OR CARGOKIT_TARGET_PLATFORM STREQUAL "ohos-arm"
+             OR CARGOKIT_TARGET_PLATFORM STREQUAL "ohos-x64")
+             set(SOURCE_LIB "../../ohos/.cxx/default/default/debug/${OHOS_ARCH}/lib${PROJECT_NAME}.so")
+             set(DEST_LIB "${TARGET_LIB_DIR}/lib${PROJECT_NAME}.so")
+             add_custom_command(
+                 OUTPUT
+                 ${OUTPUT_LIB}
+                 "${CMAKE_CURRENT_BINARY_DIR}/_phony_"
+                 COMMAND ${CMAKE_COMMAND} -E env ${CARGOKIT_ENV}
+                 "${cargokit_cmake_root}/run_build_tool${SCRIPT_EXTENSION}" build-cmake
+                 COMMAND ${CMAKE_COMMAND} -E copy ${OUTPUT_LIB} ${DEST_LIB}
+                 COMMENT "Building and copying ${OUTPUT_LIB} to ${DEST_LIB}"
+                 VERBATIM
+               )
     else()
         add_custom_command(
             OUTPUT

--- a/frb_example/integrate_third_party/rust_builder/cargokit/build_tool/lib/src/build_gradle.dart
+++ b/frb_example/integrate_third_party/rust_builder/cargokit/build_tool/lib/src/build_gradle.dart
@@ -27,7 +27,7 @@ class BuildGradle {
             "Unknown darwin target or platform: $arch, ${Environment.darwinPlatformName}");
       }
       return target;
-    }).toList();
+    }).toSet().toList();
 
     final environment = BuildEnvironment.fromEnvironment(isAndroid: true);
     final provider =

--- a/frb_example/integrate_third_party/rust_builder/cargokit/build_tool/lib/src/builder.dart
+++ b/frb_example/integrate_third_party/rust_builder/cargokit/build_tool/lib/src/builder.dart
@@ -1,6 +1,8 @@
 /// This is copied from Cargokit (which is the official way to use it currently)
 /// Details: https://fzyzcjy.github.io/flutter_rust_bridge/manual/integrate/builtin
 
+import 'dart:io';
+
 import 'package:collection/collection.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
@@ -53,6 +55,7 @@ class BuildEnvironment {
   final String? androidNdkVersion;
   final int? androidMinSdkVersion;
   final String? javaHome;
+  final String? ohosSdkHome;
 
   final String? glibcVersion;
 
@@ -68,6 +71,7 @@ class BuildEnvironment {
     this.androidMinSdkVersion,
     this.javaHome,
     this.glibcVersion,
+    this.ohosSdkHome,
   });
 
   static BuildConfiguration parseBuildConfiguration(String value) {
@@ -105,6 +109,7 @@ class BuildEnvironment {
       androidMinSdkVersion:
           isAndroid ? int.parse(Environment.minSdkVersion) : null,
       javaHome: isAndroid ? Environment.javaHome : null,
+      ohosSdkHome: Environment.ohosSdkHome,
     );
   }
 }
@@ -112,7 +117,6 @@ class BuildEnvironment {
 class RustBuilder {
   final Target target;
   final BuildEnvironment environment;
-  String? _resolvedToolchain;
 
   RustBuilder({
     required this.target,
@@ -123,28 +127,24 @@ class RustBuilder {
     Rustup rustup,
   ) {
     final toolchain = _toolchain;
-    var resolvedToolchain = rustup.resolveToolchain(toolchain);
     if (rustup.installedTargets(toolchain) == null) {
       rustup.installToolchain(toolchain);
-      resolvedToolchain = rustup.resolveToolchain(toolchain);
     }
     if (toolchain == 'nightly') {
-      rustup.installRustSrcForNightly(toolchain: resolvedToolchain);
+      rustup.installRustSrcForNightly();
     }
     if (!rustup.installedTargets(toolchain)!.contains(target.rust)) {
-      rustup.installTarget(target.rust, toolchain: resolvedToolchain);
+      rustup.installTarget(target.rust, toolchain: toolchain);
     }
     if (environment.glibcVersion != null) {
-      rustup.installZigBuild(resolvedToolchain);
+      rustup.installZigBuild(toolchain);
     }
-    _resolvedToolchain = resolvedToolchain;
   }
 
   CargoBuildOptions? get _buildOptions =>
       environment.crateOptions.cargo[environment.configuration];
 
   String get _toolchain => _buildOptions?.toolchain.name ?? 'stable';
-  String get _effectiveToolchain => _resolvedToolchain ?? _toolchain;
 
   /// Returns the path of directory containing build artifacts.
   Future<String> build() async {
@@ -154,7 +154,7 @@ class RustBuilder {
       'rustup',
       [
         'run',
-        _effectiveToolchain,
+        _toolchain,
         'cargo',
         (target.android == null && environment.glibcVersion != null)
             ? 'zigbuild'
@@ -183,32 +183,75 @@ class RustBuilder {
   }
 
   Future<Map<String, String>> _buildEnvironment() async {
-    if (target.android == null) {
-      return {};
-    } else {
-      final sdkPath = environment.androidSdkPath;
-      final ndkVersion = environment.androidNdkVersion;
-      final minSdkVersion = environment.androidMinSdkVersion;
-      if (sdkPath == null) {
-        throw BuildException('androidSdkPath is not set');
-      }
-      if (ndkVersion == null) {
-        throw BuildException('androidNdkVersion is not set');
-      }
-      if (minSdkVersion == null) {
-        throw BuildException('androidMinSdkVersion is not set');
-      }
-      final env = AndroidEnvironment(
-        sdkPath: sdkPath,
-        ndkVersion: ndkVersion,
-        minSdkVersion: minSdkVersion,
-        targetTempDir: environment.targetTempDir,
-        target: target,
-      );
-      if (!env.ndkIsInstalled() && environment.javaHome != null) {
-        env.installNdk(javaHome: environment.javaHome!);
-      }
-      return env.buildEnvironment();
+    if (target.ohos != null) {
+      return _buildOhosEnv();
     }
+    if (target.android != null) {
+      return _buildAndroidEnv();
+    }
+    return {};
+  }
+
+  Future<Map<String, String>> _buildAndroidEnv() {
+    final sdkPath = environment.androidSdkPath;
+    final ndkVersion = environment.androidNdkVersion;
+    final minSdkVersion = environment.androidMinSdkVersion;
+    if (sdkPath == null) {
+      throw BuildException('androidSdkPath is not set');
+    }
+    if (ndkVersion == null) {
+      throw BuildException('androidNdkVersion is not set');
+    }
+    if (minSdkVersion == null) {
+      throw BuildException('androidMinSdkVersion is not set');
+    }
+    final env = AndroidEnvironment(
+      sdkPath: sdkPath,
+      ndkVersion: ndkVersion,
+      minSdkVersion: minSdkVersion,
+      targetTempDir: environment.targetTempDir,
+      target: target,
+    );
+    if (!env.ndkIsInstalled() && environment.javaHome != null) {
+      env.installNdk(javaHome: environment.javaHome!);
+    }
+    return env.buildEnvironment();
+  }
+
+  Map<String, String> _buildOhosEnv() {
+    final sdkPath = environment.ohosSdkHome;
+    if (sdkPath == null) {
+      throw BuildException('OHOS SDK native path is not set');
+    }
+    final exe = Platform.isWindows ? '.exe' : '';
+    final clangPath = path.join(sdkPath, 'llvm', 'bin', 'clang$exe');
+    final sysroot = path.join(sdkPath, 'sysroot');
+    String clangTarget;
+    switch (target.ohos) {
+      case 'arm64-v8a':
+        clangTarget = 'aarch64-linux-ohos';
+        break;
+      case 'armeabi-v7a':
+        clangTarget = 'arm-linux-ohos';
+        break;
+      case 'x86_64':
+        clangTarget = 'x86_64-linux-ohos';
+        break;
+      default:
+        clangTarget = 'aarch64-linux-ohos';
+    }
+    final targetEnvName = target.rust.toUpperCase().replaceAll('-', '_');
+    final linkerEnvVar = 'CARGO_TARGET_${targetEnvName}_LINKER';
+    final rustFlagsEnvVar = 'CARGO_TARGET_${targetEnvName}_RUSTFLAGS';
+    final rustFlags = '-C link-arg=--target=$clangTarget '
+        '-C link-arg=-fuse-ld=lld '
+        '-C link-arg=--sysroot=$sysroot '
+        '-C link-arg=-D__MUSL__';
+    return {
+      rustFlagsEnvVar: rustFlags,
+      linkerEnvVar: clangPath,
+      'CC_${target.rust}': clangPath,
+      'AR_${target.rust}': path.join(sdkPath, 'llvm', 'bin', 'llvm-ar$exe'),
+    };
   }
 }

--- a/frb_example/integrate_third_party/rust_builder/cargokit/build_tool/lib/src/environment.dart
+++ b/frb_example/integrate_third_party/rust_builder/cargokit/build_tool/lib/src/environment.dart
@@ -46,6 +46,8 @@ class Environment {
   static List<String> get targetPlatforms =>
       _getEnv("CARGOKIT_TARGET_PLATFORMS").split(',');
 
+  static String? get ohosSdkHome => _getEnvOptional("CARGOKIT_OHOS_SDK_HOME");
+
   // CMAKE
   static String get targetPlatform => _getEnv("CARGOKIT_TARGET_PLATFORM");
 
@@ -64,5 +66,9 @@ class Environment {
     } else {
       return res;
     }
+  }
+
+  static String? _getEnvOptional(String key) {
+    return Platform.environment[key];
   }
 }

--- a/frb_example/integrate_third_party/rust_builder/cargokit/build_tool/lib/src/rustup.dart
+++ b/frb_example/integrate_third_party/rust_builder/cargokit/build_tool/lib/src/rustup.dart
@@ -24,17 +24,6 @@ class Rustup {
     return targets != null ? List.unmodifiable(targets) : null;
   }
 
-  String resolveToolchain(String toolchain) =>
-      _installedToolchains
-          .firstWhereOrNull(
-            (e) => _matchesRequestedToolchain(
-              installedName: e.name,
-              requestedToolchain: toolchain,
-            ),
-          )
-          ?.name ??
-      toolchain;
-
   void installToolchain(String toolchain) {
     log.info("Installing Rust toolchain: $toolchain");
     runCommand("rustup", ['toolchain', 'install', toolchain]);
@@ -74,20 +63,9 @@ class Rustup {
 
   Rustup() : _installedToolchains = _getInstalledToolchains();
 
-  bool _matchesRequestedToolchain({
-    required String installedName,
-    required String requestedToolchain,
-  }) =>
-      installedName == requestedToolchain ||
-      installedName.startsWith('$requestedToolchain-');
-
   List<String>? _installedTargets(String toolchain) => _installedToolchains
       .firstWhereOrNull(
-        (e) => _matchesRequestedToolchain(
-          installedName: e.name,
-          requestedToolchain: toolchain,
-        ),
-      )
+          (e) => e.name == toolchain || e.name.startsWith('$toolchain-'))
       ?.targets;
 
   static List<_Toolchain> _getInstalledToolchains() {
@@ -101,11 +79,11 @@ class Rustup {
 
     // To list all non-custom toolchains, we need to filter out lines that
     // don't start with "stable", "beta", or "nightly".
-    final nonCustom = RegExp(r'^(stable|beta|nightly)');
+    Pattern nonCustom = RegExp(r"^(stable|beta|nightly)");
     final lines = res.stdout
         .toString()
         .split('\n')
-        .where((e) => e.isNotEmpty && nonCustom.hasMatch(e))
+        .where((e) => e.isNotEmpty && e.startsWith(nonCustom))
         .map(extractToolchainName)
         .toList(growable: true);
 
@@ -137,14 +115,14 @@ class Rustup {
 
   bool _didInstallRustSrcForNightly = false;
 
-  void installRustSrcForNightly({String toolchain = 'nightly'}) {
+  void installRustSrcForNightly() {
     if (_didInstallRustSrcForNightly) {
       return;
     }
     // Useful for -Z build-std
     runCommand(
       "rustup",
-      ['component', 'add', 'rust-src', '--toolchain', toolchain],
+      ['component', 'add', 'rust-src', '--toolchain', 'nightly'],
     );
     _didInstallRustSrcForNightly = true;
   }

--- a/frb_example/integrate_third_party/rust_builder/cargokit/build_tool/lib/src/target.dart
+++ b/frb_example/integrate_third_party/rust_builder/cargokit/build_tool/lib/src/target.dart
@@ -15,6 +15,7 @@ class Target {
     this.androidMinSdkVersion,
     this.darwinPlatform,
     this.darwinArch,
+    this.ohos,
   });
 
   static final all = [
@@ -84,6 +85,21 @@ class Target {
       darwinPlatform: 'iphonesimulator',
       darwinArch: 'x86_64',
     ),
+    Target(
+      rust: 'aarch64-unknown-linux-ohos',
+      flutter: 'ohos-arm64',
+      ohos: 'arm64-v8a',
+    ),
+    Target(
+      rust: 'armv7-unknown-linux-ohos',
+      flutter: 'ohos-arm',
+      ohos: 'armeabi-v7a',
+    ),
+    Target(
+      rust: 'x86_64-unknown-linux-ohos',
+      flutter: 'ohos-x64',
+      ohos: 'x86_64',
+    ),
   ];
 
   static Target? forFlutterName(String flutterName) {
@@ -109,8 +125,22 @@ class Target {
         .toList(growable: false);
   }
 
+  static List<Target> ohosTargets() {
+    return all.where((element) => element.ohos != null).toList(growable: false);
+  }
+
   /// Returns buildable targets on current host platform ignoring Android targets.
   static List<Target> buildableTargets() {
+    if (Platform.operatingSystem == 'ohos') {
+      final arch = (runCommand('arch', []).stdout as String).trim();
+      if (arch.trim() == 'aarch64') {
+        return [Target.forRustTriple('aarch64-unknown-linux-ohos')!];
+      }
+      if (arch == 'armv7') {
+        return [Target.forRustTriple('armv7-unknown-linux-ohos')!];
+      }
+      return [Target.forRustTriple('x86_64-unknown-linux-ohos')!];
+    }
     if (Platform.isLinux) {
       // Right now we don't support cross-compiling on Linux. So we just return
       // the host target.
@@ -144,4 +174,5 @@ class Target {
   final int? androidMinSdkVersion;
   final String? darwinPlatform;
   final String? darwinArch;
+  final String? ohos;
 }

--- a/frb_example/integrate_third_party/rust_builder/cargokit/cmake/cargokit.cmake
+++ b/frb_example/integrate_third_party/rust_builder/cargokit/cmake/cargokit.cmake
@@ -32,6 +32,7 @@ function(apply_cargokit target manifest_dir lib_name any_symbol_name)
     else()
         set(CARGOKIT_TARGET_PLATFORM "windows-x64")
     endif()
+    set(CARGOKIT_OHOS_SDK_HOME $ENV{OHOS_SDK_HOME})
 
     set(CARGOKIT_ENV
         "CARGOKIT_CMAKE=${CMAKE_COMMAND}"
@@ -42,11 +43,22 @@ function(apply_cargokit target manifest_dir lib_name any_symbol_name)
         "CARGOKIT_TARGET_PLATFORM=${CARGOKIT_TARGET_PLATFORM}"
         "CARGOKIT_TOOL_TEMP_DIR=${CARGOKIT_TEMP_DIR}/tool"
         "CARGOKIT_ROOT_PROJECT_DIR=${CMAKE_SOURCE_DIR}"
+        "CARGOKIT_OHOS_SDK_HOME=${CARGOKIT_OHOS_SDK_HOME}"
     )
 
     if (WIN32)
         set(SCRIPT_EXTENSION ".cmd")
         set(IMPORT_LIB_EXTENSION ".lib")
+    elseif (CARGOKIT_TARGET_PLATFORM STREQUAL "ohos-arm64"
+         OR CARGOKIT_TARGET_PLATFORM STREQUAL "ohos-arm"
+         OR CARGOKIT_TARGET_PLATFORM STREQUAL "ohos-x64")
+                if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
+                    set(SCRIPT_EXTENSION ".cmd")
+                else()
+                    set(SCRIPT_EXTENSION ".sh")
+                    execute_process(COMMAND chmod +x "${cargokit_cmake_root}/run_build_tool${SCRIPT_EXTENSION}")
+                endif()
+                set(IMPORT_LIB_EXTENSION "")
     else()
         set(SCRIPT_EXTENSION ".sh")
         set(IMPORT_LIB_EXTENSION "")
@@ -65,6 +77,21 @@ function(apply_cargokit target manifest_dir lib_name any_symbol_name)
                 VERBATIM
             )
         endforeach()
+    elseif (CARGOKIT_TARGET_PLATFORM STREQUAL "ohos-arm64"
+             OR CARGOKIT_TARGET_PLATFORM STREQUAL "ohos-arm"
+             OR CARGOKIT_TARGET_PLATFORM STREQUAL "ohos-x64")
+             set(SOURCE_LIB "../../ohos/.cxx/default/default/debug/${OHOS_ARCH}/lib${PROJECT_NAME}.so")
+             set(DEST_LIB "${TARGET_LIB_DIR}/lib${PROJECT_NAME}.so")
+             add_custom_command(
+                 OUTPUT
+                 ${OUTPUT_LIB}
+                 "${CMAKE_CURRENT_BINARY_DIR}/_phony_"
+                 COMMAND ${CMAKE_COMMAND} -E env ${CARGOKIT_ENV}
+                 "${cargokit_cmake_root}/run_build_tool${SCRIPT_EXTENSION}" build-cmake
+                 COMMAND ${CMAKE_COMMAND} -E copy ${OUTPUT_LIB} ${DEST_LIB}
+                 COMMENT "Building and copying ${OUTPUT_LIB} to ${DEST_LIB}"
+                 VERBATIM
+               )
     else()
         add_custom_command(
             OUTPUT

--- a/frb_example/rust_ui_counter/ui/rust_builder/cargokit/build_tool/lib/src/build_gradle.dart
+++ b/frb_example/rust_ui_counter/ui/rust_builder/cargokit/build_tool/lib/src/build_gradle.dart
@@ -27,7 +27,7 @@ class BuildGradle {
             "Unknown darwin target or platform: $arch, ${Environment.darwinPlatformName}");
       }
       return target;
-    }).toList();
+    }).toSet().toList();
 
     final environment = BuildEnvironment.fromEnvironment(isAndroid: true);
     final provider =

--- a/frb_example/rust_ui_counter/ui/rust_builder/cargokit/build_tool/lib/src/builder.dart
+++ b/frb_example/rust_ui_counter/ui/rust_builder/cargokit/build_tool/lib/src/builder.dart
@@ -1,6 +1,8 @@
 /// This is copied from Cargokit (which is the official way to use it currently)
 /// Details: https://fzyzcjy.github.io/flutter_rust_bridge/manual/integrate/builtin
 
+import 'dart:io';
+
 import 'package:collection/collection.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
@@ -53,6 +55,7 @@ class BuildEnvironment {
   final String? androidNdkVersion;
   final int? androidMinSdkVersion;
   final String? javaHome;
+  final String? ohosSdkHome;
 
   final String? glibcVersion;
 
@@ -68,6 +71,7 @@ class BuildEnvironment {
     this.androidMinSdkVersion,
     this.javaHome,
     this.glibcVersion,
+    this.ohosSdkHome,
   });
 
   static BuildConfiguration parseBuildConfiguration(String value) {
@@ -105,6 +109,7 @@ class BuildEnvironment {
       androidMinSdkVersion:
           isAndroid ? int.parse(Environment.minSdkVersion) : null,
       javaHome: isAndroid ? Environment.javaHome : null,
+      ohosSdkHome: Environment.ohosSdkHome,
     );
   }
 }
@@ -112,7 +117,6 @@ class BuildEnvironment {
 class RustBuilder {
   final Target target;
   final BuildEnvironment environment;
-  String? _resolvedToolchain;
 
   RustBuilder({
     required this.target,
@@ -123,28 +127,24 @@ class RustBuilder {
     Rustup rustup,
   ) {
     final toolchain = _toolchain;
-    var resolvedToolchain = rustup.resolveToolchain(toolchain);
     if (rustup.installedTargets(toolchain) == null) {
       rustup.installToolchain(toolchain);
-      resolvedToolchain = rustup.resolveToolchain(toolchain);
     }
     if (toolchain == 'nightly') {
-      rustup.installRustSrcForNightly(toolchain: resolvedToolchain);
+      rustup.installRustSrcForNightly();
     }
     if (!rustup.installedTargets(toolchain)!.contains(target.rust)) {
-      rustup.installTarget(target.rust, toolchain: resolvedToolchain);
+      rustup.installTarget(target.rust, toolchain: toolchain);
     }
     if (environment.glibcVersion != null) {
-      rustup.installZigBuild(resolvedToolchain);
+      rustup.installZigBuild(toolchain);
     }
-    _resolvedToolchain = resolvedToolchain;
   }
 
   CargoBuildOptions? get _buildOptions =>
       environment.crateOptions.cargo[environment.configuration];
 
   String get _toolchain => _buildOptions?.toolchain.name ?? 'stable';
-  String get _effectiveToolchain => _resolvedToolchain ?? _toolchain;
 
   /// Returns the path of directory containing build artifacts.
   Future<String> build() async {
@@ -154,7 +154,7 @@ class RustBuilder {
       'rustup',
       [
         'run',
-        _effectiveToolchain,
+        _toolchain,
         'cargo',
         (target.android == null && environment.glibcVersion != null)
             ? 'zigbuild'
@@ -183,32 +183,75 @@ class RustBuilder {
   }
 
   Future<Map<String, String>> _buildEnvironment() async {
-    if (target.android == null) {
-      return {};
-    } else {
-      final sdkPath = environment.androidSdkPath;
-      final ndkVersion = environment.androidNdkVersion;
-      final minSdkVersion = environment.androidMinSdkVersion;
-      if (sdkPath == null) {
-        throw BuildException('androidSdkPath is not set');
-      }
-      if (ndkVersion == null) {
-        throw BuildException('androidNdkVersion is not set');
-      }
-      if (minSdkVersion == null) {
-        throw BuildException('androidMinSdkVersion is not set');
-      }
-      final env = AndroidEnvironment(
-        sdkPath: sdkPath,
-        ndkVersion: ndkVersion,
-        minSdkVersion: minSdkVersion,
-        targetTempDir: environment.targetTempDir,
-        target: target,
-      );
-      if (!env.ndkIsInstalled() && environment.javaHome != null) {
-        env.installNdk(javaHome: environment.javaHome!);
-      }
-      return env.buildEnvironment();
+    if (target.ohos != null) {
+      return _buildOhosEnv();
     }
+    if (target.android != null) {
+      return _buildAndroidEnv();
+    }
+    return {};
+  }
+
+  Future<Map<String, String>> _buildAndroidEnv() {
+    final sdkPath = environment.androidSdkPath;
+    final ndkVersion = environment.androidNdkVersion;
+    final minSdkVersion = environment.androidMinSdkVersion;
+    if (sdkPath == null) {
+      throw BuildException('androidSdkPath is not set');
+    }
+    if (ndkVersion == null) {
+      throw BuildException('androidNdkVersion is not set');
+    }
+    if (minSdkVersion == null) {
+      throw BuildException('androidMinSdkVersion is not set');
+    }
+    final env = AndroidEnvironment(
+      sdkPath: sdkPath,
+      ndkVersion: ndkVersion,
+      minSdkVersion: minSdkVersion,
+      targetTempDir: environment.targetTempDir,
+      target: target,
+    );
+    if (!env.ndkIsInstalled() && environment.javaHome != null) {
+      env.installNdk(javaHome: environment.javaHome!);
+    }
+    return env.buildEnvironment();
+  }
+
+  Map<String, String> _buildOhosEnv() {
+    final sdkPath = environment.ohosSdkHome;
+    if (sdkPath == null) {
+      throw BuildException('OHOS SDK native path is not set');
+    }
+    final exe = Platform.isWindows ? '.exe' : '';
+    final clangPath = path.join(sdkPath, 'llvm', 'bin', 'clang$exe');
+    final sysroot = path.join(sdkPath, 'sysroot');
+    String clangTarget;
+    switch (target.ohos) {
+      case 'arm64-v8a':
+        clangTarget = 'aarch64-linux-ohos';
+        break;
+      case 'armeabi-v7a':
+        clangTarget = 'arm-linux-ohos';
+        break;
+      case 'x86_64':
+        clangTarget = 'x86_64-linux-ohos';
+        break;
+      default:
+        clangTarget = 'aarch64-linux-ohos';
+    }
+    final targetEnvName = target.rust.toUpperCase().replaceAll('-', '_');
+    final linkerEnvVar = 'CARGO_TARGET_${targetEnvName}_LINKER';
+    final rustFlagsEnvVar = 'CARGO_TARGET_${targetEnvName}_RUSTFLAGS';
+    final rustFlags = '-C link-arg=--target=$clangTarget '
+        '-C link-arg=-fuse-ld=lld '
+        '-C link-arg=--sysroot=$sysroot '
+        '-C link-arg=-D__MUSL__';
+    return {
+      rustFlagsEnvVar: rustFlags,
+      linkerEnvVar: clangPath,
+      'CC_${target.rust}': clangPath,
+      'AR_${target.rust}': path.join(sdkPath, 'llvm', 'bin', 'llvm-ar$exe'),
+    };
   }
 }

--- a/frb_example/rust_ui_counter/ui/rust_builder/cargokit/build_tool/lib/src/environment.dart
+++ b/frb_example/rust_ui_counter/ui/rust_builder/cargokit/build_tool/lib/src/environment.dart
@@ -46,6 +46,8 @@ class Environment {
   static List<String> get targetPlatforms =>
       _getEnv("CARGOKIT_TARGET_PLATFORMS").split(',');
 
+  static String? get ohosSdkHome => _getEnvOptional("CARGOKIT_OHOS_SDK_HOME");
+
   // CMAKE
   static String get targetPlatform => _getEnv("CARGOKIT_TARGET_PLATFORM");
 
@@ -64,5 +66,9 @@ class Environment {
     } else {
       return res;
     }
+  }
+
+  static String? _getEnvOptional(String key) {
+    return Platform.environment[key];
   }
 }

--- a/frb_example/rust_ui_counter/ui/rust_builder/cargokit/build_tool/lib/src/rustup.dart
+++ b/frb_example/rust_ui_counter/ui/rust_builder/cargokit/build_tool/lib/src/rustup.dart
@@ -24,17 +24,6 @@ class Rustup {
     return targets != null ? List.unmodifiable(targets) : null;
   }
 
-  String resolveToolchain(String toolchain) =>
-      _installedToolchains
-          .firstWhereOrNull(
-            (e) => _matchesRequestedToolchain(
-              installedName: e.name,
-              requestedToolchain: toolchain,
-            ),
-          )
-          ?.name ??
-      toolchain;
-
   void installToolchain(String toolchain) {
     log.info("Installing Rust toolchain: $toolchain");
     runCommand("rustup", ['toolchain', 'install', toolchain]);
@@ -74,20 +63,9 @@ class Rustup {
 
   Rustup() : _installedToolchains = _getInstalledToolchains();
 
-  bool _matchesRequestedToolchain({
-    required String installedName,
-    required String requestedToolchain,
-  }) =>
-      installedName == requestedToolchain ||
-      installedName.startsWith('$requestedToolchain-');
-
   List<String>? _installedTargets(String toolchain) => _installedToolchains
       .firstWhereOrNull(
-        (e) => _matchesRequestedToolchain(
-          installedName: e.name,
-          requestedToolchain: toolchain,
-        ),
-      )
+          (e) => e.name == toolchain || e.name.startsWith('$toolchain-'))
       ?.targets;
 
   static List<_Toolchain> _getInstalledToolchains() {
@@ -101,11 +79,11 @@ class Rustup {
 
     // To list all non-custom toolchains, we need to filter out lines that
     // don't start with "stable", "beta", or "nightly".
-    final nonCustom = RegExp(r'^(stable|beta|nightly)');
+    Pattern nonCustom = RegExp(r"^(stable|beta|nightly)");
     final lines = res.stdout
         .toString()
         .split('\n')
-        .where((e) => e.isNotEmpty && nonCustom.hasMatch(e))
+        .where((e) => e.isNotEmpty && e.startsWith(nonCustom))
         .map(extractToolchainName)
         .toList(growable: true);
 
@@ -137,14 +115,14 @@ class Rustup {
 
   bool _didInstallRustSrcForNightly = false;
 
-  void installRustSrcForNightly({String toolchain = 'nightly'}) {
+  void installRustSrcForNightly() {
     if (_didInstallRustSrcForNightly) {
       return;
     }
     // Useful for -Z build-std
     runCommand(
       "rustup",
-      ['component', 'add', 'rust-src', '--toolchain', toolchain],
+      ['component', 'add', 'rust-src', '--toolchain', 'nightly'],
     );
     _didInstallRustSrcForNightly = true;
   }

--- a/frb_example/rust_ui_counter/ui/rust_builder/cargokit/build_tool/lib/src/target.dart
+++ b/frb_example/rust_ui_counter/ui/rust_builder/cargokit/build_tool/lib/src/target.dart
@@ -15,6 +15,7 @@ class Target {
     this.androidMinSdkVersion,
     this.darwinPlatform,
     this.darwinArch,
+    this.ohos,
   });
 
   static final all = [
@@ -84,6 +85,21 @@ class Target {
       darwinPlatform: 'iphonesimulator',
       darwinArch: 'x86_64',
     ),
+    Target(
+      rust: 'aarch64-unknown-linux-ohos',
+      flutter: 'ohos-arm64',
+      ohos: 'arm64-v8a',
+    ),
+    Target(
+      rust: 'armv7-unknown-linux-ohos',
+      flutter: 'ohos-arm',
+      ohos: 'armeabi-v7a',
+    ),
+    Target(
+      rust: 'x86_64-unknown-linux-ohos',
+      flutter: 'ohos-x64',
+      ohos: 'x86_64',
+    ),
   ];
 
   static Target? forFlutterName(String flutterName) {
@@ -109,8 +125,22 @@ class Target {
         .toList(growable: false);
   }
 
+  static List<Target> ohosTargets() {
+    return all.where((element) => element.ohos != null).toList(growable: false);
+  }
+
   /// Returns buildable targets on current host platform ignoring Android targets.
   static List<Target> buildableTargets() {
+    if (Platform.operatingSystem == 'ohos') {
+      final arch = (runCommand('arch', []).stdout as String).trim();
+      if (arch.trim() == 'aarch64') {
+        return [Target.forRustTriple('aarch64-unknown-linux-ohos')!];
+      }
+      if (arch == 'armv7') {
+        return [Target.forRustTriple('armv7-unknown-linux-ohos')!];
+      }
+      return [Target.forRustTriple('x86_64-unknown-linux-ohos')!];
+    }
     if (Platform.isLinux) {
       // Right now we don't support cross-compiling on Linux. So we just return
       // the host target.
@@ -144,4 +174,5 @@ class Target {
   final int? androidMinSdkVersion;
   final String? darwinPlatform;
   final String? darwinArch;
+  final String? ohos;
 }

--- a/frb_example/rust_ui_counter/ui/rust_builder/cargokit/cmake/cargokit.cmake
+++ b/frb_example/rust_ui_counter/ui/rust_builder/cargokit/cmake/cargokit.cmake
@@ -32,6 +32,7 @@ function(apply_cargokit target manifest_dir lib_name any_symbol_name)
     else()
         set(CARGOKIT_TARGET_PLATFORM "windows-x64")
     endif()
+    set(CARGOKIT_OHOS_SDK_HOME $ENV{OHOS_SDK_HOME})
 
     set(CARGOKIT_ENV
         "CARGOKIT_CMAKE=${CMAKE_COMMAND}"
@@ -42,11 +43,22 @@ function(apply_cargokit target manifest_dir lib_name any_symbol_name)
         "CARGOKIT_TARGET_PLATFORM=${CARGOKIT_TARGET_PLATFORM}"
         "CARGOKIT_TOOL_TEMP_DIR=${CARGOKIT_TEMP_DIR}/tool"
         "CARGOKIT_ROOT_PROJECT_DIR=${CMAKE_SOURCE_DIR}"
+        "CARGOKIT_OHOS_SDK_HOME=${CARGOKIT_OHOS_SDK_HOME}"
     )
 
     if (WIN32)
         set(SCRIPT_EXTENSION ".cmd")
         set(IMPORT_LIB_EXTENSION ".lib")
+    elseif (CARGOKIT_TARGET_PLATFORM STREQUAL "ohos-arm64"
+         OR CARGOKIT_TARGET_PLATFORM STREQUAL "ohos-arm"
+         OR CARGOKIT_TARGET_PLATFORM STREQUAL "ohos-x64")
+                if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
+                    set(SCRIPT_EXTENSION ".cmd")
+                else()
+                    set(SCRIPT_EXTENSION ".sh")
+                    execute_process(COMMAND chmod +x "${cargokit_cmake_root}/run_build_tool${SCRIPT_EXTENSION}")
+                endif()
+                set(IMPORT_LIB_EXTENSION "")
     else()
         set(SCRIPT_EXTENSION ".sh")
         set(IMPORT_LIB_EXTENSION "")
@@ -65,6 +77,21 @@ function(apply_cargokit target manifest_dir lib_name any_symbol_name)
                 VERBATIM
             )
         endforeach()
+    elseif (CARGOKIT_TARGET_PLATFORM STREQUAL "ohos-arm64"
+             OR CARGOKIT_TARGET_PLATFORM STREQUAL "ohos-arm"
+             OR CARGOKIT_TARGET_PLATFORM STREQUAL "ohos-x64")
+             set(SOURCE_LIB "../../ohos/.cxx/default/default/debug/${OHOS_ARCH}/lib${PROJECT_NAME}.so")
+             set(DEST_LIB "${TARGET_LIB_DIR}/lib${PROJECT_NAME}.so")
+             add_custom_command(
+                 OUTPUT
+                 ${OUTPUT_LIB}
+                 "${CMAKE_CURRENT_BINARY_DIR}/_phony_"
+                 COMMAND ${CMAKE_COMMAND} -E env ${CARGOKIT_ENV}
+                 "${cargokit_cmake_root}/run_build_tool${SCRIPT_EXTENSION}" build-cmake
+                 COMMAND ${CMAKE_COMMAND} -E copy ${OUTPUT_LIB} ${DEST_LIB}
+                 COMMENT "Building and copying ${OUTPUT_LIB} to ${DEST_LIB}"
+                 VERBATIM
+               )
     else()
         add_custom_command(
             OUTPUT

--- a/frb_example/rust_ui_todo_list/ui/rust_builder/cargokit/build_tool/lib/src/build_gradle.dart
+++ b/frb_example/rust_ui_todo_list/ui/rust_builder/cargokit/build_tool/lib/src/build_gradle.dart
@@ -27,7 +27,7 @@ class BuildGradle {
             "Unknown darwin target or platform: $arch, ${Environment.darwinPlatformName}");
       }
       return target;
-    }).toList();
+    }).toSet().toList();
 
     final environment = BuildEnvironment.fromEnvironment(isAndroid: true);
     final provider =

--- a/frb_example/rust_ui_todo_list/ui/rust_builder/cargokit/build_tool/lib/src/builder.dart
+++ b/frb_example/rust_ui_todo_list/ui/rust_builder/cargokit/build_tool/lib/src/builder.dart
@@ -1,6 +1,8 @@
 /// This is copied from Cargokit (which is the official way to use it currently)
 /// Details: https://fzyzcjy.github.io/flutter_rust_bridge/manual/integrate/builtin
 
+import 'dart:io';
+
 import 'package:collection/collection.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
@@ -53,6 +55,7 @@ class BuildEnvironment {
   final String? androidNdkVersion;
   final int? androidMinSdkVersion;
   final String? javaHome;
+  final String? ohosSdkHome;
 
   final String? glibcVersion;
 
@@ -68,6 +71,7 @@ class BuildEnvironment {
     this.androidMinSdkVersion,
     this.javaHome,
     this.glibcVersion,
+    this.ohosSdkHome,
   });
 
   static BuildConfiguration parseBuildConfiguration(String value) {
@@ -105,6 +109,7 @@ class BuildEnvironment {
       androidMinSdkVersion:
           isAndroid ? int.parse(Environment.minSdkVersion) : null,
       javaHome: isAndroid ? Environment.javaHome : null,
+      ohosSdkHome: Environment.ohosSdkHome,
     );
   }
 }
@@ -112,7 +117,6 @@ class BuildEnvironment {
 class RustBuilder {
   final Target target;
   final BuildEnvironment environment;
-  String? _resolvedToolchain;
 
   RustBuilder({
     required this.target,
@@ -123,28 +127,24 @@ class RustBuilder {
     Rustup rustup,
   ) {
     final toolchain = _toolchain;
-    var resolvedToolchain = rustup.resolveToolchain(toolchain);
     if (rustup.installedTargets(toolchain) == null) {
       rustup.installToolchain(toolchain);
-      resolvedToolchain = rustup.resolveToolchain(toolchain);
     }
     if (toolchain == 'nightly') {
-      rustup.installRustSrcForNightly(toolchain: resolvedToolchain);
+      rustup.installRustSrcForNightly();
     }
     if (!rustup.installedTargets(toolchain)!.contains(target.rust)) {
-      rustup.installTarget(target.rust, toolchain: resolvedToolchain);
+      rustup.installTarget(target.rust, toolchain: toolchain);
     }
     if (environment.glibcVersion != null) {
-      rustup.installZigBuild(resolvedToolchain);
+      rustup.installZigBuild(toolchain);
     }
-    _resolvedToolchain = resolvedToolchain;
   }
 
   CargoBuildOptions? get _buildOptions =>
       environment.crateOptions.cargo[environment.configuration];
 
   String get _toolchain => _buildOptions?.toolchain.name ?? 'stable';
-  String get _effectiveToolchain => _resolvedToolchain ?? _toolchain;
 
   /// Returns the path of directory containing build artifacts.
   Future<String> build() async {
@@ -154,7 +154,7 @@ class RustBuilder {
       'rustup',
       [
         'run',
-        _effectiveToolchain,
+        _toolchain,
         'cargo',
         (target.android == null && environment.glibcVersion != null)
             ? 'zigbuild'
@@ -183,32 +183,75 @@ class RustBuilder {
   }
 
   Future<Map<String, String>> _buildEnvironment() async {
-    if (target.android == null) {
-      return {};
-    } else {
-      final sdkPath = environment.androidSdkPath;
-      final ndkVersion = environment.androidNdkVersion;
-      final minSdkVersion = environment.androidMinSdkVersion;
-      if (sdkPath == null) {
-        throw BuildException('androidSdkPath is not set');
-      }
-      if (ndkVersion == null) {
-        throw BuildException('androidNdkVersion is not set');
-      }
-      if (minSdkVersion == null) {
-        throw BuildException('androidMinSdkVersion is not set');
-      }
-      final env = AndroidEnvironment(
-        sdkPath: sdkPath,
-        ndkVersion: ndkVersion,
-        minSdkVersion: minSdkVersion,
-        targetTempDir: environment.targetTempDir,
-        target: target,
-      );
-      if (!env.ndkIsInstalled() && environment.javaHome != null) {
-        env.installNdk(javaHome: environment.javaHome!);
-      }
-      return env.buildEnvironment();
+    if (target.ohos != null) {
+      return _buildOhosEnv();
     }
+    if (target.android != null) {
+      return _buildAndroidEnv();
+    }
+    return {};
+  }
+
+  Future<Map<String, String>> _buildAndroidEnv() {
+    final sdkPath = environment.androidSdkPath;
+    final ndkVersion = environment.androidNdkVersion;
+    final minSdkVersion = environment.androidMinSdkVersion;
+    if (sdkPath == null) {
+      throw BuildException('androidSdkPath is not set');
+    }
+    if (ndkVersion == null) {
+      throw BuildException('androidNdkVersion is not set');
+    }
+    if (minSdkVersion == null) {
+      throw BuildException('androidMinSdkVersion is not set');
+    }
+    final env = AndroidEnvironment(
+      sdkPath: sdkPath,
+      ndkVersion: ndkVersion,
+      minSdkVersion: minSdkVersion,
+      targetTempDir: environment.targetTempDir,
+      target: target,
+    );
+    if (!env.ndkIsInstalled() && environment.javaHome != null) {
+      env.installNdk(javaHome: environment.javaHome!);
+    }
+    return env.buildEnvironment();
+  }
+
+  Map<String, String> _buildOhosEnv() {
+    final sdkPath = environment.ohosSdkHome;
+    if (sdkPath == null) {
+      throw BuildException('OHOS SDK native path is not set');
+    }
+    final exe = Platform.isWindows ? '.exe' : '';
+    final clangPath = path.join(sdkPath, 'llvm', 'bin', 'clang$exe');
+    final sysroot = path.join(sdkPath, 'sysroot');
+    String clangTarget;
+    switch (target.ohos) {
+      case 'arm64-v8a':
+        clangTarget = 'aarch64-linux-ohos';
+        break;
+      case 'armeabi-v7a':
+        clangTarget = 'arm-linux-ohos';
+        break;
+      case 'x86_64':
+        clangTarget = 'x86_64-linux-ohos';
+        break;
+      default:
+        clangTarget = 'aarch64-linux-ohos';
+    }
+    final targetEnvName = target.rust.toUpperCase().replaceAll('-', '_');
+    final linkerEnvVar = 'CARGO_TARGET_${targetEnvName}_LINKER';
+    final rustFlagsEnvVar = 'CARGO_TARGET_${targetEnvName}_RUSTFLAGS';
+    final rustFlags = '-C link-arg=--target=$clangTarget '
+        '-C link-arg=-fuse-ld=lld '
+        '-C link-arg=--sysroot=$sysroot '
+        '-C link-arg=-D__MUSL__';
+    return {
+      rustFlagsEnvVar: rustFlags,
+      linkerEnvVar: clangPath,
+      'CC_${target.rust}': clangPath,
+      'AR_${target.rust}': path.join(sdkPath, 'llvm', 'bin', 'llvm-ar$exe'),
+    };
   }
 }

--- a/frb_example/rust_ui_todo_list/ui/rust_builder/cargokit/build_tool/lib/src/environment.dart
+++ b/frb_example/rust_ui_todo_list/ui/rust_builder/cargokit/build_tool/lib/src/environment.dart
@@ -46,6 +46,8 @@ class Environment {
   static List<String> get targetPlatforms =>
       _getEnv("CARGOKIT_TARGET_PLATFORMS").split(',');
 
+  static String? get ohosSdkHome => _getEnvOptional("CARGOKIT_OHOS_SDK_HOME");
+
   // CMAKE
   static String get targetPlatform => _getEnv("CARGOKIT_TARGET_PLATFORM");
 
@@ -64,5 +66,9 @@ class Environment {
     } else {
       return res;
     }
+  }
+
+  static String? _getEnvOptional(String key) {
+    return Platform.environment[key];
   }
 }

--- a/frb_example/rust_ui_todo_list/ui/rust_builder/cargokit/build_tool/lib/src/rustup.dart
+++ b/frb_example/rust_ui_todo_list/ui/rust_builder/cargokit/build_tool/lib/src/rustup.dart
@@ -24,17 +24,6 @@ class Rustup {
     return targets != null ? List.unmodifiable(targets) : null;
   }
 
-  String resolveToolchain(String toolchain) =>
-      _installedToolchains
-          .firstWhereOrNull(
-            (e) => _matchesRequestedToolchain(
-              installedName: e.name,
-              requestedToolchain: toolchain,
-            ),
-          )
-          ?.name ??
-      toolchain;
-
   void installToolchain(String toolchain) {
     log.info("Installing Rust toolchain: $toolchain");
     runCommand("rustup", ['toolchain', 'install', toolchain]);
@@ -74,20 +63,9 @@ class Rustup {
 
   Rustup() : _installedToolchains = _getInstalledToolchains();
 
-  bool _matchesRequestedToolchain({
-    required String installedName,
-    required String requestedToolchain,
-  }) =>
-      installedName == requestedToolchain ||
-      installedName.startsWith('$requestedToolchain-');
-
   List<String>? _installedTargets(String toolchain) => _installedToolchains
       .firstWhereOrNull(
-        (e) => _matchesRequestedToolchain(
-          installedName: e.name,
-          requestedToolchain: toolchain,
-        ),
-      )
+          (e) => e.name == toolchain || e.name.startsWith('$toolchain-'))
       ?.targets;
 
   static List<_Toolchain> _getInstalledToolchains() {
@@ -101,11 +79,11 @@ class Rustup {
 
     // To list all non-custom toolchains, we need to filter out lines that
     // don't start with "stable", "beta", or "nightly".
-    final nonCustom = RegExp(r'^(stable|beta|nightly)');
+    Pattern nonCustom = RegExp(r"^(stable|beta|nightly)");
     final lines = res.stdout
         .toString()
         .split('\n')
-        .where((e) => e.isNotEmpty && nonCustom.hasMatch(e))
+        .where((e) => e.isNotEmpty && e.startsWith(nonCustom))
         .map(extractToolchainName)
         .toList(growable: true);
 
@@ -137,14 +115,14 @@ class Rustup {
 
   bool _didInstallRustSrcForNightly = false;
 
-  void installRustSrcForNightly({String toolchain = 'nightly'}) {
+  void installRustSrcForNightly() {
     if (_didInstallRustSrcForNightly) {
       return;
     }
     // Useful for -Z build-std
     runCommand(
       "rustup",
-      ['component', 'add', 'rust-src', '--toolchain', toolchain],
+      ['component', 'add', 'rust-src', '--toolchain', 'nightly'],
     );
     _didInstallRustSrcForNightly = true;
   }

--- a/frb_example/rust_ui_todo_list/ui/rust_builder/cargokit/build_tool/lib/src/target.dart
+++ b/frb_example/rust_ui_todo_list/ui/rust_builder/cargokit/build_tool/lib/src/target.dart
@@ -15,6 +15,7 @@ class Target {
     this.androidMinSdkVersion,
     this.darwinPlatform,
     this.darwinArch,
+    this.ohos,
   });
 
   static final all = [
@@ -84,6 +85,21 @@ class Target {
       darwinPlatform: 'iphonesimulator',
       darwinArch: 'x86_64',
     ),
+    Target(
+      rust: 'aarch64-unknown-linux-ohos',
+      flutter: 'ohos-arm64',
+      ohos: 'arm64-v8a',
+    ),
+    Target(
+      rust: 'armv7-unknown-linux-ohos',
+      flutter: 'ohos-arm',
+      ohos: 'armeabi-v7a',
+    ),
+    Target(
+      rust: 'x86_64-unknown-linux-ohos',
+      flutter: 'ohos-x64',
+      ohos: 'x86_64',
+    ),
   ];
 
   static Target? forFlutterName(String flutterName) {
@@ -109,8 +125,22 @@ class Target {
         .toList(growable: false);
   }
 
+  static List<Target> ohosTargets() {
+    return all.where((element) => element.ohos != null).toList(growable: false);
+  }
+
   /// Returns buildable targets on current host platform ignoring Android targets.
   static List<Target> buildableTargets() {
+    if (Platform.operatingSystem == 'ohos') {
+      final arch = (runCommand('arch', []).stdout as String).trim();
+      if (arch.trim() == 'aarch64') {
+        return [Target.forRustTriple('aarch64-unknown-linux-ohos')!];
+      }
+      if (arch == 'armv7') {
+        return [Target.forRustTriple('armv7-unknown-linux-ohos')!];
+      }
+      return [Target.forRustTriple('x86_64-unknown-linux-ohos')!];
+    }
     if (Platform.isLinux) {
       // Right now we don't support cross-compiling on Linux. So we just return
       // the host target.
@@ -144,4 +174,5 @@ class Target {
   final int? androidMinSdkVersion;
   final String? darwinPlatform;
   final String? darwinArch;
+  final String? ohos;
 }

--- a/frb_example/rust_ui_todo_list/ui/rust_builder/cargokit/cmake/cargokit.cmake
+++ b/frb_example/rust_ui_todo_list/ui/rust_builder/cargokit/cmake/cargokit.cmake
@@ -32,6 +32,7 @@ function(apply_cargokit target manifest_dir lib_name any_symbol_name)
     else()
         set(CARGOKIT_TARGET_PLATFORM "windows-x64")
     endif()
+    set(CARGOKIT_OHOS_SDK_HOME $ENV{OHOS_SDK_HOME})
 
     set(CARGOKIT_ENV
         "CARGOKIT_CMAKE=${CMAKE_COMMAND}"
@@ -42,11 +43,22 @@ function(apply_cargokit target manifest_dir lib_name any_symbol_name)
         "CARGOKIT_TARGET_PLATFORM=${CARGOKIT_TARGET_PLATFORM}"
         "CARGOKIT_TOOL_TEMP_DIR=${CARGOKIT_TEMP_DIR}/tool"
         "CARGOKIT_ROOT_PROJECT_DIR=${CMAKE_SOURCE_DIR}"
+        "CARGOKIT_OHOS_SDK_HOME=${CARGOKIT_OHOS_SDK_HOME}"
     )
 
     if (WIN32)
         set(SCRIPT_EXTENSION ".cmd")
         set(IMPORT_LIB_EXTENSION ".lib")
+    elseif (CARGOKIT_TARGET_PLATFORM STREQUAL "ohos-arm64"
+         OR CARGOKIT_TARGET_PLATFORM STREQUAL "ohos-arm"
+         OR CARGOKIT_TARGET_PLATFORM STREQUAL "ohos-x64")
+                if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
+                    set(SCRIPT_EXTENSION ".cmd")
+                else()
+                    set(SCRIPT_EXTENSION ".sh")
+                    execute_process(COMMAND chmod +x "${cargokit_cmake_root}/run_build_tool${SCRIPT_EXTENSION}")
+                endif()
+                set(IMPORT_LIB_EXTENSION "")
     else()
         set(SCRIPT_EXTENSION ".sh")
         set(IMPORT_LIB_EXTENSION "")
@@ -65,6 +77,21 @@ function(apply_cargokit target manifest_dir lib_name any_symbol_name)
                 VERBATIM
             )
         endforeach()
+    elseif (CARGOKIT_TARGET_PLATFORM STREQUAL "ohos-arm64"
+             OR CARGOKIT_TARGET_PLATFORM STREQUAL "ohos-arm"
+             OR CARGOKIT_TARGET_PLATFORM STREQUAL "ohos-x64")
+             set(SOURCE_LIB "../../ohos/.cxx/default/default/debug/${OHOS_ARCH}/lib${PROJECT_NAME}.so")
+             set(DEST_LIB "${TARGET_LIB_DIR}/lib${PROJECT_NAME}.so")
+             add_custom_command(
+                 OUTPUT
+                 ${OUTPUT_LIB}
+                 "${CMAKE_CURRENT_BINARY_DIR}/_phony_"
+                 COMMAND ${CMAKE_COMMAND} -E env ${CARGOKIT_ENV}
+                 "${cargokit_cmake_root}/run_build_tool${SCRIPT_EXTENSION}" build-cmake
+                 COMMAND ${CMAKE_COMMAND} -E copy ${OUTPUT_LIB} ${DEST_LIB}
+                 COMMENT "Building and copying ${OUTPUT_LIB} to ${DEST_LIB}"
+                 VERBATIM
+               )
     else()
         add_custom_command(
             OUTPUT


### PR DESCRIPTION
## Summary

Sync checked-in generated Cargokit copies with the current integration template Cargokit submodule.

## Context

The existing `master` state makes `./frb_internal generate-internal --set-exit-if-changed --coverage` rewrite the copied Cargokit files, which blocks unrelated PRs such as #3143.

## Verification

- `./frb_internal generate-internal --set-exit-if-changed --coverage`
