### PR TITLE
Tag dev Docker images with source revision

### DIFF
--- a/.claude/skills/frb-docker/SKILL.md
+++ b/.claude/skills/frb-docker/SKILL.md
@@ -126,6 +126,7 @@ When publishing, it pushes per-platform images and then creates multi-arch tags:
 
 - `latest`
 - `flutter-<flutter_version>-rust-<rust_version>-nightly-<rust_nightly_version>`
+- `flutter-<flutter_version>-rust-<rust_version>-nightly-<rust_nightly_version>-code-<short_sha>`
 - `sha-<short_sha>`
 
 After publishing, inspect the manifest:
@@ -135,6 +136,13 @@ docker buildx imagetools inspect fzyzcjy/flutter_rust_bridge_dev:latest
 ```
 
 It should include `linux/amd64` and `linux/arm64`. BuildKit attestation manifests may appear as `unknown/unknown`; those are not platform images.
+
+Inspect the image revision label when checking exactly which source commit was published:
+
+```shell
+docker inspect fzyzcjy/flutter_rust_bridge_dev:latest \
+  --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}'
+```
 
 ## CI Workflow Guidance
 

--- a/.github/workflows/publish_dev_docker.yaml
+++ b/.github/workflows/publish_dev_docker.yaml
@@ -29,6 +29,7 @@ jobs:
       rust_version: ${{ steps.metadata.outputs.rust_version }}
       rust_nightly_version: ${{ steps.metadata.outputs.rust_nightly_version }}
       version_tag: ${{ steps.metadata.outputs.version_tag }}
+      version_code_tag: ${{ steps.metadata.outputs.version_code_tag }}
       sha_tag: ${{ steps.metadata.outputs.sha_tag }}
       should_publish: ${{ steps.metadata.outputs.should_publish }}
 
@@ -47,6 +48,7 @@ jobs:
           rust_nightly_version="$(awk -F= '/^ARG RUST_NIGHTLY_VERSION=/{print $2; exit}' .devcontainer/Dockerfile)"
           short_sha="${GITHUB_SHA::7}"
           version_tag="flutter-${flutter_version}-rust-${rust_version}-nightly-${rust_nightly_version}"
+          version_code_tag="${version_tag}-code-${short_sha}"
           sha_tag="sha-${short_sha}"
 
           if [[ "${{ github.event_name }}" == "push" || "${{ inputs.publish }}" == "true" ]]; then
@@ -60,6 +62,7 @@ jobs:
             echo "rust_version=${rust_version}"
             echo "rust_nightly_version=${rust_nightly_version}"
             echo "version_tag=${version_tag}"
+            echo "version_code_tag=${version_code_tag}"
             echo "sha_tag=${sha_tag}"
             echo "should_publish=${should_publish}"
           } >> "${GITHUB_OUTPUT}"
@@ -134,8 +137,13 @@ jobs:
           push: true
           tags: |
             ${{ env.IMAGE_NAME }}:${{ needs.metadata.outputs.sha_tag }}-${{ matrix.arch }}
+            ${{ env.IMAGE_NAME }}:${{ needs.metadata.outputs.version_code_tag }}-${{ matrix.arch }}
             ${{ env.IMAGE_NAME }}:${{ needs.metadata.outputs.version_tag }}-${{ matrix.arch }}
             ${{ env.IMAGE_NAME }}:latest-${{ matrix.arch }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/fzyzcjy/flutter_rust_bridge
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ needs.metadata.outputs.version_code_tag }}
 
       - name: Build workflow summary
         shell: bash
@@ -180,6 +188,7 @@ jobs:
           docker buildx imagetools create \
             -t "${IMAGE_NAME}:latest" \
             -t "${IMAGE_NAME}:${{ needs.metadata.outputs.version_tag }}" \
+            -t "${IMAGE_NAME}:${{ needs.metadata.outputs.version_code_tag }}" \
             -t "${IMAGE_NAME}:${{ needs.metadata.outputs.sha_tag }}" \
             "${IMAGE_NAME}:${{ needs.metadata.outputs.sha_tag }}-amd64" \
             "${IMAGE_NAME}:${{ needs.metadata.outputs.sha_tag }}-arm64"
@@ -198,5 +207,6 @@ jobs:
             echo "- Tags:"
             echo "  - \`latest\`"
             echo "  - \`${{ needs.metadata.outputs.version_tag }}\`"
+            echo "  - \`${{ needs.metadata.outputs.version_code_tag }}\`"
             echo "  - \`${{ needs.metadata.outputs.sha_tag }}\`"
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/tools/frb_internal/lib/src/makefile_dart/dev_docker_metadata.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/dev_docker_metadata.dart
@@ -16,7 +16,15 @@ class DevDockerMetadata {
   String get versionTag =>
       'flutter-$flutterVersion-rust-$rustVersion-nightly-$rustNightlyVersion';
 
+  String versionCodeTag({required String shortSha}) =>
+      '$versionTag-code-$shortSha';
+
   String imageRef({required String imageName}) => '$imageName:$versionTag';
+
+  String imageRefForRevision({
+    required String imageName,
+    required String shortSha,
+  }) => '$imageName:${versionCodeTag(shortSha: shortSha)}';
 }
 
 @visibleForTesting

--- a/tools/frb_internal/test/src/makefile_dart/test_dev_docker_metadata.dart
+++ b/tools/frb_internal/test/src/makefile_dart/test_dev_docker_metadata.dart
@@ -21,6 +21,17 @@ void main() {
       metadata.imageRef(imageName: 'fzyzcjy/flutter_rust_bridge_dev'),
       'fzyzcjy/flutter_rust_bridge_dev:flutter-3.44.0-rust-1.93.1-nightly-2025-02-01',
     );
+    expect(
+      metadata.versionCodeTag(shortSha: 'abcdef0'),
+      'flutter-3.44.0-rust-1.93.1-nightly-2025-02-01-code-abcdef0',
+    );
+    expect(
+      metadata.imageRefForRevision(
+        imageName: 'fzyzcjy/flutter_rust_bridge_dev',
+        shortSha: 'abcdef0',
+      ),
+      'fzyzcjy/flutter_rust_bridge_dev:flutter-3.44.0-rust-1.93.1-nightly-2025-02-01-code-abcdef0',
+    );
   });
 
   test('metadata imageRef respects custom image name', () {


### PR DESCRIPTION
## Summary

- keep the existing dev Docker tags: latest, version, and sha-<short_sha>
- add a combined version/source tag: flutter-<flutter_version>-rust-<rust_version>-nightly-<rust_nightly_version>-code-<short_sha>
- add OCI image labels for source repository, full revision SHA, and version tag
- update the dev Docker metadata helper/test coverage and frb-docker skill docs

## Verification

- .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- dart format tools/frb_internal/lib/src/makefile_dart/dev_docker_metadata.dart tools/frb_internal/test/src/makefile_dart/test_dev_docker_metadata.dart
- .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- bash -lc 'cd tools/frb_internal && dart test test/src/makefile_dart/test_dev_docker_metadata.dart'
- pre-commit run --all-files (not applicable: this checkout has no .pre-commit-config.yaml)
