### PR TITLE
Add online demo gallery manual test

### DIFF
--- a/.claude/skills/frb-manual-test/SKILL.md
+++ b/.claude/skills/frb-manual-test/SKILL.md
@@ -59,3 +59,15 @@ If the execution result belongs to a PR, issue, release checklist, or other revi
 If the result belongs only in chat, still fill out the execution markdown locally and include its path in the chat response.
 
 Run cleanup from the manual test report before declaring the execution complete, unless cleanup is intentionally skipped and documented in the execution record.
+
+### Reviewable Workflow Gate
+
+Before creating or updating a PR, issue comment, release checklist, or any other reviewable artifact that cites a manual test execution:
+
+1. Fill out the execution markdown file locally.
+2. Upload that exact execution markdown file as a GitHub gist.
+3. Copy the gist URL into the execution markdown's `Execution markdown gist` field if practical.
+4. Link the gist URL in the reviewable artifact.
+5. Keep local artifact paths only as supplemental audit evidence; they are not a substitute for the gist.
+
+Do not say that a PR-linked manual test execution is complete while only providing local artifact paths. If gist upload or GitHub access fails, report the manual test execution as complete locally but the PR/update step as blocked until a gist URL can be created and linked.

--- a/.claude/skills/frb-manual-test/SKILL.md
+++ b/.claude/skills/frb-manual-test/SKILL.md
@@ -54,7 +54,7 @@ Always fill out an execution markdown file before summarizing the result. Do not
 
 Execution markdown is a run artifact, not a repository test definition. Do not create it under `tools/manual_tests/` or anywhere else inside the `flutter_rust_bridge` repository. Put it in an external artifacts location such as `/private/tmp`, `~/main/artifacts/flutter_rust_bridge/`, or another run-specific artifact directory.
 
-If the execution result belongs to a PR, issue, release checklist, or other reviewable workflow, upload the filled execution markdown as a GitHub gist and link that gist in the PR description, PR comment, issue comment, or release checklist. The local execution markdown should still be kept in the run artifacts directory so the run can be audited without relying only on chat history.
+If the execution result belongs to a PR, issue, release checklist, or other reviewable workflow, upload the filled execution markdown and all review-relevant artifacts as a GitHub gist and link that gist in the PR description, PR comment, issue comment, or release checklist. Review-relevant artifacts include screenshots, recordings, logs, generated result files, and browser/device evidence needed to judge the result. The local execution markdown and artifact copies should still be kept in the run artifacts directory so the run can be audited without relying only on chat history.
 
 If the result belongs only in chat, still fill out the execution markdown locally and include its path in the chat response.
 
@@ -65,9 +65,11 @@ Run cleanup from the manual test report before declaring the execution complete,
 Before creating or updating a PR, issue comment, release checklist, or any other reviewable artifact that cites a manual test execution:
 
 1. Fill out the execution markdown file locally.
-2. Upload that exact execution markdown file as a GitHub gist.
-3. Copy the gist URL into the execution markdown's `Execution markdown gist` field if practical.
-4. Link the gist URL in the reviewable artifact.
-5. Keep local artifact paths only as supplemental audit evidence; they are not a substitute for the gist.
+2. Collect every artifact needed by the manual test's `Results To Capture` section, especially screenshots, recordings, logs, and generated evidence files.
+3. Upload the execution markdown and those review-relevant artifacts into the same GitHub gist. Use a gist git clone and push when binary artifacts such as PNG screenshots need to be included.
+4. Copy the gist URL into the execution markdown's `Execution markdown gist` field if practical.
+5. Make the execution markdown point to the gist-contained artifact filenames, embedding screenshots or linking recordings when useful.
+6. Link the gist URL in the reviewable artifact.
+7. Keep local artifact paths only as supplemental audit evidence; they are not a substitute for gist-contained artifacts.
 
-Do not say that a PR-linked manual test execution is complete while only providing local artifact paths. If gist upload or GitHub access fails, report the manual test execution as complete locally but the PR/update step as blocked until a gist URL can be created and linked.
+Do not say that a PR-linked manual test execution is complete while any review-relevant artifact exists only as a local path. If gist upload or GitHub access fails, report the manual test execution as complete locally but the PR/update step as blocked until a gist containing the execution markdown and review-relevant artifacts can be created and linked.

--- a/tools/manual_tests/online-demo-gallery.md
+++ b/tools/manual_tests/online-demo-gallery.md
@@ -1,0 +1,123 @@
+# Online Demo Gallery Smoke Test
+
+## Purpose
+
+Verify that the published flutter_rust_bridge website demo at `https://cjycode.com/flutter_rust_bridge/demo/` loads the embedded Flutter web gallery, accepts the Start action, and renders the Mandelbrot animation instead of staying on the placeholder or a broken loading state.
+
+## Source
+
+- Context: Maintainer request to catch regressions in the public website demo before users discover that the hosted demo is broken.
+- Related docs or skills: `.claude/skills/frb-manual-test/SKILL.md`, `website/docs/demo.md`, `website/src/components/FrbExampleGallery.tsx`
+
+## When To Run
+
+Run this before publishing or announcing a release, after changing the website demo page, after changing `frb_example/gallery`, after changing web build/deployment logic, and when validating that the already-published documentation site is healthy.
+
+## Preconditions
+
+- Repository: `fzyzcjy/flutter_rust_bridge`
+- Required checkout state: a checkout is useful for recording this manual test result, but the browser verification targets the published website, not local files.
+- Required credentials or account state: none.
+- Required device or simulator state: none.
+- Required network state: outbound HTTPS access to `https://cjycode.com`.
+
+## Environment
+
+- OS: macOS, Linux, or Windows with a graphical browser or browser automation tool.
+- Flutter: not required.
+- Dart: not required.
+- Rust: not required.
+- Device or simulator: not required.
+- Browser or external service: Chromium, Chrome, Firefox, Safari, or an equivalent browser that supports Flutter web and WebAssembly threads. Record the browser name and version in the execution result.
+
+## Preparation
+
+From the repository root, record the current revision and checkout state for the execution result.
+
+```bash
+git rev-parse --short HEAD
+git status --short
+```
+
+Open the published demo page in a fresh browser tab or clean browser context.
+
+```text
+https://cjycode.com/flutter_rust_bridge/demo/
+```
+
+## Test Data
+
+- Input files, API examples, account fixtures, or generated assets: none.
+- Reset procedure before each run: reload `https://cjycode.com/flutter_rust_bridge/demo/` in a fresh tab or clean browser context.
+
+## Steps
+
+1. Navigate to `https://cjycode.com/flutter_rust_bridge/demo/`.
+
+2. Wait for the page to finish its initial load. If GitHub Pages causes the documented one-time refresh, wait for that refresh to complete before judging the demo.
+
+3. Find the `Demo` section and confirm the embedded gallery area appears. Before starting, it should contain the controls `Num threads`, `Image size`, `Start`, and `Stop`, plus a square placeholder that says `Tap to start`.
+
+4. Capture a screenshot of the initial embedded gallery state.
+
+5. Click the `Start` control in the embedded Flutter demo. If browser automation cannot target the Flutter text directly, click the visible `Start` label coordinates inside the embedded gallery.
+
+6. Wait up to 20 seconds for the Mandelbrot render to appear.
+
+7. Confirm that the square on the right changes from the gray `Tap to start` placeholder into a colored Mandelbrot image. The rendered image should include multiple saturated colors and the characteristic Mandelbrot shape, including a dark central region surrounded by colored fractal bands.
+
+8. Confirm that a time label such as `Time: 13ms` appears above the rendered image and remains visible after the render completes.
+
+9. Capture a screenshot of the rendered state after clicking `Start`.
+
+## Expected Result
+
+The test passes when all of the following are true:
+
+- The page loads `https://cjycode.com/flutter_rust_bridge/demo/` without browser crash, visible Docusaurus error, or permanent `Loading...` state.
+- The embedded gallery controls are visible before starting.
+- Clicking `Start` causes the right-hand preview square to stop showing `Tap to start`.
+- Within 20 seconds, the preview square displays a colored Mandelbrot render with a dark central region and colored fractal bands.
+- A `Time: <number>ms` label is visible above the rendered image.
+
+## Failure Criteria
+
+The test fails if any of the following happens:
+
+- The page does not load, repeatedly reloads, or stays blank.
+- The embedded gallery remains in `Loading...` or only shows the `Tap to start` placeholder after `Start` is clicked.
+- The `Start` control is missing or cannot be activated.
+- No colored Mandelbrot render appears within 20 seconds.
+- The rendered square is blank, uniformly gray, visually corrupted, or missing the Mandelbrot structure.
+- Browser console errors, network errors, or WebAssembly/thread errors correlate with the broken demo behavior.
+
+Mark the run as blocked, not failed, if the executor has no network access to `https://cjycode.com` or no compatible browser is available.
+
+## Results To Capture
+
+- Browser name and version.
+- Final URL after any one-time refresh.
+- Screenshot before clicking `Start`.
+- Screenshot after the Mandelbrot render appears.
+- Whether the `Time: <number>ms` label appeared, including the observed text.
+- Any relevant browser console errors, network failures, or crash messages.
+- `git rev-parse --short HEAD` and `git status --short` from the checkout used to record the result.
+
+## Troubleshooting
+
+- If the page shows the documented GitHub Pages limitation message and refreshes once, wait for the refresh to settle before failing the run.
+- If the browser blocks WebAssembly threads, rerun with a modern Chromium-based browser and record the original browser/version as blocked.
+- If the page loads but the demo is blank, capture browser console and network failures before retrying.
+- If a flaky network request fails, reload once in a fresh browser context and record both attempts.
+
+## Cleanup
+
+Close the browser tab or browser automation context used for the run. No repository files, devices, services, or external account state should be changed by this test.
+
+```bash
+git status --short
+```
+
+## Future Automation
+
+This manual test is a good candidate for browser automation using Chromium. A future automated version should load the published URL, click `Start`, wait for `Time: <number>ms`, and compare screenshots or canvas pixels before and after the click to confirm that the Mandelbrot render changed from the placeholder to a non-uniform colored fractal image.

--- a/tools/manual_tests/online-demo-gallery.md
+++ b/tools/manual_tests/online-demo-gallery.md
@@ -16,7 +16,7 @@ Run this before publishing or announcing a release, after changing the website d
 ## Preconditions
 
 - Repository: `fzyzcjy/flutter_rust_bridge`
-- Required checkout state: a checkout is useful for recording this manual test result, but the browser verification targets the published website, not local files.
+- Required checkout state: not required; the browser verification targets the published website, not local files.
 - Required credentials or account state: none.
 - Required device or simulator state: none.
 - Required network state: outbound HTTPS access to `https://cjycode.com`.
@@ -31,13 +31,6 @@ Run this before publishing or announcing a release, after changing the website d
 - Browser or external service: Chromium, Chrome, Firefox, Safari, or an equivalent browser that supports Flutter web and WebAssembly threads. Record the browser name and version in the execution result.
 
 ## Preparation
-
-From the repository root, record the current revision and checkout state for the execution result.
-
-```bash
-git rev-parse --short HEAD
-git status --short
-```
 
 Open the published demo page in a fresh browser tab or clean browser context.
 
@@ -101,7 +94,6 @@ Mark the run as blocked, not failed, if the executor has no network access to `h
 - Screenshot after the Mandelbrot render appears.
 - Whether the `Time: <number>ms` label appeared, including the observed text.
 - Any relevant browser console errors, network failures, or crash messages.
-- `git rev-parse --short HEAD` and `git status --short` from the checkout used to record the result.
 
 ## Troubleshooting
 
@@ -113,10 +105,6 @@ Mark the run as blocked, not failed, if the executor has no network access to `h
 ## Cleanup
 
 Close the browser tab or browser automation context used for the run. No repository files, devices, services, or external account state should be changed by this test.
-
-```bash
-git status --short
-```
 
 ## Future Automation
 


### PR DESCRIPTION
Adds a manual test report for the published website demo at https://cjycode.com/flutter_rust_bridge/demo/. The test asks the executor to load the real page, click Start, and verify that the Mandelbrot render appears with a Time label instead of staying on the Tap to start placeholder.

Manual test execution: pass on 2026-06-06 16:30 CST using headless Google Chrome. Execution record and reviewable artifacts are in this gist: https://gist.github.com/fzyzcjy/5e83ee115ed439d95346e6fbc3fa108b. The gist includes initial-headless.png, rendered-headless.png, cdp-result.json, chrome.log, and execution-result.md. Local audit copies remain under /private/tmp/frb-online-demo-gallery-manual-test/.