### PR TITLE
Require precise manual test evidence

### DIFF
--- a/.claude/skills/frb-manual-test/SKILL.md
+++ b/.claude/skills/frb-manual-test/SKILL.md
@@ -54,6 +54,8 @@ Always fill out an execution markdown file before summarizing the result. Do not
 
 Execution markdown is a run artifact, not a repository test definition. Do not create it under `tools/manual_tests/` or anywhere else inside the `flutter_rust_bridge` repository. Put it in an external artifacts location such as `/private/tmp`, `~/main/artifacts/flutter_rust_bridge/`, or another run-specific artifact directory.
 
+Execution markdown must contain precise, audit-ready evidence that proves what ran and why it passed, failed, or blocked. Include the exact commands, exit status, key success or failure log lines, relevant version output, selected device or simulator identifiers, generated artifact paths, final cleanup state, and links or paths to complete logs. For successful runs, quote or summarize the concrete pass indicators such as `All tests passed!`, `test result: ok`, artifact paths, simulator UDIDs, or final `git status --short` output. Avoid vague summaries like "worked", "passed", or "looked good" without evidence.
+
 If the execution result belongs to a PR, issue, release checklist, or other reviewable workflow, upload the filled execution markdown as a GitHub gist and link that gist in the PR description, PR comment, issue comment, or release checklist. The local execution markdown should still be kept in the run artifacts directory so the run can be audited without relying only on chat history.
 
 If the result belongs only in chat, still fill out the execution markdown locally and include its path in the chat response.

--- a/.claude/skills/frb-manual-test/execution-template.md
+++ b/.claude/skills/frb-manual-test/execution-template.md
@@ -24,21 +24,24 @@ Record when, by whom, and against exactly what commit or release the manual test
 ## Procedure
 
 :::info
-Record whether the written test was followed exactly. Any deviation matters, even if the result passed.
+Record whether the written test was followed exactly. Any deviation matters, even if the result passed. Include exact commands or a path to a command script when the run used one.
 :::
 
 - Followed report revision: `TODO: commit containing the manual test report`
+- Command script or exact commands: `TODO: path to script, inline commands, or not applicable`
 - Deviations from written steps: `TODO: none, or list exact deviations`
 - Cleanup completed: `TODO: yes/no; explain if no`
 
 ## Result
 
 :::info
-Use `pass`, `fail`, `blocked`, or `partial`. The summary should explain the result without requiring the reader to open logs first.
+Use `pass`, `fail`, `blocked`, or `partial`. The summary should explain the result without requiring the reader to open logs first. Include exact command exit status and concrete pass/fail indicators from the logs.
 :::
 
 - Status: `TODO: pass/fail/blocked/partial`
 - Summary: `TODO: one or two sentences`
+- Command results: `TODO: each required command with exit status`
+- Evidence lines: `TODO: exact success/failure strings, log line numbers, or grep output proving the result`
 
 ## Artifacts
 
@@ -50,7 +53,9 @@ Link or name the artifacts captured during execution. Use `not applicable` for a
 - Terminal log: `TODO: path or link`
 - Screenshot or recording: `TODO: path or link, or not applicable`
 - Generated artifacts: `TODO: path or link, or not applicable`
-- Other evidence: `TODO: path or link, or not applicable`
+- Environment evidence: `TODO: exact tool versions, device/simulator name and UDID, browser version, or not applicable`
+- Cleanup evidence: `TODO: final git status, VM/container/device state, cleanup command output, or not applicable`
+- Other evidence: `TODO: path, link, log excerpt, or not applicable`
 
 ## Follow-up
 

--- a/tools/manual_tests/frb-local-tart-apple-dev-env.md
+++ b/tools/manual_tests/frb-local-tart-apple-dev-env.md
@@ -23,7 +23,7 @@ Run this after changing the Tart helper, Tart base VM, Apple scaffold, Flutter/X
 ## Environment
 
 - OS: host macOS capable of running Tart, plus guest macOS from `sw_vers` inside the VM.
-- Flutter: record `flutter --version` inside the Tart VM.
+- Flutter: record `flutter --version --no-version-check` inside the Tart VM.
 - Dart: record `dart --version` inside the Tart VM.
 - Rust: record `rustc --version` and `cargo --version` inside the Tart VM.
 - Device or simulator: record the selected iOS Simulator name, runtime, and UDID.
@@ -67,7 +67,7 @@ Confirm the VM can see the mounted worktree and prepare the VM-local copy used f
    sw_vers
    xcodebuild -version
    xcrun simctl list runtimes
-   flutter --version
+   flutter --version --no-version-check
    dart --version
    rustc --version
    cargo --version

--- a/tools/manual_tests/frb-local-tart-apple-dev-env.md
+++ b/tools/manual_tests/frb-local-tart-apple-dev-env.md
@@ -50,7 +50,10 @@ Confirm the VM can see the mounted worktree and prepare the VM-local copy used f
 ```bash
 .claude/skills/frb-dev-env/frb_dev_env.py tart exec -- bash -lc 'pwd && git status --short && ./frb_internal --help'
 .claude/skills/frb-dev-env/frb_dev_env.py tart upload
+.claude/skills/frb-dev-env/frb_dev_env.py tart exec -- bash -lc 'set -euo pipefail; flutter config --no-version-check; git -C /Users/admin/flutter remote set-url origin file:///Users/admin/flutter; git -C /Users/admin/flutter remote -v'
 ```
+
+The Flutter remote override is VM-local and prevents `flutter doctor -v`, which is invoked by `./frb_internal test-flutter-native`, from blocking on remote upstream checks when the local validation host has restricted network access. Record the resulting `origin file:///Users/admin/flutter` evidence in the execution result.
 
 ## Test Data
 


### PR DESCRIPTION
## Summary

- Require manual-test execution markdown to include precise, audit-ready evidence for pass/fail/blocked outcomes.
- Keep the upstream requirement to upload execution markdown plus review-relevant artifacts as a gist for PR-linked manual runs.
- Add the Tart Flutter offline setup note from the validation work.

## Manual validation

Execution gist: https://gist.github.com/fzyzcjy/95808c50b0986071d32a474e39249127

Key Tart result from `tart-full-execution.md`:
- macOS native integration test: PASS.
- macOS build smoke: PASS.
- iOS build smoke: PASS.
- iOS native integration test: NOT PASS. Xcode build completed and Runner exposed a reachable Dart VM Service, but Flutter test remained waiting for the VM Service port.

## Checks

- `pre-commit run --all-files` could not run because this repo has no `.pre-commit-config.yaml`.
