### PR TITLE
Add FRB release publishing workflow

### DIFF
--- a/.claude/skills/frb-publish-release/SKILL.md
+++ b/.claude/skills/frb-publish-release/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: frb-publish-release
+description: Publish a flutter_rust_bridge release end to end: preflight checks, changelog preparation, frb_internal release publishing, released-version polling, CI babysitting, and post-release CI verification.
+---
+
+# FRB Publish Release
+
+Use this skill when preparing, publishing, or babysitting a `flutter_rust_bridge` release.
+
+## Workflow
+
+### 1. Preflight
+
+- Work from the repository root on the intended release branch, normally fresh `master`.
+- Check `git status --short --branch` and do not start publishing from a dirty tree.
+- Confirm the target version in `CHANGELOG.md`, root `Cargo.toml`, and `frb_dart/pubspec.yaml`.
+- Confirm GitHub, crates.io, and pub.dev credentials are available before starting irreversible publish steps.
+- Confirm normal CI is green for the release commit before publishing.
+
+### 2. Write Changelog
+
+- Use `frb-write-changelog` to create or refresh the target release section in `CHANGELOG.md`.
+- Review the release section manually before publishing. The top `CHANGELOG.md` version is the source used by `frb_internal release`.
+- If changelog or version files changed, commit that release preparation before publishing.
+
+### 3. Publish
+
+Use the repository release command:
+
+```bash
+./frb_internal release
+```
+
+This command computes old/new versions from `CHANGELOG.md`, updates checked-in versions and generated version text, updates Scoop metadata, commits and pushes the version bump, creates a draft GitHub release, then runs:
+
+```bash
+./frb_internal release-publish-all
+```
+
+`release-publish-all` publishes these packages:
+
+- `frb_codegen` -> crates.io package `flutter_rust_bridge_codegen`
+- `frb_macros` -> crates.io package `flutter_rust_bridge_macros`
+- `frb_rust` -> crates.io package `flutter_rust_bridge`
+- `frb_dart` -> pub.dev package `flutter_rust_bridge`
+
+If the version bump and GitHub draft already exist and only registry publication is needed, use `./frb_internal release-publish-all` directly.
+
+### 4. Check Released Versions
+
+Poll registry state with:
+
+```bash
+./frb_internal get-released-version
+```
+
+The command prints JSON:
+
+```json
+{
+  "allReleased": true,
+  "packages": [
+    {
+      "registry": "crates.io",
+      "name": "flutter_rust_bridge_codegen",
+      "manifestVersion": "2.12.0",
+      "releasedVersion": "2.12.0",
+      "isReleased": true
+    }
+  ]
+}
+```
+
+Wait until every package has `isReleased: true` and `allReleased: true`. If one registry lags, keep polling with bounded waits and record the mismatched package instead of assuming the publish failed.
+
+### 5. Babysit CI And Post-Release CI
+
+- Keep watching the release commit's normal CI until it is green.
+- After `./frb_internal get-released-version` reports `allReleased: true`, trigger `.github/workflows/post_release.yaml` for the release commit or `master`.
+- Babysit post-release CI until it is green. Use `gh-actions-live-logs` when reading GitHub Actions logs.
+- If post-release fails, classify the failure by install mode (`cargo-install`, `cargo-binstall`, `scoop`, or `homebrew`) before changing code or rerunning.
+
+## Related Skills
+
+- `frb-write-changelog` for the release section.
+- `frb-fix-ci` or `frb-fix-main-ci` for CI failures.
+- `gh-actions-live-logs` for GitHub Actions logs.

--- a/.claude/skills/frb-publish-release/SKILL.md
+++ b/.claude/skills/frb-publish-release/SKILL.md
@@ -54,6 +54,12 @@ Poll registry state with:
 ./frb_internal get-released-version
 ```
 
+To check a target version from a checkout whose manifests have not been bumped, pass it explicitly:
+
+```bash
+./frb_internal get-released-version --version <VERSION>
+```
+
 The command prints JSON:
 
 ```json
@@ -71,7 +77,7 @@ The command prints JSON:
 }
 ```
 
-Wait until every package has `isReleased: true` and `allReleased: true`. If one registry lags, keep polling with bounded waits and record the mismatched package instead of assuming the publish failed.
+Wait until every package has `isReleased: true` and `allReleased: true`. If one registry lags, keep polling with bounded waits and record the mismatched package instead of assuming the publish failed. Do not add the target version option to the mutating `release-*` subcommands; they derive their version from `CHANGELOG.md` and checked-in manifests.
 
 ### 5. Babysit CI And Post-Release CI
 

--- a/tools/frb_internal/bin/flutter_rust_bridge_internal.dart
+++ b/tools/frb_internal/bin/flutter_rust_bridge_internal.dart
@@ -13,6 +13,8 @@ import 'package:flutter_rust_bridge_internal/src/makefile_dart/post_release.dart
     as post_release;
 import 'package:flutter_rust_bridge_internal/src/makefile_dart/release.dart'
     as release;
+import 'package:flutter_rust_bridge_internal/src/makefile_dart/released_version.dart'
+    as released_version;
 import 'package:flutter_rust_bridge_internal/src/makefile_dart/test.dart'
     as build;
 import 'package:flutter_rust_bridge_internal/src/utils/makefile_dart_infra.dart';
@@ -26,6 +28,7 @@ Future<void> main(List<String> args) async {
         ..addCommands(bench.createCommands())
         ..addCommands(misc.createCommands())
         ..addCommands(release.createCommands())
+        ..addCommands(released_version.createCommands())
         ..addCommands(post_release.createCommands())
         ..addCommands(build.createCommands());
   await runner.run(args);

--- a/tools/frb_internal/lib/src/makefile_dart/release.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/release.dart
@@ -1,14 +1,17 @@
 // ignore_for_file: avoid_print
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:args/command_runner.dart';
 import 'package:collection/collection.dart';
+import 'package:dio/dio.dart';
 import 'package:flutter_rust_bridge_internal/src/makefile_dart/consts.dart';
 import 'package:flutter_rust_bridge_internal/src/makefile_dart/misc.dart';
 import 'package:flutter_rust_bridge_internal/src/utils/makefile_dart_infra.dart';
 import 'package:glob/glob.dart';
 import 'package:glob/list_local_fs.dart';
+import 'package:toml/toml.dart';
 import 'package:yaml/yaml.dart';
 
 List<Command<void>> createCommands() {
@@ -20,6 +23,7 @@ List<Command<void>> createCommands() {
     SimpleCommand('release-update-git', releaseUpdateGit),
     SimpleCommand('release-update-github', releaseUpdateGithub),
     SimpleCommand('release-publish-all', releasePublishAll),
+    SimpleCommand('get-released-version', getReleasedVersion),
   ];
 }
 
@@ -168,6 +172,119 @@ Future<void> releasePublishAll() async {
     'cd frb_dart && flutter pub publish --force --server=https://pub.dartlang.org',
   );
 }
+
+Future<void> getReleasedVersion() async {
+  final statuses = await fetchReleasePackageStatuses();
+  print(
+    const JsonEncoder.withIndent(
+      '  ',
+    ).convert(buildReleasePackageStatusOutput(statuses)),
+  );
+}
+
+class ReleasePackageStatus {
+  final String registry;
+  final String name;
+  final String manifestVersion;
+  final String? releasedVersion;
+
+  const ReleasePackageStatus({
+    required this.registry,
+    required this.name,
+    required this.manifestVersion,
+    required this.releasedVersion,
+  });
+
+  bool get isReleased => manifestVersion == releasedVersion;
+
+  Map<String, Object?> toJson() => {
+    'registry': registry,
+    'name': name,
+    'manifestVersion': manifestVersion,
+    'releasedVersion': releasedVersion,
+    'isReleased': isReleased,
+  };
+}
+
+typedef ReleaseMetadataFetcher = Future<Map<String, dynamic>> Function(Uri uri);
+
+Future<List<ReleasePackageStatus>> fetchReleasePackageStatuses({
+  ReleaseMetadataFetcher fetcher = _defaultReleaseMetadataFetcher,
+}) async {
+  final rustVersion = getWorkspaceRustVersion();
+  final dartVersion = getFrbDartVersion();
+
+  return [
+    for (final package in [
+      'flutter_rust_bridge_codegen',
+      'flutter_rust_bridge_macros',
+      'flutter_rust_bridge',
+    ])
+      ReleasePackageStatus(
+        registry: 'crates.io',
+        name: package,
+        manifestVersion: rustVersion,
+        releasedVersion: await fetchCratesIoReleasedVersion(
+          package,
+          fetcher: fetcher,
+        ),
+      ),
+    ReleasePackageStatus(
+      registry: 'pub.dev',
+      name: 'flutter_rust_bridge',
+      manifestVersion: dartVersion,
+      releasedVersion: await fetchPubDevReleasedVersion(
+        'flutter_rust_bridge',
+        fetcher: fetcher,
+      ),
+    ),
+  ];
+}
+
+Map<String, Object?> buildReleasePackageStatusOutput(
+  List<ReleasePackageStatus> statuses,
+) => {
+  'allReleased': statuses.every((status) => status.isReleased),
+  'packages': statuses.map((status) => status.toJson()).toList(),
+};
+
+Future<String?> fetchCratesIoReleasedVersion(
+  String package, {
+  ReleaseMetadataFetcher fetcher = _defaultReleaseMetadataFetcher,
+}) async {
+  final json = await fetcher(Uri.https('crates.io', '/api/v1/crates/$package'));
+  return parseCratesIoReleasedVersion(json);
+}
+
+String? parseCratesIoReleasedVersion(Map<String, dynamic> json) =>
+    (json['crate'] as Map<String, dynamic>?)?['max_version'] as String?;
+
+Future<String?> fetchPubDevReleasedVersion(
+  String package, {
+  ReleaseMetadataFetcher fetcher = _defaultReleaseMetadataFetcher,
+}) async {
+  final json = await fetcher(Uri.https('pub.dev', '/api/packages/$package'));
+  return parsePubDevReleasedVersion(json);
+}
+
+String? parsePubDevReleasedVersion(Map<String, dynamic> json) =>
+    (json['latest'] as Map<String, dynamic>?)?['version'] as String?;
+
+Future<Map<String, dynamic>> _defaultReleaseMetadataFetcher(Uri uri) async {
+  final response = await Dio().getUri<Map<String, dynamic>>(uri);
+  final data = response.data;
+  if (data == null) {
+    throw Exception('No release metadata returned from $uri');
+  }
+  return data;
+}
+
+String getWorkspaceRustVersion() =>
+    parseWorkspaceRustVersion(File('${exec.pwd}Cargo.toml').readAsStringSync());
+
+String parseWorkspaceRustVersion(String raw) =>
+    TomlDocument.parse(raw).toMap()['workspace']['package']['version']
+        as String;
 
 String getFrbDartVersion() => loadYaml(
   File('${exec.pwd}frb_dart/pubspec.yaml').readAsStringSync(),

--- a/tools/frb_internal/lib/src/makefile_dart/release.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/release.dart
@@ -1,17 +1,14 @@
 // ignore_for_file: avoid_print
 
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:args/command_runner.dart';
 import 'package:collection/collection.dart';
-import 'package:dio/dio.dart';
 import 'package:flutter_rust_bridge_internal/src/makefile_dart/consts.dart';
 import 'package:flutter_rust_bridge_internal/src/makefile_dart/misc.dart';
 import 'package:flutter_rust_bridge_internal/src/utils/makefile_dart_infra.dart';
 import 'package:glob/glob.dart';
 import 'package:glob/list_local_fs.dart';
-import 'package:toml/toml.dart';
 import 'package:yaml/yaml.dart';
 
 List<Command<void>> createCommands() {
@@ -23,7 +20,6 @@ List<Command<void>> createCommands() {
     SimpleCommand('release-update-git', releaseUpdateGit),
     SimpleCommand('release-update-github', releaseUpdateGithub),
     SimpleCommand('release-publish-all', releasePublishAll),
-    SimpleCommand('get-released-version', getReleasedVersion),
   ];
 }
 
@@ -172,119 +168,6 @@ Future<void> releasePublishAll() async {
     'cd frb_dart && flutter pub publish --force --server=https://pub.dartlang.org',
   );
 }
-
-Future<void> getReleasedVersion() async {
-  final statuses = await fetchReleasePackageStatuses();
-  print(
-    const JsonEncoder.withIndent(
-      '  ',
-    ).convert(buildReleasePackageStatusOutput(statuses)),
-  );
-}
-
-class ReleasePackageStatus {
-  final String registry;
-  final String name;
-  final String manifestVersion;
-  final String? releasedVersion;
-
-  const ReleasePackageStatus({
-    required this.registry,
-    required this.name,
-    required this.manifestVersion,
-    required this.releasedVersion,
-  });
-
-  bool get isReleased => manifestVersion == releasedVersion;
-
-  Map<String, Object?> toJson() => {
-    'registry': registry,
-    'name': name,
-    'manifestVersion': manifestVersion,
-    'releasedVersion': releasedVersion,
-    'isReleased': isReleased,
-  };
-}
-
-typedef ReleaseMetadataFetcher = Future<Map<String, dynamic>> Function(Uri uri);
-
-Future<List<ReleasePackageStatus>> fetchReleasePackageStatuses({
-  ReleaseMetadataFetcher fetcher = _defaultReleaseMetadataFetcher,
-}) async {
-  final rustVersion = getWorkspaceRustVersion();
-  final dartVersion = getFrbDartVersion();
-
-  return [
-    for (final package in [
-      'flutter_rust_bridge_codegen',
-      'flutter_rust_bridge_macros',
-      'flutter_rust_bridge',
-    ])
-      ReleasePackageStatus(
-        registry: 'crates.io',
-        name: package,
-        manifestVersion: rustVersion,
-        releasedVersion: await fetchCratesIoReleasedVersion(
-          package,
-          fetcher: fetcher,
-        ),
-      ),
-    ReleasePackageStatus(
-      registry: 'pub.dev',
-      name: 'flutter_rust_bridge',
-      manifestVersion: dartVersion,
-      releasedVersion: await fetchPubDevReleasedVersion(
-        'flutter_rust_bridge',
-        fetcher: fetcher,
-      ),
-    ),
-  ];
-}
-
-Map<String, Object?> buildReleasePackageStatusOutput(
-  List<ReleasePackageStatus> statuses,
-) => {
-  'allReleased': statuses.every((status) => status.isReleased),
-  'packages': statuses.map((status) => status.toJson()).toList(),
-};
-
-Future<String?> fetchCratesIoReleasedVersion(
-  String package, {
-  ReleaseMetadataFetcher fetcher = _defaultReleaseMetadataFetcher,
-}) async {
-  final json = await fetcher(Uri.https('crates.io', '/api/v1/crates/$package'));
-  return parseCratesIoReleasedVersion(json);
-}
-
-String? parseCratesIoReleasedVersion(Map<String, dynamic> json) =>
-    (json['crate'] as Map<String, dynamic>?)?['max_version'] as String?;
-
-Future<String?> fetchPubDevReleasedVersion(
-  String package, {
-  ReleaseMetadataFetcher fetcher = _defaultReleaseMetadataFetcher,
-}) async {
-  final json = await fetcher(Uri.https('pub.dev', '/api/packages/$package'));
-  return parsePubDevReleasedVersion(json);
-}
-
-String? parsePubDevReleasedVersion(Map<String, dynamic> json) =>
-    (json['latest'] as Map<String, dynamic>?)?['version'] as String?;
-
-Future<Map<String, dynamic>> _defaultReleaseMetadataFetcher(Uri uri) async {
-  final response = await Dio().getUri<Map<String, dynamic>>(uri);
-  final data = response.data;
-  if (data == null) {
-    throw Exception('No release metadata returned from $uri');
-  }
-  return data;
-}
-
-String getWorkspaceRustVersion() =>
-    parseWorkspaceRustVersion(File('${exec.pwd}Cargo.toml').readAsStringSync());
-
-String parseWorkspaceRustVersion(String raw) =>
-    TomlDocument.parse(raw).toMap()['workspace']['package']['version']
-        as String;
 
 String getFrbDartVersion() => loadYaml(
   File('${exec.pwd}frb_dart/pubspec.yaml').readAsStringSync(),

--- a/tools/frb_internal/lib/src/makefile_dart/released_version.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/released_version.dart
@@ -1,0 +1,152 @@
+// ignore_for_file: avoid_print
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'package:build_cli_annotations/build_cli_annotations.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_rust_bridge_internal/src/makefile_dart/consts.dart';
+import 'package:flutter_rust_bridge_internal/src/utils/makefile_dart_infra.dart';
+import 'package:toml/toml.dart';
+import 'package:yaml/yaml.dart';
+
+part 'released_version.g.dart';
+
+List<Command<void>> createCommands() {
+  return [
+    SimpleConfigCommand(
+      'get-released-version',
+      getReleasedVersion,
+      _$populateGetReleasedVersionConfigParser,
+      _$parseGetReleasedVersionConfigResult,
+    ),
+  ];
+}
+
+@CliOptions()
+class GetReleasedVersionConfig {
+  final String? version;
+
+  const GetReleasedVersionConfig({this.version});
+}
+
+Future<void> getReleasedVersion(GetReleasedVersionConfig config) async {
+  final statuses = await fetchReleasePackageStatuses(
+    targetVersion: config.version,
+  );
+  print(
+    const JsonEncoder.withIndent(
+      '  ',
+    ).convert(buildReleasePackageStatusOutput(statuses)),
+  );
+}
+
+class ReleasePackageStatus {
+  final String registry;
+  final String name;
+  final String manifestVersion;
+  final String? releasedVersion;
+
+  const ReleasePackageStatus({
+    required this.registry,
+    required this.name,
+    required this.manifestVersion,
+    required this.releasedVersion,
+  });
+
+  bool get isReleased => manifestVersion == releasedVersion;
+
+  Map<String, Object?> toJson() => {
+    'registry': registry,
+    'name': name,
+    'manifestVersion': manifestVersion,
+    'releasedVersion': releasedVersion,
+    'isReleased': isReleased,
+  };
+}
+
+typedef ReleaseMetadataFetcher = Future<Map<String, dynamic>> Function(Uri uri);
+
+Future<List<ReleasePackageStatus>> fetchReleasePackageStatuses({
+  String? targetVersion,
+  ReleaseMetadataFetcher fetcher = _defaultReleaseMetadataFetcher,
+}) async {
+  final rustVersion = targetVersion ?? getWorkspaceRustVersion();
+  final dartVersion = targetVersion ?? getFrbDartVersion();
+
+  return [
+    for (final package in [
+      'flutter_rust_bridge_codegen',
+      'flutter_rust_bridge_macros',
+      'flutter_rust_bridge',
+    ])
+      ReleasePackageStatus(
+        registry: 'crates.io',
+        name: package,
+        manifestVersion: rustVersion,
+        releasedVersion: await fetchCratesIoReleasedVersion(
+          package,
+          fetcher: fetcher,
+        ),
+      ),
+    ReleasePackageStatus(
+      registry: 'pub.dev',
+      name: 'flutter_rust_bridge',
+      manifestVersion: dartVersion,
+      releasedVersion: await fetchPubDevReleasedVersion(
+        'flutter_rust_bridge',
+        fetcher: fetcher,
+      ),
+    ),
+  ];
+}
+
+Map<String, Object?> buildReleasePackageStatusOutput(
+  List<ReleasePackageStatus> statuses,
+) => {
+  'allReleased': statuses.every((status) => status.isReleased),
+  'packages': statuses.map((status) => status.toJson()).toList(),
+};
+
+Future<String?> fetchCratesIoReleasedVersion(
+  String package, {
+  ReleaseMetadataFetcher fetcher = _defaultReleaseMetadataFetcher,
+}) async {
+  final json = await fetcher(Uri.https('crates.io', '/api/v1/crates/$package'));
+  return parseCratesIoReleasedVersion(json);
+}
+
+String? parseCratesIoReleasedVersion(Map<String, dynamic> json) =>
+    (json['crate'] as Map<String, dynamic>?)?['max_version'] as String?;
+
+Future<String?> fetchPubDevReleasedVersion(
+  String package, {
+  ReleaseMetadataFetcher fetcher = _defaultReleaseMetadataFetcher,
+}) async {
+  final json = await fetcher(Uri.https('pub.dev', '/api/packages/$package'));
+  return parsePubDevReleasedVersion(json);
+}
+
+String? parsePubDevReleasedVersion(Map<String, dynamic> json) =>
+    (json['latest'] as Map<String, dynamic>?)?['version'] as String?;
+
+Future<Map<String, dynamic>> _defaultReleaseMetadataFetcher(Uri uri) async {
+  final response = await Dio().getUri<Map<String, dynamic>>(uri);
+  final data = response.data;
+  if (data == null) {
+    throw Exception('No release metadata returned from $uri');
+  }
+  return data;
+}
+
+String getWorkspaceRustVersion() =>
+    parseWorkspaceRustVersion(File('${exec.pwd}Cargo.toml').readAsStringSync());
+
+String parseWorkspaceRustVersion(String raw) =>
+    TomlDocument.parse(raw).toMap()['workspace']['package']['version']
+        as String;
+
+String getFrbDartVersion() => loadYaml(
+  File('${exec.pwd}frb_dart/pubspec.yaml').readAsStringSync(),
+)['version'];

--- a/tools/frb_internal/lib/src/makefile_dart/released_version.g.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/released_version.g.dart
@@ -1,0 +1,24 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: prefer_const_constructors
+
+part of 'released_version.dart';
+
+// **************************************************************************
+// CliGenerator
+// **************************************************************************
+
+GetReleasedVersionConfig _$parseGetReleasedVersionConfigResult(
+  ArgResults result,
+) => GetReleasedVersionConfig(version: result['version'] as String?);
+
+ArgParser _$populateGetReleasedVersionConfigParser(ArgParser parser) =>
+    parser..addOption('version');
+
+final _$parserForGetReleasedVersionConfig =
+    _$populateGetReleasedVersionConfigParser(ArgParser());
+
+GetReleasedVersionConfig parseGetReleasedVersionConfig(List<String> args) {
+  final result = _$parserForGetReleasedVersionConfig.parse(args);
+  return _$parseGetReleasedVersionConfigResult(result);
+}

--- a/tools/frb_internal/test/makefile_dart_test.dart
+++ b/tools/frb_internal/test/makefile_dart_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_rust_bridge_internal/src/makefile_dart/build.dart';
 import 'package:flutter_rust_bridge_internal/src/makefile_dart/generate.dart';
 import 'package:flutter_rust_bridge_internal/src/makefile_dart/lint.dart';
 import 'package:flutter_rust_bridge_internal/src/makefile_dart/quickstart_smoke.dart';
+import 'package:flutter_rust_bridge_internal/src/makefile_dart/release.dart';
 import 'package:flutter_rust_bridge_internal/src/makefile_dart/test.dart';
 import 'package:test/test.dart';
 
@@ -341,6 +342,61 @@ late final callback = ptr.asFunction<voidFunction(ffi.Pointer<ffi.Void>)>();
           ),
         ),
       );
+    });
+  });
+
+  group('release version check', () {
+    test('parses crates.io package metadata', () {
+      expect(
+        parseCratesIoReleasedVersion({
+          'crate': {'max_version': '2.12.0'},
+        }),
+        '2.12.0',
+      );
+    });
+
+    test('parses pub.dev package metadata', () {
+      expect(
+        parsePubDevReleasedVersion({
+          'latest': {'version': '2.12.0'},
+        }),
+        '2.12.0',
+      );
+    });
+
+    test('summarizes whether every package is published', () {
+      final output = buildReleasePackageStatusOutput([
+        const ReleasePackageStatus(
+          registry: 'crates.io',
+          name: 'flutter_rust_bridge',
+          manifestVersion: '2.12.0',
+          releasedVersion: '2.12.0',
+        ),
+        const ReleasePackageStatus(
+          registry: 'pub.dev',
+          name: 'flutter_rust_bridge',
+          manifestVersion: '2.12.0',
+          releasedVersion: '2.11.1',
+        ),
+      ]);
+
+      expect(output['allReleased'], false);
+      expect(output['packages'], [
+        {
+          'registry': 'crates.io',
+          'name': 'flutter_rust_bridge',
+          'manifestVersion': '2.12.0',
+          'releasedVersion': '2.12.0',
+          'isReleased': true,
+        },
+        {
+          'registry': 'pub.dev',
+          'name': 'flutter_rust_bridge',
+          'manifestVersion': '2.12.0',
+          'releasedVersion': '2.11.1',
+          'isReleased': false,
+        },
+      ]);
     });
   });
 

--- a/tools/frb_internal/test/makefile_dart_test.dart
+++ b/tools/frb_internal/test/makefile_dart_test.dart
@@ -5,7 +5,7 @@ import 'package:flutter_rust_bridge_internal/src/makefile_dart/build.dart';
 import 'package:flutter_rust_bridge_internal/src/makefile_dart/generate.dart';
 import 'package:flutter_rust_bridge_internal/src/makefile_dart/lint.dart';
 import 'package:flutter_rust_bridge_internal/src/makefile_dart/quickstart_smoke.dart';
-import 'package:flutter_rust_bridge_internal/src/makefile_dart/release.dart';
+import 'package:flutter_rust_bridge_internal/src/makefile_dart/released_version.dart';
 import 'package:flutter_rust_bridge_internal/src/makefile_dart/test.dart';
 import 'package:test/test.dart';
 
@@ -397,6 +397,28 @@ late final callback = ptr.asFunction<voidFunction(ffi.Pointer<ffi.Void>)>();
           'isReleased': false,
         },
       ]);
+    });
+
+    test('uses explicit target version for every published package', () async {
+      final statuses = await fetchReleasePackageStatuses(
+        targetVersion: '9.9.9',
+        fetcher: (uri) async {
+          if (uri.host == 'crates.io') {
+            return {
+              'crate': {'max_version': '9.9.9'},
+            };
+          }
+          return {
+            'latest': {'version': '9.9.9'},
+          };
+        },
+      );
+
+      expect(
+        statuses.map((status) => status.manifestVersion),
+        everyElement('9.9.9'),
+      );
+      expect(statuses.map((status) => status.isReleased), everyElement(true));
     });
   });
 


### PR DESCRIPTION
## Summary
- add a frb-publish-release skill covering the requested release workflow
- add ./frb_internal get-released-version in a dedicated released_version command module, reporting crates.io/pub.dev release status as JSON
- support ./frb_internal get-released-version --version <VERSION> for checking a target release without requiring bumped local manifests
- add tests for release metadata parsing and status output

## Verification
- .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- bash -lc 'cd tools/frb_internal && dart test test/makefile_dart_test.dart'
  - Observed: All tests passed, including the new explicit target-version release status test.
- .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- ./frb_internal get-released-version
  - Observed: allReleased=true. crates.io reports flutter_rust_bridge_codegen=2.12.0, flutter_rust_bridge_macros=2.12.0, flutter_rust_bridge=2.12.0; pub.dev reports flutter_rust_bridge=2.12.0. All entries have isReleased=true against manifestVersion=2.12.0.
- .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- ./frb_internal get-released-version --version 2.12.0
  - Observed: allReleased=true with the same four registry versions, proving the generated --version option checks an explicit target version without reading local manifests for the target.
- .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- bash -lc 'cd tools/frb_internal && dart analyze --fatal-infos'
  - Observed: No issues found.
- .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- ./frb_internal lint-dart
  - Observed: Dart format/analyze passed across checked packages; pana for frb_dart completed with 160/160.