### PR TITLE
Pull FRB dev Docker image before container create

### DIFF
--- a/.claude/skills/frb-dev-env/SKILL.md
+++ b/.claude/skills/frb-dev-env/SKILL.md
@@ -60,6 +60,8 @@ frb.dev.layout-version=3
 
 Commands run from the host-like worktree path inside the container. There is intentionally no `/workspace` alias, because linked git worktrees and submodule gitdir references need the same path shape that they have on the host.
 
+When creating a new per-worktree container, the helper pulls the selected Docker image before `docker run`. Existing containers are validated and reused without pulling.
+
 Typical usage:
 
 ```bash

--- a/.claude/skills/frb-dev-env/frb_dev_env.py
+++ b/.claude/skills/frb-dev-env/frb_dev_env.py
@@ -473,10 +473,16 @@ def validate_existing_container(*, container_name: str, worktree_root: Path) -> 
         )
 
 
+def pull_image(*, image: str) -> None:
+    typer.echo(f"Pulling Docker image {image}", err=True)
+    exec_command(["docker", "pull", image])
+
+
 def ensure_container(*, worktree_root: Path, image: str) -> str:
     container_name = container_name_for_worktree(worktree_root=worktree_root)
 
     if container_id_for_name(container_name=container_name) is None:
+        pull_image(image=image)
         exec_command(
             [
                 "docker",


### PR DESCRIPTION
## Summary
- Pull the selected Docker image before creating a new per-worktree FRB dev container.
- Document that existing containers are reused without pulling.

## Tests
- git diff --check
- uv run python -m py_compile .claude/skills/frb-dev-env/frb_dev_env.py
- .claude/skills/frb-dev-env/frb_dev_env.py docker create --help

Note: pre-commit run --all-files is not applicable because this repository has no .pre-commit-config.yaml.