### PR TITLE
Fix quickstart smoke screenshots on selected devices

### DIFF
--- a/tools/frb_internal/lib/src/makefile_dart/quickstart_smoke.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/quickstart_smoke.dart
@@ -280,6 +280,16 @@ String quickstartSmokePackagePathForTesting(
   String? repoRootPath,
 }) => Directory('${repoRootPath ?? exec.pwd}$package').absolute.path;
 
+@visibleForTesting
+List<String> quickstartSmokeAndroidScreenshotArgsForTesting(String deviceId) =>
+    ['-s', deviceId, 'exec-out', 'screencap', '-p'];
+
+@visibleForTesting
+List<String> quickstartSmokeIosScreenshotArgsForTesting({
+  required String deviceId,
+  required String screenshotPath,
+}) => ['simctl', 'io', deviceId, 'screenshot', screenshotPath];
+
 Future<_QuickstartSmokeFlutterRun> _startQuickstartSmokeFlutterRun(
   _QuickstartSmokeContext context,
 ) async {
@@ -489,6 +499,7 @@ Future<void> _captureAndOcrQuickstartSmokeScreenshotFromContext(
 ) async {
   await _captureAndOcrQuickstartSmokeScreenshot(
     target: context.target,
+    deviceId: context.resolvedDeviceId,
     screenshotFile: context.screenshotFile,
     preprocessedScreenshotFile: context.preprocessedScreenshotFile,
     ocrOutputFile: context.ocrOutputFile,
@@ -538,6 +549,7 @@ Future<int?> _waitForQuickstartSmokeExit(Future<int> exitCodeFuture) async {
 
 Future<void> _captureAndOcrQuickstartSmokeScreenshot({
   required QuickstartSmokeTarget target,
+  required String deviceId,
   required File screenshotFile,
   required File preprocessedScreenshotFile,
   required File ocrOutputFile,
@@ -545,6 +557,7 @@ Future<void> _captureAndOcrQuickstartSmokeScreenshot({
 }) async {
   await _captureQuickstartSmokeScreenshot(
     target: target,
+    deviceId: deviceId,
     screenshotFile: screenshotFile,
   );
   await _preprocessQuickstartSmokeScreenshot(
@@ -573,22 +586,24 @@ Future<void> _captureAndOcrQuickstartSmokeScreenshot({
 
 Future<void> _captureQuickstartSmokeScreenshot({
   required QuickstartSmokeTarget target,
+  required String deviceId,
   required File screenshotFile,
 }) async {
   final result = switch (target) {
     QuickstartSmokeTarget.android => await Process.run(
       'adb',
-      ['exec-out', 'screencap', '-p'],
+      quickstartSmokeAndroidScreenshotArgsForTesting(deviceId),
       stdoutEncoding: null,
       stderrEncoding: systemEncoding,
     ),
-    QuickstartSmokeTarget.ios => await Process.run('xcrun', [
-      'simctl',
-      'io',
-      'booted',
-      'screenshot',
-      screenshotFile.path,
-    ], stderrEncoding: systemEncoding),
+    QuickstartSmokeTarget.ios => await Process.run(
+      'xcrun',
+      quickstartSmokeIosScreenshotArgsForTesting(
+        deviceId: deviceId,
+        screenshotPath: screenshotFile.path,
+      ),
+      stderrEncoding: systemEncoding,
+    ),
     _ when Platform.isMacOS => await Process.run('screencapture', [
       '-x',
       screenshotFile.path,

--- a/tools/frb_internal/test/makefile_dart_test.dart
+++ b/tools/frb_internal/test/makefile_dart_test.dart
@@ -173,6 +173,23 @@ late final callback = ptr.asFunction<voidFunction(ffi.Pointer<ffi.Void>)>();
     );
   });
 
+  test('quickstart smoke screenshots target the requested device', () {
+    expect(quickstartSmokeAndroidScreenshotArgsForTesting('emulator-5556'), [
+      '-s',
+      'emulator-5556',
+      'exec-out',
+      'screencap',
+      '-p',
+    ]);
+    expect(
+      quickstartSmokeIosScreenshotArgsForTesting(
+        deviceId: 'IPHONE-UDID',
+        screenshotPath: '/tmp/quickstart.png',
+      ),
+      ['simctl', 'io', 'IPHONE-UDID', 'screenshot', '/tmp/quickstart.png'],
+    );
+  });
+
   test(
     'quickstart smoke waits for Flutter run readiness before screenshot',
     () {


### PR DESCRIPTION
Fixes the quickstart smoke screenshot capture so device-specific runs capture the requested device instead of whichever device happens to be the default/booted target.\n\nChanges:\n- Android screenshots now use `adb -s <device> exec-out screencap -p`.\n- iOS screenshots now use `xcrun simctl io <UDID> screenshot` instead of `booted`.\n- Adds unit coverage for the screenshot command arguments.\n\nValidation:\n- Docker: `dart format --set-exit-if-changed tools/frb_internal/lib/src/makefile_dart/quickstart_smoke.dart tools/frb_internal/test/makefile_dart_test.dart`\n- Docker: `cd tools/frb_internal && dart test test/makefile_dart_test.dart test/ci_plan_test.dart`\n- Tart: iPad (10th generation) quickstart smoke passed and OCR found `Result: Hello, Tom!`.\n- Tart: iPhone 16 Pro Max quickstart smoke failed before this change by screenshotting another booted simulator, then passed after this change with OCR finding `Result: Hello, Tom!`.