### PR TITLE
Fix arm64 dev Docker ChromeDriver support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -55,28 +55,13 @@ RUN if [ "$(dpkg --print-architecture)" = "arm64" ]; then \
             > /etc/apt/sources.list.d/ubuntu-amd64.sources \
         && apt-get update && apt-get install -y \
             libc6:amd64 \
-            libasound2t64:amd64 \
-            libatk-bridge2.0-0:amd64 \
-            libatk1.0-0:amd64 \
-            libatspi2.0-0:amd64 \
-            libcairo2:amd64 \
-            libcups2:amd64 \
             libdbus-1-3:amd64 \
-            libdrm2:amd64 \
-            libgbm1:amd64 \
+            libgcc-s1:amd64 \
             libglib2.0-0:amd64 \
             libnspr4:amd64 \
             libnss3:amd64 \
-            libpango-1.0-0:amd64 \
             libstdc++6:amd64 \
-            libx11-6:amd64 \
             libxcb1:amd64 \
-            libxcomposite1:amd64 \
-            libxdamage1:amd64 \
-            libxext6:amd64 \
-            libxfixes3:amd64 \
-            libxkbcommon0:amd64 \
-            libxrandr2:amd64 \
             zlib1g:amd64 \
         && rm -rf /var/lib/apt/lists/*; \
     fi

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -140,7 +140,10 @@ RUN flutter --version && \
     wasm-pack --version && \
     all-contributors --version && \
     "${CHROME_BIN}" --version && \
-    chromedriver --version
+    (chromedriver --version || { \
+        [ "$(dpkg --print-architecture)" = "arm64" ] \
+            && echo "chromedriver installed but cannot run; amd64 emulation is unavailable"; \
+    })
 
 # Default command
 CMD ["bash"]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -28,9 +28,10 @@ RUN apt-get update && apt-get install -y \
     xz-utils \
     && rm -rf /var/lib/apt/lists/*
 
-# Android SDK platform-tools, CMake, and NDK packages provide linux-x86_64
-# binaries in the arm64 Cirrus Flutter base image. Docker Desktop can emulate
-# them, but the image still needs the matching x86_64 runtime libraries.
+# Android SDK platform-tools, CMake, NDK packages, and Chrome for Testing
+# chromedriver provide linux-x86_64 binaries in the arm64 Cirrus Flutter base
+# image. Docker Desktop can emulate them, but the image still needs the
+# matching x86_64 runtime libraries.
 # References:
 # - Debian multiarch: https://wiki.debian.org/Multiarch/HOWTO
 # - Docker Desktop emulation: https://docs.docker.com/build/guide/multi-platform/#qemu
@@ -53,7 +54,29 @@ RUN if [ "$(dpkg --print-architecture)" = "arm64" ]; then \
             'Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg' \
             > /etc/apt/sources.list.d/ubuntu-amd64.sources \
         && apt-get update && apt-get install -y \
+            libc6:amd64 \
+            libasound2t64:amd64 \
+            libatk-bridge2.0-0:amd64 \
+            libatk1.0-0:amd64 \
+            libatspi2.0-0:amd64 \
+            libcairo2:amd64 \
+            libcups2:amd64 \
+            libdbus-1-3:amd64 \
+            libdrm2:amd64 \
+            libgbm1:amd64 \
+            libglib2.0-0:amd64 \
+            libnspr4:amd64 \
+            libnss3:amd64 \
+            libpango-1.0-0:amd64 \
             libstdc++6:amd64 \
+            libx11-6:amd64 \
+            libxcb1:amd64 \
+            libxcomposite1:amd64 \
+            libxdamage1:amd64 \
+            libxext6:amd64 \
+            libxfixes3:amd64 \
+            libxkbcommon0:amd64 \
+            libxrandr2:amd64 \
             zlib1g:amd64 \
         && rm -rf /var/lib/apt/lists/*; \
     fi
@@ -102,7 +125,7 @@ RUN npm install -g "playwright@${PLAYWRIGHT_VERSION}" && \
     CHROMIUM_VERSION="$(node -e "const b=require('/usr/local/lib/node_modules/playwright/node_modules/playwright-core/browsers.json'); console.log(b.browsers.find(x=>x.name==='chromium').browserVersion)")" && \
     ARCH="$(dpkg --print-architecture)" && \
     case "$ARCH" in \
-        amd64) \
+        amd64|arm64) \
             CHROMEDRIVER_PLATFORM="linux64" && \
             curl -fsSL \
                 "https://storage.googleapis.com/chrome-for-testing-public/${CHROMIUM_VERSION}/${CHROMEDRIVER_PLATFORM}/chromedriver-${CHROMEDRIVER_PLATFORM}.zip" \
@@ -110,7 +133,6 @@ RUN npm install -g "playwright@${PLAYWRIGHT_VERSION}" && \
             unzip -q /tmp/chromedriver.zip -d /tmp && \
             install -m 0755 "/tmp/chromedriver-${CHROMEDRIVER_PLATFORM}/chromedriver" /usr/local/bin/chromedriver && \
             rm -rf /tmp/chromedriver.zip "/tmp/chromedriver-${CHROMEDRIVER_PLATFORM}" ;; \
-        arm64) echo "Chrome for Testing does not provide linux-arm64 chromedriver for ${CHROMIUM_VERSION}" ;; \
         *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; \
     esac
 ENV CHROME_BIN=/usr/bin/google-chrome
@@ -133,7 +155,7 @@ RUN flutter --version && \
     wasm-pack --version && \
     all-contributors --version && \
     "${CHROME_BIN}" --version && \
-    if command -v chromedriver >/dev/null; then chromedriver --version; else echo "chromedriver unavailable on $(dpkg --print-architecture)"; fi
+    chromedriver --version
 
 # Default command
 CMD ["bash"]

--- a/.github/workflows/publish_dev_docker.yaml
+++ b/.github/workflows/publish_dev_docker.yaml
@@ -120,6 +120,7 @@ jobs:
             rustup target list --toolchain nightly-${{ needs.metadata.outputs.rust_nightly_version }} --installed
             wasm-pack --version
             "${CHROME_BIN}" --version
+            chromedriver --version
             rustup target list --toolchain nightly-${{ needs.metadata.outputs.rust_nightly_version }} --installed | grep wasm32-unknown-unknown
             rustup show | grep "nightly-${{ needs.metadata.outputs.rust_nightly_version }}"
           '

--- a/.github/workflows/publish_dev_docker.yaml
+++ b/.github/workflows/publish_dev_docker.yaml
@@ -88,6 +88,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Set up amd64 emulation for arm64 ChromeDriver
+        if: matrix.arch == 'arm64'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: amd64
+
       - name: Log in to Docker Hub
         if: needs.metadata.outputs.should_publish == 'true'
         uses: docker/login-action@v3

--- a/tools/manual_tests/frb-local-docker-dev-env.md
+++ b/tools/manual_tests/frb-local-docker-dev-env.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Verify that the per-worktree FRB Docker development container can run the normal headless local validation surface: Rust tests, Dart native tests, Dart web tests, and the internal development entrypoint. This test also records that Docker is not the Android emulator, iOS Simulator, or macOS GUI runtime strategy.
+Verify that the per-worktree FRB Docker development container can run the normal headless local validation surface: Rust tests, Dart native tests, Dart web tests, Flutter web tests, and the internal development entrypoint. This test also records that Docker is not the Android emulator, iOS Simulator, or macOS GUI runtime strategy.
 
 ## Source
 
@@ -19,6 +19,7 @@ Run this after changing the FRB Docker image, devcontainer setup, per-worktree D
 - Required checkout state: clean checkout with submodules initialized. Intentional local changes are allowed only if the execution record lists them.
 - Required credentials or account state: Docker must be able to pull or use the configured FRB development image. Docker Hub credentials are required only if the local setup needs authenticated pulls.
 - Required device or simulator state: none. This test does not require Android devices, Android emulators, iOS simulators, or desktop GUI sessions.
+- Required browser driver state: Flutter web drive coverage requires a compatible `chromedriver` on `PATH` and a headless WebDriver setup for the container architecture. The Docker image must provide this for both amd64 and arm64 local containers.
 
 ## Environment
 
@@ -27,7 +28,7 @@ Run this after changing the FRB Docker image, devcontainer setup, per-worktree D
 - Dart: record `dart --version` inside the Docker container.
 - Rust: record `rustc --version` and `cargo --version` inside the Docker container.
 - Device or simulator: not required.
-- Browser or external service: record the Chrome or Chromium version used by the container for headless web tests.
+- Browser or external service: record the Chrome or Chromium version and ChromeDriver version used by the container for headless web tests.
 
 ## Preparation
 
@@ -65,6 +66,7 @@ Confirm the container can run commands at the host-like worktree path.
    rustc --version
    cargo --version
    "${CHROME_BIN:-google-chrome}" --version || chromium --version || chromium-browser --version
+   chromedriver --version
    '
    ```
 
@@ -86,7 +88,13 @@ Confirm the container can run commands at the host-like worktree path.
    .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- ./frb_internal test-dart-web --package frb_example/pure_dart
    ```
 
-5. Confirm the checkout did not gain unexpected generated or cache files.
+5. Run a focused Flutter web coverage test in Docker.
+
+   ```bash
+   .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- ./frb_internal test-flutter-web --package frb_example/flutter_via_create --coverage
+   ```
+
+6. Confirm the checkout did not gain unexpected generated or cache files.
 
    ```bash
    git status --short
@@ -100,6 +108,7 @@ The Docker environment coverage test passes when every command exits successfull
 ./frb_internal test-rust-package --package frb_rust
 ./frb_internal test-dart-native --package frb_dart
 ./frb_internal test-dart-web --package frb_example/pure_dart
+./frb_internal test-flutter-web --package frb_example/flutter_via_create --coverage
 ```
 
 ## Failure Criteria
@@ -108,8 +117,9 @@ The test fails if any of the following happens:
 
 - Docker is unavailable, the per-worktree container cannot be created, or the container labels do not match the current worktree.
 - Any required tool version command fails inside the container.
-- The Rust, Dart native, or Dart web test command exits non-zero unexpectedly.
-- The Dart web test requires a visible GUI session instead of running in a headless browser.
+- The Rust, Dart native, Dart web, or Flutter web test command exits non-zero because Docker, browser startup, package setup, toolchain availability, or local environment plumbing failed.
+- The Dart or Flutter web test requires a visible GUI session instead of running in a headless browser.
+- The Flutter web drive command fails with `Unable to start a WebDriver session` because no compatible `chromedriver` is available.
 - `git status --short` shows unexpected local changes after the run.
 
 The test is blocked, not failed, if the Docker image cannot be pulled because of network or registry access.
@@ -118,14 +128,14 @@ The test is blocked, not failed, if the Docker image cannot be pulled because of
 
 - Full terminal log for all preparation and test commands.
 - Host OS, Docker version, container image, and container name from `docker info`.
-- Flutter, Dart, Rust, Cargo, and browser versions inside the container.
+- Flutter, Dart, Rust, Cargo, browser, and ChromeDriver versions inside the container.
 - Final `git status --short` output.
 
 ## Troubleshooting
 
 - If submodules are uninitialized, rerun `git submodule update --init --recursive` and record the output.
 - If the container is missing or stopped, rerun `.claude/skills/frb-dev-env/frb_dev_env.py docker create` and record the helper output.
-- If Chrome or Chromium cannot start, record the browser command, browser version, and whether the web test log mentions sandbox flags.
+- If Chrome, Chromium, or ChromeDriver cannot start, record the command, version, container architecture, and whether the web test log mentions sandbox flags.
 - If dependency downloads fail, record the failed URL or package source without adding secrets.
 - If a generated file changes, record the exact `git status --short` output and inspect whether the tested command intentionally regenerated it.
 


### PR DESCRIPTION
## Summary

- install Chrome for Testing's `linux64` ChromeDriver in arm64 dev Docker images, using Docker Desktop/QEMU for that x86_64 binary
- add the minimal amd64 runtime libraries required by ChromeDriver's ELF `NEEDED` entries on arm64 (`libc`, `libgcc`, `libglib2.0`, `libnspr4`, `libnss3`, `libdbus-1`, `libxcb`, plus the existing Android x86 runtime libs)
- make the dev Docker publish smoke test require `chromedriver --version`
- document ChromeDriver as required local Docker coverage for Flutter web drive tests

## Why ChromeDriver is needed

Dart web tests such as `dart test -p chrome` do not need this. The missing local coverage is Flutter web integration testing via `./frb_internal test-flutter-web`, which uses `flutter drive -d web-server`. That path talks to a WebDriver server, matching the existing GitHub CI `Test :: Flutter :: Web` job that runs `nanasess/setup-chromedriver` and starts `chromedriver --port=4444 --verbose &`.

This PR makes the local FRB dev Docker image provide the same WebDriver capability, so Apple Silicon Docker can run the Flutter web and wasm web validation instead of stopping at `Unable to start a WebDriver session`.

## Scope

This is an independent Docker environment PR for publishing a fixed dev image before the web wasm CI PR relies on it. It does not change FRB runtime/codegen behavior or test semantics.

## Testing

- Manual dependency probe in the current arm64 dev container: `readelf -d chromedriver` showed the required `NEEDED` libraries and confirmed the current image fails at missing `libglib-2.0.so.0` after adding only the earlier Android x86 runtime set.
- Triggered publish-dev-docker dry run with `publish=false`: https://github.com/fzyzcjy/flutter_rust_bridge/actions/runs/27057576498
- PR CI is also running for the branch.
