### PR TITLE
Isolate wasm-pack coverage environment

### DIFF
--- a/frb_dart/lib/src/cli/build_web/executor.dart
+++ b/frb_dart/lib/src/cli/build_web/executor.dart
@@ -165,14 +165,18 @@ Future<void> _executeWasmPack(
   if (rustflagsResolution.warning != null) {
     print(rustflagsResolution.warning);
   }
-  final environment = computeWasmPackEnvironment(
-    baseEnvironment: Platform.environment,
+  final environmentSplit = _splitByPredicate(
+    Platform.environment.entries,
+    (entry) => _isWasmPackCoverageEnvironmentKey(entry.key),
+  );
+  final environment = _computeWasmPackEnvironmentFromEntries(
+    environmentEntries: environmentSplit.unmatched,
     rustupToolchain: args.wasmPackRustupToolchain ?? 'nightly',
     rustflags: rustflagsResolution.rustflags,
     cargoTermColor: stdout.supportsAnsiEscapes,
   );
   final removedCoverageEnvironmentKeys =
-      _removedWasmPackCoverageEnvironmentKeys(Platform.environment);
+      environmentSplit.matched.map((entry) => entry.key).toList()..sort();
   if (removedCoverageEnvironmentKeys.isNotEmpty) {
     print(
       'INFO: Removed cargo-llvm-cov environment variables before running '
@@ -267,17 +271,45 @@ Map<String, String> computeWasmPackEnvironment({
   required String rustupToolchain,
   required String rustflags,
   required bool cargoTermColor,
-}) => {
-  for (final MapEntry(key: key, value: value) in baseEnvironment.entries)
-    if (!_isWasmPackCoverageEnvironmentKey(key)) key: value,
-  'RUSTUP_TOOLCHAIN': rustupToolchain,
-  'RUSTFLAGS': rustflags,
-  if (cargoTermColor) 'CARGO_TERM_COLOR': 'always',
-};
+}) {
+  final split = _splitByPredicate(
+    baseEnvironment.entries,
+    (entry) => _isWasmPackCoverageEnvironmentKey(entry.key),
+  );
+  return _computeWasmPackEnvironmentFromEntries(
+    environmentEntries: split.unmatched,
+    rustupToolchain: rustupToolchain,
+    rustflags: rustflags,
+    cargoTermColor: cargoTermColor,
+  );
+}
 
-List<String> _removedWasmPackCoverageEnvironmentKeys(
-  Map<String, String> environment,
-) => environment.keys.where(_isWasmPackCoverageEnvironmentKey).toList()..sort();
+Map<String, String> _computeWasmPackEnvironmentFromEntries({
+  required Iterable<MapEntry<String, String>> environmentEntries,
+  required String rustupToolchain,
+  required String rustflags,
+  required bool cargoTermColor,
+}) {
+  return {
+    for (final MapEntry(key: key, value: value) in environmentEntries)
+      key: value,
+    'RUSTUP_TOOLCHAIN': rustupToolchain,
+    'RUSTFLAGS': rustflags,
+    if (cargoTermColor) 'CARGO_TERM_COLOR': 'always',
+  };
+}
+
+({List<T> matched, List<T> unmatched}) _splitByPredicate<T>(
+  Iterable<T> values,
+  bool Function(T value) predicate,
+) {
+  final matched = <T>[];
+  final unmatched = <T>[];
+  for (final value in values) {
+    (predicate(value) ? matched : unmatched).add(value);
+  }
+  return (matched: matched, unmatched: unmatched);
+}
 
 bool _isWasmPackCoverageEnvironmentKey(String key) =>
     key == 'LLVM_PROFILE_FILE' ||

--- a/frb_dart/lib/src/cli/build_web/executor.dart
+++ b/frb_dart/lib/src/cli/build_web/executor.dart
@@ -169,7 +169,7 @@ Future<void> _executeWasmPack(
     Platform.environment.entries,
     (entry) => _isWasmPackCoverageEnvironmentKey(entry.key),
   );
-  final environment = {
+  final cmdEnv = {
     for (final MapEntry(key: key, value: value) in environmentSplit.unmatched)
       key: value,
     'RUSTUP_TOOLCHAIN': args.wasmPackRustupToolchain ?? 'nightly',
@@ -207,7 +207,7 @@ Future<void> _executeWasmPack(
       // if (config.cliOpts.noDefaultFeatures) '--no-default-features',
       // if (config.cliOpts.features != null) '--features=${config.cliOpts.features}'
     ],
-    env: environment,
+    env: cmdEnv,
     includeParentEnvironment: false,
   );
 }
@@ -264,25 +264,6 @@ WasmPackRustflagsResolution computeWasmPackRustflagsResolution({
       ? null
       : 'WARN: RUSTFLAGS will be `$argsOverride`, which does not contain the default threaded-WASM flags `$buildWebDefaultWasmPackRustflags`. Keep the default flags when overriding `--wasm-pack-rustflags`, otherwise worker startup may fail with errors such as `WebAssembly.Memory could not be cloned`.';
   return WasmPackRustflagsResolution(rustflags: argsOverride, warning: warning);
-}
-
-@visibleForTesting
-Map<String, String> computeWasmPackEnvironment({
-  required Map<String, String> baseEnvironment,
-  required String rustupToolchain,
-  required String rustflags,
-  required bool cargoTermColor,
-}) {
-  final split = _splitByPredicate(
-    baseEnvironment.entries,
-    (entry) => _isWasmPackCoverageEnvironmentKey(entry.key),
-  );
-  return {
-    for (final MapEntry(key: key, value: value) in split.unmatched) key: value,
-    'RUSTUP_TOOLCHAIN': rustupToolchain,
-    'RUSTFLAGS': rustflags,
-    if (cargoTermColor) 'CARGO_TERM_COLOR': 'always',
-  };
 }
 
 ({List<T> matched, List<T> unmatched}) _splitByPredicate<T>(

--- a/frb_dart/lib/src/cli/build_web/executor.dart
+++ b/frb_dart/lib/src/cli/build_web/executor.dart
@@ -188,11 +188,13 @@ Future<void> _executeWasmPack(
       // if (config.cliOpts.noDefaultFeatures) '--no-default-features',
       // if (config.cliOpts.features != null) '--features=${config.cliOpts.features}'
     ],
-    env: {
-      'RUSTUP_TOOLCHAIN': args.wasmPackRustupToolchain ?? 'nightly',
-      'RUSTFLAGS': rustflagsResolution.rustflags,
-      if (stdout.supportsAnsiEscapes) 'CARGO_TERM_COLOR': 'always',
-    },
+    env: computeWasmPackEnvironment(
+      baseEnvironment: Platform.environment,
+      rustupToolchain: args.wasmPackRustupToolchain ?? 'nightly',
+      rustflags: rustflagsResolution.rustflags,
+      cargoTermColor: stdout.supportsAnsiEscapes,
+    ),
+    includeParentEnvironment: false,
   );
 }
 
@@ -249,6 +251,45 @@ WasmPackRustflagsResolution computeWasmPackRustflagsResolution({
       : 'WARN: RUSTFLAGS will be `$argsOverride`, which does not contain the default threaded-WASM flags `$buildWebDefaultWasmPackRustflags`. Keep the default flags when overriding `--wasm-pack-rustflags`, otherwise worker startup may fail with errors such as `WebAssembly.Memory could not be cloned`.';
   return WasmPackRustflagsResolution(rustflags: argsOverride, warning: warning);
 }
+
+@visibleForTesting
+Map<String, String> computeWasmPackEnvironment({
+  required Map<String, String> baseEnvironment,
+  required String rustupToolchain,
+  required String rustflags,
+  required bool cargoTermColor,
+}) =>
+    <String, String>{
+      for (final key in _wasmPackInheritedEnvironmentKeys)
+        if (baseEnvironment[key] case final value?) key: value,
+      'RUSTUP_TOOLCHAIN': rustupToolchain,
+      'RUSTFLAGS': rustflags,
+      if (cargoTermColor) 'CARGO_TERM_COLOR': 'always',
+    };
+
+const _wasmPackInheritedEnvironmentKeys = [
+  'PATH',
+  'HOME',
+  'USER',
+  'USERNAME',
+  'SHELL',
+  'TMPDIR',
+  'TEMP',
+  'TMP',
+  'SYSTEMROOT',
+  'COMSPEC',
+  'PATHEXT',
+  'APPDATA',
+  'LOCALAPPDATA',
+  'CARGO_HOME',
+  'RUSTUP_HOME',
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'NO_PROXY',
+  'http_proxy',
+  'https_proxy',
+  'no_proxy',
+];
 
 Future<void> _executeWasmBindgen(
   BuildWebArgs args, {

--- a/frb_dart/lib/src/cli/build_web/executor.dart
+++ b/frb_dart/lib/src/cli/build_web/executor.dart
@@ -270,6 +270,7 @@ Map<String, String> computeWasmPackEnvironment({
 const _wasmPackInheritedEnvironmentKeys = [
   'PATH',
   'HOME',
+  'USERPROFILE',
   'USER',
   'USERNAME',
   'SHELL',
@@ -289,6 +290,11 @@ const _wasmPackInheritedEnvironmentKeys = [
   'http_proxy',
   'https_proxy',
   'no_proxy',
+  'SSH_AUTH_SOCK',
+  'LANG',
+  'LC_ALL',
+  'LC_CTYPE',
+  'TERM',
 ];
 
 Future<void> _executeWasmBindgen(

--- a/frb_dart/lib/src/cli/build_web/executor.dart
+++ b/frb_dart/lib/src/cli/build_web/executor.dart
@@ -165,6 +165,18 @@ Future<void> _executeWasmPack(
   if (rustflagsResolution.warning != null) {
     print(rustflagsResolution.warning);
   }
+  final environmentResolution = computeWasmPackEnvironmentResolution(
+    baseEnvironment: Platform.environment,
+    rustupToolchain: args.wasmPackRustupToolchain ?? 'nightly',
+    rustflags: rustflagsResolution.rustflags,
+    cargoTermColor: stdout.supportsAnsiEscapes,
+  );
+  if (environmentResolution.removedCoverageEnvironmentKeys.isNotEmpty) {
+    print(
+      'INFO: Removed cargo-llvm-cov environment variables before running '
+      'wasm-pack: ${environmentResolution.removedCoverageEnvironmentKeys.join(', ')}',
+    );
+  }
 
   await runCommand(
     'wasm-pack',
@@ -188,12 +200,7 @@ Future<void> _executeWasmPack(
       // if (config.cliOpts.noDefaultFeatures) '--no-default-features',
       // if (config.cliOpts.features != null) '--features=${config.cliOpts.features}'
     ],
-    env: computeWasmPackEnvironment(
-      baseEnvironment: Platform.environment,
-      rustupToolchain: args.wasmPackRustupToolchain ?? 'nightly',
-      rustflags: rustflagsResolution.rustflags,
-      cargoTermColor: stdout.supportsAnsiEscapes,
-    ),
+    env: environmentResolution.environment,
     includeParentEnvironment: false,
   );
 }
@@ -210,6 +217,21 @@ class WasmPackRustflagsResolution {
   const WasmPackRustflagsResolution({
     required this.rustflags,
     required this.warning,
+  });
+}
+
+/// Resolved environment output for a `wasm-pack` invocation.
+class WasmPackEnvironmentResolution {
+  /// The complete environment that will be passed to `wasm-pack`.
+  final Map<String, String> environment;
+
+  /// Coverage-specific environment keys removed before running `wasm-pack`.
+  final List<String> removedCoverageEnvironmentKeys;
+
+  /// Creates a resolved `wasm-pack` environment result.
+  const WasmPackEnvironmentResolution({
+    required this.environment,
+    required this.removedCoverageEnvironmentKeys,
   });
 }
 
@@ -258,44 +280,49 @@ Map<String, String> computeWasmPackEnvironment({
   required String rustupToolchain,
   required String rustflags,
   required bool cargoTermColor,
-}) =>
-    <String, String>{
-      for (final key in _wasmPackInheritedEnvironmentKeys)
-        if (baseEnvironment[key] case final value?) key: value,
-      'RUSTUP_TOOLCHAIN': rustupToolchain,
-      'RUSTFLAGS': rustflags,
-      if (cargoTermColor) 'CARGO_TERM_COLOR': 'always',
-    };
+}) => computeWasmPackEnvironmentResolution(
+  baseEnvironment: baseEnvironment,
+  rustupToolchain: rustupToolchain,
+  rustflags: rustflags,
+  cargoTermColor: cargoTermColor,
+).environment;
 
-const _wasmPackInheritedEnvironmentKeys = [
-  'PATH',
-  'HOME',
-  'USERPROFILE',
-  'USER',
-  'USERNAME',
-  'SHELL',
-  'TMPDIR',
-  'TEMP',
-  'TMP',
-  'SYSTEMROOT',
-  'COMSPEC',
-  'PATHEXT',
-  'APPDATA',
-  'LOCALAPPDATA',
-  'CARGO_HOME',
-  'RUSTUP_HOME',
-  'HTTP_PROXY',
-  'HTTPS_PROXY',
-  'NO_PROXY',
-  'http_proxy',
-  'https_proxy',
-  'no_proxy',
-  'SSH_AUTH_SOCK',
-  'LANG',
-  'LC_ALL',
-  'LC_CTYPE',
-  'TERM',
-];
+@visibleForTesting
+/// Resolves the complete `wasm-pack` environment and removed coverage keys.
+WasmPackEnvironmentResolution computeWasmPackEnvironmentResolution({
+  required Map<String, String> baseEnvironment,
+  required String rustupToolchain,
+  required String rustflags,
+  required bool cargoTermColor,
+}) {
+  final environment = Map<String, String>.of(baseEnvironment);
+  final removedCoverageEnvironmentKeys =
+      environment.keys.where(_isWasmPackCoverageEnvironmentKey).toList()
+        ..sort();
+  for (final key in removedCoverageEnvironmentKeys) {
+    environment.remove(key);
+  }
+
+  environment['RUSTUP_TOOLCHAIN'] = rustupToolchain;
+  environment['RUSTFLAGS'] = rustflags;
+  if (cargoTermColor) {
+    environment['CARGO_TERM_COLOR'] = 'always';
+  } else {
+    environment.remove('CARGO_TERM_COLOR');
+  }
+
+  return WasmPackEnvironmentResolution(
+    environment: environment,
+    removedCoverageEnvironmentKeys: removedCoverageEnvironmentKeys,
+  );
+}
+
+bool _isWasmPackCoverageEnvironmentKey(String key) =>
+    key == 'LLVM_PROFILE_FILE' ||
+    key == 'RUSTC_WRAPPER' ||
+    key == 'RUSTFLAGS' ||
+    key.startsWith('CARGO_LLVM_COV') ||
+    key.startsWith('__CARGO_LLVM_COV');
 
 Future<void> _executeWasmBindgen(
   BuildWebArgs args, {

--- a/frb_dart/lib/src/cli/build_web/executor.dart
+++ b/frb_dart/lib/src/cli/build_web/executor.dart
@@ -169,12 +169,13 @@ Future<void> _executeWasmPack(
     Platform.environment.entries,
     (entry) => _isWasmPackCoverageEnvironmentKey(entry.key),
   );
-  final environment = _computeWasmPackEnvironmentFromEntries(
-    environmentEntries: environmentSplit.unmatched,
-    rustupToolchain: args.wasmPackRustupToolchain ?? 'nightly',
-    rustflags: rustflagsResolution.rustflags,
-    cargoTermColor: stdout.supportsAnsiEscapes,
-  );
+  final environment = {
+    for (final MapEntry(key: key, value: value) in environmentSplit.unmatched)
+      key: value,
+    'RUSTUP_TOOLCHAIN': args.wasmPackRustupToolchain ?? 'nightly',
+    'RUSTFLAGS': rustflagsResolution.rustflags,
+    if (stdout.supportsAnsiEscapes) 'CARGO_TERM_COLOR': 'always',
+  };
   final removedCoverageEnvironmentKeys =
       environmentSplit.matched.map((entry) => entry.key).toList()..sort();
   if (removedCoverageEnvironmentKeys.isNotEmpty) {
@@ -276,23 +277,8 @@ Map<String, String> computeWasmPackEnvironment({
     baseEnvironment.entries,
     (entry) => _isWasmPackCoverageEnvironmentKey(entry.key),
   );
-  return _computeWasmPackEnvironmentFromEntries(
-    environmentEntries: split.unmatched,
-    rustupToolchain: rustupToolchain,
-    rustflags: rustflags,
-    cargoTermColor: cargoTermColor,
-  );
-}
-
-Map<String, String> _computeWasmPackEnvironmentFromEntries({
-  required Iterable<MapEntry<String, String>> environmentEntries,
-  required String rustupToolchain,
-  required String rustflags,
-  required bool cargoTermColor,
-}) {
   return {
-    for (final MapEntry(key: key, value: value) in environmentEntries)
-      key: value,
+    for (final MapEntry(key: key, value: value) in split.unmatched) key: value,
     'RUSTUP_TOOLCHAIN': rustupToolchain,
     'RUSTFLAGS': rustflags,
     if (cargoTermColor) 'CARGO_TERM_COLOR': 'always',

--- a/frb_dart/lib/src/cli/build_web/executor.dart
+++ b/frb_dart/lib/src/cli/build_web/executor.dart
@@ -165,16 +165,18 @@ Future<void> _executeWasmPack(
   if (rustflagsResolution.warning != null) {
     print(rustflagsResolution.warning);
   }
-  final environmentResolution = computeWasmPackEnvironmentResolution(
+  final environment = computeWasmPackEnvironment(
     baseEnvironment: Platform.environment,
     rustupToolchain: args.wasmPackRustupToolchain ?? 'nightly',
     rustflags: rustflagsResolution.rustflags,
     cargoTermColor: stdout.supportsAnsiEscapes,
   );
-  if (environmentResolution.removedCoverageEnvironmentKeys.isNotEmpty) {
+  final removedCoverageEnvironmentKeys =
+      _removedWasmPackCoverageEnvironmentKeys(Platform.environment);
+  if (removedCoverageEnvironmentKeys.isNotEmpty) {
     print(
       'INFO: Removed cargo-llvm-cov environment variables before running '
-      'wasm-pack: ${environmentResolution.removedCoverageEnvironmentKeys.join(', ')}',
+      'wasm-pack: ${removedCoverageEnvironmentKeys.join(', ')}',
     );
   }
 
@@ -200,7 +202,7 @@ Future<void> _executeWasmPack(
       // if (config.cliOpts.noDefaultFeatures) '--no-default-features',
       // if (config.cliOpts.features != null) '--features=${config.cliOpts.features}'
     ],
-    env: environmentResolution.environment,
+    env: environment,
     includeParentEnvironment: false,
   );
 }
@@ -217,21 +219,6 @@ class WasmPackRustflagsResolution {
   const WasmPackRustflagsResolution({
     required this.rustflags,
     required this.warning,
-  });
-}
-
-/// Resolved environment output for a `wasm-pack` invocation.
-class WasmPackEnvironmentResolution {
-  /// The complete environment that will be passed to `wasm-pack`.
-  final Map<String, String> environment;
-
-  /// Coverage-specific environment keys removed before running `wasm-pack`.
-  final List<String> removedCoverageEnvironmentKeys;
-
-  /// Creates a resolved `wasm-pack` environment result.
-  const WasmPackEnvironmentResolution({
-    required this.environment,
-    required this.removedCoverageEnvironmentKeys,
   });
 }
 
@@ -280,42 +267,17 @@ Map<String, String> computeWasmPackEnvironment({
   required String rustupToolchain,
   required String rustflags,
   required bool cargoTermColor,
-}) => computeWasmPackEnvironmentResolution(
-  baseEnvironment: baseEnvironment,
-  rustupToolchain: rustupToolchain,
-  rustflags: rustflags,
-  cargoTermColor: cargoTermColor,
-).environment;
+}) => {
+  for (final MapEntry(key: key, value: value) in baseEnvironment.entries)
+    if (!_isWasmPackCoverageEnvironmentKey(key)) key: value,
+  'RUSTUP_TOOLCHAIN': rustupToolchain,
+  'RUSTFLAGS': rustflags,
+  if (cargoTermColor) 'CARGO_TERM_COLOR': 'always',
+};
 
-@visibleForTesting
-/// Resolves the complete `wasm-pack` environment and removed coverage keys.
-WasmPackEnvironmentResolution computeWasmPackEnvironmentResolution({
-  required Map<String, String> baseEnvironment,
-  required String rustupToolchain,
-  required String rustflags,
-  required bool cargoTermColor,
-}) {
-  final environment = Map<String, String>.of(baseEnvironment);
-  final removedCoverageEnvironmentKeys =
-      environment.keys.where(_isWasmPackCoverageEnvironmentKey).toList()
-        ..sort();
-  for (final key in removedCoverageEnvironmentKeys) {
-    environment.remove(key);
-  }
-
-  environment['RUSTUP_TOOLCHAIN'] = rustupToolchain;
-  environment['RUSTFLAGS'] = rustflags;
-  if (cargoTermColor) {
-    environment['CARGO_TERM_COLOR'] = 'always';
-  } else {
-    environment.remove('CARGO_TERM_COLOR');
-  }
-
-  return WasmPackEnvironmentResolution(
-    environment: environment,
-    removedCoverageEnvironmentKeys: removedCoverageEnvironmentKeys,
-  );
-}
+List<String> _removedWasmPackCoverageEnvironmentKeys(
+  Map<String, String> environment,
+) => environment.keys.where(_isWasmPackCoverageEnvironmentKey).toList()..sort();
 
 bool _isWasmPackCoverageEnvironmentKey(String key) =>
     key == 'LLVM_PROFILE_FILE' ||

--- a/frb_dart/lib/src/cli/run_command.dart
+++ b/frb_dart/lib/src/cli/run_command.dart
@@ -32,6 +32,7 @@ Future<RunCommandOutput> runCommand(
   bool? checkExitCode,
   bool printCommandInStderr = false,
   Duration? timeout,
+  bool includeParentEnvironment = true,
 }) async {
   // ignore: avoid_print
   (printCommandInStderr ? stderr : stdout).writeAndFlush(
@@ -44,7 +45,7 @@ Future<RunCommandOutput> runCommand(
     runInShell: shell,
     workingDirectory: pwd,
     environment: env,
-    includeParentEnvironment: true,
+    includeParentEnvironment: includeParentEnvironment,
   );
 
   final stdoutText = <String>[];

--- a/frb_dart/test/build_web_executor_test.dart
+++ b/frb_dart/test/build_web_executor_test.dart
@@ -76,4 +76,33 @@ void main() {
       expect(resolution.warning, isNull);
     },
   );
+
+  test('wasm-pack environment drops cargo llvm-cov variables', () {
+    final environment = computeWasmPackEnvironment(
+      baseEnvironment: const {
+        'PATH': '/usr/bin',
+        'HOME': '/home/test',
+        'CARGO_LLVM_COV': '1',
+        'CARGO_LLVM_COV_TARGET_DIR': '/tmp/target',
+        'LLVM_PROFILE_FILE': '/tmp/profile-%p.profraw',
+        'RUSTC_WRAPPER': 'cargo-llvm-cov',
+        '__CARGO_LLVM_COV_RUSTC_WRAPPER': '1',
+        'RUSTFLAGS': '-C instrument-coverage',
+      },
+      rustupToolchain: 'nightly',
+      rustflags: '-C target-feature=+atomics',
+      cargoTermColor: true,
+    );
+
+    expect(environment['PATH'], '/usr/bin');
+    expect(environment['HOME'], '/home/test');
+    expect(environment['RUSTUP_TOOLCHAIN'], 'nightly');
+    expect(environment['RUSTFLAGS'], '-C target-feature=+atomics');
+    expect(environment['CARGO_TERM_COLOR'], 'always');
+    expect(environment, isNot(contains('CARGO_LLVM_COV')));
+    expect(environment, isNot(contains('CARGO_LLVM_COV_TARGET_DIR')));
+    expect(environment, isNot(contains('LLVM_PROFILE_FILE')));
+    expect(environment, isNot(contains('RUSTC_WRAPPER')));
+    expect(environment, isNot(contains('__CARGO_LLVM_COV_RUSTC_WRAPPER')));
+  });
 }

--- a/frb_dart/test/build_web_executor_test.dart
+++ b/frb_dart/test/build_web_executor_test.dart
@@ -78,7 +78,7 @@ void main() {
   );
 
   test('wasm-pack environment drops cargo llvm-cov variables', () {
-    final resolution = computeWasmPackEnvironmentResolution(
+    final environment = computeWasmPackEnvironment(
       baseEnvironment: const {
         'PATH': '/usr/bin',
         'HOME': '/home/test',
@@ -96,7 +96,6 @@ void main() {
       rustflags: '-C target-feature=+atomics',
       cargoTermColor: true,
     );
-    final environment = resolution.environment;
 
     expect(environment['PATH'], '/usr/bin');
     expect(environment['HOME'], '/home/test');
@@ -111,18 +110,5 @@ void main() {
     expect(environment, isNot(contains('RUSTC_WRAPPER')));
     expect(environment, isNot(contains('__CARGO_LLVM_COV_RUSTC_WRAPPER')));
     expect(environment, isNot(contains('__CARGO_LLVM_COV_EXTRA')));
-    expect(
-      resolution.removedCoverageEnvironmentKeys,
-      containsAllInOrder([
-        'CARGO_LLVM_COV',
-        'CARGO_LLVM_COV_EXTRA',
-        'CARGO_LLVM_COV_TARGET_DIR',
-        'LLVM_PROFILE_FILE',
-        'RUSTC_WRAPPER',
-        'RUSTFLAGS',
-        '__CARGO_LLVM_COV_EXTRA',
-        '__CARGO_LLVM_COV_RUSTC_WRAPPER',
-      ]),
-    );
   });
 }

--- a/frb_dart/test/build_web_executor_test.dart
+++ b/frb_dart/test/build_web_executor_test.dart
@@ -82,6 +82,12 @@ void main() {
       baseEnvironment: const {
         'PATH': '/usr/bin',
         'HOME': '/home/test',
+        'USERPROFILE': r'C:\Users\test',
+        'SSH_AUTH_SOCK': '/tmp/ssh-agent.sock',
+        'LANG': 'en_US.UTF-8',
+        'LC_ALL': 'en_US.UTF-8',
+        'LC_CTYPE': 'en_US.UTF-8',
+        'TERM': 'xterm-256color',
         'CARGO_LLVM_COV': '1',
         'CARGO_LLVM_COV_TARGET_DIR': '/tmp/target',
         'LLVM_PROFILE_FILE': '/tmp/profile-%p.profraw',
@@ -96,6 +102,12 @@ void main() {
 
     expect(environment['PATH'], '/usr/bin');
     expect(environment['HOME'], '/home/test');
+    expect(environment['USERPROFILE'], r'C:\Users\test');
+    expect(environment['SSH_AUTH_SOCK'], '/tmp/ssh-agent.sock');
+    expect(environment['LANG'], 'en_US.UTF-8');
+    expect(environment['LC_ALL'], 'en_US.UTF-8');
+    expect(environment['LC_CTYPE'], 'en_US.UTF-8');
+    expect(environment['TERM'], 'xterm-256color');
     expect(environment['RUSTUP_TOOLCHAIN'], 'nightly');
     expect(environment['RUSTFLAGS'], '-C target-feature=+atomics');
     expect(environment['CARGO_TERM_COLOR'], 'always');

--- a/frb_dart/test/build_web_executor_test.dart
+++ b/frb_dart/test/build_web_executor_test.dart
@@ -78,43 +78,51 @@ void main() {
   );
 
   test('wasm-pack environment drops cargo llvm-cov variables', () {
-    final environment = computeWasmPackEnvironment(
+    final resolution = computeWasmPackEnvironmentResolution(
       baseEnvironment: const {
         'PATH': '/usr/bin',
         'HOME': '/home/test',
-        'USERPROFILE': r'C:\Users\test',
-        'SSH_AUTH_SOCK': '/tmp/ssh-agent.sock',
-        'LANG': 'en_US.UTF-8',
-        'LC_ALL': 'en_US.UTF-8',
-        'LC_CTYPE': 'en_US.UTF-8',
-        'TERM': 'xterm-256color',
+        'FRB_CUSTOM_TOOLCHAIN_ENV': 'kept',
         'CARGO_LLVM_COV': '1',
+        'CARGO_LLVM_COV_EXTRA': 'extra',
         'CARGO_LLVM_COV_TARGET_DIR': '/tmp/target',
         'LLVM_PROFILE_FILE': '/tmp/profile-%p.profraw',
         'RUSTC_WRAPPER': 'cargo-llvm-cov',
         '__CARGO_LLVM_COV_RUSTC_WRAPPER': '1',
+        '__CARGO_LLVM_COV_EXTRA': 'extra',
         'RUSTFLAGS': '-C instrument-coverage',
       },
       rustupToolchain: 'nightly',
       rustflags: '-C target-feature=+atomics',
       cargoTermColor: true,
     );
+    final environment = resolution.environment;
 
     expect(environment['PATH'], '/usr/bin');
     expect(environment['HOME'], '/home/test');
-    expect(environment['USERPROFILE'], r'C:\Users\test');
-    expect(environment['SSH_AUTH_SOCK'], '/tmp/ssh-agent.sock');
-    expect(environment['LANG'], 'en_US.UTF-8');
-    expect(environment['LC_ALL'], 'en_US.UTF-8');
-    expect(environment['LC_CTYPE'], 'en_US.UTF-8');
-    expect(environment['TERM'], 'xterm-256color');
+    expect(environment['FRB_CUSTOM_TOOLCHAIN_ENV'], 'kept');
     expect(environment['RUSTUP_TOOLCHAIN'], 'nightly');
     expect(environment['RUSTFLAGS'], '-C target-feature=+atomics');
     expect(environment['CARGO_TERM_COLOR'], 'always');
     expect(environment, isNot(contains('CARGO_LLVM_COV')));
+    expect(environment, isNot(contains('CARGO_LLVM_COV_EXTRA')));
     expect(environment, isNot(contains('CARGO_LLVM_COV_TARGET_DIR')));
     expect(environment, isNot(contains('LLVM_PROFILE_FILE')));
     expect(environment, isNot(contains('RUSTC_WRAPPER')));
     expect(environment, isNot(contains('__CARGO_LLVM_COV_RUSTC_WRAPPER')));
+    expect(environment, isNot(contains('__CARGO_LLVM_COV_EXTRA')));
+    expect(
+      resolution.removedCoverageEnvironmentKeys,
+      containsAllInOrder([
+        'CARGO_LLVM_COV',
+        'CARGO_LLVM_COV_EXTRA',
+        'CARGO_LLVM_COV_TARGET_DIR',
+        'LLVM_PROFILE_FILE',
+        'RUSTC_WRAPPER',
+        'RUSTFLAGS',
+        '__CARGO_LLVM_COV_EXTRA',
+        '__CARGO_LLVM_COV_RUSTC_WRAPPER',
+      ]),
+    );
   });
 }

--- a/frb_dart/test/build_web_executor_test.dart
+++ b/frb_dart/test/build_web_executor_test.dart
@@ -76,39 +76,4 @@ void main() {
       expect(resolution.warning, isNull);
     },
   );
-
-  test('wasm-pack environment drops cargo llvm-cov variables', () {
-    final environment = computeWasmPackEnvironment(
-      baseEnvironment: const {
-        'PATH': '/usr/bin',
-        'HOME': '/home/test',
-        'FRB_CUSTOM_TOOLCHAIN_ENV': 'kept',
-        'CARGO_LLVM_COV': '1',
-        'CARGO_LLVM_COV_EXTRA': 'extra',
-        'CARGO_LLVM_COV_TARGET_DIR': '/tmp/target',
-        'LLVM_PROFILE_FILE': '/tmp/profile-%p.profraw',
-        'RUSTC_WRAPPER': 'cargo-llvm-cov',
-        '__CARGO_LLVM_COV_RUSTC_WRAPPER': '1',
-        '__CARGO_LLVM_COV_EXTRA': 'extra',
-        'RUSTFLAGS': '-C instrument-coverage',
-      },
-      rustupToolchain: 'nightly',
-      rustflags: '-C target-feature=+atomics',
-      cargoTermColor: true,
-    );
-
-    expect(environment['PATH'], '/usr/bin');
-    expect(environment['HOME'], '/home/test');
-    expect(environment['FRB_CUSTOM_TOOLCHAIN_ENV'], 'kept');
-    expect(environment['RUSTUP_TOOLCHAIN'], 'nightly');
-    expect(environment['RUSTFLAGS'], '-C target-feature=+atomics');
-    expect(environment['CARGO_TERM_COLOR'], 'always');
-    expect(environment, isNot(contains('CARGO_LLVM_COV')));
-    expect(environment, isNot(contains('CARGO_LLVM_COV_EXTRA')));
-    expect(environment, isNot(contains('CARGO_LLVM_COV_TARGET_DIR')));
-    expect(environment, isNot(contains('LLVM_PROFILE_FILE')));
-    expect(environment, isNot(contains('RUSTC_WRAPPER')));
-    expect(environment, isNot(contains('__CARGO_LLVM_COV_RUSTC_WRAPPER')));
-    expect(environment, isNot(contains('__CARGO_LLVM_COV_EXTRA')));
-  });
 }


### PR DESCRIPTION
## Recommendation: close this PR

After review, this PR should not stay in the native-assets PR chain and should not be merged as-is. The issue it addresses is real but narrow: `cargo llvm-cov` can leak coverage-related environment variables into a nested `wasm-pack` build. However, fixing it inside the user-facing `build-web` path by changing parent environment inheritance and stripping `RUSTFLAGS` has compatibility risk for users who intentionally provide `RUSTFLAGS` for web builds.

A better follow-up would be one of these narrower designs:

- Clean the `cargo llvm-cov` environment only in FRB's CI/internal coverage wrapper before invoking `build-web`.
- Add an explicit opt-in flag for coverage-env isolation instead of changing default `build-web` behavior.
- Fail fast with a clear diagnostic when `build-web` detects a cargo-llvm-cov environment, telling callers which variables to unset.

For #3181, this prework is not required. The native-assets backend should proceed without this adjacent web/coverage behavior change.

Part of the native-assets backend PR chain before #3181.

Stack order:

1. #3205 Refactor integration integrator modules
2. #3206 Restructure integration templates by backend
3. This PR isolates wasm-pack from cargo-llvm-cov environment variables
4. #3208 Verify checked-in Apple scaffolds
5. #3181 Support native assets integration backend

Why this is needed:

- FRB web builds can run under `cargo llvm-cov` when CI collects coverage.
- `cargo llvm-cov show-env` intentionally exports parent-process variables such as `CARGO_LLVM_COV`, `RUSTC_WRAPPER`, `LLVM_PROFILE_FILE`, `RUSTFLAGS`, and related wrapper state.
- `wasm-pack` is a separate Rust build path for `wasm32-unknown-unknown`; if it inherits the coverage wrapper environment, it can try to compile wasm through the llvm-cov rustc wrapper and coverage flags.
- That environment is useful for the native Rust coverage command, but it is not a valid default for the nested wasm-pack build.

Observed failure:

- During local validation, `cargo llvm-cov run frb_codegen build-web --dart-coverage` reached the wasm build path with the llvm-cov environment still present.
- The nested `wasm-pack` invocation inherited those coverage variables and the ARM nightly wasm build failed with `can't find crate for profiler_builtins`.
- The failure was not caused by native-assets itself; it was exposed while validating the broader #3181 branch, so it is split into this web/coverage prework PR.

What this PR changes:

- Adds an `includeParentEnvironment` option to `runCommand`.
- Runs wasm-pack with `includeParentEnvironment: false`.
- Builds the wasm-pack environment from the parent environment, then removes the cargo-llvm-cov coverage variables by denylist/prefix denylist.
- Prints the exact coverage environment keys removed before invoking wasm-pack, so local and CI logs explain what was stripped.
- Explicitly sets wasm-pack-specific values such as `RUSTUP_TOOLCHAIN`, `RUSTFLAGS`, and optional `CARGO_TERM_COLOR`.
- Keeps normal toolchain and host plumbing by default instead of maintaining a narrow allowlist.

Relationship to #3181:

This is not native-assets behavior. It was previously adjacent to the native-assets work because Codecov exposed it while that branch was being validated. It is split out here so #3181 does not need to carry unrelated web build plumbing.
