### PR TITLE
Test stable and unstable post-release channels

### DIFF
--- a/.claude/skills/frb-publish-release/SKILL.md
+++ b/.claude/skills/frb-publish-release/SKILL.md
@@ -88,7 +88,7 @@ Wait until every package has `isReleased: true` and `allReleased: true`. If one 
 - Keep watching the release commit's normal CI until it is green.
 - After `./frb_internal get-released-version` reports `allReleased: true`, trigger `.github/workflows/post_release.yaml` for the release commit or `master`.
 - Babysit post-release CI until it is green. Use `gh-actions-live-logs` when reading GitHub Actions logs.
-- If post-release fails, classify the failure by install mode (`cargo-install`, `cargo-binstall`, `scoop`, or `homebrew`) before changing code or rerunning.
+- If post-release fails, classify the failure by release channel (`stable` or `unstable`) and install mode (`cargo-install`, `cargo-binstall`, `scoop`, or `homebrew`) before changing code or rerunning.
 
 ## Related Skills
 

--- a/.github/workflows/post_release.yaml
+++ b/.github/workflows/post_release.yaml
@@ -33,6 +33,9 @@ jobs:
           - cargo-binstall
           # - scoop # TODO re-enable after configured
           # - homebrew # TODO re-enable after configured
+        release_channel:
+          - stable
+          - unstable
         exclude:
           - { image: windows-2022, codegen_install_mode: homebrew }
           - { image: macos-15-intel, codegen_install_mode: scoop }
@@ -70,4 +73,4 @@ jobs:
         uses: pyvista/setup-headless-display-action@v4
 
       # execute
-      - run: ./frb_internal post-release-mimic-quickstart --codegen-install-mode ${{ matrix.codegen_install_mode }}
+      - run: ./frb_internal post-release-mimic-quickstart --codegen-install-mode ${{ matrix.codegen_install_mode }} --release-channel ${{ matrix.release_channel }}

--- a/tools/frb_internal/lib/src/makefile_dart/post_release.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/post_release.dart
@@ -22,19 +22,32 @@ List<Command<void>> createCommands() {
 @CliOptions()
 class PostReleaseConfig {
   final CodegenInstallMode codegenInstallMode;
+  final ReleaseChannel releaseChannel;
 
-  const PostReleaseConfig({required this.codegenInstallMode});
+  const PostReleaseConfig({
+    required this.codegenInstallMode,
+    required this.releaseChannel,
+  });
 }
 
 Future<void> postReleaseMimicQuickstart(PostReleaseConfig config) async {
   await quickstartStepInstall(
     config.codegenInstallMode,
-    versionConstraint: '^2.0.0-dev.0',
+    versionConstraint: config.releaseChannel.versionConstraint,
   );
   await const MimicQuickstartTester(postRelease: true).test();
 }
 
 enum CodegenInstallMode { cargoInstall, cargoBinstall, scoop, homebrew }
+
+enum ReleaseChannel { stable, unstable }
+
+extension ReleaseChannelExtension on ReleaseChannel {
+  String get versionConstraint => switch (this) {
+    ReleaseChannel.stable => '^2.0.0',
+    ReleaseChannel.unstable => '^2.0.0-dev.0',
+  };
+}
 
 Future<void> quickstartStepInstall(
   CodegenInstallMode mode, {

--- a/tools/frb_internal/lib/src/makefile_dart/post_release.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/post_release.dart
@@ -2,9 +2,11 @@
 
 import 'package:args/command_runner.dart';
 import 'package:build_cli_annotations/build_cli_annotations.dart';
+import 'package:dio/dio.dart';
 import 'package:flutter_rust_bridge_internal/src/makefile_dart/consts.dart';
 import 'package:flutter_rust_bridge_internal/src/makefile_dart/test.dart';
 import 'package:flutter_rust_bridge_internal/src/utils/makefile_dart_infra.dart';
+import 'package:pub_semver/pub_semver.dart';
 
 part 'post_release.g.dart';
 
@@ -31,9 +33,13 @@ class PostReleaseConfig {
 }
 
 Future<void> postReleaseMimicQuickstart(PostReleaseConfig config) async {
+  final versionConstraint = await resolveCodegenVersionRequirement(
+    config.releaseChannel,
+  );
+
   await quickstartStepInstall(
     config.codegenInstallMode,
-    versionConstraint: config.releaseChannel.versionConstraint,
+    versionConstraint: versionConstraint,
   );
   await const MimicQuickstartTester(postRelease: true).test();
 }
@@ -42,11 +48,52 @@ enum CodegenInstallMode { cargoInstall, cargoBinstall, scoop, homebrew }
 
 enum ReleaseChannel { stable, unstable }
 
-extension ReleaseChannelExtension on ReleaseChannel {
-  String get versionConstraint => switch (this) {
-    ReleaseChannel.stable => '^2.0.0',
-    ReleaseChannel.unstable => '^2.0.0-dev.0',
-  };
+typedef CratesIoMetadataFetcher =
+    Future<Map<String, dynamic>> Function(String package);
+
+const _codegenPackageName = 'flutter_rust_bridge_codegen';
+
+Future<String> resolveCodegenVersionRequirement(
+  ReleaseChannel channel, {
+  CratesIoMetadataFetcher fetcher = fetchCratesIoMetadata,
+}) async {
+  switch (channel) {
+    case ReleaseChannel.stable:
+      return '^2.0.0';
+    case ReleaseChannel.unstable:
+      final version = parseLatestUnstableCodegenVersion(
+        await fetcher(_codegenPackageName),
+      );
+      return '=$version';
+  }
+}
+
+String parseLatestUnstableCodegenVersion(Map<String, dynamic> metadata) {
+  final versions = [
+    for (final rawVersion in metadata['versions'] as List<dynamic>? ?? [])
+      if (rawVersion is Map &&
+          rawVersion['yanked'] != true &&
+          rawVersion['num'] is String)
+        Version.parse(rawVersion['num'] as String),
+  ].where((version) => version.isPreRelease).toList();
+
+  if (versions.isEmpty) {
+    throw Exception('No unstable $_codegenPackageName version found');
+  }
+
+  versions.sort();
+  return versions.last.toString();
+}
+
+Future<Map<String, dynamic>> fetchCratesIoMetadata(String package) async {
+  final response = await Dio().getUri<Map<String, dynamic>>(
+    Uri.https('crates.io', '/api/v1/crates/$package'),
+  );
+  final data = response.data;
+  if (data == null) {
+    throw Exception('No crates.io metadata returned for $package');
+  }
+  return data;
 }
 
 Future<void> quickstartStepInstall(

--- a/tools/frb_internal/lib/src/makefile_dart/post_release.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/post_release.dart
@@ -37,6 +37,14 @@ Future<void> postReleaseMimicQuickstart(PostReleaseConfig config) async {
     config.releaseChannel,
   );
 
+  print(
+    'Post-release codegen install: '
+    'release_channel=${config.releaseChannel.name} '
+    'codegen_install_mode=${config.codegenInstallMode.name} '
+    'package=$_codegenPackageName '
+    'version_requirement=$versionConstraint',
+  );
+
   await quickstartStepInstall(
     config.codegenInstallMode,
     versionConstraint: versionConstraint,

--- a/tools/frb_internal/lib/src/makefile_dart/post_release.g.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/post_release.g.dart
@@ -25,6 +25,10 @@ PostReleaseConfig _$parsePostReleaseConfigResult(ArgResults result) =>
         _$CodegenInstallModeEnumMapBuildCli,
         result['codegen-install-mode'] as String,
       ),
+      releaseChannel: _$enumValueHelper(
+        _$ReleaseChannelEnumMapBuildCli,
+        result['release-channel'] as String,
+      ),
     );
 
 const _$CodegenInstallModeEnumMapBuildCli = <CodegenInstallMode, String>{
@@ -34,11 +38,17 @@ const _$CodegenInstallModeEnumMapBuildCli = <CodegenInstallMode, String>{
   CodegenInstallMode.homebrew: 'homebrew',
 };
 
-ArgParser _$populatePostReleaseConfigParser(ArgParser parser) =>
-    parser..addOption(
-      'codegen-install-mode',
-      allowed: ['cargo-install', 'cargo-binstall', 'scoop', 'homebrew'],
-    );
+const _$ReleaseChannelEnumMapBuildCli = <ReleaseChannel, String>{
+  ReleaseChannel.stable: 'stable',
+  ReleaseChannel.unstable: 'unstable',
+};
+
+ArgParser _$populatePostReleaseConfigParser(ArgParser parser) => parser
+  ..addOption(
+    'codegen-install-mode',
+    allowed: ['cargo-install', 'cargo-binstall', 'scoop', 'homebrew'],
+  )
+  ..addOption('release-channel', allowed: ['stable', 'unstable']);
 
 final _$parserForPostReleaseConfig = _$populatePostReleaseConfigParser(
   ArgParser(),

--- a/tools/frb_internal/pubspec.lock
+++ b/tools/frb_internal/pubspec.lock
@@ -385,7 +385,7 @@ packages:
     source: hosted
     version: "1.5.1"
   pub_semver:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: pub_semver
       sha256: "40d3ab1bbd474c4c2328c91e3a7df8c6dd629b79ece4c4bd04bee496a224fb0c"

--- a/tools/frb_internal/pubspec.yaml
+++ b/tools/frb_internal/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
     path: ../../frb_dart
   path: ^1.8.1
   meta: ^1.8.0
+  pub_semver: ^2.1.4
   yaml: ^3.1.2
   retry: ^3.1.2
   io: ^1.0.4

--- a/tools/frb_internal/test/makefile_dart_test.dart
+++ b/tools/frb_internal/test/makefile_dart_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_rust_bridge_internal/src/frb_example_pure_dart_generator
 import 'package:flutter_rust_bridge_internal/src/makefile_dart/build.dart';
 import 'package:flutter_rust_bridge_internal/src/makefile_dart/generate.dart';
 import 'package:flutter_rust_bridge_internal/src/makefile_dart/lint.dart';
+import 'package:flutter_rust_bridge_internal/src/makefile_dart/post_release.dart';
 import 'package:flutter_rust_bridge_internal/src/makefile_dart/quickstart_smoke.dart';
 import 'package:flutter_rust_bridge_internal/src/makefile_dart/released_version.dart';
 import 'package:flutter_rust_bridge_internal/src/makefile_dart/test.dart';
@@ -419,6 +420,25 @@ late final callback = ptr.asFunction<voidFunction(ffi.Pointer<ffi.Void>)>();
         everyElement('9.9.9'),
       );
       expect(statuses.map((status) => status.isReleased), everyElement(true));
+    });
+  });
+
+  group('post-release config', () {
+    test('uses separate constraints for stable and unstable channels', () {
+      expect(ReleaseChannel.stable.versionConstraint, '^2.0.0');
+      expect(ReleaseChannel.unstable.versionConstraint, '^2.0.0-dev.0');
+    });
+
+    test('parses release channel from CLI arguments', () {
+      final config = parsePostReleaseConfig([
+        '--codegen-install-mode',
+        'cargo-install',
+        '--release-channel',
+        'unstable',
+      ]);
+
+      expect(config.codegenInstallMode, CodegenInstallMode.cargoInstall);
+      expect(config.releaseChannel, ReleaseChannel.unstable);
     });
   });
 

--- a/tools/frb_internal/test/makefile_dart_test.dart
+++ b/tools/frb_internal/test/makefile_dart_test.dart
@@ -424,9 +424,29 @@ late final callback = ptr.asFunction<voidFunction(ffi.Pointer<ffi.Void>)>();
   });
 
   group('post-release config', () {
-    test('uses separate constraints for stable and unstable channels', () {
-      expect(ReleaseChannel.stable.versionConstraint, '^2.0.0');
-      expect(ReleaseChannel.unstable.versionConstraint, '^2.0.0-dev.0');
+    test('uses stable constraint without fetching crates.io', () async {
+      final requirement = await resolveCodegenVersionRequirement(
+        ReleaseChannel.stable,
+        fetcher: (_) => throw StateError('should not fetch'),
+      );
+
+      expect(requirement, '^2.0.0');
+    });
+
+    test('uses latest unstable exact constraint from crates.io', () async {
+      final requirement = await resolveCodegenVersionRequirement(
+        ReleaseChannel.unstable,
+        fetcher: (_) async => {
+          'versions': [
+            {'num': '2.14.0-beta.1', 'yanked': true},
+            {'num': '2.13.0-alpha.1', 'yanked': false},
+            {'num': '2.13.0-beta.1', 'yanked': false},
+            {'num': '2.12.0', 'yanked': false},
+          ],
+        },
+      );
+
+      expect(requirement, '=2.13.0-beta.1');
     });
 
     test('parses release channel from CLI arguments', () {


### PR DESCRIPTION
## Evidence

- Cargo documents that version requirements exclude prerelease versions unless they are specifically requested, and that `cargo install` avoids prereleases unless explicitly asked. That is why the stable lane uses `^2.0.0`: it selects the latest stable 2.x codegen and will not select `2.13.0-beta.1`. See https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#pre-releases.
- The same Cargo rule also means `^2.0.0-dev.0` is not a reliable way to select future beta releases such as `2.13.0-beta.1`: Cargo only auto-updates prereleases across the same base release version. Therefore the unstable lane now resolves crates.io metadata for `flutter_rust_bridge_codegen`, picks the latest unyanked prerelease, and installs it with an exact requirement like `=2.13.0-beta.1`.
- In this workflow, the stable/unstable selector applies to the codegen install step in `tools/frb_internal/lib/src/makefile_dart/post_release.dart`. The installed `flutter_rust_bridge_codegen` then runs `create`/`generate` during the post-release quickstart test.
- The generated quickstart dependencies follow the selected codegen version exactly: `frb_codegen/src/library/integration/integrator.rs` writes the Rust dependency as `=<CARGO_PKG_VERSION>` and adds the Dart package with `flutter_rust_bridge:<CARGO_PKG_VERSION>`. Thus selecting stable or unstable codegen also protects the matching Rust and Dart runtime packages.