### PR TITLE
Add manual tests for local FRB dev environments

### DIFF
--- a/.claude/skills/frb-manual-test/SKILL.md
+++ b/.claude/skills/frb-manual-test/SKILL.md
@@ -50,6 +50,10 @@ Before reporting the run result, use the bundled execution template:
 cp .claude/skills/frb-manual-test/execution-template.md EXECUTION_RESULT_PATH.md
 ```
 
-If the result belongs in a PR comment, issue comment, release checklist, or chat response instead of a file, copy the template text there and fill it out. Do not only say that the test "passed".
+Always fill out an execution markdown file before summarizing the result. Do not only say that the test "passed".
+
+If the execution result belongs to a PR, issue, release checklist, or other reviewable workflow, upload the filled execution markdown as a GitHub gist and link that gist in the PR description, PR comment, issue comment, or release checklist. The local execution markdown should still be kept in the run artifacts directory so the run can be audited without relying only on chat history.
+
+If the result belongs only in chat, still fill out the execution markdown locally and include its path in the chat response.
 
 Run cleanup from the manual test report before declaring the execution complete, unless cleanup is intentionally skipped and documented in the execution record.

--- a/.claude/skills/frb-manual-test/SKILL.md
+++ b/.claude/skills/frb-manual-test/SKILL.md
@@ -52,6 +52,8 @@ cp .claude/skills/frb-manual-test/execution-template.md EXECUTION_RESULT_PATH.md
 
 Always fill out an execution markdown file before summarizing the result. Do not only say that the test "passed".
 
+Execution markdown is a run artifact, not a repository test definition. Do not create it under `tools/manual_tests/` or anywhere else inside the `flutter_rust_bridge` repository. Put it in an external artifacts location such as `/private/tmp`, `~/main/artifacts/flutter_rust_bridge/`, or another run-specific artifact directory.
+
 If the execution result belongs to a PR, issue, release checklist, or other reviewable workflow, upload the filled execution markdown as a GitHub gist and link that gist in the PR description, PR comment, issue comment, or release checklist. The local execution markdown should still be kept in the run artifacts directory so the run can be audited without relying only on chat history.
 
 If the result belongs only in chat, still fill out the execution markdown locally and include its path in the chat response.

--- a/.claude/skills/frb-manual-test/execution-template.md
+++ b/.claude/skills/frb-manual-test/execution-template.md
@@ -46,6 +46,7 @@ Use `pass`, `fail`, `blocked`, or `partial`. The summary should explain the resu
 Link or name the artifacts captured during execution. Use `not applicable` for artifact types that do not apply.
 :::
 
+- Execution markdown gist: `TODO: gist URL if this result belongs to a PR, issue, or release checklist; otherwise not applicable`
 - Terminal log: `TODO: path or link`
 - Screenshot or recording: `TODO: path or link, or not applicable`
 - Generated artifacts: `TODO: path or link, or not applicable`

--- a/tools/manual_tests/frb-local-docker-dev-env.md
+++ b/tools/manual_tests/frb-local-docker-dev-env.md
@@ -1,0 +1,149 @@
+# Local Docker Development Environment Coverage
+
+## Purpose
+
+Verify that the per-worktree FRB Docker development container can run the normal headless local validation surface: Rust tests, Dart native tests, Dart web tests, and the internal development entrypoint. This test also records that Docker is not the Android emulator, iOS Simulator, or macOS GUI runtime strategy.
+
+## Source
+
+- Context: Maintenance check for the local FRB Docker development workflow.
+- Related docs or skills: `.claude/skills/frb-manual-test/SKILL.md`, `.claude/skills/frb-dev-env/SKILL.md`, `.claude/skills/frb-docker/SKILL.md`, `.claude/skills/frb-test/SKILL.md`
+
+## When To Run
+
+Run this after changing the FRB Docker image, devcontainer setup, per-worktree Docker helper, Rust/Dart/web test tooling, or Flutter/Rust/Dart versions. It is also useful before relying on a new local machine or worktree for headless FRB development.
+
+## Preconditions
+
+- Repository: `fzyzcjy/flutter_rust_bridge`
+- Required checkout state: clean checkout with submodules initialized. Intentional local changes are allowed only if the execution record lists them.
+- Required credentials or account state: Docker must be able to pull or use the configured FRB development image. Docker Hub credentials are required only if the local setup needs authenticated pulls.
+- Required device or simulator state: none. This test does not require Android devices, Android emulators, iOS simulators, or desktop GUI sessions.
+
+## Environment
+
+- OS: host OS capable of running Docker and repository shell scripts.
+- Flutter: record `flutter --version` inside the Docker container.
+- Dart: record `dart --version` inside the Docker container.
+- Rust: record `rustc --version` and `cargo --version` inside the Docker container.
+- Device or simulator: not required.
+- Browser or external service: record the Chrome or Chromium version used by the container for headless web tests.
+
+## Preparation
+
+Run preparation commands from the repository root of the checkout being tested.
+
+```bash
+git rev-parse --show-toplevel
+git status --short
+git submodule update --init --recursive
+docker version
+.claude/skills/frb-dev-env/frb_dev_env.py docker info
+.claude/skills/frb-dev-env/frb_dev_env.py docker create
+```
+
+Confirm the container can run commands at the host-like worktree path.
+
+```bash
+.claude/skills/frb-dev-env/frb_dev_env.py docker exec -- bash -lc 'pwd && ./frb_internal --help'
+```
+
+## Test Data
+
+- Input files, API examples, account fixtures, or generated assets: checked-in packages `frb_rust`, `frb_dart`, and `frb_example/pure_dart`.
+- Reset procedure before each run: return to a clean checkout or record intentional local changes in the execution record.
+
+## Steps
+
+1. Record container tool versions and browser availability.
+
+   ```bash
+   .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- bash -lc '
+   set -euo pipefail
+   flutter --version
+   dart --version
+   rustc --version
+   cargo --version
+   "${CHROME_BIN:-google-chrome}" --version || chromium --version || chromium-browser --version
+   '
+   ```
+
+2. Run a focused Rust package test in Docker.
+
+   ```bash
+   .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- ./frb_internal test-rust-package --package frb_rust
+   ```
+
+3. Run a focused Dart native test in Docker.
+
+   ```bash
+   .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- ./frb_internal test-dart-native --package frb_dart
+   ```
+
+4. Run a focused Dart web test in Docker.
+
+   ```bash
+   .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- ./frb_internal test-dart-web --package frb_example/pure_dart
+   ```
+
+5. Confirm the checkout did not gain unexpected generated or cache files.
+
+   ```bash
+   git status --short
+   ```
+
+## Expected Result
+
+The Docker environment coverage test passes when every command exits successfully and the terminal log shows that the commands ran inside the per-worktree container. The web step must run through a headless browser without requiring a visible GUI session.
+
+```text
+./frb_internal test-rust-package --package frb_rust
+./frb_internal test-dart-native --package frb_dart
+./frb_internal test-dart-web --package frb_example/pure_dart
+```
+
+## Failure Criteria
+
+The test fails if any of the following happens:
+
+- Docker is unavailable, the per-worktree container cannot be created, or the container labels do not match the current worktree.
+- Any required tool version command fails inside the container.
+- The Rust, Dart native, or Dart web test command exits non-zero unexpectedly.
+- The Dart web test requires a visible GUI session instead of running in a headless browser.
+- `git status --short` shows unexpected local changes after the run.
+
+The test is blocked, not failed, if the Docker image cannot be pulled because of network or registry access.
+
+## Results To Capture
+
+- Full terminal log for all preparation and test commands.
+- Host OS, Docker version, container image, and container name from `docker info`.
+- Flutter, Dart, Rust, Cargo, and browser versions inside the container.
+- Final `git status --short` output.
+
+## Troubleshooting
+
+- If submodules are uninitialized, rerun `git submodule update --init --recursive` and record the output.
+- If the container is missing or stopped, rerun `.claude/skills/frb-dev-env/frb_dev_env.py docker create` and record the helper output.
+- If Chrome or Chromium cannot start, record the browser command, browser version, and whether the web test log mentions sandbox flags.
+- If dependency downloads fail, record the failed URL or package source without adding secrets.
+- If a generated file changes, record the exact `git status --short` output and inspect whether the tested command intentionally regenerated it.
+
+## Cleanup
+
+The per-worktree Docker container may be kept for future local FRB development. Delete it only when the worktree no longer needs the cached environment.
+
+```bash
+git status --short
+.claude/skills/frb-dev-env/frb_dev_env.py docker info
+```
+
+If cleanup requires deleting the container, run:
+
+```bash
+.claude/skills/frb-dev-env/frb_dev_env.py docker delete
+```
+
+## Future Automation
+
+Most commands in this report are already suitable for automation. Keep this manual report as a local environment acceptance check for machines, worktrees, and Docker helper changes that are outside the normal CI runner lifecycle.

--- a/tools/manual_tests/frb-local-tart-apple-dev-env.md
+++ b/tools/manual_tests/frb-local-tart-apple-dev-env.md
@@ -1,0 +1,176 @@
+# Local Tart Apple Development Environment Coverage
+
+## Purpose
+
+Verify that the per-worktree FRB Tart macOS VM can run Apple-platform local validation that Docker cannot provide: macOS Flutter native testing, iOS Simulator testing, and Apple release build smoke checks. This test also records that Tart is not the Android emulator strategy.
+
+## Source
+
+- Context: Maintenance check for the local FRB Tart Apple-platform development workflow.
+- Related docs or skills: `.claude/skills/frb-manual-test/SKILL.md`, `.claude/skills/frb-dev-env/SKILL.md`, `.claude/skills/frb-tart-prepare/SKILL.md`, `.claude/skills/frb-test/SKILL.md`
+
+## When To Run
+
+Run this after changing the Tart helper, Tart base VM, Apple scaffold, Flutter/Xcode/macOS/iOS versions, CargoKit Apple integration, or any behavior that must be validated with macOS or an iOS Simulator.
+
+## Preconditions
+
+- Repository: `fzyzcjy/flutter_rust_bridge`
+- Required checkout state: clean checkout with submodules initialized. Intentional local changes are allowed only if the execution record lists them.
+- Required credentials or account state: Tart must be installed and the immutable base VM `frb-tart-base` must exist, unless the run intentionally sets `FRB_TART_BASE_VM` to another prepared base VM.
+- Required device or simulator state: an available iOS Simulator runtime inside the Tart VM. The executor must choose one available simulator UDID from `xcrun simctl list devices available`.
+
+## Environment
+
+- OS: host macOS capable of running Tart, plus guest macOS from `sw_vers` inside the VM.
+- Flutter: record `flutter --version` inside the Tart VM.
+- Dart: record `dart --version` inside the Tart VM.
+- Rust: record `rustc --version` and `cargo --version` inside the Tart VM.
+- Device or simulator: record the selected iOS Simulator name, runtime, and UDID.
+- Browser or external service: not required.
+
+## Preparation
+
+Run preparation commands from the repository root of the checkout being tested.
+
+```bash
+git rev-parse --show-toplevel
+git status --short
+git submodule update --init --recursive
+sw_vers
+tart --version
+.claude/skills/frb-dev-env/frb_dev_env.py tart info
+.claude/skills/frb-dev-env/frb_dev_env.py tart create
+.claude/skills/frb-dev-env/frb_dev_env.py tart start --wait 300
+.claude/skills/frb-dev-env/frb_dev_env.py tart ip --wait 180
+```
+
+Confirm the VM can see the mounted worktree and prepare the VM-local copy used for heavy Apple builds.
+
+```bash
+.claude/skills/frb-dev-env/frb_dev_env.py tart exec -- bash -lc 'pwd && git status --short && ./frb_internal --help'
+.claude/skills/frb-dev-env/frb_dev_env.py tart upload
+```
+
+## Test Data
+
+- Input files, API examples, account fixtures, or generated assets: checked-in package `frb_example/flutter_via_create`.
+- Reset procedure before each run: return to a clean checkout or record intentional local changes in the execution record. Reuse the VM-local uploaded copy unless the run intentionally deletes it.
+
+## Steps
+
+1. Record the Apple toolchain and FRB tool versions inside the Tart VM.
+
+   ```bash
+   .claude/skills/frb-dev-env/frb_dev_env.py tart exec -- bash -lc '
+   set -euo pipefail
+   sw_vers
+   xcodebuild -version
+   xcrun simctl list runtimes
+   flutter --version
+   dart --version
+   rustc --version
+   cargo --version
+   '
+   ```
+
+2. Run the macOS Flutter native integration test from the VM-local copy.
+
+   ```bash
+   .claude/skills/frb-dev-env/frb_dev_env.py tart exec --sync-code -- ./frb_internal test-flutter-native --package frb_example/flutter_via_create --flutter-test-args '--device-id macos'
+   ```
+
+3. List available iOS simulators and choose one bootable UDID. Record the chosen simulator name, runtime, and UDID in the execution result.
+
+   ```bash
+   .claude/skills/frb-dev-env/frb_dev_env.py tart exec -- xcrun simctl list devices available
+   ```
+
+4. Boot the selected iOS Simulator and wait for it to finish booting.
+
+   ```bash
+   .claude/skills/frb-dev-env/frb_dev_env.py tart exec -- xcrun simctl boot <UDID>
+   .claude/skills/frb-dev-env/frb_dev_env.py tart exec -- xcrun simctl bootstatus <UDID> -b
+   ```
+
+5. Run the iOS Flutter native integration test from the VM-local copy.
+
+   ```bash
+   .claude/skills/frb-dev-env/frb_dev_env.py tart exec --sync-code -- ./frb_internal test-flutter-native --package frb_example/flutter_via_create --flutter-test-args '--device-id <UDID>'
+   ```
+
+6. Smoke-test Apple release build commands from the VM-local copy.
+
+   ```bash
+   .claude/skills/frb-dev-env/frb_dev_env.py tart exec --sync-code -- ./frb_internal build-flutter --target macos
+   .claude/skills/frb-dev-env/frb_dev_env.py tart exec --sync-code -- ./frb_internal build-flutter --target ios
+   ```
+
+7. Confirm the host checkout did not gain unexpected generated or cache files.
+
+   ```bash
+   git status --short
+   ```
+
+## Expected Result
+
+The Tart Apple environment coverage test passes when every command exits successfully, the macOS and iOS native test commands complete against the requested devices, and the Apple build smoke commands copy release artifacts into `target/build_flutter_output` inside the VM-local uploaded copy.
+
+```text
+./frb_internal test-flutter-native --package frb_example/flutter_via_create --flutter-test-args '--device-id macos'
+./frb_internal test-flutter-native --package frb_example/flutter_via_create --flutter-test-args '--device-id <UDID>'
+./frb_internal build-flutter --target macos
+./frb_internal build-flutter --target ios
+```
+
+## Failure Criteria
+
+The test fails if any of the following happens:
+
+- Tart is unavailable, the base VM is unavailable, or the per-worktree VM cannot be created or started.
+- The mounted worktree or VM-local uploaded copy cannot be prepared.
+- The macOS native test command exits non-zero unexpectedly.
+- No iOS Simulator can be booted, or the iOS native test command exits non-zero unexpectedly after a simulator is booted.
+- The macOS or iOS build command exits non-zero unexpectedly.
+- `git status --short` shows unexpected local changes after the run.
+
+The test is blocked, not failed, if the host does not support Tart virtualization or the configured base VM is missing.
+
+## Results To Capture
+
+- Full terminal log for all preparation and test commands.
+- Host macOS version, Tart version, VM name, base VM name, and guest macOS version.
+- Xcode, Flutter, Dart, Rust, and Cargo versions inside the VM.
+- Selected iOS Simulator name, runtime, and UDID.
+- Paths under the VM-local copy for `target/build_flutter_output` artifacts.
+- Final host `git status --short` output.
+
+## Troubleshooting
+
+- If submodules are uninitialized, rerun `git submodule update --init --recursive` and record the output.
+- If the per-worktree VM is missing, rerun `.claude/skills/frb-dev-env/frb_dev_env.py tart create` and record the helper output.
+- If the VM is running but commands cannot find the checkout, rerun `.claude/skills/frb-dev-env/frb_dev_env.py tart upload` and record the mounted path and VM-local path.
+- If no iOS simulator is available, record `xcrun simctl list devices available` and `xcrun simctl list runtimes`, then mark the run blocked.
+- If the simulator is already booted, `xcrun simctl boot <UDID>` may report that state; continue to `bootstatus` and record the message.
+- If a generated file changes, record the exact `git status --short` output and inspect whether the tested command intentionally regenerated it.
+
+## Cleanup
+
+The per-worktree Tart VM may be kept for future local FRB Apple-platform development. Shutdown the selected simulator if it should not remain booted.
+
+```bash
+.claude/skills/frb-dev-env/frb_dev_env.py tart exec -- xcrun simctl shutdown <UDID>
+git status --short
+.claude/skills/frb-dev-env/frb_dev_env.py tart info
+```
+
+If cleanup requires stopping or deleting the VM, run:
+
+```bash
+.claude/skills/frb-dev-env/frb_dev_env.py tart stop
+.claude/skills/frb-dev-env/frb_dev_env.py tart delete
+```
+
+## Future Automation
+
+The command sequence can be automated on a dedicated Apple host with Tart and a prepared base VM. Keep this as a manual report while VM lifecycle, simulator selection, host storage, and Xcode runtime availability remain machine-specific.

--- a/tools/manual_tests/frb-local-tart-apple-dev-env.md
+++ b/tools/manual_tests/frb-local-tart-apple-dev-env.md
@@ -89,7 +89,7 @@ Confirm the VM can see the mounted worktree and prepare the VM-local copy used f
 4. Boot the selected iOS Simulator and wait for it to finish booting.
 
    ```bash
-   .claude/skills/frb-dev-env/frb_dev_env.py tart exec -- xcrun simctl boot <UDID>
+   .claude/skills/frb-dev-env/frb_dev_env.py tart exec -- bash -lc 'xcrun simctl boot <UDID> || true'
    .claude/skills/frb-dev-env/frb_dev_env.py tart exec -- xcrun simctl bootstatus <UDID> -b
    ```
 
@@ -159,7 +159,7 @@ The test is blocked, not failed, if the host does not support Tart virtualizatio
 The per-worktree Tart VM may be kept for future local FRB Apple-platform development. Shutdown the selected simulator if it should not remain booted.
 
 ```bash
-.claude/skills/frb-dev-env/frb_dev_env.py tart exec -- xcrun simctl shutdown <UDID>
+.claude/skills/frb-dev-env/frb_dev_env.py tart exec -- bash -lc 'xcrun simctl shutdown <UDID> || true'
 git status --short
 .claude/skills/frb-dev-env/frb_dev_env.py tart info
 ```


### PR DESCRIPTION
## Summary
- Add a Docker manual test report for Rust, Dart native, and headless web validation.
- Add a Tart manual test report for macOS and iOS Simulator validation.
- Document platform boundaries: Docker is not Apple runtime coverage, and Tart is not the Android emulator strategy.
- Update the manual-test skill so execution markdown is required and PR/issue/release executions should be uploaded as a GitHub gist and linked from the reviewable artifact.

## Manual Test Execution
- Execution markdown gist: https://gist.github.com/fzyzcjy/95808c50b0986071d32a474e39249127
- Docker manual test: pass.
- Tart manual test: partial. Tart VM create/start/mount/upload worked, but `flutter --version` blocked in a GitHub remote version check before macOS/iOS/build smoke steps.

## Testing
- Passed: `./frb_internal test-rust-package --package frb_rust` inside Docker.
- Passed: `./frb_internal test-dart-native --package frb_dart` inside Docker.
- Passed: `./frb_internal test-dart-web --package frb_example/pure_dart` inside Docker.
- Partial: Tart setup path executed through VM-local upload; Apple-platform test commands were not reached because `flutter --version` hung.
- Attempted: `timeout 300 pre-commit run --all-files` failed because `.pre-commit-config.yaml` is not present in this repository.
