### PR TITLE
Comment on manual CI dispatch runs

### DIFF
--- a/.claude/skills/frb-ci-filter/SKILL.md
+++ b/.claude/skills/frb-ci-filter/SKILL.md
@@ -60,6 +60,17 @@ gh pr edit <pr-number> --remove-label ci-manual-dispatch
 
 Then let the normal full CI surface run. Removing the label triggers PR CI because the workflow listens to `labeled` and `unlabeled` pull request events.
 
+## Manual Dispatch PR Comment
+
+Every `workflow_dispatch` run of `.github/workflows/ci.yaml` attempts to comment on the open PR whose head branch matches the dispatched branch. The comment includes:
+
+- the exact `ci_filter`
+- the workflow run link
+- the branch name
+- a reminder that this is not the normal automatic PR CI surface
+
+This comment is only emitted by the `Plan :: CI` job for manual `workflow_dispatch` runs. Normal `push` and `pull_request` CI do not post this comment. If the dispatch ref is not a branch, or if no open PR exists for that branch in the base repository, the comment step skips without failing CI.
+
 ## Local Planning
 
 Before dispatching an expensive manual run, smoke the filter locally:

--- a/.claude/skills/frb-ci-filter/SKILL.md
+++ b/.claude/skills/frb-ci-filter/SKILL.md
@@ -62,14 +62,7 @@ Then let the normal full CI surface run. Removing the label triggers PR CI becau
 
 ## Manual Dispatch PR Comment
 
-Every `workflow_dispatch` run of `.github/workflows/ci.yaml` attempts to comment on the open PR whose head branch matches the dispatched branch. The comment includes:
-
-- the exact `ci_filter`
-- the workflow run link
-- the branch name
-- a reminder that this is not the normal automatic PR CI surface
-
-This comment is only emitted by the `Plan :: CI` job for manual `workflow_dispatch` runs. Normal `push` and `pull_request` CI do not post this comment. If the dispatch ref is not a branch, or if no open PR exists for that branch in the base repository, the comment step skips without failing CI.
+Manual `workflow_dispatch` runs of `.github/workflows/ci.yaml` comment from `Plan :: CI` on the matching open PR with the selected `ci_filter` and run link; normal `push` and `pull_request` runs do not comment.
 
 ## Local Planning
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,10 @@ jobs:
     if: ${{ github.event.action != 'closed' }}
     name: 'Plan :: CI'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
     outputs:
       plan: ${{ steps.plan.outputs.plan }}
 
@@ -56,6 +60,79 @@ jobs:
             --filter '${{ inputs.ci_filter || 'full' }}' \
             --automatic-ci-disabled=${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci-manual-dispatch') }} \
             --github-output "$GITHUB_OUTPUT"
+      - name: Comment on matching pull request
+        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const ref = context.ref;
+
+            if (!ref.startsWith('refs/heads/')) {
+              core.notice(`Manual CI dispatch ref ${ref} is not a branch; skipping PR comment.`);
+              return;
+            }
+
+            const branch = ref.substring('refs/heads/'.length);
+            const pullRequests = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: 'open',
+              head: `${owner}:${branch}`,
+              per_page: 100,
+            });
+
+            if (pullRequests.length === 0) {
+              core.notice(`No open PR found for branch ${branch}; skipping PR comment.`);
+              return;
+            }
+
+            const pullRequest = pullRequests[0];
+            const marker = `<!-- ci-manual-dispatch-comment:${context.runId} -->`;
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const ciFilter = context.payload.inputs?.ci_filter ?? 'full';
+            const body = [
+              marker,
+              '## Manual CI dispatch',
+              '',
+              `Filter: \`${ciFilter}\``,
+              `Run: [${context.runId}](${runUrl})`,
+              `Branch: \`${branch}\``,
+              '',
+              'This is a manually dispatched CI run. It is not the normal automatic PR CI surface.',
+              '',
+            ].join('\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: pullRequest.number,
+              per_page: 100,
+            });
+            const existingComment = comments.find(
+              (comment) =>
+                comment.user?.type === 'Bot' &&
+                typeof comment.body === 'string' &&
+                comment.body.includes(marker),
+            );
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existingComment.id,
+                body,
+              });
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: pullRequest.number,
+              body,
+            });
 
   # ----------------------------------- deploy -----------------------------------
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
     outputs:
       plan: ${{ steps.plan.outputs.plan }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,35 +104,39 @@ jobs:
               '',
             ].join('\n');
 
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner,
-              repo,
-              issue_number: pullRequest.number,
-              per_page: 100,
-            });
-            const existingComment = comments.find(
-              (comment) =>
-                comment.user?.type === 'Bot' &&
-                typeof comment.body === 'string' &&
-                comment.body.includes(marker),
-            );
-
-            if (existingComment) {
-              await github.rest.issues.updateComment({
+            try {
+              const comments = await github.paginate(github.rest.issues.listComments, {
                 owner,
                 repo,
-                comment_id: existingComment.id,
+                issue_number: pullRequest.number,
+                per_page: 100,
+              });
+              const existingComment = comments.find(
+                (comment) =>
+                  comment.user?.type === 'Bot' &&
+                  typeof comment.body === 'string' &&
+                  comment.body.includes(marker),
+              );
+
+              if (existingComment) {
+                await github.rest.issues.updateComment({
+                  owner,
+                  repo,
+                  comment_id: existingComment.id,
+                  body,
+                });
+                return;
+              }
+
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pullRequest.number,
                 body,
               });
-              return;
+            } catch (error) {
+              core.warning(`Could not write manual CI dispatch PR comment: ${error.message}`);
             }
-
-            await github.rest.issues.createComment({
-              owner,
-              repo,
-              issue_number: pullRequest.number,
-              body,
-            });
 
   # ----------------------------------- deploy -----------------------------------
 

--- a/tools/manual_tests/ci-filter-single-matrix-dispatch.md
+++ b/tools/manual_tests/ci-filter-single-matrix-dispatch.md
@@ -120,6 +120,7 @@ The manual test passes when all of the following are true:
 - The automatic pull request CI run only executes the lightweight planning/status surface and does not run unrelated heavy matrix jobs.
 - The workflow dispatch run is named with the selected filter.
 - The `Plan :: CI` job succeeds and prints a plan where `test_dart_native.enable` is `true`.
+- The `Plan :: CI` job posts a PR comment for the manual dispatch, including the exact `ci_filter`, the workflow run link, and a reminder that it is not the normal automatic PR CI surface.
 - Exactly one `Test :: Dart :: Native` matrix job is scheduled for `ubuntu-24.04` and `frb_example--dart_minimal`.
 - Unselected CI jobs are skipped or absent from the scheduled job set.
 - The selected matrix job exits successfully.
@@ -148,6 +149,7 @@ Mark the run as blocked, not failed, if GitHub Actions capacity prevents the sel
 - PR labels at the time of dispatch.
 - Exact `ci_filter` string.
 - Local `plan-ci` smoke-check output.
+- Manual dispatch PR comment URL or screenshot.
 - Pull request event run URL and job summary.
 - Workflow dispatch run URL and job summary.
 - Selected job URL, status, conclusion, runner image, and key success log lines.


### PR DESCRIPTION
## Summary

- Add a workflow_dispatch-only PR comment step to Plan :: CI with the selected ci_filter and run link.
- Document the manual dispatch comment behavior in the frb-ci-filter skill and manual test.

## Validation

- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yaml"); puts "ci.yaml OK"'
- .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- bash -lc "./frb_internal plan-ci --filter 'test_dart_native[image=ubuntu-24.04,package=frb_example--dart_minimal]'"
- git diff --check

Note: Started ./frb_internal lint --fix, but the user requested opening the PR first before waiting for the full lint run.