### PR TITLE
Fix wasm dry-run JS interop check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1132,6 +1132,8 @@ jobs:
           lsof -i :4444
 
       # execute
+      - if: ${{ matrix.package == 'frb_example--flutter_via_create' }}
+        run: cd frb_example/flutter_via_create && flutter build web
       - run: ./frb_internal test-flutter-web --package ${{ matrix.package }} --coverage
 
       # report

--- a/frb_dart/lib/src/codec/sse.dart
+++ b/frb_dart/lib/src/codec/sse.dart
@@ -5,7 +5,6 @@ import 'package:flutter_rust_bridge/src/codec/dco.dart';
 import 'package:flutter_rust_bridge/src/generalized_frb_rust_binding/generalized_frb_rust_binding.dart';
 import 'package:flutter_rust_bridge/src/manual_impl/manual_impl.dart';
 import 'package:flutter_rust_bridge/src/platform_types/platform_types.dart';
-import 'package:flutter_rust_bridge/src/platform_utils/platform_utils.dart';
 import 'package:flutter_rust_bridge/src/third_party/flutter_foundation_serialization/read_buffer.dart';
 import 'package:flutter_rust_bridge/src/third_party/flutter_foundation_serialization/write_buffer.dart';
 
@@ -26,8 +25,6 @@ class SseCodec<S, E extends Object>
 
   @override
   S decodeObject(dynamic raw) {
-    raw = maybeDartify(raw);
-
     if (raw is! Uint8List) {
       return _decodeObjectOfOtherType(raw);
     }

--- a/frb_dart/lib/src/generalized_isolate/_web.dart
+++ b/frb_dart/lib/src/generalized_isolate/_web.dart
@@ -52,14 +52,14 @@ class ReceivePort extends Stream<dynamic> {
     return subscription;
   }
 
-  static dynamic _extractData(web.MessageEvent event) => event.data;
-
   /// {@macro flutter_rust_bridge.same_as_native}
   SendPort get sendPort => _rawReceivePort.sendPort;
 
   /// {@macro flutter_rust_bridge.same_as_native}
   void close() => _rawReceivePort.close();
 }
+
+dynamic _extractData(web.MessageEvent event) => event.data.dartify();
 
 /// {@macro flutter_rust_bridge.same_as_native}
 class RawReceivePort {
@@ -73,7 +73,7 @@ class RawReceivePort {
 
   /// {@macro flutter_rust_bridge.same_as_native}
   set handler(Function(dynamic) handler) {
-    _webReceivePort._onMessage.listen((event) => handler(event.data));
+    _webReceivePort._onMessage.listen((event) => handler(_extractData(event)));
     _webReceivePort._start();
   }
 

--- a/frb_dart/lib/src/platform_utils/_io.dart
+++ b/frb_dart/lib/src/platform_utils/_io.dart
@@ -1,2 +1,1 @@
-/// {@macro flutter_rust_bridge.internal}
-Object? maybeDartify(Object? object) => object;
+

--- a/frb_dart/lib/src/platform_utils/_web.dart
+++ b/frb_dart/lib/src/platform_utils/_web.dart
@@ -39,12 +39,3 @@ BigInt jsBigIntToDartBigInt(Object? raw) {
     'jsBigIntToDartBigInt see unexpected type=${raw.runtimeType} value=$raw',
   );
 }
-
-/// {@macro flutter_rust_bridge.internal}
-Object? maybeDartify(Object? object) {
-  // ignore: invalid_runtime_check_with_js_interop_types
-  if (object is JSAny) {
-    return object.dartify();
-  }
-  return object;
-}

--- a/frb_dart/lib/src/platform_utils/_web.dart
+++ b/frb_dart/lib/src/platform_utils/_web.dart
@@ -42,5 +42,9 @@ BigInt jsBigIntToDartBigInt(Object? raw) {
 
 /// {@macro flutter_rust_bridge.internal}
 Object? maybeDartify(Object? object) {
-  return object.jsify().dartify();
+  // ignore: invalid_runtime_check_with_js_interop_types
+  if (object is JSAny) {
+    return object.dartify();
+  }
+  return object;
 }

--- a/frb_dart/lib/src/platform_utils/_web.dart
+++ b/frb_dart/lib/src/platform_utils/_web.dart
@@ -42,8 +42,5 @@ BigInt jsBigIntToDartBigInt(Object? raw) {
 
 /// {@macro flutter_rust_bridge.internal}
 Object? maybeDartify(Object? object) {
-  if (object is JSAny) {
-    return object.dartify();
-  }
-  return object;
+  return object.jsify().dartify();
 }


### PR DESCRIPTION
## Summary

- Fix issue #3158 by dartifying `web.MessageEvent.data` at the JS interop boundary before the payload flows into Dart-side message handling.
- Preserve the existing Dart-side message/event behavior without reintroducing `maybeDartify` or any `invalid_runtime_check_with_js_interop_types` ignore.
- Add a CI `flutter build web` reproducer for `frb_example/flutter_via_create` so the wasm dry-run path is covered.

Close #3158

## CI Reproduction Baseline

Intentional red reproduction PR: #3177

Narrowed red CI run:

- Run: https://github.com/fzyzcjy/flutter_rust_bridge/actions/runs/27052329891
- Job: https://github.com/fzyzcjy/flutter_rust_bridge/actions/runs/27052329891/job/79850167158
- Job name: `Test :: Flutter :: Web (frb_example--flutter_via_create)`
- Narrowing: repository GitHub Actions skipped Precommit Autofix and all unrelated CI jobs; only the Flutter Web reproducer job ran.

Reproducer command:

```bash
cd frb_example/flutter_via_create
flutter build web
```

Matching issue text from the red run:

```text
Wasm dry run findings:
Found incompatibilities with WebAssembly.

file:///home/runner/work/flutter_rust_bridge/flutter_rust_bridge/frb_dart/lib/src/platform_utils/_web.dart 45:7 - invalid_runtime_check_with_js_interop_types lint violation: Runtime check between `Object?` and `JSAny` checks whether a Dart value is a JS interop type, which might not be platform-consistent. (7)
```

## Local Reproduction

Baseline commit: `3cb7f6e0e745a39ecadf25da4c7bfe2aff0ed829`

Environment:

```text
FRB Docker dev image: fzyzcjy/flutter_rust_bridge_dev:latest
Flutter 3.41.2
Dart 3.11.0
```

Command:

```bash
.claude/skills/frb-dev-env/frb_dev_env.py docker exec -- bash -lc "cd frb_example/flutter_via_create && timeout 900 flutter build web"
```

Observed before this fix:

```text
Wasm dry run findings:
Found incompatibilities with WebAssembly.

frb_dart/lib/src/platform_utils/_web.dart 45:7 - invalid_runtime_check_with_js_interop_types lint violation: Runtime check between `Object?` and `JSAny` checks whether a Dart value is a JS interop type, which might not be platform-consistent. (7)
```

Expected after this fix:

```text
Wasm dry run succeeded. Consider building and testing your application with the `--wasm` flag. See docs for more info: https://docs.flutter.dev/platform-integration/web/wasm
```

A detailed local reproduction report and full command logs were saved locally during development.

## Verification

```bash
.claude/skills/frb-dev-env/frb_dev_env.py docker exec -- bash -lc "cd frb_example/flutter_via_create && timeout 900 flutter build web"
.claude/skills/frb-dev-env/frb_dev_env.py docker exec -- bash -lc "timeout 900 ./frb_internal test-dart-native --package frb_dart"
.claude/skills/frb-dev-env/frb_dev_env.py docker exec -- bash -lc "timeout 900 ./frb_internal lint-dart"
```

Results:

- Local `flutter build web`: `Wasm dry run succeeded`; no `invalid_runtime_check_with_js_interop_types` / `Found incompatibilities` matches in the saved fixed log.
- Local `test-dart-native --package frb_dart`: `00:00 +67: All tests passed!`
- Local `lint-dart`: all `dart analyze --fatal-infos` checks passed; `pana` reports `WASM-ready` and `Points: 160/160`.
- Fix PR CI same-path verification: `Test :: Flutter :: Web (frb_example--flutter_via_create)` passed on https://github.com/fzyzcjy/flutter_rust_bridge/actions/runs/27050516358/job/79845041809.
