### PR TITLE
Require narrow CI for reproduction PRs

### DIFF
--- a/.claude/skills/frb-fix-ci/SKILL.md
+++ b/.claude/skills/frb-fix-ci/SKILL.md
@@ -34,15 +34,7 @@ Do not answer from stale CI state. Read the latest relevant run or job informati
 
 ### Temporary CI Narrowing
 
-When CI feedback is slow and only one job family matters for the current investigation, it is acceptable to temporarily narrow `.github/workflows/ci.yaml` so unrelated jobs do not trigger.
-Common patterns include adding an always-false `if` guard to jobs you do not care about yet, or otherwise reducing triggers to the job family being debugged.
-
-Rules:
-
-- Keep the narrowing obvious and temporary; prefer a standalone commit that can be reverted cleanly.
-- Say in the PR or follow-up status that the CI workflow is intentionally narrowed while iterating.
-- Do not treat a narrowed CI run as final readiness evidence.
-- Before final review or merge readiness, revert the temporary workflow change and run the normal CI surface again.
+When CI feedback is slow and only one job family matters for the current investigation, read `frb-narrow-ci` before temporarily narrowing `.github/workflows/ci.yaml` or related workflow configuration.
 
 ## Quick Reference
 

--- a/.claude/skills/frb-issue-to-green-pr/SKILL.md
+++ b/.claude/skills/frb-issue-to-green-pr/SKILL.md
@@ -25,6 +25,7 @@ Read these when entering the matching phase:
 - `frb-pr-review` before treating a non-trivial PR as ready.
 - `frb-fix-ci` before diagnosing any CI failure.
 - `frb-manual-test` before writing a manual regression test report under `tools/manual_tests/`.
+- `frb-narrow-ci` before creating an intentional red CI reproduction PR or temporarily narrowing CI.
 - `gh-actions-live-logs` before reading GitHub Actions logs.
 - `frb-debugging` when generated code is surprising or codegen behavior is unclear.
 
@@ -48,9 +49,7 @@ Read these when entering the matching phase:
 - Create an independent reproduction PR whose only purpose is to prove the bad behavior. The branch name, PR title, and PR body must say clearly that it is an intentional reproduction PR, not a real fix PR.
 - For intentional red CI reproduction PRs, use the title `Reproduce ISSUE_SUMMARY with intentional red CI`.
 - For manual-test reproduction PRs, use the title `Add manual reproduction for ISSUE_SUMMARY`.
-- If CI can reproduce the bad behavior, make the reproduction PR an intentional red CI PR: unchanged fix code, minimal reproducer or workflow adjustment, forced CI narrowing to only the single relevant test, command, or job path, and a failure whose error matches the user's report.
-- The reproduction PR must not run the full CI matrix, broad job families, or unrelated tests. If the current workflow cannot narrow to the single interesting test, temporarily modify the reproduction PR's CI configuration so only that reproducer runs.
-- The reproduction PR body must state the exact narrowed test, command, or job path that is expected to run and which expensive or unrelated CI paths were intentionally disabled.
+- If CI can reproduce the bad behavior, read `frb-narrow-ci` and make the reproduction PR an intentional red CI PR: unchanged fix code, minimal reproducer or workflow adjustment, mandatory CI narrowing, and a failure whose error matches the user's report.
 - If CI cannot realistically reproduce the bad behavior, read `frb-manual-test` and make the independent reproduction PR add or update `tools/manual_tests/NAME.md` with a normal manual test procedure and mechanical execution steps an agent or human can run.
 - Do not proceed to the fix PR until the reproduction PR exists and has either a matching red CI run or a precise manual test report.
 - Save the reproduction PR URL, red CI run URL when applicable, job name or manual-test path, and matching error text for the fix PR reproduction report.

--- a/.claude/skills/frb-issue-to-green-pr/SKILL.md
+++ b/.claude/skills/frb-issue-to-green-pr/SKILL.md
@@ -48,7 +48,9 @@ Read these when entering the matching phase:
 - Create an independent reproduction PR whose only purpose is to prove the bad behavior. The branch name, PR title, and PR body must say clearly that it is an intentional reproduction PR, not a real fix PR.
 - For intentional red CI reproduction PRs, use the title `Reproduce ISSUE_SUMMARY with intentional red CI`.
 - For manual-test reproduction PRs, use the title `Add manual reproduction for ISSUE_SUMMARY`.
-- If CI can reproduce the bad behavior, make the reproduction PR an intentional red CI PR: unchanged fix code, minimal reproducer or workflow adjustment, forced CI narrowing to only the relevant job family, and a failure whose error matches the user's report.
+- If CI can reproduce the bad behavior, make the reproduction PR an intentional red CI PR: unchanged fix code, minimal reproducer or workflow adjustment, forced CI narrowing to only the single relevant test, command, or job path, and a failure whose error matches the user's report.
+- The reproduction PR must not run the full CI matrix, broad job families, or unrelated tests. If the current workflow cannot narrow to the single interesting test, temporarily modify the reproduction PR's CI configuration so only that reproducer runs.
+- The reproduction PR body must state the exact narrowed test, command, or job path that is expected to run and which expensive or unrelated CI paths were intentionally disabled.
 - If CI cannot realistically reproduce the bad behavior, read `frb-manual-test` and make the independent reproduction PR add or update `tools/manual_tests/NAME.md` with a normal manual test procedure and mechanical execution steps an agent or human can run.
 - Do not proceed to the fix PR until the reproduction PR exists and has either a matching red CI run or a precise manual test report.
 - Save the reproduction PR URL, red CI run URL when applicable, job name or manual-test path, and matching error text for the fix PR reproduction report.

--- a/.claude/skills/frb-narrow-ci/SKILL.md
+++ b/.claude/skills/frb-narrow-ci/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: frb-narrow-ci
+description: Use when temporarily narrowing flutter_rust_bridge GitHub Actions CI so only the relevant test, command, job path, or job family runs, especially for intentional red reproduction PRs or expensive CI iteration.
+---
+
+# FRB Narrow CI
+
+Use this skill when CI feedback is too expensive or slow and the current task only needs a focused CI signal.
+
+Temporary CI narrowing is allowed only when it is obvious, documented, and later reverted unless the PR is explicitly about CI behavior.
+
+## Intentional Red Reproduction PRs
+
+For intentional red CI reproduction PRs, narrowing is mandatory.
+
+- Narrow CI to only the single relevant test, command, or job path that proves the reported bad behavior.
+- Do not run the full CI matrix, broad job families, or unrelated tests.
+- If the current workflow cannot already select that single target, temporarily modify the reproduction PR's CI configuration so only that reproducer runs.
+- Keep fix code unchanged; the reproduction PR exists only to demonstrate the failure.
+- The reproduction PR body must state:
+  - the exact narrowed test, command, or job path expected to run
+  - the expected failure text or behavior
+  - which expensive or unrelated CI paths were intentionally disabled
+- Do not treat this narrowed red run as fix readiness evidence. It is only the baseline proof that the bad behavior is observable.
+
+## Iteration Branches
+
+For ordinary CI debugging or iteration branches, narrowing is optional.
+
+- Narrow only to the smallest job family needed for the current investigation.
+- Keep the narrowing obvious and temporary; prefer a standalone commit that can be reverted cleanly.
+- Say in the PR or follow-up status that CI is intentionally narrowed while iterating.
+- Do not treat a narrowed CI run as final readiness evidence.
+- Before final review or merge readiness, revert temporary workflow narrowing and run the normal CI surface again.
+
+## Common Patterns
+
+- Add an always-false `if` guard to jobs that are unrelated to the current investigation.
+- Reduce matrix entries so only the target platform, package, or command remains.
+- Restrict workflow triggers or job dependencies only when that is the clearest way to isolate the target.
+
+Keep the temporary CI diff easy to review and easy to remove.

--- a/.claude/skills/frb-prepare-pr/SKILL.md
+++ b/.claude/skills/frb-prepare-pr/SKILL.md
@@ -46,7 +46,7 @@ Before creating a PR, ensure generated code is up to date, lint passes, and bug 
 5. [ ] (Optional) Read `frb-test` skill, run relevant tests
 6. [ ] **REQUIRED for non-trivial PRs:** Read `frb-pr-review`, run the review gate before final readiness
 7. [ ] **REQUIRED for bug fixes:** PR description includes the reproduction report from `frb-develop-feature`, including baseline commit, mechanical steps, observed failure, and expected behavior
-8. [ ] **REQUIRED for CI iteration branches:** Revert any temporary workflow narrowing that made unrelated CI jobs not trigger, unless the PR is explicitly about changing CI behavior
+8. [ ] **REQUIRED for CI iteration branches:** Read `frb-narrow-ci`, then revert any temporary workflow narrowing that made unrelated CI jobs not trigger, unless the PR is explicitly about changing CI behavior
 9. [ ] Commit all changes
 10. [ ] Push and create PR
 
@@ -59,7 +59,7 @@ CI automatically runs:
 
 Run lint locally to avoid CI failures. Tests are optional locally.
 
-While iterating, it can be useful to temporarily narrow `.github/workflows/ci.yaml` so only the relevant job family runs. Do not leave that temporary narrowing in the final PR unless changing CI behavior is the actual purpose of the PR.
+While iterating, it can be useful to temporarily narrow `.github/workflows/ci.yaml` so only the relevant job family runs. Read `frb-narrow-ci` before doing this. Do not leave temporary narrowing in the final PR unless changing CI behavior is the actual purpose of the PR.
 
 If your PR fixes Flutter integrate example outputs and the real bug is inside the embedded `cargokit` submodule, do not stop at copied example files. Push the `cargokit` fix to `fzyzcjy/cargokit` and update the submodule ref in this repo before pushing the PR branch.
 
@@ -71,4 +71,5 @@ If the PR changes integrate-generated example output but not `frb_codegen/assets
 - `frb-lint` - Lint and format checks
 - `frb-test` - For local debugging when CI fails
 - `frb-pr-review` - PR readiness review gate
+- `frb-narrow-ci` - Temporary CI narrowing rules
 - `creating-pull-requests` - Standard PR creation process


### PR DESCRIPTION
## Summary

- Add a dedicated `frb-narrow-ci` skill for temporary FRB CI narrowing.
- Make intentional red reproduction PRs read `frb-narrow-ci` and require mandatory narrowing to the single relevant test, command, or job path.
- Point other CI narrowing guidance in `frb-fix-ci` and `frb-prepare-pr` to the new shared skill.

## Testing

- git diff --check
- git diff --cached --check