### PR TITLE
Disable flaky workflow telemetry

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,7 +77,8 @@ jobs:
 
     steps:
       # setup
-      - uses: catchpoint/workflow-telemetry-action@v2
+      - if: ${{ false }}
+        uses: catchpoint/workflow-telemetry-action@v2
         continue-on-error: true
         env:
           WORKFLOW_TELEMETRY_SERVER_PORT: 7778
@@ -109,7 +110,8 @@ jobs:
 
     steps:
       # setup
-      - uses: catchpoint/workflow-telemetry-action@v2
+      - if: ${{ false }}
+        uses: catchpoint/workflow-telemetry-action@v2
         continue-on-error: true
         env:
           WORKFLOW_TELEMETRY_SERVER_PORT: 7778
@@ -133,7 +135,8 @@ jobs:
 
     steps:
       # setup
-      - uses: catchpoint/workflow-telemetry-action@v2
+      - if: ${{ false }}
+        uses: catchpoint/workflow-telemetry-action@v2
         continue-on-error: true
         env:
           WORKFLOW_TELEMETRY_SERVER_PORT: 7778
@@ -219,7 +222,8 @@ jobs:
 
     steps:
       # setup
-      - uses: catchpoint/workflow-telemetry-action@v2
+      - if: ${{ false }}
+        uses: catchpoint/workflow-telemetry-action@v2
         continue-on-error: true
         env:
           WORKFLOW_TELEMETRY_SERVER_PORT: 7778
@@ -274,7 +278,8 @@ jobs:
 
     steps:
       # setup
-      - uses: catchpoint/workflow-telemetry-action@v2
+      - if: ${{ false }}
+        uses: catchpoint/workflow-telemetry-action@v2
         continue-on-error: true
         env:
           WORKFLOW_TELEMETRY_SERVER_PORT: 7778
@@ -332,7 +337,8 @@ jobs:
 
     steps:
       # setup
-      - uses: catchpoint/workflow-telemetry-action@v2
+      - if: ${{ false }}
+        uses: catchpoint/workflow-telemetry-action@v2
         continue-on-error: true
         env:
           WORKFLOW_TELEMETRY_SERVER_PORT: 7778
@@ -378,7 +384,8 @@ jobs:
 
     steps:
       # setup
-      - uses: catchpoint/workflow-telemetry-action@v2
+      - if: ${{ false }}
+        uses: catchpoint/workflow-telemetry-action@v2
         continue-on-error: true
         env:
           WORKFLOW_TELEMETRY_SERVER_PORT: 7778
@@ -471,7 +478,8 @@ jobs:
 
     steps:
       # setup
-      - uses: catchpoint/workflow-telemetry-action@v2
+      - if: ${{ false }}
+        uses: catchpoint/workflow-telemetry-action@v2
         continue-on-error: true
         env:
           WORKFLOW_TELEMETRY_SERVER_PORT: 7778
@@ -537,7 +545,8 @@ jobs:
 
     steps:
       # setup
-      - uses: catchpoint/workflow-telemetry-action@v2
+      - if: ${{ false }}
+        uses: catchpoint/workflow-telemetry-action@v2
         continue-on-error: true
         env:
           WORKFLOW_TELEMETRY_SERVER_PORT: 7778
@@ -635,7 +644,8 @@ jobs:
 
     steps:
       # setup
-      - uses: catchpoint/workflow-telemetry-action@v2
+      - if: ${{ false }}
+        uses: catchpoint/workflow-telemetry-action@v2
         continue-on-error: true
         env:
           WORKFLOW_TELEMETRY_SERVER_PORT: 7778
@@ -694,7 +704,8 @@ jobs:
 
     steps:
       # setup
-      - uses: catchpoint/workflow-telemetry-action@v2
+      - if: ${{ false }}
+        uses: catchpoint/workflow-telemetry-action@v2
         continue-on-error: true
         env:
           WORKFLOW_TELEMETRY_SERVER_PORT: 7778
@@ -738,7 +749,8 @@ jobs:
 
     steps:
       # setup
-      - uses: catchpoint/workflow-telemetry-action@v2
+      - if: ${{ false }}
+        uses: catchpoint/workflow-telemetry-action@v2
         continue-on-error: true
         env:
           WORKFLOW_TELEMETRY_SERVER_PORT: 7778
@@ -795,7 +807,8 @@ jobs:
 
     steps:
       # setup
-      - uses: catchpoint/workflow-telemetry-action@v2
+      - if: ${{ false }}
+        uses: catchpoint/workflow-telemetry-action@v2
         continue-on-error: true
         env:
           WORKFLOW_TELEMETRY_SERVER_PORT: 7778
@@ -840,7 +853,8 @@ jobs:
 
     steps:
       # setup
-      - uses: catchpoint/workflow-telemetry-action@v2
+      - if: ${{ false }}
+        uses: catchpoint/workflow-telemetry-action@v2
         continue-on-error: true
         env:
           WORKFLOW_TELEMETRY_SERVER_PORT: 7778
@@ -887,7 +901,8 @@ jobs:
 
     steps:
       # setup
-      - uses: catchpoint/workflow-telemetry-action@v2
+      - if: ${{ false }}
+        uses: catchpoint/workflow-telemetry-action@v2
         with:
           comment_on_pr: false
       - uses: actions/checkout@v5
@@ -954,7 +969,8 @@ jobs:
 
     steps:
       # setup
-      - uses: catchpoint/workflow-telemetry-action@v2
+      - if: ${{ false }}
+        uses: catchpoint/workflow-telemetry-action@v2
         continue-on-error: true
         env:
           WORKFLOW_TELEMETRY_SERVER_PORT: 7778
@@ -1043,7 +1059,8 @@ jobs:
 
     steps:
       # setup
-      - uses: catchpoint/workflow-telemetry-action@v2
+      - if: ${{ false }}
+        uses: catchpoint/workflow-telemetry-action@v2
         continue-on-error: true
         env:
           WORKFLOW_TELEMETRY_SERVER_PORT: 7778
@@ -1079,7 +1096,8 @@ jobs:
           - frb_example--gallery
 
     steps:
-      - uses: catchpoint/workflow-telemetry-action@v2
+      - if: ${{ false }}
+        uses: catchpoint/workflow-telemetry-action@v2
         continue-on-error: true
         env:
           WORKFLOW_TELEMETRY_SERVER_PORT: 7778


### PR DESCRIPTION
## Summary

Disable the Catchpoint workflow telemetry steps in CI.

## Context

Several unrelated PR jobs are failing in the telemetry action/post-action with `AggregateError` even though the steps already use `continue-on-error`. This makes normal Rust and generated-output jobs red before the project checks can be trusted.

## Verification

- `git diff --check`
