### PR TITLE
Fix duplicate auto upgrade test module

### DIFF
--- a/frb_codegen/src/library/codegen/polisher/auto_upgrade.rs
+++ b/frb_codegen/src/library/codegen/polisher/auto_upgrade.rs
@@ -115,7 +115,7 @@ impl<'a> RustUpgrader<'a> {
 }
 
 #[cfg(test)]
-mod tests {
+mod rust_upgrader_tests {
     use super::*;
     use crate::codegen::polisher::internal_config::PolisherInternalConfig;
     use std::cell::Cell;


### PR DESCRIPTION
Fixes a Rust test compile failure on master by giving the newly added auto-upgrade coverage module a distinct name instead of defining a second sibling test module in the same file.

Verification:
- cargo test --manifest-path frb_codegen/Cargo.toml --lib library::codegen::polisher::auto_upgrade