### PR TITLE
Fix macOS quickstart smoke capture

### DIFF
--- a/tools/frb_internal/lib/src/makefile_dart/quickstart_smoke.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/quickstart_smoke.dart
@@ -241,15 +241,11 @@ Duration quickstartSmokeFlutterRunReadyTimeoutForTesting(
 Duration quickstartSmokeVisibleTextTimeoutForTesting(
   QuickstartSmokeTarget target,
 ) => switch (target) {
-  QuickstartSmokeTarget.web ||
+  QuickstartSmokeTarget.web => const Duration(seconds: 45),
   QuickstartSmokeTarget.desktop ||
   QuickstartSmokeTarget.android ||
-  QuickstartSmokeTarget.ios => const Duration(seconds: 30),
+  QuickstartSmokeTarget.ios => const Duration(seconds: 90),
 };
-
-@visibleForTesting
-Duration quickstartSmokeScreenshotRetryIntervalForTesting() =>
-    const Duration(seconds: 2);
 
 @visibleForTesting
 String? quickstartSmokeOutputFailurePatternForTesting(String output) {
@@ -388,10 +384,10 @@ Future<_QuickstartSmokeScreenshotEvidence> _captureQuickstartSmokeEvidence({
   print(
     'Waiting up to $visibleTextTimeout for quickstart text to become OCR-visible',
   );
+  await Future<void>.delayed(const Duration(seconds: 5));
 
   Exception? lastOcrException;
   var attempt = 0;
-  final retryInterval = quickstartSmokeScreenshotRetryIntervalForTesting();
   do {
     attempt++;
     print('Capturing quickstart screenshot/OCR attempt #$attempt');
@@ -410,7 +406,7 @@ Future<_QuickstartSmokeScreenshotEvidence> _captureQuickstartSmokeEvidence({
       lastOcrException = exception;
       print('Quickstart screenshot OCR did not match yet: $exception');
       if (!DateTime.now().isBefore(visibleTextDeadline)) break;
-      await Future<void>.delayed(retryInterval);
+      await Future<void>.delayed(const Duration(seconds: 5));
     }
   } while (DateTime.now().isBefore(visibleTextDeadline));
 

--- a/tools/frb_internal/lib/src/makefile_dart/quickstart_smoke.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/quickstart_smoke.dart
@@ -1,7 +1,6 @@
 // ignore_for_file: avoid_print
 
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_rust_bridge_internal/src/makefile_dart/consts.dart';
@@ -69,7 +68,6 @@ class _QuickstartSmokeContext {
   final File preprocessedScreenshotFile;
   final File ocrOutputFile;
   final File preprocessedOcrOutputFile;
-  final File vmServiceOutputFile;
   final File logFile;
   final File? chromeWrapper;
 
@@ -84,7 +82,6 @@ class _QuickstartSmokeContext {
     required this.preprocessedScreenshotFile,
     required this.ocrOutputFile,
     required this.preprocessedOcrOutputFile,
-    required this.vmServiceOutputFile,
     required this.logFile,
     required this.chromeWrapper,
   });
@@ -123,9 +120,6 @@ class _QuickstartSmokeContext {
       preprocessedOcrOutputFile: File(
         '${absolutePackage.path}/$artifactDir/quickstart-$targetName-processed.txt',
       ),
-      vmServiceOutputFile: File(
-        '${absolutePackage.path}/$artifactDir/quickstart-$targetName-vm-service.txt',
-      ),
       logFile: File(
         '${absolutePackage.path}/$artifactDir/quickstart-$targetName.log',
       ),
@@ -158,7 +152,6 @@ class _QuickstartSmokeContext {
       preprocessedScreenshotFile,
       ocrOutputFile,
       preprocessedOcrOutputFile,
-      vmServiceOutputFile,
       logFile,
     ]) {
       if (file.existsSync()) file.deleteSync();
@@ -203,13 +196,11 @@ class _QuickstartSmokeFlutterRun {
 class _QuickstartSmokeScreenshotEvidence {
   final bool readyForScreenshot;
   final bool ocrMatched;
-  final bool vmServiceMatched;
   final Exception? lastOcrException;
 
   const _QuickstartSmokeScreenshotEvidence({
     required this.readyForScreenshot,
     required this.ocrMatched,
-    required this.vmServiceMatched,
     required this.lastOcrException,
   });
 }
@@ -285,22 +276,6 @@ bool quickstartSmokeFlutterRunIsReadyForTesting(String output) {
 }
 
 @visibleForTesting
-Uri? quickstartSmokeVmServiceUriForTesting(String output) {
-  final match = RegExp(
-    r'A Dart VM Service.*? at: (http://\S+/)',
-  ).firstMatch(output);
-  if (match == null) return null;
-  return Uri.parse(match.group(1)!);
-}
-
-@visibleForTesting
-String quickstartSmokeInspectorTextForTesting(Object? json) {
-  final buffer = StringBuffer();
-  _writeQuickstartSmokeInspectorText(buffer, json);
-  return buffer.toString();
-}
-
-@visibleForTesting
 String quickstartSmokePackagePathForTesting(
   String package, {
   String? repoRootPath,
@@ -315,6 +290,11 @@ List<String> quickstartSmokeIosScreenshotArgsForTesting({
   required String deviceId,
   required String screenshotPath,
 }) => ['simctl', 'io', deviceId, 'screenshot', screenshotPath];
+
+@visibleForTesting
+List<String> quickstartSmokeMacosScreenshotArgsForTesting(
+  String screenshotPath,
+) => ['-x', '-T', '1', screenshotPath];
 
 Future<_QuickstartSmokeFlutterRun> _startQuickstartSmokeFlutterRun(
   _QuickstartSmokeContext context,
@@ -393,7 +373,6 @@ Future<_QuickstartSmokeScreenshotEvidence> _captureQuickstartSmokeEvidence({
     return _QuickstartSmokeScreenshotEvidence(
       readyForScreenshot: readyForScreenshot,
       ocrMatched: false,
-      vmServiceMatched: false,
       lastOcrException: null,
     );
   }
@@ -421,7 +400,6 @@ Future<_QuickstartSmokeScreenshotEvidence> _captureQuickstartSmokeEvidence({
       return _QuickstartSmokeScreenshotEvidence(
         readyForScreenshot: readyForScreenshot,
         ocrMatched: true,
-        vmServiceMatched: false,
         lastOcrException: null,
       );
     } on Exception catch (exception) {
@@ -432,115 +410,11 @@ Future<_QuickstartSmokeScreenshotEvidence> _captureQuickstartSmokeEvidence({
     }
   } while (DateTime.now().isBefore(visibleTextDeadline));
 
-  final vmServiceMatched = await _captureQuickstartMacosVmServiceEvidence(
-    context: context,
-    flutterRun: flutterRun,
-  );
-
   return _QuickstartSmokeScreenshotEvidence(
     readyForScreenshot: readyForScreenshot,
     ocrMatched: false,
-    vmServiceMatched: vmServiceMatched,
     lastOcrException: lastOcrException,
   );
-}
-
-Future<bool> _captureQuickstartMacosVmServiceEvidence({
-  required _QuickstartSmokeContext context,
-  required _QuickstartSmokeFlutterRun flutterRun,
-}) async {
-  if (context.target != QuickstartSmokeTarget.desktop || !Platform.isMacOS) {
-    return false;
-  }
-
-  print('Trying macOS Flutter VM service evidence after screenshot OCR miss');
-  try {
-    final text = await _readQuickstartMacosVmServiceText(
-      flutterRun.combinedOutput,
-    );
-    context.vmServiceOutputFile.writeAsStringSync(text);
-    checkQuickstartSmokeOcrTextForTesting(text);
-    print('macOS Flutter VM service evidence contains expected text');
-    return true;
-  } on Exception catch (exception) {
-    context.vmServiceOutputFile.writeAsStringSync(exception.toString());
-    print('macOS Flutter VM service evidence did not match: $exception');
-    return false;
-  }
-}
-
-Future<String> _readQuickstartMacosVmServiceText(
-  String flutterRunOutput,
-) async {
-  final vmServiceUri = quickstartSmokeVmServiceUriForTesting(flutterRunOutput);
-  if (vmServiceUri == null) {
-    throw Exception('Could not find Flutter VM Service URL in flutter run log');
-  }
-
-  final vm = await _getQuickstartSmokeVmServiceJson(
-    vmServiceUri.resolve('getVM'),
-  );
-  final isolates = (vm['result'] as Map<String, Object?>)['isolates'] as List;
-  if (isolates.isEmpty) {
-    throw Exception('Flutter VM Service reported no app isolates');
-  }
-  final isolateId = (isolates.single as Map<String, Object?>)['id'] as String;
-
-  final tree = await _getQuickstartSmokeVmServiceJson(
-    vmServiceUri.replace(
-      path:
-          '${vmServiceUri.path}ext.flutter.inspector.getRootWidgetSummaryTree',
-      queryParameters: {
-        'isolateId': isolateId,
-        'objectGroup': 'quickstartSmoke',
-        'subtreeDepth': '20',
-      },
-    ),
-  );
-  final textWidgetIds = _findQuickstartSmokeTextWidgetIds(tree);
-  if (textWidgetIds.isEmpty) {
-    throw Exception('Flutter inspector did not report any app Text widgets');
-  }
-
-  final buffer = StringBuffer();
-  for (final textWidgetId in textWidgetIds) {
-    final properties = await _getQuickstartSmokeVmServiceJson(
-      vmServiceUri.replace(
-        path: '${vmServiceUri.path}ext.flutter.inspector.getProperties',
-        queryParameters: {
-          'isolateId': isolateId,
-          'objectGroup': 'quickstartSmoke',
-          'arg': textWidgetId,
-        },
-      ),
-    );
-    buffer.writeln(quickstartSmokeInspectorTextForTesting(properties));
-  }
-  return buffer.toString();
-}
-
-Future<Map<String, Object?>> _getQuickstartSmokeVmServiceJson(Uri uri) async {
-  final client = HttpClient();
-  try {
-    final request = await client.getUrl(uri);
-    final response = await request.close();
-    final body = await response.transform(utf8.decoder).join();
-    if (response.statusCode != HttpStatus.ok) {
-      throw Exception(
-        'Flutter VM Service request failed '
-        '(status=${response.statusCode}, uri=$uri, body=$body)',
-      );
-    }
-    return jsonDecode(body) as Map<String, Object?>;
-  } finally {
-    client.close(force: true);
-  }
-}
-
-List<String> _findQuickstartSmokeTextWidgetIds(Object? json) {
-  final result = <String>[];
-  _collectQuickstartSmokeTextWidgetIds(result, json);
-  return result;
 }
 
 Future<_QuickstartSmokeExitStatus> _stopQuickstartSmokeFlutterRun({
@@ -570,10 +444,6 @@ void _printQuickstartSmokeEvidence(_QuickstartSmokeContext context) {
   if (context.ocrOutputFile.existsSync()) {
     print('\n===== screenshot OCR (${context.targetName}) =====');
     print(context.ocrOutputFile.readAsStringSync());
-  }
-  if (context.vmServiceOutputFile.existsSync()) {
-    print('\n===== VM service evidence (${context.targetName}) =====');
-    print(context.vmServiceOutputFile.readAsStringSync());
   }
 }
 
@@ -614,7 +484,7 @@ void _validateQuickstartSmokeResult({
       'produce OCR output at `${context.ocrOutputFile.path}`',
     );
   }
-  if (!screenshotEvidence.ocrMatched && !screenshotEvidence.vmServiceMatched) {
+  if (!screenshotEvidence.ocrMatched) {
     if (screenshotEvidence.lastOcrException != null) {
       throw screenshotEvidence.lastOcrException!;
     }
@@ -741,10 +611,9 @@ Future<void> _captureQuickstartSmokeScreenshot({
       ),
       stderrEncoding: systemEncoding,
     ),
-    _ when Platform.isMacOS => await Process.run('screencapture', [
-      '-x',
-      screenshotFile.path,
-    ], stderrEncoding: systemEncoding),
+    _ when Platform.isMacOS => await _captureMacosQuickstartSmokeScreenshot(
+      screenshotFile,
+    ),
     _ when Platform.isWindows => await _captureWindowsQuickstartSmokeScreenshot(
       screenshotFile,
     ),
@@ -761,6 +630,30 @@ Future<void> _captureQuickstartSmokeScreenshot({
     throw Exception(
       'Failed to capture quickstart screenshot (exitCode=${result.exitCode}, '
       'stderr=${result.stderr})',
+    );
+  }
+}
+
+Future<ProcessResult> _captureMacosQuickstartSmokeScreenshot(
+  File screenshotFile,
+) async {
+  await _activateMacosQuickstartSmokeApp();
+  return Process.run(
+    'screencapture',
+    quickstartSmokeMacosScreenshotArgsForTesting(screenshotFile.path),
+    stderrEncoding: systemEncoding,
+  );
+}
+
+Future<void> _activateMacosQuickstartSmokeApp() async {
+  final result = await Process.run('osascript', [
+    '-e',
+    'tell application "flutter_via_create" to activate',
+  ], stderrEncoding: systemEncoding);
+  if (result.exitCode != 0) {
+    print(
+      'Failed to activate macOS quickstart app before screenshot '
+      '(exitCode=${result.exitCode}, stderr=${result.stderr})',
     );
   }
 }
@@ -831,42 +724,6 @@ Future<void> _runQuickstartSmokeOcr({
       'Failed to OCR quickstart screenshot (exitCode=${result.exitCode}, '
       'stderr=${result.stderr})',
     );
-  }
-}
-
-void _collectQuickstartSmokeTextWidgetIds(List<String> result, Object? json) {
-  if (json is List) {
-    for (final item in json) {
-      _collectQuickstartSmokeTextWidgetIds(result, item);
-    }
-    return;
-  }
-  if (json is! Map) return;
-
-  if (json['widgetRuntimeType'] == 'Text' &&
-      json['createdByLocalProject'] == true &&
-      json['valueId'] is String) {
-    result.add(json['valueId'] as String);
-  }
-  for (final value in json.values) {
-    _collectQuickstartSmokeTextWidgetIds(result, value);
-  }
-}
-
-void _writeQuickstartSmokeInspectorText(StringBuffer buffer, Object? json) {
-  if (json is List) {
-    for (final item in json) {
-      _writeQuickstartSmokeInspectorText(buffer, item);
-    }
-    return;
-  }
-  if (json is! Map) return;
-
-  if (json['type'] == 'StringProperty' && json['value'] is String) {
-    buffer.writeln(json['value']);
-  }
-  for (final value in json.values) {
-    _writeQuickstartSmokeInspectorText(buffer, value);
   }
 }
 

--- a/tools/frb_internal/lib/src/makefile_dart/quickstart_smoke.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/quickstart_smoke.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: avoid_print
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_rust_bridge_internal/src/makefile_dart/consts.dart';
@@ -36,6 +37,7 @@ Future<void> runFlutterViaCreateQuickstartSmokeTest({
     final screenshotEvidence = await _captureQuickstartSmokeEvidence(
       context: context,
       readyForScreenshot: readyForScreenshot,
+      flutterRun: activeFlutterRun,
     );
     final exitStatus = await _stopQuickstartSmokeFlutterRun(
       flutterRun: activeFlutterRun,
@@ -67,6 +69,7 @@ class _QuickstartSmokeContext {
   final File preprocessedScreenshotFile;
   final File ocrOutputFile;
   final File preprocessedOcrOutputFile;
+  final File vmServiceOutputFile;
   final File logFile;
   final File? chromeWrapper;
 
@@ -81,6 +84,7 @@ class _QuickstartSmokeContext {
     required this.preprocessedScreenshotFile,
     required this.ocrOutputFile,
     required this.preprocessedOcrOutputFile,
+    required this.vmServiceOutputFile,
     required this.logFile,
     required this.chromeWrapper,
   });
@@ -119,6 +123,9 @@ class _QuickstartSmokeContext {
       preprocessedOcrOutputFile: File(
         '${absolutePackage.path}/$artifactDir/quickstart-$targetName-processed.txt',
       ),
+      vmServiceOutputFile: File(
+        '${absolutePackage.path}/$artifactDir/quickstart-$targetName-vm-service.txt',
+      ),
       logFile: File(
         '${absolutePackage.path}/$artifactDir/quickstart-$targetName.log',
       ),
@@ -151,6 +158,7 @@ class _QuickstartSmokeContext {
       preprocessedScreenshotFile,
       ocrOutputFile,
       preprocessedOcrOutputFile,
+      vmServiceOutputFile,
       logFile,
     ]) {
       if (file.existsSync()) file.deleteSync();
@@ -195,11 +203,13 @@ class _QuickstartSmokeFlutterRun {
 class _QuickstartSmokeScreenshotEvidence {
   final bool readyForScreenshot;
   final bool ocrMatched;
+  final bool vmServiceMatched;
   final Exception? lastOcrException;
 
   const _QuickstartSmokeScreenshotEvidence({
     required this.readyForScreenshot,
     required this.ocrMatched,
+    required this.vmServiceMatched,
     required this.lastOcrException,
   });
 }
@@ -272,6 +282,22 @@ bool quickstartSmokeFlutterRunIsReadyForTesting(String output) {
     'A Dart VM Service',
   ];
   return readyPatterns.any(output.contains);
+}
+
+@visibleForTesting
+Uri? quickstartSmokeVmServiceUriForTesting(String output) {
+  final match = RegExp(
+    r'A Dart VM Service.*? at: (http://\S+/)',
+  ).firstMatch(output);
+  if (match == null) return null;
+  return Uri.parse(match.group(1)!);
+}
+
+@visibleForTesting
+String quickstartSmokeInspectorTextForTesting(Object? json) {
+  final buffer = StringBuffer();
+  _writeQuickstartSmokeInspectorText(buffer, json);
+  return buffer.toString();
 }
 
 @visibleForTesting
@@ -359,6 +385,7 @@ Future<bool> _waitForQuickstartSmokeFlutterRunReady({
 Future<_QuickstartSmokeScreenshotEvidence> _captureQuickstartSmokeEvidence({
   required _QuickstartSmokeContext context,
   required bool readyForScreenshot,
+  required _QuickstartSmokeFlutterRun flutterRun,
 }) async {
   if (!readyForScreenshot) {
     print('Capturing one diagnostic screenshot before failing readiness check');
@@ -366,6 +393,7 @@ Future<_QuickstartSmokeScreenshotEvidence> _captureQuickstartSmokeEvidence({
     return _QuickstartSmokeScreenshotEvidence(
       readyForScreenshot: readyForScreenshot,
       ocrMatched: false,
+      vmServiceMatched: false,
       lastOcrException: null,
     );
   }
@@ -393,6 +421,7 @@ Future<_QuickstartSmokeScreenshotEvidence> _captureQuickstartSmokeEvidence({
       return _QuickstartSmokeScreenshotEvidence(
         readyForScreenshot: readyForScreenshot,
         ocrMatched: true,
+        vmServiceMatched: false,
         lastOcrException: null,
       );
     } on Exception catch (exception) {
@@ -403,11 +432,115 @@ Future<_QuickstartSmokeScreenshotEvidence> _captureQuickstartSmokeEvidence({
     }
   } while (DateTime.now().isBefore(visibleTextDeadline));
 
+  final vmServiceMatched = await _captureQuickstartMacosVmServiceEvidence(
+    context: context,
+    flutterRun: flutterRun,
+  );
+
   return _QuickstartSmokeScreenshotEvidence(
     readyForScreenshot: readyForScreenshot,
     ocrMatched: false,
+    vmServiceMatched: vmServiceMatched,
     lastOcrException: lastOcrException,
   );
+}
+
+Future<bool> _captureQuickstartMacosVmServiceEvidence({
+  required _QuickstartSmokeContext context,
+  required _QuickstartSmokeFlutterRun flutterRun,
+}) async {
+  if (context.target != QuickstartSmokeTarget.desktop || !Platform.isMacOS) {
+    return false;
+  }
+
+  print('Trying macOS Flutter VM service evidence after screenshot OCR miss');
+  try {
+    final text = await _readQuickstartMacosVmServiceText(
+      flutterRun.combinedOutput,
+    );
+    context.vmServiceOutputFile.writeAsStringSync(text);
+    checkQuickstartSmokeOcrTextForTesting(text);
+    print('macOS Flutter VM service evidence contains expected text');
+    return true;
+  } on Exception catch (exception) {
+    context.vmServiceOutputFile.writeAsStringSync(exception.toString());
+    print('macOS Flutter VM service evidence did not match: $exception');
+    return false;
+  }
+}
+
+Future<String> _readQuickstartMacosVmServiceText(
+  String flutterRunOutput,
+) async {
+  final vmServiceUri = quickstartSmokeVmServiceUriForTesting(flutterRunOutput);
+  if (vmServiceUri == null) {
+    throw Exception('Could not find Flutter VM Service URL in flutter run log');
+  }
+
+  final vm = await _getQuickstartSmokeVmServiceJson(
+    vmServiceUri.resolve('getVM'),
+  );
+  final isolates = (vm['result'] as Map<String, Object?>)['isolates'] as List;
+  if (isolates.isEmpty) {
+    throw Exception('Flutter VM Service reported no app isolates');
+  }
+  final isolateId = (isolates.single as Map<String, Object?>)['id'] as String;
+
+  final tree = await _getQuickstartSmokeVmServiceJson(
+    vmServiceUri.replace(
+      path:
+          '${vmServiceUri.path}ext.flutter.inspector.getRootWidgetSummaryTree',
+      queryParameters: {
+        'isolateId': isolateId,
+        'objectGroup': 'quickstartSmoke',
+        'subtreeDepth': '20',
+      },
+    ),
+  );
+  final textWidgetIds = _findQuickstartSmokeTextWidgetIds(tree);
+  if (textWidgetIds.isEmpty) {
+    throw Exception('Flutter inspector did not report any app Text widgets');
+  }
+
+  final buffer = StringBuffer();
+  for (final textWidgetId in textWidgetIds) {
+    final properties = await _getQuickstartSmokeVmServiceJson(
+      vmServiceUri.replace(
+        path: '${vmServiceUri.path}ext.flutter.inspector.getProperties',
+        queryParameters: {
+          'isolateId': isolateId,
+          'objectGroup': 'quickstartSmoke',
+          'arg': textWidgetId,
+        },
+      ),
+    );
+    buffer.writeln(quickstartSmokeInspectorTextForTesting(properties));
+  }
+  return buffer.toString();
+}
+
+Future<Map<String, Object?>> _getQuickstartSmokeVmServiceJson(Uri uri) async {
+  final client = HttpClient();
+  try {
+    final request = await client.getUrl(uri);
+    final response = await request.close();
+    final body = await response.transform(utf8.decoder).join();
+    if (response.statusCode != HttpStatus.ok) {
+      throw Exception(
+        'Flutter VM Service request failed '
+        '(status=${response.statusCode}, uri=$uri, body=$body)',
+      );
+    }
+    return jsonDecode(body) as Map<String, Object?>;
+  } finally {
+    client.close(force: true);
+  }
+}
+
+List<String> _findQuickstartSmokeTextWidgetIds(Object? json) {
+  final result = <String>[];
+  _collectQuickstartSmokeTextWidgetIds(result, json);
+  return result;
 }
 
 Future<_QuickstartSmokeExitStatus> _stopQuickstartSmokeFlutterRun({
@@ -437,6 +570,10 @@ void _printQuickstartSmokeEvidence(_QuickstartSmokeContext context) {
   if (context.ocrOutputFile.existsSync()) {
     print('\n===== screenshot OCR (${context.targetName}) =====');
     print(context.ocrOutputFile.readAsStringSync());
+  }
+  if (context.vmServiceOutputFile.existsSync()) {
+    print('\n===== VM service evidence (${context.targetName}) =====');
+    print(context.vmServiceOutputFile.readAsStringSync());
   }
 }
 
@@ -477,7 +614,7 @@ void _validateQuickstartSmokeResult({
       'produce OCR output at `${context.ocrOutputFile.path}`',
     );
   }
-  if (!screenshotEvidence.ocrMatched) {
+  if (!screenshotEvidence.ocrMatched && !screenshotEvidence.vmServiceMatched) {
     if (screenshotEvidence.lastOcrException != null) {
       throw screenshotEvidence.lastOcrException!;
     }
@@ -694,6 +831,42 @@ Future<void> _runQuickstartSmokeOcr({
       'Failed to OCR quickstart screenshot (exitCode=${result.exitCode}, '
       'stderr=${result.stderr})',
     );
+  }
+}
+
+void _collectQuickstartSmokeTextWidgetIds(List<String> result, Object? json) {
+  if (json is List) {
+    for (final item in json) {
+      _collectQuickstartSmokeTextWidgetIds(result, item);
+    }
+    return;
+  }
+  if (json is! Map) return;
+
+  if (json['widgetRuntimeType'] == 'Text' &&
+      json['createdByLocalProject'] == true &&
+      json['valueId'] is String) {
+    result.add(json['valueId'] as String);
+  }
+  for (final value in json.values) {
+    _collectQuickstartSmokeTextWidgetIds(result, value);
+  }
+}
+
+void _writeQuickstartSmokeInspectorText(StringBuffer buffer, Object? json) {
+  if (json is List) {
+    for (final item in json) {
+      _writeQuickstartSmokeInspectorText(buffer, item);
+    }
+    return;
+  }
+  if (json is! Map) return;
+
+  if (json['type'] == 'StringProperty' && json['value'] is String) {
+    buffer.writeln(json['value']);
+  }
+  for (final value in json.values) {
+    _writeQuickstartSmokeInspectorText(buffer, value);
   }
 }
 

--- a/tools/frb_internal/lib/src/makefile_dart/quickstart_smoke.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/quickstart_smoke.dart
@@ -241,11 +241,15 @@ Duration quickstartSmokeFlutterRunReadyTimeoutForTesting(
 Duration quickstartSmokeVisibleTextTimeoutForTesting(
   QuickstartSmokeTarget target,
 ) => switch (target) {
-  QuickstartSmokeTarget.web => const Duration(seconds: 45),
+  QuickstartSmokeTarget.web ||
   QuickstartSmokeTarget.desktop ||
   QuickstartSmokeTarget.android ||
-  QuickstartSmokeTarget.ios => const Duration(seconds: 90),
+  QuickstartSmokeTarget.ios => const Duration(seconds: 30),
 };
+
+@visibleForTesting
+Duration quickstartSmokeScreenshotRetryIntervalForTesting() =>
+    const Duration(seconds: 2);
 
 @visibleForTesting
 String? quickstartSmokeOutputFailurePatternForTesting(String output) {
@@ -384,10 +388,10 @@ Future<_QuickstartSmokeScreenshotEvidence> _captureQuickstartSmokeEvidence({
   print(
     'Waiting up to $visibleTextTimeout for quickstart text to become OCR-visible',
   );
-  await Future<void>.delayed(const Duration(seconds: 5));
 
   Exception? lastOcrException;
   var attempt = 0;
+  final retryInterval = quickstartSmokeScreenshotRetryIntervalForTesting();
   do {
     attempt++;
     print('Capturing quickstart screenshot/OCR attempt #$attempt');
@@ -406,7 +410,7 @@ Future<_QuickstartSmokeScreenshotEvidence> _captureQuickstartSmokeEvidence({
       lastOcrException = exception;
       print('Quickstart screenshot OCR did not match yet: $exception');
       if (!DateTime.now().isBefore(visibleTextDeadline)) break;
-      await Future<void>.delayed(const Duration(seconds: 5));
+      await Future<void>.delayed(retryInterval);
     }
   } while (DateTime.now().isBefore(visibleTextDeadline));
 

--- a/tools/frb_internal/test/makefile_dart_test.dart
+++ b/tools/frb_internal/test/makefile_dart_test.dart
@@ -206,6 +206,34 @@ late final callback = ptr.asFunction<voidFunction(ffi.Pointer<ffi.Void>)>();
     },
   );
 
+  test('quickstart smoke parses Flutter VM service URL from logs', () {
+    expect(
+      quickstartSmokeVmServiceUriForTesting(
+        'A Dart VM Service on macOS is available at: '
+        'http://127.0.0.1:61042/NXgpX5-MgL0=/',
+      ).toString(),
+      'http://127.0.0.1:61042/NXgpX5-MgL0=/',
+    );
+  });
+
+  test('quickstart smoke extracts Text data from inspector properties', () {
+    expect(
+      quickstartSmokeInspectorTextForTesting({
+        'result': {
+          'result': [
+            {
+              'type': 'StringProperty',
+              'name': 'data',
+              'value':
+                  'Action: Call Rust `greet("Tom")`\nResult: `Hello, Tom!`',
+            },
+          ],
+        },
+      }),
+      contains('Result: `Hello, Tom!`'),
+    );
+  });
+
   test('quickstart smoke does not capture while Flutter is still building', () {
     expect(
       quickstartSmokeFlutterRunIsReadyForTesting(

--- a/tools/frb_internal/test/makefile_dart_test.dart
+++ b/tools/frb_internal/test/makefile_dart_test.dart
@@ -163,6 +163,19 @@ late final callback = ptr.asFunction<voidFunction(ffi.Pointer<ffi.Void>)>();
     );
   });
 
+  test('quickstart smoke polls screenshots quickly for visible text', () {
+    for (final target in QuickstartSmokeTarget.values) {
+      expect(
+        quickstartSmokeVisibleTextTimeoutForTesting(target),
+        const Duration(seconds: 30),
+      );
+    }
+    expect(
+      quickstartSmokeScreenshotRetryIntervalForTesting(),
+      const Duration(seconds: 2),
+    );
+  });
+
   test('quickstart smoke resolves package from repo root instead of cwd', () {
     expect(
       quickstartSmokePackagePathForTesting(

--- a/tools/frb_internal/test/makefile_dart_test.dart
+++ b/tools/frb_internal/test/makefile_dart_test.dart
@@ -163,19 +163,6 @@ late final callback = ptr.asFunction<voidFunction(ffi.Pointer<ffi.Void>)>();
     );
   });
 
-  test('quickstart smoke polls screenshots quickly for visible text', () {
-    for (final target in QuickstartSmokeTarget.values) {
-      expect(
-        quickstartSmokeVisibleTextTimeoutForTesting(target),
-        const Duration(seconds: 30),
-      );
-    }
-    expect(
-      quickstartSmokeScreenshotRetryIntervalForTesting(),
-      const Duration(seconds: 2),
-    );
-  });
-
   test('quickstart smoke resolves package from repo root instead of cwd', () {
     expect(
       quickstartSmokePackagePathForTesting(

--- a/tools/frb_internal/test/makefile_dart_test.dart
+++ b/tools/frb_internal/test/makefile_dart_test.dart
@@ -188,6 +188,12 @@ late final callback = ptr.asFunction<voidFunction(ffi.Pointer<ffi.Void>)>();
       ),
       ['simctl', 'io', 'IPHONE-UDID', 'screenshot', '/tmp/quickstart.png'],
     );
+    expect(quickstartSmokeMacosScreenshotArgsForTesting('/tmp/smoke.png'), [
+      '-x',
+      '-T',
+      '1',
+      '/tmp/smoke.png',
+    ]);
   });
 
   test(
@@ -205,34 +211,6 @@ late final callback = ptr.asFunction<voidFunction(ffi.Pointer<ffi.Void>)>();
       );
     },
   );
-
-  test('quickstart smoke parses Flutter VM service URL from logs', () {
-    expect(
-      quickstartSmokeVmServiceUriForTesting(
-        'A Dart VM Service on macOS is available at: '
-        'http://127.0.0.1:61042/NXgpX5-MgL0=/',
-      ).toString(),
-      'http://127.0.0.1:61042/NXgpX5-MgL0=/',
-    );
-  });
-
-  test('quickstart smoke extracts Text data from inspector properties', () {
-    expect(
-      quickstartSmokeInspectorTextForTesting({
-        'result': {
-          'result': [
-            {
-              'type': 'StringProperty',
-              'name': 'data',
-              'value':
-                  'Action: Call Rust `greet("Tom")`\nResult: `Hello, Tom!`',
-            },
-          ],
-        },
-      }),
-      contains('Result: `Hello, Tom!`'),
-    );
-  });
 
   test('quickstart smoke does not capture while Flutter is still building', () {
     expect(


### PR DESCRIPTION
Keeps the macOS quickstart smoke path screenshot-based after #3176, and removes the VM Service inspector fallback from the first version of this PR.

What changed:

- Keep quickstart smoke success tied to screenshot OCR containing `Hello, Tom`.
- Remove the macOS Flutter VM Service / inspector widget-tree fallback; this PR no longer proves success by reading `Text.data` internally.
- Before macOS `screencapture`, activate the `flutter_via_create` app and use a short delayed capture so a normal foreground-window case has time to redraw.
- Keep the screenshot and OCR artifacts as the only success evidence.

Current macOS finding:

- Local Tart still fails screenshot OCR: the app launches and the menu bar switches to `flutter_via_create`, but `screencapture` only captures the desktop/menu bar, not the app window.
- `flutter screenshot -d macos` is not available (`Screenshot not supported for macOS.`).
- This points to Tart/macOS Screen Recording/TCC capture restrictions, not a quickstart app startup failure.
- I cancelled the previous focused run because it targeted the old inspector-fallback commit and should not be treated as valid.

Validation:

- Docker: `dart format --set-exit-if-changed tools/frb_internal/lib/src/makefile_dart/quickstart_smoke.dart tools/frb_internal/test/makefile_dart_test.dart`
- Docker: `cd tools/frb_internal && dart test test/makefile_dart_test.dart`
- Docker: `cd tools/frb_internal && dart test test/ci_plan_test.dart test/makefile_dart_test.dart && cd ../.. && ./frb_internal plan-ci --filter "test_flutter_quickstart_smoke[platform=macos]"`
- Tart macOS screenshot/OCR: still fails because the screenshot lacks the app window content under the local Tart VM.
