### PR TITLE
Add Linux Flutter Docker manual coverage

### DIFF
--- a/tools/frb_internal/lib/src/makefile_dart/build.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/build.dart
@@ -60,7 +60,11 @@ Future<void> buildFlutter(BuildFlutterConfig config) async {
       // https://docs.flutter.dev/deployment/linux
       // https://stackoverflow.com/questions/73278689/how-to-run-a-standalone-linux-app-built-with-flutter
       await exec('flutter build linux --verbose', relativePwd: package);
-      copyArtifacts(['build/linux/x64/release/bundle']);
+      copyArtifacts([
+        linuxBuildBundlePathForTesting(
+          machineArchitecture: currentMachineArchitectureForTesting(),
+        ),
+      ]);
 
     case BuildTarget.androidAab:
       // https://docs.flutter.dev/deployment/android
@@ -88,3 +92,25 @@ Future<void> buildFlutter(BuildFlutterConfig config) async {
       copyArtifacts(['build/ohos/hap']);
   }
 }
+
+String linuxBuildBundlePathForTesting({required String machineArchitecture}) =>
+    'build/linux/${_linuxFlutterArchitecture(machineArchitecture)}/release/bundle';
+
+String currentMachineArchitectureForTesting() {
+  final result = Process.runSync('uname', ['-m']);
+  if (result.exitCode != 0) {
+    throw StateError('Failed to detect machine architecture: ${result.stderr}');
+  }
+
+  return (result.stdout as String).trim();
+}
+
+String _linuxFlutterArchitecture(String machineArchitecture) =>
+    switch (machineArchitecture) {
+      'x86_64' || 'amd64' => 'x64',
+      'aarch64' || 'arm64' => 'arm64',
+      'riscv64' => 'riscv64',
+      _ => throw UnsupportedError(
+        'Unsupported Linux machine architecture: $machineArchitecture',
+      ),
+    };

--- a/tools/frb_internal/lib/src/makefile_dart/build.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/build.dart
@@ -97,12 +97,20 @@ String linuxBuildBundlePathForTesting({required String machineArchitecture}) =>
     'build/linux/${_linuxFlutterArchitecture(machineArchitecture)}/release/bundle';
 
 String currentMachineArchitectureForTesting() {
-  final result = Process.runSync('uname', ['-m']);
-  if (result.exitCode != 0) {
-    throw StateError('Failed to detect machine architecture: ${result.stderr}');
-  }
+  try {
+    final result = Process.runSync('uname', ['-m']);
+    if (result.exitCode != 0) {
+      throw StateError(
+        'Failed to detect machine architecture: ${result.stderr}',
+      );
+    }
 
-  return (result.stdout as String).trim();
+    return (result.stdout as String).trim();
+  } on ProcessException catch (error) {
+    throw StateError(
+      'Failed to run "uname" to detect machine architecture: ${error.message}',
+    );
+  }
 }
 
 String _linuxFlutterArchitecture(String machineArchitecture) =>

--- a/tools/frb_internal/test/makefile_dart_test.dart
+++ b/tools/frb_internal/test/makefile_dart_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter_rust_bridge_internal/src/frb_example_pure_dart_generator/generator.dart';
+import 'package:flutter_rust_bridge_internal/src/makefile_dart/build.dart';
 import 'package:flutter_rust_bridge_internal/src/makefile_dart/generate.dart';
 import 'package:flutter_rust_bridge_internal/src/makefile_dart/lint.dart';
 import 'package:flutter_rust_bridge_internal/src/makefile_dart/test.dart';
@@ -25,6 +26,29 @@ void main() {
     expect(
       dartValgrindOutputExecutablePathForTesting(),
       'build/valgrind_test_output/bundle/bin/dart_valgrind_test_entrypoint',
+    );
+  });
+
+  test('linux build bundle path follows the current machine architecture', () {
+    expect(
+      linuxBuildBundlePathForTesting(machineArchitecture: 'x86_64'),
+      'build/linux/x64/release/bundle',
+    );
+    expect(
+      linuxBuildBundlePathForTesting(machineArchitecture: 'amd64'),
+      'build/linux/x64/release/bundle',
+    );
+    expect(
+      linuxBuildBundlePathForTesting(machineArchitecture: 'aarch64'),
+      'build/linux/arm64/release/bundle',
+    );
+    expect(
+      linuxBuildBundlePathForTesting(machineArchitecture: 'arm64'),
+      'build/linux/arm64/release/bundle',
+    );
+    expect(
+      linuxBuildBundlePathForTesting(machineArchitecture: 'riscv64'),
+      'build/linux/riscv64/release/bundle',
     );
   });
 

--- a/tools/manual_tests/frb-local-docker-dev-env.md
+++ b/tools/manual_tests/frb-local-docker-dev-env.md
@@ -20,7 +20,7 @@ Run this after changing the FRB Docker image, devcontainer setup, per-worktree D
 - Required credentials or account state: Docker must be able to pull or use the configured FRB development image. Docker Hub credentials are required only if the local setup needs authenticated pulls.
 - Required device or simulator state: none. This test does not require Android devices, Android emulators, iOS simulators, or visible desktop GUI sessions.
 - Required browser driver state: Flutter web drive coverage requires a compatible `chromedriver` on `PATH` and a headless WebDriver setup for the container architecture. The Docker image must provide this for both amd64 and arm64 local containers.
-- Required Rust web build state: Flutter web drive coverage requires `rust-src` and `llvm-tools-preview` on the container's `nightly` Rust toolchain because `build-web --dart-coverage` builds the standard library with `-Z build-std` under `cargo llvm-cov`.
+- Required Rust web build state: Flutter web drive coverage requires the Docker image to provide `rust-src` and `llvm-tools-preview` on the pinned nightly Rust toolchain because `build-web --dart-coverage` builds the standard library with `-Z build-std` under `cargo llvm-cov`.
 - Required Linux desktop test state: Linux Flutter native coverage requires the container to provide Flutter Linux desktop build dependencies and a headless display runner such as `xvfb-run`.
 
 ## Environment
@@ -51,14 +51,16 @@ Confirm the container can run commands at the host-like worktree path.
 .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- bash -lc 'pwd && ./frb_internal --help'
 ```
 
-Ensure the nightly Rust toolchain has the components needed by the Flutter web coverage step.
+Verify the Docker image already contains the pinned nightly Rust toolchain components needed by the Flutter web coverage step.
 
 ```bash
 .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- bash -lc '
 set -euo pipefail
-rustup toolchain install nightly
-rustup component add rust-src --toolchain nightly
-rustup component add llvm-tools-preview --toolchain nightly
+nightly_version="$(awk -F= '"'"'/^ARG RUST_NIGHTLY_VERSION=/{print $2; exit}'"'"' .devcontainer/Dockerfile)"
+nightly_toolchain="nightly-${nightly_version}"
+rustup toolchain list | grep "${nightly_toolchain}"
+rustup component list --toolchain "${nightly_toolchain}" --installed | grep rust-src
+rustup component list --toolchain "${nightly_toolchain}" --installed | grep llvm-tools
 '
 ```
 
@@ -171,8 +173,8 @@ The test is blocked, not failed, if the Docker image cannot be pulled because of
 - If submodules are uninitialized, rerun `git submodule update --init --recursive` and record the output.
 - If the container is missing or stopped, rerun `.claude/skills/frb-dev-env/frb_dev_env.py docker create` and record the helper output.
 - If Chrome, Chromium, or ChromeDriver cannot start, record the command, version, container architecture, and whether the web test log mentions sandbox flags.
-- If the Flutter web coverage step fails with a missing `Cargo.lock` under the nightly standard library source, rerun the preparation command that installs `rust-src` for the container's `nightly` host toolchain.
-- If the Flutter web coverage step fails with `can't find crate for profiler_builtins`, rerun the preparation command that installs `llvm-tools-preview` for the container's `nightly` host toolchain.
+- If the Flutter web coverage step fails with a missing `Cargo.lock` under the nightly standard library source, verify the container is using the current Docker image and that the image has `rust-src` installed for the pinned nightly toolchain.
+- If the Flutter web coverage step fails with `can't find crate for profiler_builtins`, verify the container is using the current Docker image and that the image has `llvm-tools-preview` installed for the pinned nightly toolchain.
 - If the Linux Flutter native test cannot start, record `flutter devices`, `xvfb-run --help`, and whether the log mentions GTK, display, OpenGL, or missing Linux desktop dependencies.
 - If the Linux Flutter build fails, record `flutter doctor -v`, `cmake --version`, `ninja --version`, and `pkg-config --version` from inside the container.
 - If dependency downloads fail, record the failed URL or package source without adding secrets.

--- a/tools/manual_tests/frb-local-docker-dev-env.md
+++ b/tools/manual_tests/frb-local-docker-dev-env.md
@@ -20,7 +20,7 @@ Run this after changing the FRB Docker image, devcontainer setup, per-worktree D
 - Required credentials or account state: Docker must be able to pull or use the configured FRB development image. Docker Hub credentials are required only if the local setup needs authenticated pulls.
 - Required device or simulator state: none. This test does not require Android devices, Android emulators, iOS simulators, or visible desktop GUI sessions.
 - Required browser driver state: Flutter web drive coverage requires a compatible `chromedriver` on `PATH` and a headless WebDriver setup for the container architecture. The Docker image must provide this for both amd64 and arm64 local containers.
-- Required Rust web build state: Flutter web drive coverage requires `rust-src` on the container's `nightly` Rust toolchain because `build-web --dart-coverage` builds the standard library with `-Z build-std`.
+- Required Rust web build state: Flutter web drive coverage requires `rust-src` and `llvm-tools-preview` on the container's `nightly` Rust toolchain because `build-web --dart-coverage` builds the standard library with `-Z build-std` under `cargo llvm-cov`.
 - Required Linux desktop test state: Linux Flutter native coverage requires the container to provide Flutter Linux desktop build dependencies and a headless display runner such as `xvfb-run`.
 
 ## Environment
@@ -51,7 +51,7 @@ Confirm the container can run commands at the host-like worktree path.
 .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- bash -lc 'pwd && ./frb_internal --help'
 ```
 
-Ensure the nightly Rust toolchain has the `rust-src` component needed by the Flutter web coverage step.
+Ensure the nightly Rust toolchain has the components needed by the Flutter web coverage step.
 
 ```bash
 .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- bash -lc '
@@ -59,6 +59,7 @@ set -euo pipefail
 nightly_host="$(rustc -vV | sed -n "s/^host: //p")"
 rustup toolchain install nightly
 rustup component add rust-src --toolchain "nightly-${nightly_host}"
+rustup component add llvm-tools-preview --toolchain "nightly-${nightly_host}"
 '
 ```
 
@@ -172,6 +173,7 @@ The test is blocked, not failed, if the Docker image cannot be pulled because of
 - If the container is missing or stopped, rerun `.claude/skills/frb-dev-env/frb_dev_env.py docker create` and record the helper output.
 - If Chrome, Chromium, or ChromeDriver cannot start, record the command, version, container architecture, and whether the web test log mentions sandbox flags.
 - If the Flutter web coverage step fails with a missing `Cargo.lock` under the nightly standard library source, rerun the preparation command that installs `rust-src` for the container's `nightly` host toolchain.
+- If the Flutter web coverage step fails with `can't find crate for profiler_builtins`, rerun the preparation command that installs `llvm-tools-preview` for the container's `nightly` host toolchain.
 - If the Linux Flutter native test cannot start, record `flutter devices`, `xvfb-run --help`, and whether the log mentions GTK, display, OpenGL, or missing Linux desktop dependencies.
 - If the Linux Flutter build fails, record `flutter doctor -v`, `cmake --version`, `ninja --version`, and `pkg-config --version` from inside the container.
 - If dependency downloads fail, record the failed URL or package source without adding secrets.

--- a/tools/manual_tests/frb-local-docker-dev-env.md
+++ b/tools/manual_tests/frb-local-docker-dev-env.md
@@ -20,6 +20,7 @@ Run this after changing the FRB Docker image, devcontainer setup, per-worktree D
 - Required credentials or account state: Docker must be able to pull or use the configured FRB development image. Docker Hub credentials are required only if the local setup needs authenticated pulls.
 - Required device or simulator state: none. This test does not require Android devices, Android emulators, iOS simulators, or visible desktop GUI sessions.
 - Required browser driver state: Flutter web drive coverage requires a compatible `chromedriver` on `PATH` and a headless WebDriver setup for the container architecture. The Docker image must provide this for both amd64 and arm64 local containers.
+- Required Rust web build state: Flutter web drive coverage requires `rust-src` on the container's `nightly` Rust toolchain because `build-web --dart-coverage` builds the standard library with `-Z build-std`.
 - Required Linux desktop test state: Linux Flutter native coverage requires the container to provide Flutter Linux desktop build dependencies and a headless display runner such as `xvfb-run`.
 
 ## Environment
@@ -48,6 +49,17 @@ Confirm the container can run commands at the host-like worktree path.
 
 ```bash
 .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- bash -lc 'pwd && ./frb_internal --help'
+```
+
+Ensure the nightly Rust toolchain has the `rust-src` component needed by the Flutter web coverage step.
+
+```bash
+.claude/skills/frb-dev-env/frb_dev_env.py docker exec -- bash -lc '
+set -euo pipefail
+nightly_host="$(rustc -vV | sed -n "s/^host: //p")"
+rustup toolchain install nightly
+rustup component add rust-src --toolchain "nightly-${nightly_host}"
+'
 ```
 
 ## Test Data
@@ -159,6 +171,7 @@ The test is blocked, not failed, if the Docker image cannot be pulled because of
 - If submodules are uninitialized, rerun `git submodule update --init --recursive` and record the output.
 - If the container is missing or stopped, rerun `.claude/skills/frb-dev-env/frb_dev_env.py docker create` and record the helper output.
 - If Chrome, Chromium, or ChromeDriver cannot start, record the command, version, container architecture, and whether the web test log mentions sandbox flags.
+- If the Flutter web coverage step fails with a missing `Cargo.lock` under the nightly standard library source, rerun the preparation command that installs `rust-src` for the container's `nightly` host toolchain.
 - If the Linux Flutter native test cannot start, record `flutter devices`, `xvfb-run --help`, and whether the log mentions GTK, display, OpenGL, or missing Linux desktop dependencies.
 - If the Linux Flutter build fails, record `flutter doctor -v`, `cmake --version`, `ninja --version`, and `pkg-config --version` from inside the container.
 - If dependency downloads fail, record the failed URL or package source without adding secrets.

--- a/tools/manual_tests/frb-local-docker-dev-env.md
+++ b/tools/manual_tests/frb-local-docker-dev-env.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Verify that the per-worktree FRB Docker development container can run the normal headless local validation surface: Rust tests, Dart native tests, Dart web tests, Flutter web tests, and the internal development entrypoint. This test also records that Docker is not the Android emulator, iOS Simulator, or macOS GUI runtime strategy.
+Verify that the per-worktree FRB Docker development container can run the normal headless local validation surface: Rust tests, Dart native tests, Dart web tests, Flutter web tests, Linux Flutter native tests, Linux Flutter release builds, and the internal development entrypoint. This test also records that Docker is not the Android emulator, iOS Simulator, or macOS GUI runtime strategy.
 
 ## Source
 
@@ -11,15 +11,16 @@ Verify that the per-worktree FRB Docker development container can run the normal
 
 ## When To Run
 
-Run this after changing the FRB Docker image, devcontainer setup, per-worktree Docker helper, Rust/Dart/web test tooling, or Flutter/Rust/Dart versions. It is also useful before relying on a new local machine or worktree for headless FRB development.
+Run this after changing the FRB Docker image, devcontainer setup, per-worktree Docker helper, Rust/Dart/web/Linux Flutter test tooling, Linux Flutter build tooling, or Flutter/Rust/Dart versions. It is also useful before relying on a new local machine or worktree for headless FRB development.
 
 ## Preconditions
 
 - Repository: `fzyzcjy/flutter_rust_bridge`
 - Required checkout state: clean checkout with submodules initialized. Intentional local changes are allowed only if the execution record lists them.
 - Required credentials or account state: Docker must be able to pull or use the configured FRB development image. Docker Hub credentials are required only if the local setup needs authenticated pulls.
-- Required device or simulator state: none. This test does not require Android devices, Android emulators, iOS simulators, or desktop GUI sessions.
+- Required device or simulator state: none. This test does not require Android devices, Android emulators, iOS simulators, or visible desktop GUI sessions.
 - Required browser driver state: Flutter web drive coverage requires a compatible `chromedriver` on `PATH` and a headless WebDriver setup for the container architecture. The Docker image must provide this for both amd64 and arm64 local containers.
+- Required Linux desktop test state: Linux Flutter native coverage requires the container to provide Flutter Linux desktop build dependencies and a headless display runner such as `xvfb-run`.
 
 ## Environment
 
@@ -27,7 +28,7 @@ Run this after changing the FRB Docker image, devcontainer setup, per-worktree D
 - Flutter: record `flutter --version` inside the Docker container.
 - Dart: record `dart --version` inside the Docker container.
 - Rust: record `rustc --version` and `cargo --version` inside the Docker container.
-- Device or simulator: not required.
+- Device or simulator: the Linux Flutter native test uses Flutter's `linux` device inside the container.
 - Browser or external service: record the Chrome or Chromium version and ChromeDriver version used by the container for headless web tests.
 
 ## Preparation
@@ -65,6 +66,11 @@ Confirm the container can run commands at the host-like worktree path.
    dart --version
    rustc --version
    cargo --version
+   uname -a
+   cmake --version
+   ninja --version
+   pkg-config --version
+   xvfb-run --help >/dev/null
    "${CHROME_BIN:-google-chrome}" --version || chromium --version || chromium-browser --version
    chromedriver --version
    '
@@ -94,7 +100,19 @@ Confirm the container can run commands at the host-like worktree path.
    .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- ./frb_internal test-flutter-web --package frb_example/flutter_via_create --coverage
    ```
 
-6. Confirm the checkout did not gain unexpected generated or cache files.
+6. Run a focused Linux Flutter native integration test in Docker through a headless display.
+
+   ```bash
+   .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- xvfb-run -a ./frb_internal test-flutter-native --package frb_example/flutter_via_create --flutter-test-args '--device-id linux'
+   ```
+
+7. Smoke-test the Linux Flutter release build command in Docker.
+
+   ```bash
+   .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- ./frb_internal build-flutter --target linux
+   ```
+
+8. Confirm the checkout did not gain unexpected generated or cache files.
 
    ```bash
    git status --short
@@ -102,13 +120,15 @@ Confirm the container can run commands at the host-like worktree path.
 
 ## Expected Result
 
-The Docker environment coverage test passes when every command exits successfully and the terminal log shows that the commands ran inside the per-worktree container. The web step must run through a headless browser without requiring a visible GUI session.
+The Docker environment coverage test passes when every command exits successfully and the terminal log shows that the commands ran inside the per-worktree container. The web step must run through a headless browser without requiring a visible GUI session. The Linux Flutter native step must run against Flutter's `linux` device through a headless display, and the Linux build step must copy release artifacts into `target/build_flutter_output`.
 
 ```text
 ./frb_internal test-rust-package --package frb_rust
 ./frb_internal test-dart-native --package frb_dart
 ./frb_internal test-dart-web --package frb_example/pure_dart
 ./frb_internal test-flutter-web --package frb_example/flutter_via_create --coverage
+xvfb-run -a ./frb_internal test-flutter-native --package frb_example/flutter_via_create --flutter-test-args '--device-id linux'
+./frb_internal build-flutter --target linux
 ```
 
 ## Failure Criteria
@@ -117,9 +137,11 @@ The test fails if any of the following happens:
 
 - Docker is unavailable, the per-worktree container cannot be created, or the container labels do not match the current worktree.
 - Any required tool version command fails inside the container.
-- The Rust, Dart native, Dart web, or Flutter web test command exits non-zero because Docker, browser startup, package setup, toolchain availability, or local environment plumbing failed.
+- The Rust, Dart native, Dart web, Flutter web, or Linux Flutter native test command exits non-zero because Docker, browser startup, Linux desktop startup, package setup, toolchain availability, or local environment plumbing failed.
 - The Dart or Flutter web test requires a visible GUI session instead of running in a headless browser.
 - The Flutter web drive command fails with `Unable to start a WebDriver session` because no compatible `chromedriver` is available.
+- The Linux Flutter native test cannot find the `linux` device, cannot start under `xvfb-run`, or exits non-zero unexpectedly.
+- The Linux Flutter build command exits non-zero unexpectedly or does not produce release artifacts under `target/build_flutter_output`.
 - `git status --short` shows unexpected local changes after the run.
 
 The test is blocked, not failed, if the Docker image cannot be pulled because of network or registry access.
@@ -128,7 +150,8 @@ The test is blocked, not failed, if the Docker image cannot be pulled because of
 
 - Full terminal log for all preparation and test commands.
 - Host OS, Docker version, container image, and container name from `docker info`.
-- Flutter, Dart, Rust, Cargo, browser, and ChromeDriver versions inside the container.
+- Flutter, Dart, Rust, Cargo, Linux kernel, CMake, Ninja, pkg-config, browser, and ChromeDriver versions inside the container.
+- Linux Flutter native test success lines and Linux build output artifact paths.
 - Final `git status --short` output.
 
 ## Troubleshooting
@@ -136,6 +159,8 @@ The test is blocked, not failed, if the Docker image cannot be pulled because of
 - If submodules are uninitialized, rerun `git submodule update --init --recursive` and record the output.
 - If the container is missing or stopped, rerun `.claude/skills/frb-dev-env/frb_dev_env.py docker create` and record the helper output.
 - If Chrome, Chromium, or ChromeDriver cannot start, record the command, version, container architecture, and whether the web test log mentions sandbox flags.
+- If the Linux Flutter native test cannot start, record `flutter devices`, `xvfb-run --help`, and whether the log mentions GTK, display, OpenGL, or missing Linux desktop dependencies.
+- If the Linux Flutter build fails, record `flutter doctor -v`, `cmake --version`, `ninja --version`, and `pkg-config --version` from inside the container.
 - If dependency downloads fail, record the failed URL or package source without adding secrets.
 - If a generated file changes, record the exact `git status --short` output and inspect whether the tested command intentionally regenerated it.
 

--- a/tools/manual_tests/frb-local-docker-dev-env.md
+++ b/tools/manual_tests/frb-local-docker-dev-env.md
@@ -56,10 +56,9 @@ Ensure the nightly Rust toolchain has the components needed by the Flutter web c
 ```bash
 .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- bash -lc '
 set -euo pipefail
-nightly_host="$(rustc -vV | sed -n "s/^host: //p")"
 rustup toolchain install nightly
-rustup component add rust-src --toolchain "nightly-${nightly_host}"
-rustup component add llvm-tools-preview --toolchain "nightly-${nightly_host}"
+rustup component add rust-src --toolchain nightly
+rustup component add llvm-tools-preview --toolchain nightly
 '
 ```
 


### PR DESCRIPTION
## Summary

- Add Linux Flutter native test and release build steps to the Docker manual test report.
- Document the Docker Rust toolchain preparation needed by Flutter web coverage.
- Fix Linux Flutter build artifact copying on non-x64 hosts by using the Flutter architecture-specific bundle directory.

## Manual test execution

Execution gist: https://gist.github.com/fzyzcjy/2e7e332563ad05b37fc1c3618f37894d

The Linux Flutter portion passed in Docker after the build artifact path fix:

- `xvfb-run -a ./frb_internal test-flutter-native --package frb_example/flutter_via_create --flutter-test-args '--device-id linux'`
- `./frb_internal build-flutter --target linux`

Key evidence from `linux-flutter-only.log` in the gist:

- Linux device detected as `linux-arm64`.
- Flutter native test reported `All tests passed!`.
- Release build produced `build/linux/arm64/release/bundle/flutter_via_create`.
- `target/build_flutter_output` contains the Linux executable and required shared libraries.

The full Docker manual test execution remains partial because the existing Flutter web coverage step fails on arm64 Docker in nested wasm coverage with `can't find crate for profiler_builtins`. That failure is captured in the gist and is separate from the Linux Flutter verification added here.

## Verification

- `git diff --check`
- `cd tools/frb_internal && dart pub get && dart format lib/src/makefile_dart/build.dart test/makefile_dart_test.dart`
- `cd tools/frb_internal && dart test test/makefile_dart_test.dart`
- Docker Linux Flutter manual verification commands listed above

`pre-commit run --all-files` could not be completed locally: the Docker image does not include `pre-commit`, and the host checkout has no `.pre-commit-config.yaml`.
