### PR TITLE
Document feature flag test coverage rules

### DIFF
--- a/.claude/skills/frb-develop-feature/SKILL.md
+++ b/.claude/skills/frb-develop-feature/SKILL.md
@@ -29,8 +29,7 @@ Before pushing, opening a PR, requesting review, or monitoring CI as if the work
 - Confirm every final regression or feature test has been moved from `frb_example/dart_minimal` to `frb_example/pure_dart`.
 - Confirm the final Rust APIs/types/functions in `pure_dart` use the `TwinNormal` suffix pattern where applicable.
 - Confirm code generation has produced the matching `pure_dart_pde` coverage.
-- For feature flags whose enabled and disabled behavior both need coverage, confirm the flag is exposed in `flutter_rust_bridge.yaml` and the command-line interface, and prefer adding an item-level `#[frb(...)]` override when feasible.
-- For such feature flags, prefer `pure_dart` tests that use the `#[frb(...)]` override so enabled and disabled cases are both exercised in the same package.
+- For feature flags, read and apply `frb-feature-flag` before treating the coverage as final.
 - Remove the temporary `dart_minimal` reproducer unless it is intentionally kept as a minimal example in addition to the `pure_dart` regression.
 
 If any of these checks fail, return to Phase 2. Do not treat a passing `dart_minimal` test as final readiness.

--- a/.claude/skills/frb-develop-feature/SKILL.md
+++ b/.claude/skills/frb-develop-feature/SKILL.md
@@ -29,6 +29,8 @@ Before pushing, opening a PR, requesting review, or monitoring CI as if the work
 - Confirm every final regression or feature test has been moved from `frb_example/dart_minimal` to `frb_example/pure_dart`.
 - Confirm the final Rust APIs/types/functions in `pure_dart` use the `TwinNormal` suffix pattern where applicable.
 - Confirm code generation has produced the matching `pure_dart_pde` coverage.
+- For feature flags whose enabled and disabled behavior both need coverage, confirm the flag is exposed in `flutter_rust_bridge.yaml` and the command-line interface, and prefer adding an item-level `#[frb(...)]` override when feasible.
+- For such feature flags, prefer `pure_dart` tests that use the `#[frb(...)]` override so enabled and disabled cases are both exercised in the same package.
 - Remove the temporary `dart_minimal` reproducer unless it is intentionally kept as a minimal example in addition to the `pure_dart` regression.
 
 If any of these checks fail, return to Phase 2. Do not treat a passing `dart_minimal` test as final readiness.

--- a/.claude/skills/frb-feature-flag/SKILL.md
+++ b/.claude/skills/frb-feature-flag/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frb-feature-flag
-description: Use when adding or testing flutter_rust_bridge feature flags, especially flags that require coverage for both enabled and disabled states or should have package-level config plus item-level #[frb(...)] overrides.
+description: "Use when adding or testing flutter_rust_bridge feature flags, especially flags that require coverage for both enabled and disabled states or should have package-level config plus item-level #[frb(...)] overrides."
 ---
 
 # FRB Feature Flags

--- a/.claude/skills/frb-feature-flag/SKILL.md
+++ b/.claude/skills/frb-feature-flag/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: frb-feature-flag
+description: Use when adding or testing flutter_rust_bridge feature flags, especially flags that require coverage for both enabled and disabled states or should have package-level config plus item-level #[frb(...)] overrides.
+---
+
+# FRB Feature Flags
+
+Use this skill when adding a feature flag, changing a feature flag, or writing coverage for a feature flag.
+
+## API Surface
+
+For feature flags requiring coverage for both enabled and disabled states:
+
+- Expose the flag in `flutter_rust_bridge.yaml`.
+- Expose the flag in the command-line interface.
+- Prefer adding an item-level `#[frb(...)]` override when the behavior can reasonably be scoped to a Rust item.
+
+## Test Coverage
+
+In `frb_example/pure_dart`, prefer tests that use the item-level `#[frb(...)]` override so enabled and disabled cases are both exercised in the same package.
+
+Do not rely only on package-level config differences when both states can be covered clearly with item-level Rust APIs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,18 +10,15 @@
 | `*.freezed.dart` | Freezed output |
 | `*.g.dart` | Code generator output |
 
-### Feature flags that need both enabled and disabled coverage
+### Feature flags
 
-When adding a feature flag whose enabled and disabled behavior both need coverage:
-
-- Add the flag to `flutter_rust_bridge.yaml` and the command-line interface.
-- Also prefer adding an item-level `#[frb(...)]` override when the feature can reasonably be scoped to a Rust item.
-- In `frb_example/pure_dart` tests, prefer using the `#[frb(...)]` override to cover enabled and disabled behavior in the same package instead of relying only on package-level config differences.
+When adding or testing feature flags, read `frb-feature-flag`.
 
 ## Skills
 
 - `frb-code-generation` - Which generation commands to run
 - `frb-develop-feature` - New feature development workflow
+- `frb-feature-flag` - Feature flag API surface and enabled/disabled coverage rules
 - `frb-test` - How to run tests
 - `frb-debugging` - Debug code generation issues
 - `frb-lint` - Lint and format checks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,14 @@
 | `*.freezed.dart` | Freezed output |
 | `*.g.dart` | Code generator output |
 
+### Feature flags that need both enabled and disabled coverage
+
+When adding a feature flag whose enabled and disabled behavior both need coverage:
+
+- Add the flag to `flutter_rust_bridge.yaml` and the command-line interface.
+- Also prefer adding an item-level `#[frb(...)]` override when the feature can reasonably be scoped to a Rust item.
+- In `frb_example/pure_dart` tests, prefer using the `#[frb(...)]` override to cover enabled and disabled behavior in the same package instead of relying only on package-level config differences.
+
 ## Skills
 
 - `frb-code-generation` - Which generation commands to run


### PR DESCRIPTION
## Changes

- Add a repo-local `frb-feature-flag` skill for feature flag API surface and enabled/disabled coverage rules.
- Reference the new skill from `CLAUDE.md` and the `frb-develop-feature` final placement gate to avoid duplicating the guidance.

## Validation

- `pre-commit run --all-files` was attempted, but this repo has no `.pre-commit-config.yaml`.