### PR TITLE
Avoid CI reruns on PR metadata edits

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,6 @@ on:
       - synchronize
       - reopened
       - ready_for_review
-      - edited
   workflow_dispatch: { }
 
 env:

--- a/.github/workflows/precommit_autofix.yaml
+++ b/.github/workflows/precommit_autofix.yaml
@@ -7,7 +7,6 @@ on:
       - synchronize
       - reopened
       - ready_for_review
-      - edited
   workflow_dispatch: { }
 
 concurrency:


### PR DESCRIPTION
## Summary

Remove the `pull_request: edited` trigger from CI and Precommit Autofix.

## Why

Editing PR metadata, such as the title or description, does not change code but currently restarts the expensive CI matrix and precommit autofix workflow. Code changes still trigger workflows through `synchronize`, and newly opened/reopened/ready-for-review PRs still run as before.

## Validation

- Checked workflow triggers with `rg edited .github/workflows`.
