### PR TITLE
Reduce mobile device CI matrix

### DIFF
--- a/tools/frb_internal/lib/src/makefile_dart/ci_plan/full_jobs.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/ci_plan/full_jobs.dart
@@ -150,19 +150,14 @@ final kCiJobs = [
     'test_flutter_native_android',
     matrix: CiMatrix([
       for (final package in _flutterNativePackages)
-        for (final device in ['pixel', 'Nexus 6'])
-          {'package': package, 'device': device, 'api-level': 35},
+        {'package': package, 'device': 'pixel', 'api-level': 35},
     ]),
   ),
   CiJob(
     'test_flutter_native_ios',
     matrix: CiMatrix([
       for (final package in _flutterNativePackages)
-        for (final device in [
-          'iPad (10th generation) Simulator (18.6)',
-          'iPhone 16 Pro Max Simulator (18.6)',
-        ])
-          {'package': package, 'device': device},
+        {'package': package, 'device': 'iPhone 16 Pro Max Simulator (18.6)'},
     ]),
   ),
   CiJob(
@@ -207,21 +202,6 @@ final kCiJobs = [
           'target': 'android',
           'device': 'pixel',
           'api-level': 35,
-          'package': 'frb_example--flutter_via_create',
-        },
-        {
-          'image': 'ubuntu-latest',
-          'platform': 'android',
-          'target': 'android',
-          'device': 'Nexus 6',
-          'api-level': 35,
-          'package': 'frb_example--flutter_via_create',
-        },
-        {
-          'image': 'macos-latest',
-          'platform': 'ios',
-          'target': 'ios',
-          'device': 'iPad (10th generation) Simulator (18.6)',
           'package': 'frb_example--flutter_via_create',
         },
         {

--- a/tools/frb_internal/test/ci_plan_test_snapshot_full.json
+++ b/tools/frb_internal/test/ci_plan_test_snapshot_full.json
@@ -447,18 +447,8 @@
           "api-level": 35
         },
         {
-          "package": "frb_example--flutter_via_create",
-          "device": "Nexus 6",
-          "api-level": 35
-        },
-        {
           "package": "frb_example--flutter_package--example",
           "device": "pixel",
-          "api-level": 35
-        },
-        {
-          "package": "frb_example--flutter_package--example",
-          "device": "Nexus 6",
           "api-level": 35
         },
         {
@@ -467,18 +457,8 @@
           "api-level": 35
         },
         {
-          "package": "frb_example--rust_ui_counter--ui",
-          "device": "Nexus 6",
-          "api-level": 35
-        },
-        {
           "package": "frb_example--rust_ui_todo_list--ui",
           "device": "pixel",
-          "api-level": 35
-        },
-        {
-          "package": "frb_example--rust_ui_todo_list--ui",
-          "device": "Nexus 6",
           "api-level": 35
         }
       ]
@@ -488,15 +468,7 @@
       "matrix": [
         {
           "package": "frb_example--flutter_via_create",
-          "device": "iPad (10th generation) Simulator (18.6)"
-        },
-        {
-          "package": "frb_example--flutter_via_create",
           "device": "iPhone 16 Pro Max Simulator (18.6)"
-        },
-        {
-          "package": "frb_example--flutter_package--example",
-          "device": "iPad (10th generation) Simulator (18.6)"
         },
         {
           "package": "frb_example--flutter_package--example",
@@ -504,15 +476,7 @@
         },
         {
           "package": "frb_example--rust_ui_counter--ui",
-          "device": "iPad (10th generation) Simulator (18.6)"
-        },
-        {
-          "package": "frb_example--rust_ui_counter--ui",
           "device": "iPhone 16 Pro Max Simulator (18.6)"
-        },
-        {
-          "package": "frb_example--rust_ui_todo_list--ui",
-          "device": "iPad (10th generation) Simulator (18.6)"
         },
         {
           "package": "frb_example--rust_ui_todo_list--ui",
@@ -660,25 +624,6 @@
             "target": "android",
             "device": "pixel",
             "api-level": 35,
-            "package": "frb_example--flutter_via_create"
-          }
-        },
-        {
-          "info": {
-            "image": "ubuntu-latest",
-            "platform": "android",
-            "target": "android",
-            "device": "Nexus 6",
-            "api-level": 35,
-            "package": "frb_example--flutter_via_create"
-          }
-        },
-        {
-          "info": {
-            "image": "macos-latest",
-            "platform": "ios",
-            "target": "ios",
-            "device": "iPad (10th generation) Simulator (18.6)",
             "package": "frb_example--flutter_via_create"
           }
         },


### PR DESCRIPTION
Part of the native-assets backend PR chain before #3181.

Stack order:

1. #3205 Refactor integration integrator modules
2. #3206 Restructure integration templates by backend
3. #3208 Regenerate Apple scaffold on macOS and expect no git diff
4. This PR reduces duplicate mobile device CI matrix entries
5. #3181 Support native assets integration backend

What this PR changes:

- Keeps one Android emulator profile for Flutter native tests: `pixel`.
- Keeps one iOS simulator profile for Flutter native tests: `iPhone 16 Pro Max Simulator (18.6)`.
- Removes the extra Android `Nexus 6` and iOS iPad quickstart smoke entries.
- Updates the full CI plan snapshot accordingly.

This is split out so #3181 does not carry CI-matrix cleanup together with native-assets backend changes.
