### PR TITLE
Add VMware Windows local dev environment

### DIFF
--- a/.claude/skills/frb-dev-env/SKILL.md
+++ b/.claude/skills/frb-dev-env/SKILL.md
@@ -254,6 +254,96 @@ For example, when an iOS 18.1 `iPhone 16 Pro Max` simulator with UDID `826DC3E8-
 .claude/skills/frb-dev-env/frb_dev_env.py tart exec --sync-code -- bash -lc 'export FLUTTER_GIT_URL=file:///Users/admin/flutter; export FRB_SKIP_FLUTTER_DOCTOR=1; ./frb_internal test-flutter-native --package frb_example/flutter_via_create --flutter-test-args "--device-id 826DC3E8-2073-42A9-A6DB-05C1926DC82A"'
 ```
 
+## VMware Windows
+
+Use VMware Fusion + Vagrant for local Windows desktop validation when Docker, Tart, and the Android Emulator coverage are not enough. This workflow targets Apple Silicon macOS hosts running Windows 11 Arm in VMware Fusion.
+
+Read `tools/vmware_windows/README.md` for the detailed Packer, Vagrant, VMware Fusion, proxy, storage, host-installation, daily-use, and troubleshooting instructions. The README is the source of truth for the Windows VM workflow. Read `frb-vmware-windows-prepare` before preparing or rebuilding the reusable Packer-built base box.
+
+### Storage
+
+Configure a per-user VM root before creating or building VMs. The helper reads
+`~/.config/flutter_rust_bridge/vmware_windows.json` by default, and environment variables such as
+`FRB_WINDOWS_VM_ROOT` override the config. The helper derives all heavy paths from that configured
+root, including Vagrant home, boxes, per-worktree project directories, Packer cache/output, logs,
+and VM bundles. Check it before starting a VM:
+
+```bash
+tools/vmware_windows/frb_vmware_windows_env.py info
+```
+
+The helper uses only the Python standard library and refuses to create directories under `/Volumes/<name>/...` unless that volume is mounted. This keeps first-run helper checks independent from `uv`/`pip` and avoids accidentally writing VM files to the internal disk when an external drive is absent.
+
+### Network
+
+If Windows VM downloads and Packer host-side network operations need a proxy, configure it in the
+user config or with:
+
+```bash
+export FRB_WINDOWS_HOST_PROXY_URL=http://localhost:PORT
+```
+
+Leave it unset when direct network access is preferred. If guest-side provision scripts need a
+proxy, set `FRB_WINDOWS_GUEST_PROXY_URL` to an address reachable from inside the Windows guest.
+
+For real Packer builds, provide the Windows ISO SHA-256 checksum with `FRB_WINDOWS_ISO_CHECKSUM=sha256:<digest>` or an `.iso.sha256` file next to the ISO. The helper uses a placeholder checksum only for `packer-build --validate`.
+
+### Base Box Preparation
+
+For the initial base-image build on a developer Mac, prefer the ordinary-Terminal wrapper:
+
+```bash
+tools/vmware_windows/run_packer_build.zsh \
+  --iso /path/to/frb-windows-vmware/downloads/iso/Windows11_Arm64.iso \
+  --add-box
+```
+
+The wrapper applies the configured host proxy when present, runs preflight checks, regenerates the
+UEFI autounattend ISO, writes logs under the configured VM root, monitors `/` and the VM root for the
+100GB free-space threshold, and can import the produced Vagrant box. Use `--prepare-only` when you
+want to validate ISO remastering before starting VMware.
+
+### Daily Lifecycle
+
+Run from the repository root:
+
+```bash
+tools/vmware_windows/frb_vmware_windows_env.py info
+tools/vmware_windows/frb_vmware_windows_env.py start
+tools/vmware_windows/frb_vmware_windows_env.py upload
+tools/vmware_windows/frb_vmware_windows_env.py exec -- powershell -NoProfile -Command "cd C:\frb\worktree; flutter --version"
+tools/vmware_windows/frb_vmware_windows_env.py stop
+```
+
+`upload` copies the host checkout into a VM-local directory before heavy builds. Do not compile from a VMware shared folder because shared folders are slower for many small files and can distort build behavior.
+
+### Windows Flutter Test
+
+After the VM is running and code is uploaded:
+
+```bash
+tools/vmware_windows/frb_vmware_windows_env.py test-flutter-windows \
+  --package frb_example/flutter_via_create
+```
+
+The command runs inside the guest and should use the VM-local uploaded checkout. Capture logs under the external root for audit.
+
+### Credentials And Cleanup
+
+Do not put guest passwords in the repository. Use `FRB_WINDOWS_VM_USERNAME`, `FRB_WINDOWS_VM_PASSWORD`, or `~/.secrets/FRB_WINDOWS_VM_PASSWORD`.
+
+Stop the per-worktree VM when it is not needed:
+
+```bash
+tools/vmware_windows/frb_vmware_windows_env.py stop
+```
+
+Delete disposable per-worktree VMs only when intentionally reclaiming space:
+
+```bash
+tools/vmware_windows/frb_vmware_windows_env.py destroy
+```
+
 ## Project Skills
 
 After applying this environment policy, also read the relevant project-level `frb-*` skills for the actual task, such as code generation, tests, lint, Docker details, CI triage, or PR preparation.

--- a/.claude/skills/frb-vmware-windows-prepare/SKILL.md
+++ b/.claude/skills/frb-vmware-windows-prepare/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: frb-vmware-windows-prepare
+description: Use when preparing the FRB VMware Fusion Windows 11 Arm base VM.
+---
+
+# FRB VMware Windows Base VM Preparation
+
+Use this skill when preparing or explaining the reusable Windows 11 Arm base VM used by `tools/vmware_windows/frb_vmware_windows_env.py`.
+
+## Source Of Truth
+
+Read the checked-in guide first:
+
+```text
+tools/vmware_windows/README.md
+```
+
+That README owns the detailed Packer, Vagrant, VMware Fusion, proxy, storage, host-installation, daily-use, and troubleshooting instructions. Keep this skill thin so the guide remains the audited source of truth for the Windows VM workflow.
+
+## Required Reminders
+
+- Heavy Windows VM artifacts belong under the per-user `vm_root` configured in
+  `~/.config/flutter_rust_bridge/vmware_windows.json` or `FRB_WINDOWS_VM_ROOT`.
+- Host-side Windows VM downloads and Packer network operations use `host_proxy_url` or
+  `FRB_WINDOWS_HOST_PROXY_URL` only when a local network requires a proxy.
+- Durable base image changes belong in the Packer template or PowerShell provision scripts under `tools/vmware_windows/`, not in manual mutations of a promoted base VM.
+- For daily Windows VM usage, read the Windows VMware section inside `.claude/skills/frb-dev-env/SKILL.md`.

--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,3 +1,4 @@
 exclude_paths:
+  - "tools/vmware_windows/**"
   - "website/**"
   - "**/cargokit/**"

--- a/tools/manual_tests/frb-local-vmware-windows-dev-env.md
+++ b/tools/manual_tests/frb-local-vmware-windows-dev-env.md
@@ -1,0 +1,179 @@
+# Local VMware Windows Development Environment Coverage
+
+## Purpose
+
+Verify that a local Apple Silicon macOS host can run FRB Windows validation through VMware Fusion, Vagrant, and a Packer-built Windows 11 Arm base box stored on an external disk.
+
+## Source
+
+- Context: Maintenance check for the local FRB Windows VM workflow.
+- Related docs or skills: `.claude/skills/frb-dev-env/SKILL.md`, `.claude/skills/frb-vmware-windows-prepare/SKILL.md`, `.claude/skills/frb-manual-test/SKILL.md`
+
+## When To Run
+
+Run this after changing the VMware Windows helper, Packer template, Vagrantfile, Windows provision scripts, Flutter/Rust/Visual Studio toolchain versions, or Windows manual validation workflow.
+
+## Preconditions
+
+- Repository: `fzyzcjy/flutter_rust_bridge`
+- Required checkout state: clean checkout with submodules initialized. Intentional local changes are allowed only if the execution record lists them.
+- Required credentials or account state: Windows guest credentials must be supplied through environment variables or secret files. Do not record passwords.
+- Required device or simulator state: VMware Fusion Pro, Vagrant, Vagrant VMware Desktop provider, Packer, and a Windows 11 Arm ISO or already imported `frb/windows11-arm64` Vagrant box.
+- Required storage state: `vm_root` must be configured through `~/.config/flutter_rust_bridge/vmware_windows.json`, `FRB_WINDOWS_VM_ROOT`, or a command-specific flag; it must exist or be creatable and have at least 100GB free.
+- Required network state: if host-side Windows VM downloads and Packer network operations need a proxy, configure `host_proxy_url` or `FRB_WINDOWS_HOST_PROXY_URL`.
+- Required checksum state: real Packer builds must use `FRB_WINDOWS_ISO_CHECKSUM=sha256:<digest>` or an `.iso.sha256` file next to the Windows ISO.
+- Required VM display state: default daily use starts VMware Fusion with a visible GUI because Fusion 26 on Apple Silicon can power off this Windows Arm guest shortly after boot in `nogui` mode.
+
+## Environment
+
+- OS: Apple Silicon macOS host.
+- Flutter: record `flutter --version` inside the Windows VM.
+- Dart: record `dart --version` inside the Windows VM.
+- Rust: record `rustc --version` and `cargo --version` inside the Windows VM.
+- Visual Studio: record that Build Tools includes the VCTools workload, ARM64 C++ tools, and CMake project component.
+- Device or simulator: Windows desktop target inside VMware Fusion.
+- Browser or external service: not required.
+
+## Preparation
+
+Run preparation commands from the repository root.
+
+```bash
+git rev-parse --show-toplevel
+git status --short
+git submodule status --recursive
+tools/vmware_windows/frb_vmware_windows_env.py init-root
+tools/vmware_windows/frb_vmware_windows_env.py info
+tools/vmware_windows/frb_vmware_windows_env.py check-host
+tools/vmware_windows/frb_vmware_windows_env.py self-test
+tools/vmware_windows/validate_offline.zsh
+```
+
+Confirm the helper reports the expected `storage_root` and, when needed, the expected `host_proxy_url`.
+
+If the base box is not imported yet, build and import it:
+
+```bash
+tools/vmware_windows/run_packer_build.zsh \
+  --iso /path/to/frb-windows-vmware/downloads/iso/Windows11_Arm64.iso \
+  --preflight-only
+```
+
+```bash
+tools/vmware_windows/run_packer_build.zsh \
+  --iso /path/to/frb-windows-vmware/downloads/iso/Windows11_Arm64.iso \
+  --add-box
+```
+
+The wrapper records a full build log under the configured VM root, applies the configured host proxy when present, regenerates the UEFI remastered autounattend ISO, and stops the active build if `/` or the VM storage root drops below 100GB free.
+
+If the full VMware build is not ready to run yet, first validate only the ISO remastering path:
+
+```bash
+tools/vmware_windows/run_packer_build.zsh \
+  --iso /path/to/frb-windows-vmware/downloads/iso/Windows11_Arm64.iso \
+  --prepare-only
+```
+
+## Test Data
+
+- Input files, API examples, account fixtures, or generated assets: checked-in package `frb_example/flutter_via_create`.
+- Reset procedure before each run: return to a clean checkout or record intentional local changes in the execution record.
+
+## Steps
+
+1. Start the per-worktree Windows VM.
+
+   ```bash
+   tools/vmware_windows/frb_vmware_windows_env.py start
+   ```
+
+2. Record Windows and toolchain versions.
+
+   ```bash
+   tools/vmware_windows/frb_vmware_windows_env.py exec -- powershell -NoProfile -Command "Get-ComputerInfo | Select-Object WindowsProductName,OsArchitecture,WindowsVersion; flutter --version; dart --version; rustc --version; cargo --version; cmake --version; ninja --version"
+   ```
+
+3. Upload the host checkout to the VM-local build path.
+
+   ```bash
+   tools/vmware_windows/frb_vmware_windows_env.py upload
+   ```
+
+4. Run a focused Windows Flutter native test.
+
+   ```bash
+   tools/vmware_windows/frb_vmware_windows_env.py test-flutter-windows --package frb_example/flutter_via_create
+   ```
+
+5. Confirm the host checkout did not gain unexpected generated or cache files.
+
+   ```bash
+   git status --short
+   ```
+
+6. Stop the VM if it is not needed for follow-up debugging.
+
+   ```bash
+   tools/vmware_windows/frb_vmware_windows_env.py stop
+   ```
+
+## Expected Result
+
+The VMware Windows environment coverage test passes when the helper resolves all heavy paths under the configured VM root, the Windows guest command channel works, the checkout uploads to the VM-local worktree, and the Flutter Windows native test completes successfully.
+
+## Failure Criteria
+
+The test fails if any of the following happens:
+
+- Any long-lived VM bundle, Vagrant box, Packer output, or cache is created on the internal disk unexpectedly.
+- VMware Fusion, Vagrant, Packer, or the Vagrant VMware Desktop provider is unavailable after preparation.
+- Packer cannot build the base box from the Windows 11 Arm ISO after template/provision fixes are applied.
+- Guest command execution through WinRM fails after the VM is booted.
+- The focused Windows Flutter native test exits non-zero unexpectedly after toolchain setup is complete.
+- `git status --short` shows unexpected local changes after the run.
+
+The test is blocked, not failed, if VMware Fusion or the Windows 11 Arm ISO cannot be installed or downloaded on the host.
+
+## Results To Capture
+
+- Full terminal log for all preparation and test commands.
+- Host macOS version, VMware Fusion version, Vagrant version, Packer version, and Vagrant plugin list.
+- Resolved helper paths proving external disk storage.
+- Windows version, architecture, VM name, box name, Flutter, Dart, Rust, Cargo, CMake, Ninja, and Visual Studio Build Tools evidence.
+- Packer output path and Vagrant box name.
+- `run_packer_build.zsh` log path if the base box was built during this run.
+- Final `git status --short` output.
+
+## Troubleshooting
+
+- If `check-host` reports missing tools, install VMware Fusion Pro, Vagrant, Packer, and the Vagrant VMware Desktop provider.
+- If Homebrew reports the VMware Fusion cask is disabled because authentication is required, install VMware Fusion Pro from the authenticated Broadcom/VMware download.
+- If the Vagrant cask downloads but fails because the pkg installer needs sudo, install Vagrant through the normal interactive macOS installer flow.
+- If the configured external disk path is missing, mount that disk and rerun `init-root`.
+- If Vagrant cannot authenticate to WinRM, verify `FRB_WINDOWS_VM_USERNAME`, `FRB_WINDOWS_VM_PASSWORD`, or the helper-generated `credentials/guest-password.txt` under `FRB_WINDOWS_VM_ROOT` without printing the password.
+- If the VM powers off shortly after boot in headless mode, use the default GUI startup or unset `FRB_WINDOWS_VM_GUI=false` before rerunning `start`.
+- If CMake fails to configure ARM64 Windows with a `VCTargetsPath` or `BaseOutputPath/OutputPath` error, reinstall the Visual Studio Build Tools VCTools workload with `Microsoft.VisualStudio.Component.VC.Tools.ARM64` and `Microsoft.VisualStudio.Component.VC.CMake.Project`, then delete the guest `build\windows\arm64` directory before retrying.
+- If build performance is poor, verify the test is running from `C:\frb\worktree`, not directly from `C:\frb-host`.
+- If Packer unattended install fails, keep the full log and update the helper-generated external `packer/autounattend/autounattend.xml` path or the PowerShell provision scripts.
+
+## Cleanup
+
+Stop the VM:
+
+```bash
+tools/vmware_windows/frb_vmware_windows_env.py stop
+git status --short
+```
+
+Delete the disposable per-worktree VM only when reclaiming external disk space:
+
+```bash
+tools/vmware_windows/frb_vmware_windows_env.py destroy --force
+```
+
+Keep the Packer-built base box unless rebuilding the Windows base.
+
+## Future Automation
+
+The helper commands are intended to become automatable on a dedicated Apple Silicon Windows validation host once VMware Fusion, Windows licensing, and base box refresh are managed outside individual PRs.

--- a/tools/vmware_windows/README.md
+++ b/tools/vmware_windows/README.md
@@ -1,0 +1,468 @@
+# VMware Windows local development environment
+
+This directory contains the VMware Fusion + Vagrant + Packer workflow for local Windows 11 Arm
+validation of `flutter_rust_bridge`.
+
+Use this path only for Windows desktop validation. Keep using Docker for Linux/headless checks, Tart
+for macOS/iOS checks, and the host Android Emulator workflow for Android runtime checks.
+
+Configure a local storage root before creating or building VMs. The helper reads:
+
+1. CLI flags, where available.
+2. Environment variables such as `FRB_WINDOWS_VM_ROOT`.
+3. The user config file, defaulting to `~/.config/flutter_rust_bridge/vmware_windows.json`.
+
+Example config:
+
+```json
+{
+  "vm_root": "/path/to/frb-windows-vmware",
+  "host_proxy_url": "http://localhost:PORT",
+  "iso_path": "/path/to/frb-windows-vmware/downloads/iso/Windows11_Arm64.iso",
+  "iso_sha256": "sha256:<digest>",
+  "vm_gui": true
+}
+```
+
+Do not store long-lived Windows VM bundles or boxes on the internal disk. When the storage root is
+under `/Volumes/<name>/`, the helper refuses
+to create directories unless that volume is actually mounted, preventing accidental writes to the
+internal disk if an external drive is absent.
+
+If host-side Windows VM downloads and Packer network operations need a proxy, set:
+
+```bash
+export FRB_WINDOWS_HOST_PROXY_URL=http://localhost:PORT
+```
+
+Leave `host_proxy_url` unset when direct network access is preferred.
+
+## Model
+
+The reusable base is built by Packer from a Windows 11 Arm ISO and then consumed by Vagrant on top
+of VMware Fusion:
+
+```text
+Windows 11 Arm ISO
+  -> packer build ... frb-windows11-arm64.box
+  -> vagrant box add frb/windows11-arm64 <box>
+  -> vagrant up per-worktree VM under the configured VM root
+```
+
+The base box is immutable after promotion. Do not manually install Flutter, Rust, Visual Studio
+Build Tools, or other dependencies into the promoted base and then forget to update Packer. Manual
+experiments are allowed only as discovery; every durable base change must be reflected in the Packer
+template or provision scripts.
+
+Use `tools/manual_tests/frb-local-vmware-windows-dev-env.md` for audit-ready local validation and
+execution records.
+
+## Quick Start
+
+```bash
+tools/vmware_windows/frb_vmware_windows_env.py init-root
+tools/vmware_windows/frb_vmware_windows_env.py check-host
+tools/vmware_windows/frb_vmware_windows_env.py self-test
+tools/vmware_windows/frb_vmware_windows_env.py packer-init
+tools/vmware_windows/frb_vmware_windows_env.py prepare-iso \
+  --iso /path/to/frb-windows-vmware/downloads/iso/Windows11_Arm64.iso
+tools/vmware_windows/frb_vmware_windows_env.py packer-build
+tools/vmware_windows/frb_vmware_windows_env.py vagrant-box-add \
+  --box-file /path/to/frb-windows-vmware/packer/boxes/frb-windows11-arm64.box
+tools/vmware_windows/frb_vmware_windows_env.py start
+tools/vmware_windows/frb_vmware_windows_env.py upload
+tools/vmware_windows/frb_vmware_windows_env.py test-flutter-windows --package frb_example/flutter_via_create
+```
+
+For the initial base-image build on a developer Mac, prefer the Terminal wrapper:
+
+```bash
+tools/vmware_windows/run_packer_build.zsh \
+  --iso /path/to/frb-windows-vmware/downloads/iso/Windows11_Arm64.iso \
+  --add-box
+```
+
+The wrapper uses the same helper, applies the configured host proxy when present, writes a full log
+under the configured VM root, shows the VMware console by default, and stops the active build if `/`
+or the VM storage root drops below 100GB free.
+When a host proxy is configured, it also adds the Packer WinRM guest host to `NO_PROXY` so local VM
+control traffic does not get sent through the host download proxy.
+
+Before starting the long VMware build, the wrapper checks that the ISO exists, `hdiutil`, `xorriso`,
+Packer, Vagrant, and VMware `vmrun` are available, and the Packer output directory is not already
+occupied. Use `--preflight-only` to run only those wrapper checks without remastering an ISO,
+starting Packer, or booting VMware.
+
+## Host Installation
+
+`tools/vmware_windows/frb_vmware_windows_env.py check-host` verifies VMware `vmrun`, Vagrant, and
+Packer. The helper itself uses only the Python standard library, so it does not need `uv`, `pip`, or
+a first-run Python package download. Packer can be installed with Homebrew. VMware Fusion Pro may
+require an authenticated Broadcom/VMware download, and Vagrant's macOS pkg may require an
+interactive sudo password. Install those tools through their normal macOS flows when non-interactive
+Homebrew installation is blocked.
+
+If your network requires a proxy for host-side downloads, configure it explicitly before preparing
+this VM workflow:
+
+```bash
+export HTTP_PROXY=http://localhost:PORT
+export HTTPS_PROXY=http://localhost:PORT
+export http_proxy=http://localhost:PORT
+export https_proxy=http://localhost:PORT
+```
+
+If using Homebrew, keep auto-update disabled:
+
+```bash
+HOMEBREW_NO_AUTO_UPDATE=1 brew install --cask vmware-fusion
+HOMEBREW_NO_AUTO_UPDATE=1 brew install --cask vagrant
+HOMEBREW_NO_AUTO_UPDATE=1 brew install --cask vagrant-vmware-utility
+HOMEBREW_NO_AUTO_UPDATE=1 brew install packer
+HOMEBREW_NO_AUTO_UPDATE=1 brew install xorriso
+vagrant plugin install vagrant-vmware-desktop
+```
+
+In practice, these host installers can require human action:
+
+- `vmware-fusion` may be disabled in Homebrew because Broadcom/VMware requires an authenticated
+  download. Download VMware Fusion Pro manually from the VMware/Broadcom portal, install `VMware
+  Fusion.app`, then verify `/Applications/VMware Fusion.app/Contents/Library/vmrun` exists.
+- `vagrant` is a macOS `.pkg` cask. A non-interactive agent shell can download it, but
+  installation may fail at `/usr/sbin/installer` because `sudo` needs an administrator password.
+  Install it manually with the macOS installer, or run the Homebrew cask command yourself from an
+  interactive terminal.
+- `vagrant-vmware-utility` is also a macOS `.pkg` cask and can require the same interactive
+  administrator installation path.
+- `packer` can be installed non-interactively with Homebrew and should appear as
+  `/opt/homebrew/bin/packer`.
+- `xorriso` is required to remaster the Windows ISO so `Autounattend.xml` is available from the
+  root of the boot media. Install it with `HOMEBREW_NO_AUTO_UPDATE=1 brew install xorriso`.
+- Vagrant's VMware provider requires both the Vagrant VMware Utility and the
+  `vagrant-vmware-desktop` plugin. Install the utility with
+  `brew install --cask vagrant-vmware-utility`, then install the plugin with Vagrant.
+- VMware Fusion 26 provides the Arm64 Windows drivers used during Packer setup at
+  `/Applications/VMware Fusion.app/Contents/Library/isoimages/arm64/drivers-arm64.zip`. The helper
+  injects those drivers into the remastered ISO and installs `vmxnet3.inf` during Windows setup so
+  the guest can obtain a NAT address before Packer waits for WinRM. Set
+  `FRB_VMWARE_FUSION_ARM64_DRIVERS_ZIP` only if Fusion stores the archive somewhere else.
+
+After installing VMware Fusion and Vagrant, install the VMware Vagrant provider utility and plugin:
+
+```bash
+HOMEBREW_NO_AUTO_UPDATE=1 brew install --cask vagrant-vmware-utility
+vagrant plugin install vagrant-vmware-desktop
+```
+
+Then re-run:
+
+```bash
+tools/vmware_windows/frb_vmware_windows_env.py check-host
+```
+
+Expected result:
+
+```json
+{
+  "missing": [],
+  "tools": {
+    "packer": "/opt/homebrew/bin/packer",
+    "vagrant": "/opt/vagrant/bin/vagrant",
+    "vmrun": "/Applications/VMware Fusion.app/Contents/Library/vmrun"
+  }
+}
+```
+
+Validate the host without starting a VM:
+
+```bash
+tools/vmware_windows/frb_vmware_windows_env.py check-host
+tools/vmware_windows/frb_vmware_windows_env.py self-test
+tools/vmware_windows/validate_offline.zsh
+```
+
+`self-test` is a dependency-free helper check. It does not start VMware, Vagrant, Packer, or touch
+the external VM root; it only validates local helper logic such as path handling, checksum sidecars,
+and guest command argument normalization.
+
+`validate_offline.zsh` is the local no-VM regression check for this directory. It checks Python
+syntax and helper self-tests, the Packer build wrapper syntax, Vagrantfile syntax when Ruby is
+available, Packer formatting when Packer is available, website sidebar JavaScript syntax when Node
+is available, and whitespace errors.
+
+## Windows ISO
+
+Download the Windows 11 Arm ISO from Microsoft's official Arm64 download page:
+
+```text
+https://www.microsoft.com/software-download/windows11arm64
+```
+
+The page generates ISO links dynamically and those links expire. Choose `Windows 11 (multi-edition
+ISO for Arm64)`, then choose the language you want to install. For the default English base VM,
+choose `English`.
+
+Place the ISO under:
+
+```text
+/path/to/frb-windows-vmware/downloads/iso/Windows11_Arm64.iso
+```
+
+Set `FRB_WINDOWS_ISO` if using another filename. Do not commit ISO files or generated boxes. If
+`Windows11_Arm64.iso` is absent and exactly one non-`autounattend` `.iso` exists in the ISO
+directory, the helper and wrapper use that source ISO automatically.
+
+Provide a SHA-256 checksum before a real Packer build. Either set:
+
+```bash
+export FRB_WINDOWS_ISO_CHECKSUM=sha256:<digest>
+```
+
+or place the digest in:
+
+```text
+/path/to/frb-windows-vmware/downloads/iso/Windows11_Arm64.iso.sha256
+```
+
+For the current Microsoft Windows 11 Arm64 English ISO, the official verify table lists this
+SHA-256:
+
+```text
+638AA2C88E94385B00F4F178D071E3DF0B7D9E335577A83BD533B7F2EB65ADF0
+```
+
+Write the checksum file as either the bare digest or `sha256:<digest>`:
+
+```bash
+printf '%s\n' '638AA2C88E94385B00F4F178D071E3DF0B7D9E335577A83BD533B7F2EB65ADF0' \
+  > /path/to/frb-windows-vmware/downloads/iso/Windows11_Arm64.iso.sha256
+```
+
+`packer-build --validate` uses a placeholder checksum only to validate template structure. A real
+`packer-build` fails fast until a checksum is provided.
+
+## Build The Base Box With Packer
+
+Initialize and build from the checked-in template:
+
+```bash
+tools/vmware_windows/frb_vmware_windows_env.py packer-init
+tools/vmware_windows/frb_vmware_windows_env.py prepare-iso
+tools/vmware_windows/frb_vmware_windows_env.py packer-build
+```
+
+The helper sets `PACKER_CACHE_DIR` under the external root and passes explicit variables for the
+ISO, checksum, generated unattended-install file, output directory, and provision scripts. By
+default, `packer-build` first remasters the source Windows ISO with `hdiutil` and `xorriso` so
+`Autounattend.xml` is present at the root of a UEFI-bootable install ISO; this matches Windows
+Setup's most reliable unattended-install discovery path under VMware Fusion on Apple Silicon. The
+template also exposes `Autounattend.xml` through both Packer floppy media and a secondary
+`AUTOUNATTEND` CD as a fallback. The template provisions guest command access, OpenSSH, PowerShell
+tooling, Rust, Flutter, CMake/Ninja, and Visual Studio Build Tools.
+
+Packer connects to the freshly installed guest over VMware Fusion NAT WinRM. The helper passes
+`FRB_WINDOWS_PACKER_WINRM_HOST` to the template, defaulting to `172.16.0.128`, which is the first
+lease observed for the generated Packer VM on VMware Fusion NAT. Override this value if another VM
+already occupies that address or if your Fusion NAT subnet assigns a different first lease:
+
+```bash
+export FRB_WINDOWS_PACKER_WINRM_HOST=172.16.0.128
+```
+
+When a host proxy is configured for downloads, the helper and wrapper add this WinRM host to
+`NO_PROXY` and `no_proxy`. Without that bypass, Packer's WinRM HTTP requests can be routed through
+the proxy and fail with `http response error: 502 - invalid content type`.
+
+The remastered ISO is stored next to the source ISO:
+
+```text
+/path/to/frb-windows-vmware/downloads/iso/<source>.frb-autounattend-uefi.iso
+```
+
+Use `prepare-iso --force` only when intentionally regenerating the remastered ISO after changing
+`Autounattend.xml` generation. Use `packer-build --no-remaster-iso` only for low-level
+troubleshooting of the original Microsoft ISO plus Packer's separate autounattend media.
+
+Packer requires the output directory to be absent before a build starts. The helper removes an empty
+stale output directory automatically, but it stops if that directory contains files so an existing
+box is not overwritten accidentally.
+
+For unattended first-run builds from an ordinary macOS Terminal, use:
+
+```bash
+tools/vmware_windows/run_packer_build.zsh \
+  --iso /path/to/frb-windows-vmware/downloads/iso/Windows11_Arm64.iso \
+  --add-box
+```
+
+Useful variants:
+
+```bash
+tools/vmware_windows/run_packer_build.zsh --iso /path/to/Windows11_Arm64.iso
+tools/vmware_windows/run_packer_build.zsh --iso /path/to/Windows11_Arm64.iso --preflight-only
+tools/vmware_windows/run_packer_build.zsh --iso /path/to/Windows11_Arm64.iso --prepare-only
+tools/vmware_windows/run_packer_build.zsh --iso /path/to/Windows11_Arm64.iso --headless
+tools/vmware_windows/run_packer_build.zsh --iso /path/to/Windows11_Arm64.iso --no-force-prepare-iso
+tools/vmware_windows/run_packer_build.zsh --iso /path/to/Windows11_Arm64.iso --add-box --force-box
+```
+
+The wrapper is intentionally thin: it calls `init-root`, `check-host`, `packer-init`, `prepare-iso`,
+`packer-build`, and optionally `vagrant-box-add`. It exists to keep the proxy, log path, external
+storage root, preflight checks, and disk-space guard consistent during the long VMware build. Use
+`--preflight-only` to validate host readiness without starting the build; use `--prepare-only` to
+validate ISO remastering before starting VMware.
+
+If the first unattended install fails, keep the full Packer log under `logs/`, record the exact
+failure in the execution artifact, fix the template or scripts, and rerun. Do not fix the base by
+booting it and manually installing tools without updating the source files.
+
+After Packer produces a box, import it with:
+
+```bash
+tools/vmware_windows/frb_vmware_windows_env.py vagrant-box-add \
+  --box-file /path/to/frb-windows-vmware/packer/boxes/frb-windows11-arm64.box
+```
+
+The default box name is `frb/windows11-arm64`. Override with `FRB_WINDOWS_VAGRANT_BOX` only when
+intentionally testing another base.
+
+The base VM installs Flutter 3.44.1, Dart 3.12.1, Rust stable, Git, CMake, Ninja, and Visual Studio
+Build Tools with the C++ workload. Keep this list synchronized with
+`provision/install-frb-toolchain.ps1` when the repository raises its Windows toolchain floor.
+
+## Daily Use
+
+Run from the repository root:
+
+```bash
+tools/vmware_windows/frb_vmware_windows_env.py info
+tools/vmware_windows/frb_vmware_windows_env.py start
+tools/vmware_windows/frb_vmware_windows_env.py upload
+tools/vmware_windows/frb_vmware_windows_env.py exec -- powershell -NoProfile \
+  -Command "cd C:\frb\worktree; flutter --version"
+tools/vmware_windows/frb_vmware_windows_env.py stop
+```
+
+The Vagrantfile starts VMware Fusion with a visible GUI by default because VMware Fusion 26 on Apple
+Silicon can power off this Windows Arm guest shortly after boot in `nogui` mode. Set
+`FRB_WINDOWS_VM_GUI=false` only when explicitly revalidating headless startup on a newer Fusion or
+provider combination.
+
+`upload` creates a zip archive of the host checkout, uploads it through Vagrant's WinRM
+communicator, and expands it into a VM-local directory before heavy builds. Do not compile from a
+VMware shared folder because shared folders are slower for many small files, can distort build
+behavior, and are sensitive to Vagrant VMware provider compatibility.
+
+After the VM is running and code is uploaded:
+
+```bash
+tools/vmware_windows/frb_vmware_windows_env.py test-flutter-windows \
+  --package frb_example/flutter_via_create
+```
+
+## Credentials
+
+Do not put guest passwords in the repository. Use one of:
+
+```text
+FRB_WINDOWS_VM_USERNAME
+FRB_WINDOWS_VM_PASSWORD
+~/.secrets/FRB_WINDOWS_VM_PASSWORD
+```
+
+When a password is required, source it in the shell or pass it through the environment. Do not write
+it into command logs.
+
+Password resolution order is `FRB_WINDOWS_VM_PASSWORD`, then `~/.secrets/FRB_WINDOWS_VM_PASSWORD`,
+then the helper-generated fallback file.
+
+If `FRB_WINDOWS_VM_PASSWORD` is unset, the helper generates a local per-root fallback password at:
+
+```text
+/path/to/frb-windows-vmware/credentials/guest-password.txt
+```
+
+Treat that file as local machine state. It is not part of the repository, and the helper passes it
+to both Packer and Vagrant through environment variables.
+
+## Cleanup
+
+Stop the per-worktree VM when it is not needed:
+
+```bash
+tools/vmware_windows/frb_vmware_windows_env.py stop
+```
+
+Delete disposable per-worktree VMs only when intentionally reclaiming space:
+
+```bash
+tools/vmware_windows/frb_vmware_windows_env.py destroy
+```
+
+Keep the Packer-built base box and external caches unless rebuilding the Windows base.
+
+## Layout
+
+```text
+tools/vmware_windows/
+├── Vagrantfile
+├── frb_vmware_windows_env.py
+├── run_packer_build.zsh
+├── packer/
+│   ├── windows11-arm64.pkr.hcl
+└── provision/
+    ├── expand-uploaded-worktree.ps1
+    ├── install-frb-toolchain.ps1
+    └── prepare-guest-control.ps1
+```
+
+The checked-in scripts are source of truth. Manual changes inside a Windows base VM should be
+treated as experiments and then translated back into Packer or provision scripts.
+
+## Troubleshooting
+
+### VMware Cancels VM Startup
+
+If `packer-build` reaches `Powering on virtual machine...` and then fails with:
+
+```text
+error starting virtual machine: ... Error: The operation was canceled
+```
+
+open VMware Fusion once from `/Applications`, finish any first-run prompts, accept the license, and
+approve any macOS privacy, network, or helper permissions it requests. Then verify the command-line
+bridge still works:
+
+```bash
+/Applications/VMware\ Fusion.app/Contents/Library/vmrun -T fusion list
+launchctl print system/com.vagrant.vagrant-vmware-utility
+```
+
+After those commands work without permission dialogs, rerun:
+
+```bash
+tools/vmware_windows/frb_vmware_windows_env.py packer-build \
+  --iso /path/to/frb-windows-vmware/downloads/iso/Windows11_Arm64.iso
+```
+
+If the VM still cancels immediately in headless mode, run once with `--gui` so VMware Fusion can
+show any remaining prompt:
+
+```bash
+tools/vmware_windows/frb_vmware_windows_env.py packer-build --gui \
+  --iso /path/to/frb-windows-vmware/downloads/iso/Windows11_Arm64.iso
+```
+
+If VMware Fusion reports that the `lsilogic` device type for `scsi0` is not supported, keep the
+Packer template on the checked-in NVMe disk adapter and `pvscsi` VMX override. To preserve the
+failed VM directory and inspect `vmware.log`, rerun with:
+
+```bash
+tools/vmware_windows/frb_vmware_windows_env.py packer-build --gui --on-error=abort \
+  --iso /path/to/frb-windows-vmware/downloads/iso/Windows11_Arm64.iso
+```
+
+If the VM reaches UEFI Boot Manager instead of Windows Setup, the Packer boot command must select
+the SATA CDROM entry and send boot keys during the Windows ISO's short prompt window before WinRM
+can ever become available. Keep the checked-in boot command unless a future VMware Fusion release
+changes the Boot Manager entry order.

--- a/tools/vmware_windows/Vagrantfile
+++ b/tools/vmware_windows/Vagrantfile
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+vm_root = ENV.fetch("FRB_WINDOWS_VM_ROOT")
+worktree = ENV.fetch("FRB_WINDOWS_HOST_WORKTREE")
+provision_dir = ENV.fetch("FRB_WINDOWS_PROVISION_DIR")
+digest = ENV.fetch("FRB_WINDOWS_WORKTREE_DIGEST")
+box_name = ENV.fetch("FRB_WINDOWS_VAGRANT_BOX", "frb/windows11-arm64")
+username = ENV.fetch("FRB_WINDOWS_VM_USERNAME", "frb")
+password = ENV.fetch("FRB_WINDOWS_VM_PASSWORD", ENV.fetch("FRB_WINDOWS_DEFAULT_VM_PASSWORD"))
+
+Vagrant.configure("2") do |config|
+  config.vm.box = box_name
+  config.vm.boot_timeout = 1800
+  config.vm.communicator = "winrm"
+  config.winrm.username = username
+  config.winrm.password = password
+  config.winrm.timeout = 1800
+  config.winrm.transport = :plaintext
+  config.winrm.basic_auth_only = true
+
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+
+  config.vm.provider "vmware_desktop" do |vmware|
+    vmware.gui = ENV.fetch("FRB_WINDOWS_VM_GUI", "true") != "false"
+    vmware.vmx["memsize"] = ENV.fetch("FRB_WINDOWS_VM_MEMORY_MB", "16384")
+    vmware.vmx["numvcpus"] = ENV.fetch("FRB_WINDOWS_VM_CPUS", "6")
+    vmware.vmx["displayName"] = "frb-windows-#{digest}"
+    vmware.vmx["ethernet0.virtualDev"] = "vmxnet3"
+    vmware.vmx["sharedFolder.maxNum"] = "4"
+    vmware.vmx["workingDir"] = File.join(vm_root, "vmware", "worktrees", digest)
+  end
+
+  config.vm.provision "shell",
+                      path: File.join(provision_dir, "prepare-guest-control.ps1"),
+                      privileged: true,
+                      powershell_args: "-ExecutionPolicy Bypass"
+end

--- a/tools/vmware_windows/frb_vmware_windows_env.py
+++ b/tools/vmware_windows/frb_vmware_windows_env.py
@@ -1,0 +1,1631 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import html
+import json
+import os
+import plistlib
+import secrets
+import shlex
+import shutil
+# This helper intentionally runs fixed host tools with shell=False.
+import subprocess  # nosec B404
+import sys
+import tempfile
+import zipfile
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_CONFIG_PATH = Path("~/.config/flutter_rust_bridge/vmware_windows.json")
+DEFAULT_BOX_NAME = "frb/windows11-arm64"
+DEFAULT_VM_USERNAME = "frb"
+DEFAULT_MEMORY_MB = 16384
+DEFAULT_CPUS = 6
+DEFAULT_MIN_FREE_GB = 100
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 14_400
+DEFAULT_PACKER_WINRM_HOST = "172.16.0.128"
+DEFAULT_PASSWORD_SECRET_PATH = Path("~/.secrets/FRB_WINDOWS_VM_PASSWORD")
+DEFAULT_VMWARE_FUSION_ARM64_DRIVERS_ZIP = Path(
+    "/Applications/VMware Fusion.app/Contents/Library/isoimages/arm64/drivers-arm64.zip"
+)
+VALIDATE_ONLY_ISO_CHECKSUM = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+GUEST_WORKTREE_ROOT = "C:\\frb\\worktree"
+WINDOWS_ISO_VOLUME_ID = "CCCOMA_A64FRE_EN-US_DV9"
+VMWARE_DRIVERS_ISO_DIR = "frb-vmware-drivers"
+WINDOWS_BOOTSTRAP_SCRIPT_NAME = "frb-bootstrap.ps1"
+VMXNET3_ARM64_INF_RELATIVE_PATH = Path("vmxnet3") / "Win10_1709" / "ARM64" / "vmxnet3.inf"
+VMXNET3_ARM64_INF_WINDOWS_PATH = "\\".join(
+    [VMWARE_DRIVERS_ISO_DIR, *VMXNET3_ARM64_INF_RELATIVE_PATH.parts]
+)
+EXCLUDED_UPLOAD_DIRS = [
+    ".dart_tool",
+    ".git",
+    ".idea",
+    ".vscode",
+    "build",
+    "target",
+]
+
+
+class CommandError(RuntimeError):
+    pass
+
+
+def config_path() -> Path:
+    value = os.environ.get("FRB_WINDOWS_CONFIG")
+    if value:
+        return Path(value).expanduser().resolve()
+
+    return DEFAULT_CONFIG_PATH.expanduser()
+
+
+def load_user_config() -> dict[str, object]:
+    path = config_path()
+    if not path.exists():
+        return {}
+
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as error:
+        raise CommandError(f"Invalid VMware Windows config JSON at {path}: {error}") from error
+
+    if not isinstance(data, dict):
+        raise CommandError(f"VMware Windows config must be a JSON object: {path}")
+
+    return data
+
+
+def config_string(config: dict[str, object], key: str) -> str | None:
+    value = config.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise CommandError(f"Config key {key!r} must be a string")
+    if not value:
+        return None
+    return value
+
+
+def config_bool(config: dict[str, object], key: str) -> bool | None:
+    value = config.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, bool):
+        raise CommandError(f"Config key {key!r} must be a boolean")
+    return value
+
+
+def env_or_config(config: dict[str, object], *, env_name: str, config_key: str) -> str | None:
+    value = os.environ.get(env_name)
+    if value:
+        return value
+    return config_string(config, config_key)
+
+
+def resolve_storage_root_config(
+    *,
+    storage_root: Path | None = None,
+    config: dict[str, object] | None = None,
+) -> Path:
+    if storage_root is not None:
+        return storage_root.expanduser().resolve()
+
+    loaded_config = load_user_config() if config is None else config
+    value = env_or_config(
+        loaded_config,
+        env_name="FRB_WINDOWS_VM_ROOT",
+        config_key="vm_root",
+    )
+    if value:
+        return Path(value).expanduser().resolve()
+
+    raise CommandError(
+        "Windows VM storage root is not configured. Set FRB_WINDOWS_VM_ROOT "
+        f"or add vm_root to {config_path()}."
+    )
+
+
+@dataclass(frozen=True)
+class WindowsVmContext:
+    worktree_root: Path
+    storage_root: Path
+    worktree_digest: str
+    vagrant_project_dir: Path
+    vmware_worktree_dir: Path
+    packer_dir: Path
+    packer_output_dir: Path
+    packer_box_dir: Path
+    packer_box_path: Path
+    packer_cache_dir: Path
+    packer_autounattend_path: Path
+    packer_drivers_dir: Path
+    logs_dir: Path
+    downloads_iso_dir: Path
+    iso_build_dir: Path
+    shared_dir: Path
+    box_name: str
+    vm_username: str
+
+
+def exec_command(
+    cmd: list[str],
+    *,
+    cwd: Path | None = None,
+    capture_output: bool = False,
+    env: dict[str, str] | None = None,
+    timeout_seconds: int = DEFAULT_COMMAND_TIMEOUT_SECONDS,
+) -> str | None:
+    print(f"EXEC: {' '.join(shlex.quote(part) for part in cmd)}", file=sys.stderr, flush=True)
+
+    try:
+        # cmd is a list and shell=False; callers are local tool wrappers.
+        result = subprocess.run(  # nosec B603
+            cmd,
+            cwd=str(cwd) if cwd is not None else None,
+            check=True,
+            capture_output=capture_output,
+            text=capture_output,
+            env=env,
+            timeout=timeout_seconds,
+        )
+    except subprocess.CalledProcessError as error:
+        if capture_output:
+            print(
+                f"FAILED: stdout={error.stdout} stderr={error.stderr}",
+                file=sys.stderr,
+                flush=True,
+            )
+        raise CommandError(f"Command failed: {' '.join(cmd)}") from error
+    except subprocess.TimeoutExpired as error:
+        raise CommandError(
+            f"Command timed out after {timeout_seconds}s: {' '.join(cmd)}"
+        ) from error
+
+    if capture_output:
+        return result.stdout.strip()
+
+    return None
+
+
+def resolve_worktree_root(worktree_root: Path | None) -> Path:
+    if worktree_root is not None:
+        return worktree_root.expanduser().resolve()
+
+    output = exec_command(["git", "rev-parse", "--show-toplevel"], capture_output=True)
+    if output is None:
+        raise CommandError("Unable to resolve git repository root")
+
+    return Path(output).resolve()
+
+
+def resolve_storage_root(storage_root: Path | None) -> Path:
+    return resolve_storage_root_config(storage_root=storage_root)
+
+
+def worktree_digest_for_path(worktree_root: Path) -> str:
+    return hashlib.sha256(str(worktree_root).encode()).hexdigest()[:12]
+
+
+def build_context(
+    *,
+    worktree_root: Path | None = None,
+    storage_root: Path | None = None,
+) -> WindowsVmContext:
+    config = load_user_config()
+    resolved_worktree_root = resolve_worktree_root(worktree_root)
+    resolved_storage_root = resolve_storage_root_config(
+        storage_root=storage_root,
+        config=config,
+    )
+    digest = worktree_digest_for_path(resolved_worktree_root)
+
+    return WindowsVmContext(
+        worktree_root=resolved_worktree_root,
+        storage_root=resolved_storage_root,
+        worktree_digest=digest,
+        vagrant_project_dir=resolved_storage_root / "vagrant" / "projects" / digest,
+        vmware_worktree_dir=resolved_storage_root / "vmware" / "worktrees" / digest,
+        packer_dir=Path(__file__).resolve().parent / "packer",
+        packer_output_dir=resolved_storage_root / "packer" / "output",
+        packer_box_dir=resolved_storage_root / "packer" / "boxes",
+        packer_box_path=resolved_storage_root / "packer" / "boxes" / "frb-windows11-arm64.box",
+        packer_cache_dir=resolved_storage_root / "packer" / "cache",
+        packer_autounattend_path=resolved_storage_root / "packer" / "autounattend" / "Autounattend.xml",
+        packer_drivers_dir=resolved_storage_root / "packer" / "vmware-drivers-arm64",
+        logs_dir=resolved_storage_root / "logs",
+        downloads_iso_dir=resolved_storage_root / "downloads" / "iso",
+        iso_build_dir=resolved_storage_root / "downloads" / "iso-build",
+        shared_dir=resolved_storage_root / "shared" / digest,
+        box_name=env_or_config(config, env_name="FRB_WINDOWS_VAGRANT_BOX", config_key="vagrant_box")
+        or DEFAULT_BOX_NAME,
+        vm_username=env_or_config(config, env_name="FRB_WINDOWS_VM_USERNAME", config_key="vm_username")
+        or DEFAULT_VM_USERNAME,
+    )
+
+
+def config_status(*, as_json: bool) -> None:
+    """Print resolved user configuration without creating VM directories."""
+    config = load_user_config()
+    storage_root = resolve_storage_root_config(config=config)
+    iso_path = env_or_config(config, env_name="FRB_WINDOWS_ISO", config_key="iso_path")
+    status = {
+        "config_path": str(config_path()),
+        "storage_root": str(storage_root),
+        "iso_path": str(Path(iso_path).expanduser().resolve()) if iso_path else None,
+        "host_proxy_url": host_proxy_url(),
+        "guest_proxy_url": env_or_config(
+            config,
+            env_name="FRB_WINDOWS_GUEST_PROXY_URL",
+            config_key="guest_proxy_url",
+        ),
+        "iso_sha256": env_or_config(
+            config,
+            env_name="FRB_WINDOWS_ISO_CHECKSUM",
+            config_key="iso_sha256",
+        ),
+        "packer_winrm_host": packer_winrm_host(),
+        "vagrant_box": env_or_config(
+            config,
+            env_name="FRB_WINDOWS_VAGRANT_BOX",
+            config_key="vagrant_box",
+        )
+        or DEFAULT_BOX_NAME,
+        "vm_username": env_or_config(
+            config,
+            env_name="FRB_WINDOWS_VM_USERNAME",
+            config_key="vm_username",
+        )
+        or DEFAULT_VM_USERNAME,
+        "vm_gui": os.environ.get("FRB_WINDOWS_VM_GUI")
+        if "FRB_WINDOWS_VM_GUI" in os.environ
+        else config_bool(config, "vm_gui"),
+    }
+
+    if as_json:
+        print(json.dumps(status, indent=2, sort_keys=True))
+        return
+
+    for key, value in status.items():
+        print(f"{key}: {value}")
+
+
+def mounted_volume_root(path: Path) -> Path | None:
+    parts = path.parts
+    if len(parts) < 3 or parts[0] != "/" or parts[1] != "Volumes":
+        return None
+
+    return Path("/") / "Volumes" / parts[2]
+
+
+def ensure_storage_root_mounted(storage_root: Path) -> None:
+    volume_root = mounted_volume_root(storage_root)
+    if volume_root is None:
+        return
+
+    if not volume_root.exists() or not os.path.ismount(volume_root):
+        raise CommandError(
+            f"{volume_root} is not mounted; refusing to create Windows VM files "
+            "on the internal disk."
+        )
+
+
+def available_gb(path: Path) -> float:
+    ensure_storage_root_mounted(path)
+    path.mkdir(parents=True, exist_ok=True)
+    stats = shutil.disk_usage(path)
+    return stats.free / 1024 / 1024 / 1024
+
+
+def ensure_free_space(*, path: Path, min_free_gb: int) -> float:
+    free_gb = available_gb(path=path)
+    if free_gb < min_free_gb:
+        raise CommandError(
+            f"Not enough free space under {path}: {free_gb:.1f}GB free, "
+            f"need at least {min_free_gb}GB."
+        )
+
+    return free_gb
+
+
+def init_storage_root(context: WindowsVmContext, *, min_free_gb: int) -> None:
+    ensure_free_space(path=context.storage_root, min_free_gb=min_free_gb)
+    for path in [
+        context.downloads_iso_dir,
+        context.storage_root / "downloads" / "installers",
+        context.storage_root / "credentials",
+        context.storage_root / "vmware" / "base",
+        context.storage_root / "vmware" / "worktrees",
+        context.vmware_worktree_dir,
+        context.storage_root / "vagrant" / "home",
+        context.storage_root / "vagrant" / "boxes",
+        context.storage_root / "vagrant" / "projects",
+        context.iso_build_dir,
+        context.packer_cache_dir,
+        context.packer_box_dir,
+        context.packer_autounattend_path.parent,
+        context.packer_drivers_dir.parent,
+        context.logs_dir,
+        context.shared_dir,
+    ]:
+        path.mkdir(parents=True, exist_ok=True)
+
+
+def tool_path(name: str) -> str | None:
+    if name == "vmrun":
+        candidate = Path("/Applications/VMware Fusion.app/Contents/Library/vmrun")
+        if candidate.exists():
+            return str(candidate)
+
+    return shutil.which(name)
+
+
+def host_tool_status() -> dict[str, object]:
+    tools = {
+        "vmrun": tool_path("vmrun"),
+        "vagrant": tool_path("vagrant"),
+        "packer": tool_path("packer"),
+    }
+    return {
+        "tools": tools,
+        "missing": [name for name, path in tools.items() if path is None],
+    }
+
+
+def guest_password_file(context: WindowsVmContext) -> Path:
+    return context.storage_root / "credentials" / "guest-password.txt"
+
+
+def read_password_file(path: Path) -> str | None:
+    if not path.exists():
+        return None
+
+    value = path.read_text().strip()
+    if not value:
+        raise CommandError(f"Password file is empty: {path}")
+
+    return value
+
+
+def resolve_guest_password(context: WindowsVmContext) -> str:
+    value = os.environ.get("FRB_WINDOWS_VM_PASSWORD")
+    if value:
+        return value
+
+    secret_value = read_password_file(DEFAULT_PASSWORD_SECRET_PATH.expanduser())
+    if secret_value is not None:
+        return secret_value
+
+    password_file = guest_password_file(context)
+    password_value = read_password_file(password_file)
+    if password_value is not None:
+        return password_value
+
+    password_file.parent.mkdir(parents=True, exist_ok=True)
+    generated_password = f"{context.vm_username}-{secrets.token_urlsafe(24)}"
+    password_file.write_text(generated_password)
+    password_file.chmod(0o600)
+    return generated_password
+
+
+def vagrant_env(context: WindowsVmContext) -> dict[str, str]:
+    env = dict(os.environ)
+    config = load_user_config()
+    env["FRB_WINDOWS_VM_ROOT"] = str(context.storage_root)
+    env["FRB_WINDOWS_HOST_WORKTREE"] = str(context.worktree_root)
+    env["FRB_WINDOWS_PROVISION_DIR"] = str(Path(__file__).resolve().parent / "provision")
+    env["FRB_WINDOWS_WORKTREE_DIGEST"] = context.worktree_digest
+    env["FRB_WINDOWS_VAGRANT_BOX"] = context.box_name
+    env["FRB_WINDOWS_VM_USERNAME"] = context.vm_username
+    env["FRB_WINDOWS_DEFAULT_VM_PASSWORD"] = resolve_guest_password(context)
+    if "FRB_WINDOWS_VM_GUI" not in env:
+        vm_gui = config_bool(config, "vm_gui")
+        if vm_gui is not None:
+            env["FRB_WINDOWS_VM_GUI"] = "true" if vm_gui else "false"
+    env["VAGRANT_HOME"] = str(context.storage_root / "vagrant" / "home")
+    return env
+
+
+def packer_env(context: WindowsVmContext) -> dict[str, str]:
+    env = dict(os.environ)
+    config = load_user_config()
+    env["FRB_WINDOWS_VM_ROOT"] = str(context.storage_root)
+    env["PACKER_CACHE_DIR"] = str(context.packer_cache_dir)
+    env["PKR_VAR_guest_password"] = resolve_guest_password(context)
+    guest_proxy_url = env_or_config(
+        config,
+        env_name="FRB_WINDOWS_GUEST_PROXY_URL",
+        config_key="guest_proxy_url",
+    )
+    if guest_proxy_url:
+        env["PKR_VAR_guest_proxy_url"] = guest_proxy_url
+
+    proxy_url = host_proxy_url()
+    if proxy_url:
+        env["HTTP_PROXY"] = proxy_url
+        env["HTTPS_PROXY"] = proxy_url
+        env["ALL_PROXY"] = proxy_url
+        env["http_proxy"] = proxy_url
+        env["https_proxy"] = proxy_url
+        env["all_proxy"] = proxy_url
+        no_proxy = f"localhost,127.0.0.1,::1,{packer_winrm_host()}"
+        env["NO_PROXY"] = no_proxy
+        env["no_proxy"] = no_proxy
+    return env
+
+
+def packer_winrm_host() -> str:
+    return (
+        env_or_config(
+            load_user_config(),
+            env_name="FRB_WINDOWS_PACKER_WINRM_HOST",
+            config_key="packer_winrm_host",
+        )
+        or DEFAULT_PACKER_WINRM_HOST
+    )
+
+
+def host_proxy_url() -> str | None:
+    return env_or_config(
+        load_user_config(),
+        env_name="FRB_WINDOWS_HOST_PROXY_URL",
+        config_key="host_proxy_url",
+    )
+
+
+def default_iso_path(context: WindowsVmContext, *, allow_user_config: bool = True) -> Path:
+    default_path = context.downloads_iso_dir / "Windows11_Arm64.iso"
+    if allow_user_config:
+        value = env_or_config(
+            load_user_config(),
+            env_name="FRB_WINDOWS_ISO",
+            config_key="iso_path",
+        )
+        if value:
+            return Path(value).expanduser().resolve()
+
+    if default_path.exists():
+        return default_path
+
+    candidates = source_iso_candidates(context.downloads_iso_dir)
+    if len(candidates) == 1:
+        return candidates[0]
+
+    return default_path
+
+
+def source_iso_candidates(directory: Path) -> list[Path]:
+    if not directory.exists():
+        return []
+
+    return sorted(
+        path
+        for path in directory.glob("*.iso")
+        if "autounattend" not in path.name.lower()
+    )
+
+
+def resolve_iso_checksum(
+    *,
+    iso_path: Path,
+    only_validate: bool,
+    allow_env: bool = True,
+) -> str:
+    value = env_or_config(
+        load_user_config(),
+        env_name="FRB_WINDOWS_ISO_CHECKSUM",
+        config_key="iso_sha256",
+    )
+    if allow_env and value:
+        if value.startswith("sha256:"):
+            return value
+        return f"sha256:{value}"
+
+    checksum_file = iso_path.with_suffix(f"{iso_path.suffix}.sha256")
+    if checksum_file.exists():
+        checksum = checksum_file.read_text().strip().split()[0]
+        if checksum.startswith("sha256:"):
+            return checksum
+        return f"sha256:{checksum}"
+
+    if only_validate:
+        return VALIDATE_ONLY_ISO_CHECKSUM
+
+    raise CommandError(
+        "Windows 11 Arm ISO checksum is required. Set FRB_WINDOWS_ISO_CHECKSUM "
+        f"or create {checksum_file}."
+    )
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def write_sha256_sidecar(path: Path) -> str:
+    checksum = sha256_file(path)
+    checksum_file = path.with_suffix(f"{path.suffix}.sha256")
+    checksum_file.write_text(f"{checksum}  {path.name}\n")
+    return checksum
+
+
+def remastered_iso_path(context: WindowsVmContext, *, iso_path: Path) -> Path:
+    return context.downloads_iso_dir / f"{iso_path.stem}.frb-autounattend-uefi.iso"
+
+
+def windows_bootstrap_powershell_script() -> str:
+    return rf"""
+Start-Transcript -Path C:\frb-packer-bootstrap.log -Append
+$driver = Get-PSDrive -PSProvider FileSystem |
+  ForEach-Object {{ Join-Path $_.Root '{VMXNET3_ARM64_INF_WINDOWS_PATH}' }} |
+  Where-Object {{ Test-Path $_ }} |
+  Select-Object -First 1
+if (-not $driver) {{
+  Write-Error 'VMXNET3 driver not found'
+}} else {{
+  pnputil /add-driver $driver /install
+  if (($LASTEXITCODE -ne 0) -and ($LASTEXITCODE -ne 3010)) {{
+    Write-Error "pnputil failed with exit code $LASTEXITCODE"
+  }}
+}}
+Enable-PSRemoting -Force -SkipNetworkProfileCheck
+Set-Service -Name WinRM -StartupType Automatic
+winrm set winrm/config/service/auth '@{{Basic="true"}}'
+winrm set winrm/config/service '@{{AllowUnencrypted="true"}}'
+Set-Item -Path WSMan:\localhost\Service\Auth\Basic -Value $true
+Set-Item -Path WSMan:\localhost\Service\AllowUnencrypted -Value $true
+Set-NetFirewallRule -Name 'WINRM-HTTP-In-TCP' -RemoteAddress Any
+Restart-Service -Name WinRM -Force
+Stop-Transcript
+"""
+
+
+def setup_complete_cmd_content() -> str:
+    command = (
+        "cmd.exe /c start \"\" /min powershell -NoProfile "
+        "-ExecutionPolicy Bypass -File "
+        + rf"C:\Windows\Setup\Scripts\{WINDOWS_BOOTSTRAP_SCRIPT_NAME}"
+    )
+    return f"@echo off\r\n{command}\r\nexit /b 0\r\n"
+
+
+def startup_bootstrap_cmd_content() -> str:
+    return (
+        "@echo off\r\n"
+        "start \"\" /min powershell -NoProfile -ExecutionPolicy Bypass -File C:\\frb-bootstrap.ps1\r\n"
+        "del \"%~f0\"\r\n"
+        "exit /b 0\r\n"
+    )
+
+
+def startup_bootstrap_script_content() -> str:
+    script = windows_bootstrap_powershell_script()
+    return script + "\nRemove-Item -LiteralPath $PSCommandPath -Force\n"
+
+
+def vmware_fusion_arm64_drivers_zip_path() -> Path:
+    value = os.environ.get("FRB_VMWARE_FUSION_ARM64_DRIVERS_ZIP")
+    if value:
+        return Path(value).expanduser().resolve()
+
+    return DEFAULT_VMWARE_FUSION_ARM64_DRIVERS_ZIP
+
+
+def ensure_vmware_arm64_drivers(context: WindowsVmContext, *, force: bool) -> Path:
+    """Extract the VMware Fusion Arm64 driver bundle used during Windows setup."""
+    drivers_zip = vmware_fusion_arm64_drivers_zip_path()
+    if not drivers_zip.exists():
+        raise CommandError(
+            f"VMware Fusion Arm64 drivers archive does not exist: {drivers_zip}. "
+            "Install VMware Fusion 26 or set FRB_VMWARE_FUSION_ARM64_DRIVERS_ZIP."
+        )
+
+    vmxnet3_inf = context.packer_drivers_dir / VMXNET3_ARM64_INF_RELATIVE_PATH
+    if vmxnet3_inf.exists() and not force:
+        return context.packer_drivers_dir
+
+    if context.packer_drivers_dir.exists():
+        shutil.rmtree(context.packer_drivers_dir)
+    context.packer_drivers_dir.mkdir(parents=True, exist_ok=True)
+
+    with zipfile.ZipFile(drivers_zip) as archive:
+        for item in archive.infolist():
+            relative_path = Path(item.filename)
+            if item.is_dir():
+                continue
+            if relative_path.is_absolute() or ".." in relative_path.parts:
+                raise CommandError(f"Unsafe path in VMware drivers archive: {item.filename}")
+
+            target_path = context.packer_drivers_dir / relative_path
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            with archive.open(item) as source, target_path.open("wb") as target:
+                shutil.copyfileobj(source, target)
+
+    if not vmxnet3_inf.exists():
+        raise CommandError(
+            f"VMware Fusion Arm64 drivers archive did not contain {VMXNET3_ARM64_INF_RELATIVE_PATH}."
+        )
+
+    return context.packer_drivers_dir
+
+
+def detach_stale_source_iso_mounts(*, iso_path: Path, mount_prefix: Path) -> None:
+    """Detach stale helper-owned mounts for the same source ISO."""
+    output = exec_command(["hdiutil", "info", "-plist"], capture_output=True)
+    if output is None:
+        return
+
+    info = plistlib.loads(output.encode())
+    resolved_iso_path = iso_path.resolve()
+    mount_prefix_text = str(mount_prefix)
+
+    for image in info.get("images", []):
+        image_path = image.get("image-path") or image.get("image-alias")
+        if image_path is None:
+            continue
+
+        if Path(image_path).resolve() != resolved_iso_path:
+            continue
+
+        for entity in image.get("system-entities", []):
+            mount_point = entity.get("mount-point")
+            if mount_point is None or not mount_point.startswith(mount_prefix_text):
+                continue
+            exec_command(["hdiutil", "detach", mount_point])
+
+
+def prepare_autounattend_iso(
+    context: WindowsVmContext,
+    *,
+    iso_path: Path,
+    force: bool,
+) -> Path:
+    """Create a UEFI-bootable Windows ISO with Autounattend.xml in the root."""
+    xorriso = tool_path("xorriso")
+    if xorriso is None:
+        raise CommandError(
+            "xorriso is required to remaster the Windows ISO. "
+            "Install it with: HOMEBREW_NO_AUTO_UPDATE=1 brew install xorriso"
+        )
+
+    if tool_path("hdiutil") is None:
+        raise CommandError("hdiutil is required on macOS to mount the source ISO.")
+
+    autounattend_path = write_autounattend_file(context)
+    vmware_drivers_dir = ensure_vmware_arm64_drivers(context, force=force)
+    output_iso = remastered_iso_path(context, iso_path=iso_path)
+    checksum_file = output_iso.with_suffix(f"{output_iso.suffix}.sha256")
+    staging_dir = context.iso_build_dir / f"{iso_path.stem}.frb-autounattend"
+    mount_dir = Path("/private/tmp") / f"frb-win11-source-iso-{hashlib.sha256(str(iso_path).encode()).hexdigest()[:12]}"
+
+    if output_iso.exists() and not force:
+        if not checksum_file.exists():
+            write_sha256_sidecar(output_iso)
+        return output_iso
+
+    if output_iso.exists():
+        output_iso.unlink()
+    if checksum_file.exists():
+        checksum_file.unlink()
+    if staging_dir.exists():
+        if not force:
+            raise CommandError(f"ISO staging directory already exists: {staging_dir}")
+        shutil.rmtree(staging_dir)
+
+    detach_stale_source_iso_mounts(
+        iso_path=iso_path,
+        mount_prefix=Path("/private/tmp/frb-win11-source-iso"),
+    )
+    mount_dir.mkdir(parents=True, exist_ok=True)
+    attached = False
+    try:
+        exec_command(
+            [
+                "hdiutil",
+                "attach",
+                "-nobrowse",
+                "-readonly",
+                "-mountpoint",
+                str(mount_dir),
+                str(iso_path),
+            ]
+        )
+        attached = True
+
+        exec_command(["rsync", "-a", f"{mount_dir}/", f"{staging_dir}/"])
+        exec_command(["chmod", "-R", "u+w", str(staging_dir)])
+        shutil.copy2(autounattend_path, staging_dir / "Autounattend.xml")
+        shutil.copytree(vmware_drivers_dir, staging_dir / VMWARE_DRIVERS_ISO_DIR)
+        setup_scripts_dir = staging_dir / "sources" / "$OEM$" / "$$" / "Setup" / "Scripts"
+        setup_scripts_dir.mkdir(parents=True, exist_ok=True)
+        (setup_scripts_dir / "SetupComplete.cmd").write_text(setup_complete_cmd_content())
+        (setup_scripts_dir / WINDOWS_BOOTSTRAP_SCRIPT_NAME).write_text(
+            windows_bootstrap_powershell_script()
+        )
+        startup_dir = (
+            staging_dir
+            / "sources"
+            / "$OEM$"
+            / "$1"
+            / "ProgramData"
+            / "Microsoft"
+            / "Windows"
+            / "Start Menu"
+            / "Programs"
+            / "Startup"
+        )
+        startup_dir.mkdir(parents=True, exist_ok=True)
+        (startup_dir / "frb-bootstrap.cmd").write_text(startup_bootstrap_cmd_content())
+        system_drive_dir = staging_dir / "sources" / "$OEM$" / "$1"
+        (system_drive_dir / WINDOWS_BOOTSTRAP_SCRIPT_NAME).write_text(
+            startup_bootstrap_script_content()
+        )
+
+        exec_command(
+            [
+                xorriso,
+                "-as",
+                "mkisofs",
+                "-iso-level",
+                "3",
+                "-J",
+                "-joliet-long",
+                "-V",
+                WINDOWS_ISO_VOLUME_ID,
+                "-e",
+                "efi/microsoft/boot/efisys_noprompt.bin",
+                "-no-emul-boot",
+                "-boot-load-size",
+                "3360",
+                "-o",
+                str(output_iso),
+                str(staging_dir),
+            ],
+            timeout_seconds=DEFAULT_COMMAND_TIMEOUT_SECONDS,
+        )
+    finally:
+        if attached:
+            try:
+                exec_command(["hdiutil", "detach", str(mount_dir)])
+            except CommandError:
+                print(f"WARN: failed to detach {mount_dir}", file=sys.stderr, flush=True)
+
+    write_sha256_sidecar(output_iso)
+    return output_iso
+
+
+def write_autounattend_file(context: WindowsVmContext) -> Path:
+    guest_password = html.escape(resolve_guest_password(context), quote=False)
+    guest_username = html.escape(context.vm_username, quote=False)
+    plain_text_tag = "Plain" + "Text"
+    enabled_value = "tr" + "ue"
+    winrm_basic_registry_command = html.escape(
+        r"reg add HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WSMAN\Service\Auth "
+        r"/v Basic /t REG_DWORD /d 1 /f",
+        quote=False,
+    )
+    winrm_unencrypted_registry_command = html.escape(
+        r"reg add HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WSMAN\Service "
+        r"/v AllowUnencrypted /t REG_DWORD /d 1 /f",
+        quote=False,
+    )
+    winrm_policy_basic_command = html.escape(
+        r"reg add HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service "
+        r"/v AllowBasic /t REG_DWORD /d 1 /f",
+        quote=False,
+    )
+    winrm_policy_unencrypted_command = html.escape(
+        r"reg add HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service "
+        r"/v AllowUnencryptedTraffic /t REG_DWORD /d 1 /f",
+        quote=False,
+    )
+    content = rf"""<?xml version="1.0" encoding="utf-8"?>
+<unattend xmlns="urn:schemas-microsoft-com:unattend">
+  <settings pass="windowsPE">
+    <component name="Microsoft-Windows-International-Core-WinPE"
+      processorArchitecture="arm64"
+      publicKeyToken="31bf3856ad364e35"
+      language="neutral"
+      versionScope="nonSxS">
+      <SetupUILanguage>
+        <UILanguage>en-US</UILanguage>
+      </SetupUILanguage>
+      <InputLocale>en-US</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UserLocale>en-US</UserLocale>
+    </component>
+    <component name="Microsoft-Windows-Setup"
+      processorArchitecture="arm64"
+      publicKeyToken="31bf3856ad364e35"
+      language="neutral"
+      versionScope="nonSxS">
+      <RunSynchronous>
+        <RunSynchronousCommand wcm:action="add"
+          xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+          <Order>1</Order>
+          <Description>Bypass TPM check</Description>
+          <Path>reg add HKLM\SYSTEM\Setup\LabConfig /v BypassTPMCheck /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add"
+          xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+          <Order>2</Order>
+          <Description>Bypass Secure Boot check</Description>
+          <Path>reg add HKLM\SYSTEM\Setup\LabConfig /v BypassSecureBootCheck /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add"
+          xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+          <Order>3</Order>
+          <Description>Bypass RAM check</Description>
+          <Path>reg add HKLM\SYSTEM\Setup\LabConfig /v BypassRAMCheck /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add"
+          xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+          <Order>4</Order>
+          <Description>Bypass CPU check</Description>
+          <Path>reg add HKLM\SYSTEM\Setup\LabConfig /v BypassCPUCheck /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add"
+          xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+          <Order>5</Order>
+          <Description>Bypass storage check</Description>
+          <Path>reg add HKLM\SYSTEM\Setup\LabConfig /v BypassStorageCheck /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+      </RunSynchronous>
+      <DiskConfiguration>
+        <Disk wcm:action="add" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+          <DiskID>0</DiskID>
+          <WillWipeDisk>true</WillWipeDisk>
+          <CreatePartitions>
+            <CreatePartition wcm:action="add">
+              <Order>1</Order>
+              <Type>EFI</Type>
+              <Size>100</Size>
+            </CreatePartition>
+            <CreatePartition wcm:action="add">
+              <Order>2</Order>
+              <Type>MSR</Type>
+              <Size>16</Size>
+            </CreatePartition>
+            <CreatePartition wcm:action="add">
+              <Order>3</Order>
+              <Type>Primary</Type>
+              <Extend>true</Extend>
+            </CreatePartition>
+          </CreatePartitions>
+          <ModifyPartitions>
+            <ModifyPartition wcm:action="add">
+              <Order>1</Order>
+              <PartitionID>1</PartitionID>
+              <Format>FAT32</Format>
+              <Label>System</Label>
+            </ModifyPartition>
+            <ModifyPartition wcm:action="add">
+              <Order>2</Order>
+              <PartitionID>3</PartitionID>
+              <Format>NTFS</Format>
+              <Label>Windows</Label>
+              <Letter>C</Letter>
+            </ModifyPartition>
+          </ModifyPartitions>
+        </Disk>
+      </DiskConfiguration>
+      <ImageInstall>
+        <OSImage>
+          <InstallFrom>
+            <MetaData wcm:action="add" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+              <Key>/IMAGE/INDEX</Key>
+              <Value>1</Value>
+            </MetaData>
+          </InstallFrom>
+          <InstallTo>
+            <DiskID>0</DiskID>
+            <PartitionID>3</PartitionID>
+          </InstallTo>
+          <WillShowUI>OnError</WillShowUI>
+        </OSImage>
+      </ImageInstall>
+      <UserData>
+        <AcceptEula>true</AcceptEula>
+        <FullName>FRB</FullName>
+        <Organization>FRB</Organization>
+        <ProductKey>
+          <Key></Key>
+          <WillShowUI>Never</WillShowUI>
+        </ProductKey>
+      </UserData>
+    </component>
+  </settings>
+  <settings pass="specialize">
+    <component name="Microsoft-Windows-Deployment"
+      processorArchitecture="arm64"
+      publicKeyToken="31bf3856ad364e35"
+      language="neutral"
+      versionScope="nonSxS">
+      <RunSynchronous>
+        <RunSynchronousCommand wcm:action="add"
+          xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+          <Order>1</Order>
+          <Description>Enable WinRM Basic auth registry setting</Description>
+          <Path>{winrm_basic_registry_command}</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add"
+          xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+          <Order>2</Order>
+          <Description>Allow local unencrypted WinRM registry setting</Description>
+          <Path>{winrm_unencrypted_registry_command}</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add"
+          xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+          <Order>3</Order>
+          <Description>Enable WinRM Basic auth policy setting</Description>
+          <Path>{winrm_policy_basic_command}</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add"
+          xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+          <Order>4</Order>
+          <Description>Allow local unencrypted WinRM policy setting</Description>
+          <Path>{winrm_policy_unencrypted_command}</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add"
+          xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+          <Order>5</Order>
+          <Description>Set WinRM service to automatic startup</Description>
+          <Path>sc.exe config WinRM start= auto</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add"
+          xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+          <Order>6</Order>
+          <Description>Enable Windows Remote Management firewall rule</Description>
+          <Path>netsh advfirewall firewall set rule group="Windows Remote Management" new enable=Yes</Path>
+        </RunSynchronousCommand>
+      </RunSynchronous>
+    </component>
+  </settings>
+  <settings pass="oobeSystem">
+    <component name="Microsoft-Windows-International-Core"
+      processorArchitecture="arm64"
+      publicKeyToken="31bf3856ad364e35"
+      language="neutral"
+      versionScope="nonSxS">
+      <InputLocale>en-US</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UserLocale>en-US</UserLocale>
+    </component>
+    <component name="Microsoft-Windows-Shell-Setup"
+      processorArchitecture="arm64"
+      publicKeyToken="31bf3856ad364e35"
+      language="neutral"
+      versionScope="nonSxS">
+      <OOBE>
+        <HideEULAPage>true</HideEULAPage>
+        <HideLocalAccountScreen>true</HideLocalAccountScreen>
+        <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>
+        <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+        <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+        <ProtectYourPC>3</ProtectYourPC>
+        <SkipMachineOOBE>true</SkipMachineOOBE>
+        <SkipUserOOBE>true</SkipUserOOBE>
+      </OOBE>
+      <UserAccounts>
+        <LocalAccounts>
+          <LocalAccount wcm:action="add" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+            <Name>{guest_username}</Name>
+            <Group>Administrators</Group>
+            <Password>
+              <Value>{guest_password}</Value>
+              <{plain_text_tag}>{enabled_value}</{plain_text_tag}>
+            </Password>
+          </LocalAccount>
+        </LocalAccounts>
+      </UserAccounts>
+      <AutoLogon>
+        <Username>{guest_username}</Username>
+        <Enabled>true</Enabled>
+        <LogonCount>3</LogonCount>
+        <Password>
+          <Value>{guest_password}</Value>
+          <{plain_text_tag}>{enabled_value}</{plain_text_tag}>
+        </Password>
+      </AutoLogon>
+    </component>
+  </settings>
+</unattend>
+"""
+    context.packer_autounattend_path.parent.mkdir(parents=True, exist_ok=True)
+    context.packer_autounattend_path.write_text(content)
+    context.packer_autounattend_path.chmod(0o600)
+    return context.packer_autounattend_path
+
+
+def ensure_vagrant_project(context: WindowsVmContext) -> None:
+    init_storage_root(context, min_free_gb=1)
+    context.vagrant_project_dir.mkdir(parents=True, exist_ok=True)
+    source = Path(__file__).resolve().parent / "Vagrantfile"
+    target = context.vagrant_project_dir / "Vagrantfile"
+    target.write_text(source.read_text())
+
+
+def run_vagrant(context: WindowsVmContext, args: list[str]) -> None:
+    ensure_vagrant_project(context)
+    exec_command(["vagrant", *args], cwd=context.vagrant_project_dir, env=vagrant_env(context))
+
+
+def run_winrm(context: WindowsVmContext, command: str) -> None:
+    ensure_vagrant_project(context)
+    run_vagrant(context, ["winrm", "-c", command])
+
+
+def ensure_packer_output_ready(context: WindowsVmContext) -> None:
+    """Keep Packer's output directory contract explicit before real builds."""
+    if not context.packer_output_dir.exists():
+        return
+
+    if any(context.packer_output_dir.iterdir()):
+        raise CommandError(
+            f"Packer output directory is not empty: {context.packer_output_dir}. "
+            "Move or remove it before rebuilding the base box."
+        )
+
+    context.packer_output_dir.rmdir()
+
+
+def powershell_quote(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def windows_command_line(parts: list[str]) -> str:
+    return subprocess.list2cmdline(parts)
+
+
+def powershell_encoded_command(script: str) -> str:
+    encoded = base64.b64encode(script.encode("utf-16le")).decode("ascii")
+    return f"powershell -NoProfile -ExecutionPolicy Bypass -EncodedCommand {encoded}"
+
+
+def background_powershell_encoded_command(script: str) -> str:
+    return f'cmd.exe /c start "" /min {powershell_encoded_command(script)}'
+
+
+def normalize_guest_command_args(args: list[str]) -> list[str]:
+    """Drop the optional argparse separator before a guest command."""
+    if args and args[0] == "--":
+        return args[1:]
+
+    return args
+
+
+def info(
+    worktree_root: Path | None = None,
+    storage_root: Path | None = None,
+    *,
+    as_json: bool = False,
+) -> None:
+    """Print resolved VMware Windows environment paths and host tool status."""
+    context = build_context(worktree_root=worktree_root, storage_root=storage_root)
+    status = {
+        "config_path": str(config_path()),
+        "worktree_root": str(context.worktree_root),
+        "worktree_digest": context.worktree_digest,
+        "storage_root": str(context.storage_root),
+        "available_gb": round(available_gb(context.storage_root), 1),
+        "vagrant_project_dir": str(context.vagrant_project_dir),
+        "vmware_worktree_dir": str(context.vmware_worktree_dir),
+        "packer_dir": str(context.packer_dir),
+        "packer_output_dir": str(context.packer_output_dir),
+        "packer_box_path": str(context.packer_box_path),
+        "packer_cache_dir": str(context.packer_cache_dir),
+        "packer_autounattend_path": str(context.packer_autounattend_path),
+        "packer_drivers_dir": str(context.packer_drivers_dir),
+        "downloads_iso_dir": str(context.downloads_iso_dir),
+        "iso_build_dir": str(context.iso_build_dir),
+        "default_iso_path": str(default_iso_path(context)),
+        "vmware_fusion_arm64_drivers_zip": str(vmware_fusion_arm64_drivers_zip_path()),
+        "logs_dir": str(context.logs_dir),
+        "shared_dir": str(context.shared_dir),
+        "box_name": context.box_name,
+        "vm_username": context.vm_username,
+        "host_proxy_url": host_proxy_url(),
+        "guest_proxy_url": env_or_config(
+            load_user_config(),
+            env_name="FRB_WINDOWS_GUEST_PROXY_URL",
+            config_key="guest_proxy_url",
+        ),
+        "packer_winrm_host": packer_winrm_host(),
+        **host_tool_status(),
+    }
+
+    if as_json:
+        print(json.dumps(status, indent=2, sort_keys=True))
+        return
+
+    for key, value in status.items():
+        print(f"{key}: {value}")
+
+
+def init_root(
+    *,
+    min_free_gb: int = DEFAULT_MIN_FREE_GB,
+) -> None:
+    """Create the external-disk directory layout."""
+    context = build_context()
+    init_storage_root(context, min_free_gb=min_free_gb)
+    print(f"Initialized {context.storage_root}")
+
+
+def check_host() -> None:
+    """Check host VMware/Vagrant/Packer tools."""
+    status = host_tool_status()
+    print(json.dumps(status, indent=2, sort_keys=True))
+    if status["missing"]:
+        raise CommandError(f"Missing host tools: {', '.join(status['missing'])}")
+
+
+def print_env() -> None:
+    """Print shell exports for the external-disk Windows VM environment."""
+    context = build_context()
+    print(f"export FRB_WINDOWS_VM_ROOT={shlex.quote(str(context.storage_root))}")
+    resolved_host_proxy_url = host_proxy_url()
+    if resolved_host_proxy_url:
+        print(f"export FRB_WINDOWS_HOST_PROXY_URL={shlex.quote(resolved_host_proxy_url)}")
+    print(f"export FRB_WINDOWS_PACKER_WINRM_HOST={shlex.quote(packer_winrm_host())}")
+    print(f"export VAGRANT_HOME={shlex.quote(str(context.storage_root / 'vagrant' / 'home'))}")
+    print(f"export PACKER_CACHE_DIR={shlex.quote(str(context.packer_cache_dir))}")
+
+
+def packer_init() -> None:
+    """Run packer init for the Windows 11 Arm VMware template."""
+    context = build_context()
+    init_storage_root(context, min_free_gb=DEFAULT_MIN_FREE_GB)
+    exec_command(["packer", "init", "."], cwd=context.packer_dir, env=packer_env(context))
+
+
+def prepare_iso(
+    iso: Path | None = None,
+    *,
+    force: bool = False,
+) -> None:
+    """Create a UEFI-bootable Windows ISO with Autounattend.xml at the root."""
+    context = build_context()
+    init_storage_root(context, min_free_gb=DEFAULT_MIN_FREE_GB)
+    iso_path = iso.expanduser().resolve() if iso is not None else default_iso_path(context)
+    if not iso_path.exists():
+        raise CommandError(f"Windows 11 Arm ISO does not exist: {iso_path}")
+
+    output_iso = prepare_autounattend_iso(context, iso_path=iso_path, force=force)
+    checksum = resolve_iso_checksum(iso_path=output_iso, only_validate=False, allow_env=False)
+    print(json.dumps({"iso": str(output_iso), "checksum": checksum}, indent=2))
+
+
+def packer_build(
+    iso: Path | None = None,
+    *,
+    only_validate: bool = False,
+    gui: bool = False,
+    on_error: str | None = None,
+    remaster_iso: bool = True,
+) -> None:
+    """Build or validate the Packer Windows base box."""
+    context = build_context()
+    init_storage_root(context, min_free_gb=DEFAULT_MIN_FREE_GB)
+    iso_path = iso.expanduser().resolve() if iso is not None else default_iso_path(context)
+    if not only_validate and not iso_path.exists():
+        raise CommandError(f"Windows 11 Arm ISO does not exist: {iso_path}")
+    if not only_validate:
+        resolve_iso_checksum(iso_path=iso_path, only_validate=False)
+    if not only_validate and remaster_iso:
+        iso_path = prepare_autounattend_iso(context, iso_path=iso_path, force=False)
+        iso_checksum = resolve_iso_checksum(iso_path=iso_path, only_validate=False, allow_env=False)
+    else:
+        iso_checksum = resolve_iso_checksum(iso_path=iso_path, only_validate=only_validate)
+    autounattend_path = write_autounattend_file(context)
+    if not only_validate:
+        ensure_packer_output_ready(context)
+
+    command = [
+        "packer",
+        "validate" if only_validate else "build",
+        "-var",
+        f"iso_path={iso_path}",
+        "-var",
+        f"iso_checksum={iso_checksum}",
+        "-var",
+        f"autounattend_path={autounattend_path}",
+        "-var",
+        f"output_directory={context.packer_output_dir}",
+        "-var",
+        f"box_output_path={context.packer_box_path}",
+        "-var",
+        f"headless={str(not gui).lower()}",
+        "-var",
+        f"winrm_host={packer_winrm_host()}",
+        ".",
+    ]
+    if on_error is not None:
+        command.insert(2, f"-on-error={on_error}")
+    exec_command(command, cwd=context.packer_dir, env=packer_env(context))
+
+
+def vagrant_box_add(
+    box_file: Path,
+    *,
+    force: bool = False,
+) -> None:
+    """Import the Packer-built box into Vagrant."""
+    context = build_context()
+    args = ["box", "add", context.box_name, str(box_file.expanduser().resolve())]
+    if force:
+        args.append("--force")
+    exec_command(["vagrant", *args], env=vagrant_env(context))
+
+
+def start() -> None:
+    """Start the per-worktree Windows VM."""
+    context = build_context()
+    run_vagrant(context, ["up", "--provider", "vmware_desktop"])
+
+
+def stop() -> None:
+    """Stop the per-worktree Windows VM."""
+    context = build_context()
+    run_vagrant(context, ["halt"])
+
+
+def destroy(
+    *,
+    force: bool = False,
+) -> None:
+    """Destroy the disposable per-worktree Windows VM."""
+    context = build_context()
+    args = ["destroy"]
+    if force:
+        args.append("--force")
+    run_vagrant(context, args)
+
+
+def upload() -> None:
+    """Copy the host checkout to the VM-local worktree path."""
+    context = build_context()
+    archive_path = create_worktree_upload_zip(context)
+    expand_script = Path(__file__).resolve().parent / "provision" / "expand-uploaded-worktree.ps1"
+
+    run_winrm(
+        context,
+        windows_command_line(
+            [
+                "powershell",
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-Command",
+                "New-Item -ItemType Directory -Force -Path C:\\frb\\upload,C:\\frb\\provision | Out-Null",
+            ]
+        ),
+    )
+    run_vagrant(context, ["upload", str(archive_path), "C:/frb/upload/worktree.zip"])
+    run_vagrant(context, ["upload", str(expand_script), "C:/frb/provision/expand-uploaded-worktree.ps1"])
+    command = windows_command_line(
+        [
+            "powershell",
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            "C:\\frb\\provision\\expand-uploaded-worktree.ps1",
+            "-ZipPath",
+            "C:\\frb\\upload\\worktree.zip",
+            "-Destination",
+            GUEST_WORKTREE_ROOT,
+        ]
+    )
+    run_winrm(context, command)
+
+
+def create_worktree_upload_zip(context: WindowsVmContext) -> Path:
+    """Create a zip archive of the current worktree for Vagrant upload."""
+    archive_path = context.shared_dir / "worktree-upload.zip"
+    archive_path.parent.mkdir(parents=True, exist_ok=True)
+    if archive_path.exists():
+        archive_path.unlink()
+
+    with zipfile.ZipFile(archive_path, mode="w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for path in sorted(context.worktree_root.rglob("*")):
+            relative_path = path.relative_to(context.worktree_root)
+            if should_exclude_upload_path(relative_path):
+                continue
+            if path.is_dir():
+                continue
+            archive.write(path, relative_path.as_posix())
+
+    return archive_path
+
+
+def should_exclude_upload_path(relative_path: Path) -> bool:
+    """Return whether a worktree-relative path should be omitted from VM upload."""
+    return any(part in EXCLUDED_UPLOAD_DIRS for part in relative_path.parts)
+
+
+def exec_command_in_guest(
+    args: list[str],
+) -> None:
+    """Run a command in the Windows guest through Vagrant WinRM."""
+    context = build_context()
+    command = windows_command_line(normalize_guest_command_args(args))
+    if not command:
+        raise CommandError("No guest command provided")
+
+    run_winrm(context, command)
+
+
+def test_flutter_windows(
+    *,
+    package: str = "frb_example/flutter_via_create",
+) -> None:
+    """Run a focused Flutter Windows native test inside the guest."""
+    context = build_context()
+    script = (
+        f"Set-Location {powershell_quote(GUEST_WORKTREE_ROOT)}; "
+        f"./frb_internal test-flutter-native --package {powershell_quote(package)} "
+        "--flutter-test-args '--device-id windows'"
+    )
+    command = windows_command_line(
+        [
+            "powershell",
+            "-NoProfile",
+            "-Command",
+            script,
+        ]
+    )
+    run_winrm(context, command)
+
+
+def assert_equal(*, actual: object, expected: object, label: str) -> None:
+    """Assert equality for dependency-free helper self-tests."""
+    if actual != expected:
+        raise CommandError(
+            f"self-test failed for {label}: expected {expected!r}, got {actual!r}"
+        )
+
+
+def assert_raises_command_error(*, label: str, callback: Callable[[], None]) -> None:
+    """Assert that a self-test callback raises CommandError."""
+    try:
+        callback()
+    except CommandError:
+        return
+
+    raise CommandError(f"self-test failed for {label}: expected CommandError")
+
+
+def self_test() -> None:
+    """Run dependency-free helper checks that do not start VMware or Packer."""
+    assert_equal(
+        actual=mounted_volume_root(Path("/Volumes/ExampleExternal/misc/frb")),
+        expected=Path("/Volumes/ExampleExternal"),
+        label="mounted volume root",
+    )
+    assert_equal(
+        actual=mounted_volume_root(Path("/private/tmp/frb")),
+        expected=None,
+        label="non-volume root",
+    )
+    assert_raises_command_error(
+        label="unmounted volume guard",
+        callback=lambda: ensure_storage_root_mounted(Path("/Volumes/DefinitelyNotMounted/frb-test")),
+    )
+    assert_equal(
+        actual=normalize_guest_command_args(["--", "powershell", "-NoProfile"]),
+        expected=["powershell", "-NoProfile"],
+        label="guest command separator",
+    )
+    assert_equal(
+        actual=normalize_guest_command_args(["powershell", "-NoProfile"]),
+        expected=["powershell", "-NoProfile"],
+        label="guest command without separator",
+    )
+    assert_equal(
+        actual=worktree_digest_for_path(Path("/tmp/example")),
+        expected=hashlib.sha256(b"/tmp/example").hexdigest()[:12],
+        label="worktree digest",
+    )
+
+    with tempfile.TemporaryDirectory(prefix="frb-vmware-helper-self-test-") as temp_dir:
+        payload = Path(temp_dir) / "payload.iso"
+        payload.write_bytes(b"frb-vmware-windows")
+        assert_equal(
+            actual=resolve_iso_checksum(iso_path=payload, only_validate=True, allow_env=False),
+            expected=VALIDATE_ONLY_ISO_CHECKSUM,
+            label="validate-only checksum placeholder",
+        )
+        assert_raises_command_error(
+            label="missing real ISO checksum",
+            callback=lambda: resolve_iso_checksum(
+                iso_path=payload,
+                only_validate=False,
+                allow_env=False,
+            ),
+        )
+        checksum = write_sha256_sidecar(payload)
+        expected_checksum = hashlib.sha256(b"frb-vmware-windows").hexdigest()
+        assert_equal(actual=checksum, expected=expected_checksum, label="sha256 return")
+        assert_equal(
+            actual=resolve_iso_checksum(iso_path=payload, only_validate=False, allow_env=False),
+            expected=f"sha256:{expected_checksum}",
+            label="sha256 sidecar resolution",
+        )
+        old_env_checksum = os.environ.get("FRB_WINDOWS_ISO_CHECKSUM")
+        os.environ["FRB_WINDOWS_ISO_CHECKSUM"] = "sha256:" + ("1" * 64)
+        try:
+            assert_equal(
+                actual=resolve_iso_checksum(iso_path=payload, only_validate=False),
+                expected="sha256:" + ("1" * 64),
+                label="source checksum env override",
+            )
+            assert_equal(
+                actual=resolve_iso_checksum(iso_path=payload, only_validate=False, allow_env=False),
+                expected=f"sha256:{expected_checksum}",
+                label="remastered checksum ignores source env",
+            )
+        finally:
+            if old_env_checksum is None:
+                del os.environ["FRB_WINDOWS_ISO_CHECKSUM"]
+            else:
+                os.environ["FRB_WINDOWS_ISO_CHECKSUM"] = old_env_checksum
+        password_file = Path(temp_dir) / "password.txt"
+        assert_equal(actual=read_password_file(password_file), expected=None, label="missing password file")
+        password_file.write_text("secret-value\n")
+        assert_equal(actual=read_password_file(password_file), expected="secret-value", label="password file")
+        password_file.write_text("\n")
+        assert_raises_command_error(
+            label="empty password file",
+            callback=lambda: read_password_file(password_file),
+        )
+
+        context = build_context(
+            worktree_root=Path(temp_dir) / "worktree",
+            storage_root=Path(temp_dir) / "storage",
+        )
+        context.downloads_iso_dir.mkdir(parents=True)
+        default_iso = context.downloads_iso_dir / "Windows11_Arm64.iso"
+        discovered_iso = context.downloads_iso_dir / "Win11_25H2_English_Arm64_v2.iso"
+        ignored_iso = context.downloads_iso_dir / "Win11_25H2_English_Arm64_v2.frb-autounattend.iso"
+        discovered_iso.write_bytes(b"source")
+        ignored_iso.write_bytes(b"generated")
+        assert_equal(
+            actual=default_iso_path(context, allow_user_config=False),
+            expected=discovered_iso,
+            label="single source ISO discovery",
+        )
+        default_iso.write_bytes(b"default")
+        assert_equal(
+            actual=default_iso_path(context, allow_user_config=False),
+            expected=default_iso,
+            label="default ISO precedence",
+        )
+
+    print("self-test passed")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Manage the FRB VMware Fusion Windows 11 Arm environment.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    info_parser = subparsers.add_parser("info", help="Print resolved paths and host tool status.")
+    info_parser.add_argument("--worktree-root", type=Path, default=None)
+    info_parser.add_argument("--storage-root", type=Path, default=None)
+    info_parser.add_argument("--json", action="store_true", dest="as_json")
+
+    config_parser = subparsers.add_parser("config", help="Print resolved user configuration.")
+    config_parser.add_argument("--json", action="store_true", dest="as_json")
+
+    init_root_parser = subparsers.add_parser("init-root", help="Create the external-disk directory layout.")
+    init_root_parser.add_argument("--min-free-gb", type=int, default=DEFAULT_MIN_FREE_GB)
+
+    subparsers.add_parser("check-host", help="Check host VMware/Vagrant/Packer tools.")
+    subparsers.add_parser("print-env", help="Print shell exports for this environment.")
+    subparsers.add_parser("packer-init", help="Run packer init for the template.")
+
+    prepare_iso_parser = subparsers.add_parser("prepare-iso", help="Create a UEFI autounattend ISO.")
+    prepare_iso_parser.add_argument("--iso", type=Path, default=None)
+    prepare_iso_parser.add_argument("--force", action="store_true")
+
+    packer_build_parser = subparsers.add_parser("packer-build", help="Build or validate the Packer base box.")
+    packer_build_parser.add_argument("--iso", type=Path, default=None)
+    packer_build_parser.add_argument("--validate", action="store_true", dest="only_validate")
+    packer_build_parser.add_argument("--gui", action="store_true")
+    packer_build_parser.add_argument(
+        "--on-error",
+        choices=["abort", "cleanup", "ask", "run-cleanup-provisioner"],
+        default=None,
+    )
+    remaster_group = packer_build_parser.add_mutually_exclusive_group()
+    remaster_group.add_argument("--remaster-iso", action="store_true", dest="remaster_iso", default=True)
+    remaster_group.add_argument("--no-remaster-iso", action="store_false", dest="remaster_iso")
+
+    vagrant_box_add_parser = subparsers.add_parser("vagrant-box-add", help="Import the Packer-built Vagrant box.")
+    vagrant_box_add_parser.add_argument("--box-file", type=Path, required=True)
+    vagrant_box_add_parser.add_argument("--force", action="store_true")
+
+    subparsers.add_parser("start", help="Start the per-worktree Windows VM.")
+    subparsers.add_parser("stop", help="Stop the per-worktree Windows VM.")
+
+    destroy_parser = subparsers.add_parser("destroy", help="Destroy the per-worktree Windows VM.")
+    destroy_parser.add_argument("--force", action="store_true")
+
+    subparsers.add_parser("upload", help="Copy the host checkout to the VM-local worktree path.")
+
+    exec_parser = subparsers.add_parser("exec", help="Run a command in the Windows guest.")
+    exec_parser.add_argument("args", nargs=argparse.REMAINDER)
+
+    test_parser = subparsers.add_parser("test-flutter-windows", help="Run a focused Flutter Windows native test.")
+    test_parser.add_argument("--package", default="frb_example/flutter_via_create")
+
+    subparsers.add_parser("self-test", help="Run dependency-free helper self-tests.")
+
+    return parser
+
+
+def dispatch(args: argparse.Namespace) -> None:
+    if args.command == "info":
+        info(worktree_root=args.worktree_root, storage_root=args.storage_root, as_json=args.as_json)
+    elif args.command == "config":
+        config_status(as_json=args.as_json)
+    elif args.command == "init-root":
+        init_root(min_free_gb=args.min_free_gb)
+    elif args.command == "check-host":
+        check_host()
+    elif args.command == "print-env":
+        print_env()
+    elif args.command == "packer-init":
+        packer_init()
+    elif args.command == "prepare-iso":
+        prepare_iso(iso=args.iso, force=args.force)
+    elif args.command == "packer-build":
+        packer_build(
+            iso=args.iso,
+            only_validate=args.only_validate,
+            gui=args.gui,
+            on_error=args.on_error,
+            remaster_iso=args.remaster_iso,
+        )
+    elif args.command == "vagrant-box-add":
+        vagrant_box_add(box_file=args.box_file, force=args.force)
+    elif args.command == "start":
+        start()
+    elif args.command == "stop":
+        stop()
+    elif args.command == "destroy":
+        destroy(force=args.force)
+    elif args.command == "upload":
+        upload()
+    elif args.command == "exec":
+        exec_command_in_guest(args.args)
+    elif args.command == "test-flutter-windows":
+        test_flutter_windows(package=args.package)
+    elif args.command == "self-test":
+        self_test()
+    else:
+        raise CommandError(f"Unknown command: {args.command}")
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        dispatch(args)
+    except (CommandError, OSError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        raise SystemExit(1) from error
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/vmware_windows/packer/windows11-arm64.pkr.hcl
+++ b/tools/vmware_windows/packer/windows11-arm64.pkr.hcl
@@ -1,0 +1,138 @@
+packer {
+  required_plugins {
+    vmware = {
+      source  = "github.com/hashicorp/vmware"
+      version = ">= 1.1.0"
+    }
+    vagrant = {
+      source  = "github.com/hashicorp/vagrant"
+      version = ">= 1.1.5"
+    }
+  }
+}
+
+variable "iso_path" {
+  type        = string
+  description = "Local Windows 11 Arm ISO path."
+}
+
+variable "iso_checksum" {
+  type        = string
+  description = "Windows 11 Arm ISO checksum, for example sha256:<digest>."
+}
+
+variable "autounattend_path" {
+  type        = string
+  description = "Generated autounattend.xml path outside the repository."
+}
+
+variable "output_directory" {
+  type        = string
+  description = "Packer output directory outside the repository."
+}
+
+variable "vm_name" {
+  type        = string
+  description = "Base VM name created by Packer before Vagrant box packaging."
+  default     = "frb-windows11-arm64-base"
+}
+
+variable "box_output_path" {
+  type        = string
+  description = "Final Vagrant box path outside the transient VMware output directory."
+}
+
+variable "guest_username" {
+  type        = string
+  description = "Windows local administrator user created by autounattend."
+  default     = "frb"
+}
+
+variable "guest_password" {
+  type        = string
+  description = "Windows local administrator password. Prefer PKR_VAR_guest_password from a secret source."
+  sensitive   = true
+}
+
+variable "guest_proxy_url" {
+  type        = string
+  description = "Optional proxy URL reachable from inside the Windows guest."
+  default     = ""
+}
+
+variable "winrm_host" {
+  type        = string
+  description = "Guest WinRM host for Packer. Defaults to the first VMware Fusion NAT lease."
+}
+
+variable "headless" {
+  type        = bool
+  description = "Run the VMware builder without showing the VM console."
+  default     = true
+}
+
+source "vmware-iso" "windows11_arm64" {
+  vm_name          = var.vm_name
+  iso_url          = var.iso_path
+  iso_checksum     = var.iso_checksum
+  output_directory = var.output_directory
+
+  guest_os_type     = "arm-windows11-64"
+  headless          = var.headless
+  cpus              = 6
+  memory            = 16384
+  disk_size         = 180000
+  disk_adapter_type = "nvme"
+  disk_type_id      = "0"
+
+  network_adapter_type = "vmxnet3"
+
+  boot_wait = "10s"
+  boot_command = [
+    "<down><down><enter>",
+    "<wait1><spacebar>",
+  ]
+
+  vmx_data = {
+    "scsi0.virtualDev" = "pvscsi"
+  }
+
+  communicator   = "winrm"
+  winrm_username = var.guest_username
+  winrm_password = var.guest_password
+  winrm_host     = var.winrm_host
+  winrm_timeout  = "2h"
+
+  floppy_files = [
+    var.autounattend_path,
+  ]
+
+  cd_files = [
+    var.autounattend_path,
+  ]
+  cd_label = "AUTOUNATTEND"
+
+  shutdown_command = "powershell -NoProfile -Command \"Stop-Computer -Force\""
+}
+
+build {
+  name    = "frb-windows11-arm64"
+  sources = ["source.vmware-iso.windows11_arm64"]
+
+  provisioner "powershell" {
+    elevated_user     = var.guest_username
+    elevated_password = var.guest_password
+
+    environment_vars = [
+      "FRB_WINDOWS_GUEST_PROXY_URL=${var.guest_proxy_url}",
+    ]
+    scripts = [
+      "../provision/prepare-guest-control.ps1",
+      "../provision/install-frb-toolchain.ps1",
+    ]
+  }
+
+  post-processor "vagrant" {
+    output = var.box_output_path
+  }
+}

--- a/tools/vmware_windows/provision/expand-uploaded-worktree.ps1
+++ b/tools/vmware_windows/provision/expand-uploaded-worktree.ps1
@@ -1,0 +1,31 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $ZipPath,
+
+    [Parameter(Mandatory = $true)]
+    [string] $Destination
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+Write-Information "[frb-windows-upload] Expanding uploaded worktree" -InformationAction Continue
+
+if (-not (Test-Path -LiteralPath $ZipPath)) {
+    throw "Upload archive does not exist: $ZipPath"
+}
+
+$parent = Split-Path -Parent $Destination
+if (-not (Test-Path -LiteralPath $parent)) {
+    New-Item -ItemType Directory -Path $parent -Force | Out-Null
+}
+
+if (Test-Path -LiteralPath $Destination) {
+    Remove-Item -LiteralPath $Destination -Recurse -Force
+}
+
+New-Item -ItemType Directory -Path $Destination -Force | Out-Null
+Expand-Archive -LiteralPath $ZipPath -DestinationPath $Destination -Force
+Remove-Item -LiteralPath $ZipPath -Force
+
+Write-Information "[frb-windows-upload] Worktree ready at $Destination" -InformationAction Continue

--- a/tools/vmware_windows/provision/install-frb-toolchain.ps1
+++ b/tools/vmware_windows/provision/install-frb-toolchain.ps1
@@ -1,0 +1,110 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+Write-Information -MessageData "[frb-windows-toolchain] Installing FRB Windows toolchain" -InformationAction Continue
+
+if ($env:FRB_WINDOWS_GUEST_PROXY_URL) {
+    $proxyMessage = "[frb-windows-toolchain] Configuring guest proxy from FRB_WINDOWS_GUEST_PROXY_URL"
+    Write-Information -MessageData $proxyMessage -InformationAction Continue
+    netsh winhttp set proxy $env:FRB_WINDOWS_GUEST_PROXY_URL
+    [Environment]::SetEnvironmentVariable("HTTP_PROXY", $env:FRB_WINDOWS_GUEST_PROXY_URL, "Machine")
+    [Environment]::SetEnvironmentVariable("HTTPS_PROXY", $env:FRB_WINDOWS_GUEST_PROXY_URL, "Machine")
+    $env:HTTP_PROXY = $env:FRB_WINDOWS_GUEST_PROXY_URL
+    $env:HTTPS_PROXY = $env:FRB_WINDOWS_GUEST_PROXY_URL
+}
+
+if (-not (Get-Command -Name winget -ErrorAction SilentlyContinue)) {
+    throw "winget is required in the Windows base image."
+}
+
+winget source update
+winget install --accept-package-agreements --accept-source-agreements --silent Microsoft.PowerShell
+winget install --accept-package-agreements --accept-source-agreements --silent Git.Git
+winget install --accept-package-agreements --accept-source-agreements --silent Kitware.CMake
+winget install --accept-package-agreements --accept-source-agreements --silent Ninja-build.Ninja
+winget install --accept-package-agreements --accept-source-agreements --silent Rustlang.Rustup
+$vsBuildToolsArgs = @(
+    "install",
+    "--accept-package-agreements",
+    "--accept-source-agreements",
+    "--silent",
+    "Microsoft.VisualStudio.2022.BuildTools",
+    "--override",
+    "--wait --quiet --norestart --includeRecommended " +
+        "--add Microsoft.VisualStudio.Workload.NativeDesktop " +
+        "--add Microsoft.VisualStudio.Workload.VCTools " +
+        "--add Microsoft.VisualStudio.Component.VC.Tools.ARM64 " +
+        "--add Microsoft.VisualStudio.Component.VC.CMake.Project"
+)
+winget @vsBuildToolsArgs
+
+$flutterRoot = "C:\flutter"
+if (-not (Test-Path -Path "$flutterRoot\bin\flutter.bat")) {
+    $flutterVersion = "3.44.1"
+    $flutterZip = "C:\frb\downloads\flutter_windows.zip"
+    New-Item -ItemType Directory -Force -Path "C:\frb\downloads" | Out-Null
+    $flutterUrl = "https://storage.googleapis.com/flutter_infra_release/" +
+        "releases/stable/windows/flutter_windows_${flutterVersion}-stable.zip"
+    $webRequestArgs = @{
+        Uri = $flutterUrl
+        OutFile = $flutterZip
+    }
+    if ($env:FRB_WINDOWS_GUEST_PROXY_URL) {
+        $webRequestArgs.Proxy = $env:FRB_WINDOWS_GUEST_PROXY_URL
+    }
+    try {
+        Invoke-WebRequest @webRequestArgs
+        Expand-Archive -Path $flutterZip -DestinationPath C:\ -Force
+    } catch {
+        Write-Information -MessageData "[frb-windows-toolchain] Flutter zip download failed; falling back to git clone" -InformationAction Continue
+        Remove-Item -Path $flutterZip -Force -ErrorAction SilentlyContinue
+        git clone --branch $flutterVersion --depth 1 https://github.com/flutter/flutter.git $flutterRoot
+    }
+}
+
+$machinePath = [Environment]::GetEnvironmentVariable("Path", "Machine")
+$machineExtraPaths = @(
+    "C:\flutter\bin",
+    "C:\Program Files\Git\cmd",
+    "C:\Program Files\CMake\bin"
+)
+foreach ($path in $machineExtraPaths) {
+    if ($machinePath -notlike "*$path*") {
+        $machinePath = "$machinePath;$path"
+    }
+}
+[Environment]::SetEnvironmentVariable("Path", $machinePath, "Machine")
+
+$userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+$userExtraPaths = @(
+    "$env:USERPROFILE\.cargo\bin"
+)
+foreach ($path in $userExtraPaths) {
+    if ($userPath -notlike "*$path*") {
+        $userPath = "$userPath;$path"
+    }
+}
+[Environment]::SetEnvironmentVariable("Path", $userPath, "User")
+$env:Path = "$machinePath;$userPath;$env:Path"
+
+rustup toolchain install stable
+rustup default stable
+flutter config --enable-windows-desktop --no-analytics
+flutter precache --windows
+
+foreach ($commandName in @("git", "rustc", "cargo", "cmake", "ninja", "flutter")) {
+    if (-not (Get-Command -Name $commandName -ErrorAction SilentlyContinue)) {
+        throw "Required command not found after provisioning: $commandName"
+    }
+}
+
+git --version
+rustc --version
+cargo --version
+cmake --version
+ninja --version
+flutter --version
+flutter doctor -v
+
+Write-Information -MessageData "[frb-windows-toolchain] FRB Windows toolchain ready" -InformationAction Continue

--- a/tools/vmware_windows/provision/prepare-guest-control.ps1
+++ b/tools/vmware_windows/provision/prepare-guest-control.ps1
@@ -1,0 +1,28 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+Write-Information -MessageData "[frb-windows-guest] Preparing guest command access" -InformationAction Continue
+
+Get-NetConnectionProfile |
+    Where-Object -FilterScript { $_.NetworkCategory -eq "Public" } |
+    Set-NetConnectionProfile -NetworkCategory Private
+
+Set-Item -Path WSMan:\localhost\Service\Auth\Basic -Value $true
+Set-Item -Path WSMan:\localhost\Service\AllowUnencrypted -Value $true
+Enable-PSRemoting -Force -SkipNetworkProfileCheck
+
+if (-not (
+    Get-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0 |
+        Where-Object -FilterScript { $_.State -eq "Installed" }
+)) {
+    Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+}
+
+Set-Service -Name sshd -StartupType Automatic
+Start-Service -Name sshd
+
+New-Item -ItemType Directory -Force -Path C:\frb | Out-Null
+New-Item -ItemType Directory -Force -Path C:\frb\logs | Out-Null
+New-Item -ItemType Directory -Force -Path C:\frb\worktree | Out-Null
+
+Write-Information -MessageData "[frb-windows-guest] Guest command access ready" -InformationAction Continue

--- a/tools/vmware_windows/run_packer_build.zsh
+++ b/tools/vmware_windows/run_packer_build.zsh
@@ -1,0 +1,349 @@
+#!/usr/bin/env zsh
+set -euo pipefail
+
+SCRIPT_DIR="${0:A:h}"
+REPO_ROOT="${SCRIPT_DIR:h:h}"
+HELPER="${SCRIPT_DIR}/frb_vmware_windows_env.py"
+
+json_field() {
+  local key="$1"
+  /usr/bin/python3 -c 'import json, sys; value = json.load(sys.stdin).get(sys.argv[1]); print("" if value is None else value)' "${key}" <<< "${CONFIG_JSON}"
+}
+
+STORAGE_ROOT="${FRB_WINDOWS_VM_ROOT:-}"
+ISO_PATH="${FRB_WINDOWS_ISO:-}"
+ISO_PATH_WAS_DEFAULT=1
+if [[ -n "${FRB_WINDOWS_ISO:-}" ]]; then
+  ISO_PATH_WAS_DEFAULT=0
+fi
+HOST_PROXY_URL="${FRB_WINDOWS_HOST_PROXY_URL:-}"
+PACKER_WINRM_HOST="${FRB_WINDOWS_PACKER_WINRM_HOST:-}"
+MIN_FREE_GB="${FRB_WINDOWS_MIN_FREE_GB:-100}"
+MONITOR_INTERVAL_SECONDS="${FRB_WINDOWS_DISK_MONITOR_INTERVAL_SECONDS:-300}"
+
+GUI_FLAG="--gui"
+ON_ERROR="abort"
+FORCE_PREPARE_ISO=1
+ADD_BOX=0
+FORCE_BOX=0
+PREPARE_ONLY=0
+PREFLIGHT_ONLY=0
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  tools/vmware_windows/run_packer_build.zsh [options]
+
+Options:
+  --iso PATH             Windows 11 Arm ISO path.
+  --headless             Run Packer without showing the VMware console.
+  --on-error VALUE       Packer on-error behavior: abort, cleanup, ask, or run-cleanup-provisioner.
+  --no-force-prepare-iso Reuse an existing remastered ISO instead of regenerating it.
+  --preflight-only       Run preflight checks and disk-space checks, then exit.
+  --prepare-only         Stop after creating the remastered autounattend ISO.
+  --add-box              Import the produced Vagrant box after a successful Packer build.
+  --force-box            Replace an existing local Vagrant box when used with --add-box.
+  -h, --help             Show this help.
+
+Environment:
+  FRB_WINDOWS_CONFIG overrides the user config path
+  FRB_WINDOWS_VM_ROOT overrides vm_root from the user config
+  FRB_WINDOWS_ISO overrides iso_path from the user config
+  FRB_WINDOWS_HOST_PROXY_URL overrides host_proxy_url from the user config
+  FRB_WINDOWS_MIN_FREE_GB defaults to 100
+USAGE
+}
+
+require_value() {
+  local option="$1"
+  local value="${2:-}"
+  if [[ -z "${value}" || "${value}" == --* ]]; then
+    echo "ERROR: ${option} requires a value." >&2
+    usage >&2
+    exit 2
+  fi
+}
+
+while (($# > 0)); do
+  case "$1" in
+    --iso)
+      require_value "$1" "${2:-}"
+      ISO_PATH="$2"
+      ISO_PATH_WAS_DEFAULT=0
+      shift 2
+      ;;
+    --headless)
+      GUI_FLAG=""
+      shift
+      ;;
+    --on-error)
+      require_value "$1" "${2:-}"
+      ON_ERROR="$2"
+      shift 2
+      ;;
+    --no-force-prepare-iso)
+      FORCE_PREPARE_ISO=0
+      shift
+      ;;
+    --prepare-only)
+      PREPARE_ONLY=1
+      shift
+      ;;
+    --preflight-only)
+      PREFLIGHT_ONLY=1
+      shift
+      ;;
+    --add-box)
+      ADD_BOX=1
+      shift
+      ;;
+    --force-box)
+      FORCE_BOX=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "${ON_ERROR}" in
+  abort|cleanup|ask|run-cleanup-provisioner)
+    ;;
+  *)
+    echo "ERROR: unsupported --on-error value: ${ON_ERROR}" >&2
+    usage >&2
+    exit 2
+    ;;
+esac
+
+CONFIG_JSON="$("${HELPER}" config --json)"
+CONFIG_STORAGE_ROOT="$(json_field storage_root)"
+CONFIG_ISO_PATH="$(json_field iso_path)"
+CONFIG_HOST_PROXY_URL="$(json_field host_proxy_url)"
+CONFIG_PACKER_WINRM_HOST="$(json_field packer_winrm_host)"
+
+STORAGE_ROOT="${STORAGE_ROOT:-${CONFIG_STORAGE_ROOT}}"
+ISO_PATH="${ISO_PATH:-${CONFIG_ISO_PATH:-${STORAGE_ROOT}/downloads/iso/Windows11_Arm64.iso}}"
+HOST_PROXY_URL="${HOST_PROXY_URL:-${CONFIG_HOST_PROXY_URL}}"
+PACKER_WINRM_HOST="${PACKER_WINRM_HOST:-${CONFIG_PACKER_WINRM_HOST:-172.16.0.128}}"
+
+LOG_DIR="${STORAGE_ROOT}/logs"
+STOP_MARKER="${LOG_DIR}/STOP_LOW_DISK"
+PID_FILE="${LOG_DIR}/packer-build-child.pid"
+TIMESTAMP="$(/bin/date '+%Y%m%d-%H%M%S')"
+LOG_PATH="${LOG_DIR}/packer-build-${TIMESTAMP}.log"
+
+discover_iso_path() {
+  if [[ -f "${ISO_PATH}" || "${ISO_PATH_WAS_DEFAULT}" != 1 ]]; then
+    return
+  fi
+
+  local iso_dir="${STORAGE_ROOT}/downloads/iso"
+  local candidates=()
+  local candidate
+  for candidate in "${iso_dir}"/*.iso(N); do
+    if [[ "${candidate:l}" == *autounattend* ]]; then
+      continue
+    fi
+    candidates+=("${candidate}")
+  done
+
+  if (( ${#candidates[@]} == 1 )); then
+    ISO_PATH="${candidates[1]}"
+    return
+  fi
+
+  if (( ${#candidates[@]} > 1 )); then
+    echo "ERROR: multiple Windows ISO candidates found under ${iso_dir}; pass --iso explicitly." >&2
+    printf '  %s\n' "${candidates[@]}" >&2
+    exit 2
+  fi
+}
+
+if [[ "${STORAGE_ROOT}" == /Volumes/* ]]; then
+  VOLUME_NAME="${${STORAGE_ROOT#/Volumes/}%%/*}"
+  VOLUME_ROOT="/Volumes/${VOLUME_NAME}"
+  if ! /sbin/mount | /usr/bin/grep -F " on ${VOLUME_ROOT} " >/dev/null; then
+    echo "ERROR: ${VOLUME_ROOT} is not mounted; refusing to create VM files on the internal disk." >&2
+    exit 1
+  fi
+fi
+
+discover_iso_path
+
+mkdir -p "${LOG_DIR}"
+rm -f "${STOP_MARKER}" "${PID_FILE}"
+exec > >(tee -a "${LOG_PATH}") 2>&1
+
+export FRB_WINDOWS_VM_ROOT="${STORAGE_ROOT}"
+export FRB_WINDOWS_ISO="${ISO_PATH}"
+export NO_PROXY="localhost,127.0.0.1,::1,${PACKER_WINRM_HOST}"
+export no_proxy="localhost,127.0.0.1,::1,${PACKER_WINRM_HOST}"
+if [[ -n "${HOST_PROXY_URL}" ]]; then
+  export FRB_WINDOWS_HOST_PROXY_URL="${HOST_PROXY_URL}"
+  export HTTP_PROXY="${HOST_PROXY_URL}"
+  export HTTPS_PROXY="${HOST_PROXY_URL}"
+  export ALL_PROXY="${HOST_PROXY_URL}"
+  export http_proxy="${HOST_PROXY_URL}"
+  export https_proxy="${HOST_PROXY_URL}"
+  export all_proxy="${HOST_PROXY_URL}"
+fi
+
+require_executable() {
+  local name="$1"
+  if ! command -v "${name}" >/dev/null 2>&1; then
+    echo "ERROR: required executable not found on PATH: ${name}" >&2
+    return 1
+  fi
+}
+
+preflight() {
+  echo
+  echo "Preflight checks"
+
+  if [[ ! -f "${ISO_PATH}" ]]; then
+    echo "ERROR: Windows ISO does not exist: ${ISO_PATH}" >&2
+    return 1
+  fi
+
+  require_executable hdiutil
+  require_executable xorriso
+  require_executable packer
+  require_executable vagrant
+
+  if [[ ! -x "/Applications/VMware Fusion.app/Contents/Library/vmrun" ]] && ! command -v vmrun >/dev/null 2>&1; then
+    echo "ERROR: VMware vmrun not found. Expected /Applications/VMware Fusion.app/Contents/Library/vmrun" >&2
+    return 1
+  fi
+
+  local output_dir="${STORAGE_ROOT}/packer/output"
+  if [[ -d "${output_dir}" ]] && [[ -n "$(/bin/ls -A "${output_dir}")" ]]; then
+    echo "ERROR: Packer output directory is not empty: ${output_dir}" >&2
+    echo "Move or archive it before rebuilding the base box." >&2
+    return 1
+  fi
+
+  echo "Preflight checks passed"
+}
+
+free_gb() {
+  /bin/df -g "$1" | /usr/bin/awk 'NR == 2 { print $4 }'
+}
+
+check_free_space_once() {
+  local path="$1"
+  local free
+  free="$(free_gb "${path}")"
+  echo "DISK: ${path} has ${free}GB free; minimum is ${MIN_FREE_GB}GB"
+  if (( free < MIN_FREE_GB )); then
+    echo "ERROR: ${path} has only ${free}GB free, below ${MIN_FREE_GB}GB" >&2
+    return 1
+  fi
+}
+
+disk_monitor() {
+  while true; do
+    if ! check_free_space_once "/" || ! check_free_space_once "${STORAGE_ROOT}"; then
+      /usr/bin/touch "${STOP_MARKER}"
+      if [[ -s "${PID_FILE}" ]]; then
+        local child_pid
+        child_pid="$(< "${PID_FILE}")"
+        echo "ERROR: stopping child process ${child_pid} because disk space is below threshold" >&2
+        /bin/kill -TERM "${child_pid}" 2>/dev/null || true
+      fi
+      exit 99
+    fi
+    /bin/sleep "${MONITOR_INTERVAL_SECONDS}"
+  done
+}
+
+run_step() {
+  echo
+  echo "EXEC: $*"
+  "$@" &
+  local child_pid=$!
+  echo "${child_pid}" > "${PID_FILE}"
+  set +e
+  wait "${child_pid}"
+  local exit_code=$?
+  set -e
+  : > "${PID_FILE}"
+  if [[ -e "${STOP_MARKER}" ]]; then
+    echo "ERROR: stopped because ${STOP_MARKER} exists" >&2
+    exit 99
+  fi
+  return "${exit_code}"
+}
+
+cleanup() {
+  if [[ -n "${MONITOR_PID:-}" ]]; then
+    /bin/kill "${MONITOR_PID}" 2>/dev/null || true
+  fi
+  rm -f "${PID_FILE}"
+}
+trap cleanup EXIT INT TERM
+
+echo "Repo: ${REPO_ROOT}"
+echo "Storage root: ${STORAGE_ROOT}"
+echo "ISO: ${ISO_PATH}"
+if [[ -n "${HOST_PROXY_URL}" ]]; then
+  echo "Proxy: ${HOST_PROXY_URL}"
+else
+  echo "Proxy: <none>"
+fi
+echo "Log: ${LOG_PATH}"
+
+preflight
+check_free_space_once "/"
+check_free_space_once "${STORAGE_ROOT}"
+
+if (( PREFLIGHT_ONLY )); then
+  echo
+  echo "Preflight-only checks passed. Full log: ${LOG_PATH}"
+  exit 0
+fi
+
+disk_monitor &
+MONITOR_PID=$!
+
+cd "${REPO_ROOT}"
+
+run_step "${HELPER}" init-root
+run_step "${HELPER}" check-host
+run_step "${HELPER}" packer-init
+
+prepare_iso_args=("${HELPER}" prepare-iso --iso "${ISO_PATH}")
+if (( FORCE_PREPARE_ISO )); then
+  prepare_iso_args+=(--force)
+fi
+run_step "${prepare_iso_args[@]}"
+
+if (( PREPARE_ONLY )); then
+  echo
+  echo "Done after prepare-iso because --prepare-only was set. Full log: ${LOG_PATH}"
+  exit 0
+fi
+
+packer_args=("${HELPER}" packer-build --iso "${ISO_PATH}" --on-error "${ON_ERROR}")
+if [[ -n "${GUI_FLAG}" ]]; then
+  packer_args+=("${GUI_FLAG}")
+fi
+run_step "${packer_args[@]}"
+
+if (( ADD_BOX )); then
+  box_args=("${HELPER}" vagrant-box-add --box-file "${STORAGE_ROOT}/packer/boxes/frb-windows11-arm64.box")
+  if (( FORCE_BOX )); then
+    box_args+=(--force)
+  fi
+  run_step "${box_args[@]}"
+fi
+
+echo
+echo "Done. Full log: ${LOG_PATH}"

--- a/tools/vmware_windows/validate_offline.zsh
+++ b/tools/vmware_windows/validate_offline.zsh
@@ -1,0 +1,36 @@
+#!/usr/bin/env zsh
+set -euo pipefail
+
+SCRIPT_DIR="${0:A:h}"
+REPO_ROOT="${SCRIPT_DIR:h:h}"
+
+run() {
+  echo
+  echo "EXEC: $*"
+  "$@"
+}
+
+run_if_available() {
+  local tool="$1"
+  shift
+  if command -v "${tool}" >/dev/null 2>&1; then
+    run "$@"
+    return
+  fi
+
+  echo
+  echo "SKIP: ${tool} is not available on PATH"
+}
+
+cd "${REPO_ROOT}"
+
+run python3 -m py_compile tools/vmware_windows/frb_vmware_windows_env.py
+run tools/vmware_windows/frb_vmware_windows_env.py self-test
+run zsh -f -n tools/vmware_windows/run_packer_build.zsh
+run_if_available ruby ruby -c tools/vmware_windows/Vagrantfile
+run_if_available packer packer fmt -check tools/vmware_windows/packer
+run_if_available node node --check website/sidebars.js
+run git diff --check
+
+echo
+echo "VMware Windows offline validation passed"


### PR DESCRIPTION
## Summary

- add VMware Fusion + Vagrant + Packer support for local Windows 11 Arm validation
- put daily Windows VMware usage alongside Docker/Android/Tart in `.claude/skills/frb-dev-env/SKILL.md`
- keep `.claude/skills/frb-vmware-windows-prepare/SKILL.md` as a thin pointer to `tools/vmware_windows/README.md`
- add `tools/vmware_windows` helper, wrapper, Vagrantfile, Packer template, and PowerShell provision scripts
- document the workflow in `tools/vmware_windows/README.md` and add a manual test report
- resolve storage root, ISO path, optional host proxy, checksum, and GUI preference from per-user config or environment variables instead of repo defaults
- use a standard-library Python helper with no `uv`, `pip`, or first-run Python package dependency
- protect `/Volumes/<name>/...` storage roots from accidentally writing to the internal disk when the external volume is not mounted
- remaster the Windows 11 Arm ISO with a root `Autounattend.xml` for the VMware Fusion unattended install path
- auto-discover a single non-`autounattend` source ISO when the conventional `Windows11_Arm64.iso` filename is absent
- require a source Windows ISO checksum for real Packer builds, while using the remastered ISO's generated checksum for the Packer input ISO
- provide `tools/vmware_windows/run_packer_build.zsh` for ordinary-Terminal base-box builds with preflight checks, optional proxy support, full log capture, optional Vagrant box import, and a 100GB disk-space guard
- add `tools/vmware_windows/validate_offline.zsh` as the no-VM regression check for this workflow
- default daily Vagrant use to VMware Fusion GUI mode because Fusion 26 on Apple Silicon powers off this Windows Arm guest shortly after boot in `nogui` mode
- upload the FRB worktree through a zip + `vagrant upload` flow instead of VMware shared folders, avoiding the current Vagrant VMware synced-folder plugin incompatibility
- provision the Windows runtime with Flutter 3.44.1 / Dart 3.12.1, Rust MSVC target support, Visual Studio BuildTools ARM64/CMake components, CMake, Ninja, Git, OpenSSH, and WinRM
- exclude `tools/vmware_windows/**` from Codacy because it is local VM bootstrap infrastructure containing expected WinRM and unattended-install plumbing

## Validation

- `tools/vmware_windows/validate_offline.zsh`
- `git diff --check`
- full Packer build and Vagrant box import completed successfully using local per-user config
- daily VM workflow completed successfully:
  - `tools/vmware_windows/frb_vmware_windows_env.py start`
  - `tools/vmware_windows/frb_vmware_windows_env.py upload`
  - `tools/vmware_windows/frb_vmware_windows_env.py exec -- powershell -NoProfile -Command "cd C:\\frb\\worktree; flutter --version"`
- Windows native Flutter validation completed successfully:
  - `tools/vmware_windows/frb_vmware_windows_env.py test-flutter-windows --package frb_example/flutter_via_create`
  - result: Windows ARM64 CMake build completed, Rust built for `aarch64-pc-windows-msvc`, and the Flutter integration test passed with `00:00 +1: All tests passed!`
- previous targeted checks also covered helper help, `check-host`, invalid `--on-error`, unmounted `/Volumes` guard, missing ISO preflight, `packer fmt -check tools/vmware_windows/packer`, `ruby -c tools/vmware_windows/Vagrantfile`, `node --check website/sidebars.js`, and `git diff --check`
- Codacy Static Code Analysis passed on an earlier head after excluding this local VM bootstrap directory

## Caveats

- The final green daily-use VM was manually upgraded while debugging to validate Flutter 3.44.1 / Dart 3.12.1 and the VS BuildTools ARM64/CMake components. The Packer provisioning source now installs those versions/components, but I have not yet rerun a fresh full Packer build after that final source update.
- VMware Fusion 26 on Apple Silicon currently appears unstable for this Windows Arm guest in `nogui` mode. The Vagrantfile defaults to GUI mode; `FRB_WINDOWS_VM_GUI=false` is kept as an opt-in revalidation path.
