### PR TITLE
Document temporary CI narrowing tip

### DIFF
--- a/.claude/skills/frb-fix-ci/SKILL.md
+++ b/.claude/skills/frb-fix-ci/SKILL.md
@@ -32,6 +32,18 @@ Use this order before diving into individual failure types:
 
 Do not answer from stale CI state. Read the latest relevant run or job information first.
 
+### Temporary CI Narrowing
+
+When CI feedback is slow and only one job family matters for the current investigation, it is acceptable to temporarily narrow `.github/workflows/ci.yaml` so unrelated jobs do not trigger.
+Common patterns include adding an always-false `if` guard to jobs you do not care about yet, or otherwise reducing triggers to the job family being debugged.
+
+Rules:
+
+- Keep the narrowing obvious and temporary; prefer a standalone commit that can be reverted cleanly.
+- Say in the PR or follow-up status that the CI workflow is intentionally narrowed while iterating.
+- Do not treat a narrowed CI run as final readiness evidence.
+- Before final review or merge readiness, revert the temporary workflow change and run the normal CI surface again.
+
 ## Quick Reference
 
 | Symptom | Fix |
@@ -311,6 +323,7 @@ In that situation:
 - Continuing package-by-package `Generate` sync commits after two similar generated Dart drifts, instead of escalating to clean remote `precommit-generate`
 - Fixing downstream build/test jobs before upstream generate/integrate/high-relevance generate-internal stages are stable
 - Answering from stale CI state instead of reading the latest relevant run or job information first
+- Forgetting to revert temporary workflow narrowing before treating the PR as ready
 
 ## Related Skills
 

--- a/.claude/skills/frb-prepare-pr/SKILL.md
+++ b/.claude/skills/frb-prepare-pr/SKILL.md
@@ -46,8 +46,9 @@ Before creating a PR, ensure generated code is up to date, lint passes, and bug 
 5. [ ] (Optional) Read `frb-test` skill, run relevant tests
 6. [ ] **REQUIRED for non-trivial PRs:** Read `frb-pr-review`, run the review gate before final readiness
 7. [ ] **REQUIRED for bug fixes:** PR description includes the reproduction report from `frb-develop-feature`, including baseline commit, mechanical steps, observed failure, and expected behavior
-8. [ ] Commit all changes
-9. [ ] Push and create PR
+8. [ ] **REQUIRED for CI iteration branches:** Revert any temporary workflow narrowing that made unrelated CI jobs not trigger, unless the PR is explicitly about changing CI behavior
+9. [ ] Commit all changes
+10. [ ] Push and create PR
 
 ## What CI Will Do
 
@@ -57,6 +58,8 @@ CI automatically runs:
 - Lint and format checks
 
 Run lint locally to avoid CI failures. Tests are optional locally.
+
+While iterating, it can be useful to temporarily narrow `.github/workflows/ci.yaml` so only the relevant job family runs. Do not leave that temporary narrowing in the final PR unless changing CI behavior is the actual purpose of the PR.
 
 If your PR fixes Flutter integrate example outputs and the real bug is inside the embedded `cargokit` submodule, do not stop at copied example files. Push the `cargokit` fix to `fzyzcjy/cargokit` and update the submodule ref in this repo before pushing the PR branch.
 

--- a/website/docs/guides/contributing/tip.md
+++ b/website/docs/guides/contributing/tip.md
@@ -22,6 +22,12 @@ For example, `./frb_internal precommit --mode fast` (or `--mode slow`) runs code
 If generated or normalized files are missing from a pull request, the `Precommit Autofix` bot comment explains how to apply its patch artifact locally.
 For fork pull requests, a follow-up trusted workflow posts the comment after the patch workflow completes, as the latter runs with read-only permissions.
 
+### Temporarily narrow CI while iterating
+
+When a PR needs several quick CI iterations, it is fine to temporarily make unrelated jobs not trigger, for example by adding an always-false `if` guard or otherwise narrowing the workflow to the jobs you are actively debugging.
+Keep this as a separate temporary commit whenever possible, and revert it before the PR is ready for review or merge.
+The final PR should run the normal CI surface again, so reviewers can trust that the broad matrix was not accidentally bypassed.
+
 ### The `just codegen`
 
 To run the `flutter_rust_bridge_codegen`, but using the local code (instead of a released version),


### PR DESCRIPTION
## Changes

Document that contributors and agents may temporarily narrow CI while iterating, and must restore the normal CI surface before final review or merge readiness.

## Validation

- git diff --check HEAD~1 HEAD