### PR TITLE
Skip stale unstable post-release versions

### DIFF
--- a/tools/frb_internal/lib/src/makefile_dart/post_release.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/post_release.dart
@@ -33,21 +33,32 @@ class PostReleaseConfig {
 }
 
 Future<void> postReleaseMimicQuickstart(PostReleaseConfig config) async {
-  final versionConstraint = await resolveCodegenVersionRequirement(
+  final versionRequirement = await resolveCodegenVersionRequirement(
     config.releaseChannel,
   );
+
+  if (versionRequirement == null) {
+    print(
+      'Post-release codegen install skipped: '
+      'release_channel=${config.releaseChannel.name} '
+      'codegen_install_mode=${config.codegenInstallMode.name} '
+      'package=$_codegenPackageName '
+      'reason=no newer unstable version',
+    );
+    return;
+  }
 
   print(
     'Post-release codegen install: '
     'release_channel=${config.releaseChannel.name} '
     'codegen_install_mode=${config.codegenInstallMode.name} '
     'package=$_codegenPackageName '
-    'version_requirement=$versionConstraint',
+    'version_requirement=$versionRequirement',
   );
 
   await quickstartStepInstall(
     config.codegenInstallMode,
-    versionConstraint: versionConstraint,
+    versionConstraint: versionRequirement,
   );
   await const MimicQuickstartTester(postRelease: true).test();
 }
@@ -61,7 +72,7 @@ typedef CratesIoMetadataFetcher =
 
 const _codegenPackageName = 'flutter_rust_bridge_codegen';
 
-Future<String> resolveCodegenVersionRequirement(
+Future<String?> resolveCodegenVersionRequirement(
   ReleaseChannel channel, {
   CratesIoMetadataFetcher fetcher = fetchCratesIoMetadata,
 }) async {
@@ -72,25 +83,49 @@ Future<String> resolveCodegenVersionRequirement(
       final version = parseLatestUnstableCodegenVersion(
         await fetcher(_codegenPackageName),
       );
-      return '=$version';
+      return version == null ? null : '=$version';
   }
 }
 
-String parseLatestUnstableCodegenVersion(Map<String, dynamic> metadata) {
+String? parseLatestUnstableCodegenVersion(Map<String, dynamic> metadata) {
   final versions = [
     for (final rawVersion in metadata['versions'] as List<dynamic>? ?? [])
       if (rawVersion is Map &&
           rawVersion['yanked'] != true &&
           rawVersion['num'] is String)
         Version.parse(rawVersion['num'] as String),
-  ].where((version) => version.isPreRelease).toList();
+  ];
 
-  if (versions.isEmpty) {
-    throw Exception('No unstable $_codegenPackageName version found');
+  final maxStableVersion = _parseMaxStableVersion(metadata, versions);
+  final newerUnstableVersions = versions
+      .where((version) => version.isPreRelease && version > maxStableVersion)
+      .toList();
+
+  if (newerUnstableVersions.isEmpty) {
+    return null;
   }
 
-  versions.sort();
-  return versions.last.toString();
+  newerUnstableVersions.sort();
+  return newerUnstableVersions.last.toString();
+}
+
+Version _parseMaxStableVersion(
+  Map<String, dynamic> metadata,
+  List<Version> versions,
+) {
+  final crate = metadata['crate'];
+  final rawMaxStableVersion = crate is Map
+      ? crate['max_stable_version'] as String?
+      : null;
+  if (rawMaxStableVersion != null) {
+    return Version.parse(rawMaxStableVersion);
+  }
+
+  final stableVersions = versions.where((version) => !version.isPreRelease);
+  if (stableVersions.isEmpty) {
+    throw Exception('No stable $_codegenPackageName version found');
+  }
+  return stableVersions.reduce((a, b) => a > b ? a : b);
 }
 
 Future<Map<String, dynamic>> fetchCratesIoMetadata(String package) async {

--- a/tools/frb_internal/test/makefile_dart_test.dart
+++ b/tools/frb_internal/test/makefile_dart_test.dart
@@ -437,6 +437,7 @@ late final callback = ptr.asFunction<voidFunction(ffi.Pointer<ffi.Void>)>();
       final requirement = await resolveCodegenVersionRequirement(
         ReleaseChannel.unstable,
         fetcher: (_) async => {
+          'crate': {'max_stable_version': '2.12.0'},
           'versions': [
             {'num': '2.14.0-beta.1', 'yanked': true},
             {'num': '2.13.0-alpha.1', 'yanked': false},
@@ -447,6 +448,21 @@ late final callback = ptr.asFunction<voidFunction(ffi.Pointer<ffi.Void>)>();
       );
 
       expect(requirement, '=2.13.0-beta.1');
+    });
+
+    test('skips unstable channel when only old prereleases exist', () async {
+      final requirement = await resolveCodegenVersionRequirement(
+        ReleaseChannel.unstable,
+        fetcher: (_) async => {
+          'crate': {'max_stable_version': '2.12.0'},
+          'versions': [
+            {'num': '2.12.0', 'yanked': false},
+            {'num': '2.0.0-dev.42', 'yanked': false},
+          ],
+        },
+      );
+
+      expect(requirement, isNull);
     });
 
     test('parses release channel from CLI arguments', () {


### PR DESCRIPTION
## Summary

- Skip unstable post-release lanes when crates.io only has prereleases older than the latest stable release.
- Continue exact-installing a newer prerelease once one exists, e.g. a future `2.13.0-beta.1` above `2.12.0`.
- Keep the codegen install/skip decision visible in CI logs.

## Verification

- `cd tools/frb_internal && dart test test/makefile_dart_test.dart`

## Context

Manual post-release run https://github.com/fzyzcjy/flutter_rust_bridge/actions/runs/27452711790 expanded the stable/unstable matrix correctly, but current crates.io metadata has `max_stable_version=2.12.0` and no newer prerelease. The previous resolver selected historical `2.0.0-dev.42`, which made the `cargo-install` unstable lane fail.