### PR TITLE
Add release publish container mode

### DIFF
--- a/.claude/skills/frb-dev-env/SKILL.md
+++ b/.claude/skills/frb-dev-env/SKILL.md
@@ -72,11 +72,11 @@ Typical usage:
 .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- bash -lc './frb_internal --help'
 ```
 
-### Publish Mode
+### Temporary Docker Commands With Publish Credentials
 
-Use publish mode only for release publishing commands that need host credentials. Unlike the normal long-lived development container, publish mode runs a fresh temporary container with `docker run --rm`, mounts the worktree and git common root, mounts the host credential directories read-only, copies the credential files into temporary container-local homes, checks login status, runs the requested command, then discards the container.
+Use `docker-run-rm --with-publish-credentials` only for release publishing commands that need host credentials. Unlike the normal long-lived development container, this runs a fresh temporary container with `docker run --rm`, mounts the worktree and git common root, mounts the host credential directories read-only, copies the credential files into temporary container-local homes, checks login status, runs the requested command, then discards the container.
 
-Publish mode mounts these host credential sources when present:
+The publish credential flag mounts these host credential sources when present:
 
 - GitHub CLI config from `GH_CONFIG_DIR` or `~/.config/gh`
 - Cargo credentials and config from `CARGO_HOME` or `~/.cargo`
@@ -86,16 +86,16 @@ Publish mode mounts these host credential sources when present:
 Run the credential preflight before any irreversible release step:
 
 ```bash
-.claude/skills/frb-dev-env/frb_dev_env.py docker publish-preflight
+.claude/skills/frb-dev-env/frb_dev_env.py docker-run-rm --with-publish-credentials -- true
 ```
 
-Run release publishing through publish mode:
+Run release publishing through a temporary publish-credential container:
 
 ```bash
-.claude/skills/frb-dev-env/frb_dev_env.py docker publish -- ./frb_internal release
+.claude/skills/frb-dev-env/frb_dev_env.py docker-run-rm --with-publish-credentials -- ./frb_internal release
 ```
 
-The publish preflight fails before running the release command if host GitHub CLI auth is invalid, Cargo credentials are missing, or Dart pub credentials are missing. It then re-checks GitHub CLI auth inside the temporary container and runs `gh auth setup-git` there so HTTPS `git push` can use the mounted GitHub CLI auth.
+The credential preflight fails before running release commands if host GitHub CLI auth is invalid, Cargo credentials are missing, or Dart pub credentials are missing. It then re-checks GitHub CLI auth inside the temporary container and runs `gh auth setup-git` there so HTTPS `git push` can use the mounted GitHub CLI auth.
 
 ### Cleanup
 

--- a/.claude/skills/frb-dev-env/SKILL.md
+++ b/.claude/skills/frb-dev-env/SKILL.md
@@ -72,6 +72,31 @@ Typical usage:
 .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- bash -lc './frb_internal --help'
 ```
 
+### Publish Mode
+
+Use publish mode only for release publishing commands that need host credentials. Unlike the normal long-lived development container, publish mode runs a fresh temporary container with `docker run --rm`, mounts the worktree and git common root, mounts the host credential directories read-only, copies the credential files into temporary container-local homes, checks login status, runs the requested command, then discards the container.
+
+Publish mode mounts these host credential sources when present:
+
+- GitHub CLI config from `GH_CONFIG_DIR` or `~/.config/gh`
+- Cargo credentials and config from `CARGO_HOME` or `~/.cargo`
+- Git config from `~/.gitconfig` and `~/.config/git`
+- Dart pub credentials from `~/.pub-cache`, `~/.config/dart`, or `~/Library/Application Support/dart`
+
+Run the credential preflight before any irreversible release step:
+
+```bash
+.claude/skills/frb-dev-env/frb_dev_env.py docker publish-preflight
+```
+
+Run release publishing through publish mode:
+
+```bash
+.claude/skills/frb-dev-env/frb_dev_env.py docker publish -- ./frb_internal release
+```
+
+The publish preflight fails before running the release command if host GitHub CLI auth is invalid, Cargo credentials are missing, or Dart pub credentials are missing. It then re-checks GitHub CLI auth inside the temporary container and runs `gh auth setup-git` there so HTTPS `git push` can use the mounted GitHub CLI auth.
+
 ### Cleanup
 
 Delete a worktree's Docker container when the worktree is no longer needed, or when local Docker resources are getting crowded:

--- a/.claude/skills/frb-dev-env/frb_dev_env.py
+++ b/.claude/skills/frb-dev-env/frb_dev_env.py
@@ -208,7 +208,7 @@ def validate_publish_credentials(paths: PublishCredentialPaths) -> None:
 
     if missing:
         raise CommandError(
-            "Missing release credentials before starting publish mode:\n"
+            "Missing release credentials before starting publish credentials mode:\n"
             + "\n".join(f"- {entry}" for entry in missing)
         )
 
@@ -271,8 +271,7 @@ def publish_container_environment_args() -> list[str]:
     return docker_exec_env_args(env)
 
 
-def publish_container_bootstrap_script(*, preflight_only: bool) -> str:
-    command = "exit 0" if preflight_only else 'exec "$@"'
+def publish_container_bootstrap_script() -> str:
     cargo_credential_root = shlex.quote(str(PUBLISH_CREDENTIAL_ROOT / "cargo"))
     dart_config_root = shlex.quote(str(PUBLISH_CREDENTIAL_ROOT / "dart-config"))
     gh_credential_root = shlex.quote(str(PUBLISH_CREDENTIAL_ROOT / "gh"))
@@ -294,25 +293,25 @@ def publish_container_bootstrap_script(*, preflight_only: bool) -> str:
             f"for name in credentials.toml credentials config.toml config; do if [ -f {cargo_credential_root}/$name ]; then cp {cargo_credential_root}/$name \"$CARGO_HOME/$name\"; fi; done",
             f"if [ -f {pub_cache_root}/credentials.json ]; then cp {pub_cache_root}/credentials.json \"$PUB_CACHE/credentials.json\"; fi",
             f"for name in pub-credentials.json credentials.json; do if [ -f {dart_config_root}/$name ]; then cp {dart_config_root}/$name \"$XDG_CONFIG_HOME/dart/$name\"; fi; done",
+            'command -v gh >/dev/null || { echo "GitHub CLI (gh) is required in the Docker image" >&2; exit 1; }',
             f"gh auth status --hostname {shlex.quote(PUBLISH_GH_HOST)}",
             f"gh auth setup-git --hostname {shlex.quote(PUBLISH_GH_HOST)}",
             'test -s "$CARGO_HOME/credentials.toml" || test -s "$CARGO_HOME/credentials"',
             'test -s "$PUB_CACHE/credentials.json" || test -s "$XDG_CONFIG_HOME/dart/pub-credentials.json" || test -s "$XDG_CONFIG_HOME/dart/credentials.json"',
-            command,
+            'exec "$@"',
         ]
     )
 
 
-def build_publish_container_command(
+def build_docker_run_rm_command(
     *,
     worktree_root: Path,
     git_common_root: Path | None = None,
     image: str,
     command: list[str],
-    preflight_only: bool,
-    paths: PublishCredentialPaths,
+    with_publish_credentials: bool,
+    publish_credential_paths: PublishCredentialPaths | None = None,
 ) -> list[str]:
-    container_command = [] if preflight_only else command
     worktree_volumes = (
         docker_volume_args_for_roots(
             worktree_root=worktree_root,
@@ -321,23 +320,49 @@ def build_publish_container_command(
         if git_common_root is not None
         else docker_volume_args(worktree_root=worktree_root)
     )
+    credential_args = (
+        [
+            *publish_container_environment_args(),
+            *publish_credential_volume_args(
+                _expect_publish_credential_paths(publish_credential_paths)
+            ),
+        ]
+        if with_publish_credentials
+        else []
+    )
+    command_args = (
+        [
+            "bash",
+            "-lc",
+            publish_container_bootstrap_script(),
+            "frb-publish-container",
+            *command,
+        ]
+        if with_publish_credentials
+        else command
+    )
+
     return [
         "docker",
         "run",
         "--rm",
         "-i",
-        *publish_container_environment_args(),
+        *credential_args,
         *worktree_volumes,
-        *publish_credential_volume_args(paths),
         "--workdir",
         str(worktree_root),
         image,
-        "bash",
-        "-lc",
-        publish_container_bootstrap_script(preflight_only=preflight_only),
-        "frb-publish-container",
-        *container_command,
+        *command_args,
     ]
+
+
+def _expect_publish_credential_paths(
+    paths: PublishCredentialPaths | None,
+) -> PublishCredentialPaths:
+    if paths is None:
+        raise CommandError("publish credential paths are required")
+
+    return paths
 
 
 def get_image(image: str | None) -> str:
@@ -1260,41 +1285,11 @@ def exec_in_container(
     )
 
 
-@docker_app.command(name="publish-preflight")
-def publish_preflight(
-    worktree_root: Annotated[
-        Path | None,
-        typer.Option("--worktree-root", help="FRB worktree root. Defaults to git root."),
-    ] = None,
-    image: Annotated[
-        str | None,
-        typer.Option("--image", help="Docker image. Defaults to FRB_DOCKER_IMAGE or the published FRB dev image."),
-    ] = None,
-) -> None:
-    """Check release credentials inside a temporary publish container."""
-
-    resolved_worktree_root = resolve_worktree_root(worktree_root=worktree_root)
-    resolved_image = get_image(image=image)
-    credential_paths = resolve_publish_credential_paths()
-    validate_publish_credentials(credential_paths)
-    check_publish_host_login_status()
-    pull_image(image=resolved_image)
-    exec_command(
-        build_publish_container_command(
-            worktree_root=resolved_worktree_root,
-            image=resolved_image,
-            command=[],
-            preflight_only=True,
-            paths=credential_paths,
-        )
-    )
-
-
-@docker_app.command(name="publish")
-def publish_in_container(
+@app.command(name="docker-run-rm")
+def docker_run_rm(
     command: Annotated[
         list[str],
-        typer.Argument(help="Release command to execute inside the temporary publish container."),
+        typer.Argument(help="Command to execute inside the temporary Docker container."),
     ],
     worktree_root: Annotated[
         Path | None,
@@ -1304,27 +1299,37 @@ def publish_in_container(
         str | None,
         typer.Option("--image", help="Docker image. Defaults to FRB_DOCKER_IMAGE or the published FRB dev image."),
     ] = None,
+    with_publish_credentials: Annotated[
+        bool,
+        typer.Option(
+            "--with-publish-credentials",
+            help="Mount and check host GitHub, Cargo, Git, and Dart pub credentials.",
+        ),
+    ] = False,
 ) -> None:
-    """Run a release command inside a temporary container with mounted credentials."""
+    """Run a command in a temporary Docker container."""
 
     if not command:
         raise typer.BadParameter(
-            "publish requires a command, for example: publish -- ./frb_internal release"
+            "docker-run-rm requires a command, for example: docker-run-rm -- ./frb_internal --help"
         )
 
     resolved_worktree_root = resolve_worktree_root(worktree_root=worktree_root)
     resolved_image = get_image(image=image)
-    credential_paths = resolve_publish_credential_paths()
-    validate_publish_credentials(credential_paths)
-    check_publish_host_login_status()
+    credential_paths = None
+    if with_publish_credentials:
+        credential_paths = resolve_publish_credential_paths()
+        validate_publish_credentials(credential_paths)
+        check_publish_host_login_status()
+
     pull_image(image=resolved_image)
     exec_command(
-        build_publish_container_command(
+        build_docker_run_rm_command(
             worktree_root=resolved_worktree_root,
             image=resolved_image,
             command=command,
-            preflight_only=False,
-            paths=credential_paths,
+            with_publish_credentials=with_publish_credentials,
+            publish_credential_paths=credential_paths,
         )
     )
 

--- a/.claude/skills/frb-dev-env/frb_dev_env.py
+++ b/.claude/skills/frb-dev-env/frb_dev_env.py
@@ -11,6 +11,7 @@ import shlex
 import subprocess
 import sys
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Annotated
 
@@ -50,6 +51,12 @@ TART_LOCAL_COPY_EXCLUDES = [
     "target",
 ]
 DEFAULT_TART_FLUTTER_ROOT = Path("/Users/admin/flutter")
+PUBLISH_CREDENTIAL_ROOT = Path("/frb-publish-host-credentials")
+PUBLISH_HOME = Path("/tmp/frb-publish-home")
+PUBLISH_CARGO_HOME = Path("/tmp/frb-publish-cargo-home")
+PUBLISH_PUB_CACHE = Path("/tmp/frb-publish-pub-cache")
+PUBLISH_XDG_CONFIG_HOME = Path("/tmp/frb-publish-config")
+PUBLISH_GH_HOST = "github.com"
 
 
 # ========== Common ==========
@@ -118,6 +125,13 @@ def container_name_for_worktree(worktree_root: Path) -> str:
 
 def docker_volume_args(*, worktree_root: Path) -> list[str]:
     git_common_root = resolve_git_common_root(worktree_root=worktree_root)
+    return docker_volume_args_for_roots(
+        worktree_root=worktree_root,
+        git_common_root=git_common_root,
+    )
+
+
+def docker_volume_args_for_roots(*, worktree_root: Path, git_common_root: Path) -> list[str]:
     volumes = [
         "--volume",
         f"{worktree_root}:{worktree_root}",
@@ -131,6 +145,199 @@ def docker_volume_args(*, worktree_root: Path) -> list[str]:
         )
 
     return volumes
+
+
+@dataclass(frozen=True)
+class PublishCredentialPaths:
+    cargo_home: Path
+    gh_config_dir: Path
+    git_config: Path | None
+    git_config_dir: Path | None
+    pub_cache_dir: Path | None
+    dart_config_dir: Path | None
+
+
+def resolve_publish_credential_paths(*, home: Path | None = None) -> PublishCredentialPaths:
+    resolved_home = (home or Path.home()).expanduser().resolve()
+    cargo_home = env_path("CARGO_HOME") or resolved_home / ".cargo"
+    gh_config_dir = env_path("GH_CONFIG_DIR") or resolved_home / ".config" / "gh"
+    git_config = _existing_file(resolved_home / ".gitconfig")
+    git_config_dir = _existing_dir(resolved_home / ".config" / "git")
+    pub_cache_dir = _existing_dir(resolved_home / ".pub-cache")
+    dart_config_dir = _first_existing_dir(
+        [
+            resolved_home / ".config" / "dart",
+            resolved_home / "Library" / "Application Support" / "dart",
+        ]
+    )
+
+    return PublishCredentialPaths(
+        cargo_home=cargo_home,
+        gh_config_dir=gh_config_dir,
+        git_config=git_config,
+        git_config_dir=git_config_dir,
+        pub_cache_dir=pub_cache_dir,
+        dart_config_dir=dart_config_dir,
+    )
+
+
+def _existing_file(path: Path) -> Path | None:
+    return path if path.is_file() else None
+
+
+def _existing_dir(path: Path) -> Path | None:
+    return path if path.is_dir() else None
+
+
+def _first_existing_dir(paths: list[Path]) -> Path | None:
+    return next((path for path in paths if path.is_dir()), None)
+
+
+def validate_publish_credentials(paths: PublishCredentialPaths) -> None:
+    missing = []
+
+    if not paths.gh_config_dir.is_dir():
+        missing.append(f"GitHub CLI config directory: {paths.gh_config_dir}")
+    if not _has_cargo_credentials(paths.cargo_home):
+        missing.append(f"Cargo credentials file in: {paths.cargo_home}")
+    if not _has_pub_credentials(paths):
+        missing.append(
+            "Dart pub credentials file in ~/.pub-cache, ~/.config/dart, "
+            "or ~/Library/Application Support/dart"
+        )
+
+    if missing:
+        raise CommandError(
+            "Missing release credentials before starting publish mode:\n"
+            + "\n".join(f"- {entry}" for entry in missing)
+        )
+
+
+def check_publish_host_login_status() -> None:
+    exec_command(["gh", "auth", "status", "--hostname", PUBLISH_GH_HOST])
+
+
+def _has_cargo_credentials(cargo_home: Path) -> bool:
+    return any(
+        (cargo_home / name).is_file()
+        for name in ["credentials.toml", "credentials"]
+    )
+
+
+def _has_pub_credentials(paths: PublishCredentialPaths) -> bool:
+    candidates = []
+    if paths.pub_cache_dir is not None:
+        candidates.append(paths.pub_cache_dir / "credentials.json")
+    if paths.dart_config_dir is not None:
+        candidates.extend(
+            [
+                paths.dart_config_dir / "pub-credentials.json",
+                paths.dart_config_dir / "credentials.json",
+            ]
+        )
+
+    return any(path.is_file() for path in candidates)
+
+
+def publish_credential_volume_args(paths: PublishCredentialPaths) -> list[str]:
+    volumes = [
+        "--volume",
+        f"{paths.cargo_home}:{PUBLISH_CREDENTIAL_ROOT / 'cargo'}:ro",
+        "--volume",
+        f"{paths.gh_config_dir}:{PUBLISH_CREDENTIAL_ROOT / 'gh'}:ro",
+    ]
+
+    optional_volumes = [
+        (paths.git_config, PUBLISH_CREDENTIAL_ROOT / "gitconfig"),
+        (paths.git_config_dir, PUBLISH_CREDENTIAL_ROOT / "git-config"),
+        (paths.pub_cache_dir, PUBLISH_CREDENTIAL_ROOT / "pub-cache"),
+        (paths.dart_config_dir, PUBLISH_CREDENTIAL_ROOT / "dart-config"),
+    ]
+    for host_path, container_path in optional_volumes:
+        if host_path is not None:
+            volumes.extend(["--volume", f"{host_path}:{container_path}:ro"])
+
+    return volumes
+
+
+def publish_container_environment_args() -> list[str]:
+    env = {
+        "HOME": str(PUBLISH_HOME),
+        "CARGO_HOME": str(PUBLISH_CARGO_HOME),
+        "PUB_CACHE": str(PUBLISH_PUB_CACHE),
+        "XDG_CONFIG_HOME": str(PUBLISH_XDG_CONFIG_HOME),
+        "GH_CONFIG_DIR": str(PUBLISH_HOME / ".config" / "gh"),
+    }
+    return docker_exec_env_args(env)
+
+
+def publish_container_bootstrap_script(*, preflight_only: bool) -> str:
+    command = "exit 0" if preflight_only else 'exec "$@"'
+    cargo_credential_root = shlex.quote(str(PUBLISH_CREDENTIAL_ROOT / "cargo"))
+    dart_config_root = shlex.quote(str(PUBLISH_CREDENTIAL_ROOT / "dart-config"))
+    gh_credential_root = shlex.quote(str(PUBLISH_CREDENTIAL_ROOT / "gh"))
+    git_config_root = shlex.quote(str(PUBLISH_CREDENTIAL_ROOT / "git-config"))
+    gitconfig_path = shlex.quote(str(PUBLISH_CREDENTIAL_ROOT / "gitconfig"))
+    pub_cache_root = shlex.quote(str(PUBLISH_CREDENTIAL_ROOT / "pub-cache"))
+    return "\n".join(
+        [
+            "set -euo pipefail",
+            f"export HOME={shlex.quote(str(PUBLISH_HOME))}",
+            f"export CARGO_HOME={shlex.quote(str(PUBLISH_CARGO_HOME))}",
+            f"export PUB_CACHE={shlex.quote(str(PUBLISH_PUB_CACHE))}",
+            f"export XDG_CONFIG_HOME={shlex.quote(str(PUBLISH_XDG_CONFIG_HOME))}",
+            f"export GH_CONFIG_DIR={shlex.quote(str(PUBLISH_HOME / '.config' / 'gh'))}",
+            'mkdir -p "$HOME/.config" "$CARGO_HOME" "$PUB_CACHE" "$XDG_CONFIG_HOME/dart"',
+            f"cp -a {gh_credential_root} \"$HOME/.config/gh\"",
+            f"if [ -f {gitconfig_path} ]; then cp {gitconfig_path} \"$HOME/.gitconfig\"; fi",
+            f"if [ -d {git_config_root} ]; then mkdir -p \"$HOME/.config\" && cp -a {git_config_root} \"$HOME/.config/git\"; fi",
+            f"for name in credentials.toml credentials config.toml config; do if [ -f {cargo_credential_root}/$name ]; then cp {cargo_credential_root}/$name \"$CARGO_HOME/$name\"; fi; done",
+            f"if [ -f {pub_cache_root}/credentials.json ]; then cp {pub_cache_root}/credentials.json \"$PUB_CACHE/credentials.json\"; fi",
+            f"for name in pub-credentials.json credentials.json; do if [ -f {dart_config_root}/$name ]; then cp {dart_config_root}/$name \"$XDG_CONFIG_HOME/dart/$name\"; fi; done",
+            f"gh auth status --hostname {shlex.quote(PUBLISH_GH_HOST)}",
+            f"gh auth setup-git --hostname {shlex.quote(PUBLISH_GH_HOST)}",
+            'test -s "$CARGO_HOME/credentials.toml" || test -s "$CARGO_HOME/credentials"',
+            'test -s "$PUB_CACHE/credentials.json" || test -s "$XDG_CONFIG_HOME/dart/pub-credentials.json" || test -s "$XDG_CONFIG_HOME/dart/credentials.json"',
+            command,
+        ]
+    )
+
+
+def build_publish_container_command(
+    *,
+    worktree_root: Path,
+    git_common_root: Path | None = None,
+    image: str,
+    command: list[str],
+    preflight_only: bool,
+    paths: PublishCredentialPaths,
+) -> list[str]:
+    container_command = [] if preflight_only else command
+    worktree_volumes = (
+        docker_volume_args_for_roots(
+            worktree_root=worktree_root,
+            git_common_root=git_common_root,
+        )
+        if git_common_root is not None
+        else docker_volume_args(worktree_root=worktree_root)
+    )
+    return [
+        "docker",
+        "run",
+        "--rm",
+        "-i",
+        *publish_container_environment_args(),
+        *worktree_volumes,
+        *publish_credential_volume_args(paths),
+        "--workdir",
+        str(worktree_root),
+        image,
+        "bash",
+        "-lc",
+        publish_container_bootstrap_script(preflight_only=preflight_only),
+        "frb-publish-container",
+        *container_command,
+    ]
 
 
 def get_image(image: str | None) -> str:
@@ -1053,6 +1260,75 @@ def exec_in_container(
     )
 
 
+@docker_app.command(name="publish-preflight")
+def publish_preflight(
+    worktree_root: Annotated[
+        Path | None,
+        typer.Option("--worktree-root", help="FRB worktree root. Defaults to git root."),
+    ] = None,
+    image: Annotated[
+        str | None,
+        typer.Option("--image", help="Docker image. Defaults to FRB_DOCKER_IMAGE or the published FRB dev image."),
+    ] = None,
+) -> None:
+    """Check release credentials inside a temporary publish container."""
+
+    resolved_worktree_root = resolve_worktree_root(worktree_root=worktree_root)
+    resolved_image = get_image(image=image)
+    credential_paths = resolve_publish_credential_paths()
+    validate_publish_credentials(credential_paths)
+    check_publish_host_login_status()
+    pull_image(image=resolved_image)
+    exec_command(
+        build_publish_container_command(
+            worktree_root=resolved_worktree_root,
+            image=resolved_image,
+            command=[],
+            preflight_only=True,
+            paths=credential_paths,
+        )
+    )
+
+
+@docker_app.command(name="publish")
+def publish_in_container(
+    command: Annotated[
+        list[str],
+        typer.Argument(help="Release command to execute inside the temporary publish container."),
+    ],
+    worktree_root: Annotated[
+        Path | None,
+        typer.Option("--worktree-root", help="FRB worktree root. Defaults to git root."),
+    ] = None,
+    image: Annotated[
+        str | None,
+        typer.Option("--image", help="Docker image. Defaults to FRB_DOCKER_IMAGE or the published FRB dev image."),
+    ] = None,
+) -> None:
+    """Run a release command inside a temporary container with mounted credentials."""
+
+    if not command:
+        raise typer.BadParameter(
+            "publish requires a command, for example: publish -- ./frb_internal release"
+        )
+
+    resolved_worktree_root = resolve_worktree_root(worktree_root=worktree_root)
+    resolved_image = get_image(image=image)
+    credential_paths = resolve_publish_credential_paths()
+    validate_publish_credentials(credential_paths)
+    check_publish_host_login_status()
+    pull_image(image=resolved_image)
+    exec_command(
+        build_publish_container_command(
+            worktree_root=resolved_worktree_root,
+            image=resolved_image,
+            command=command,
+            preflight_only=False,
+            paths=credential_paths,
+        )
+    )
+
+
 # ========== Tart commands ==========
 
 
@@ -1376,4 +1652,4 @@ if __name__ == "__main__":
         app()
     except CommandError as error:
         typer.echo(f"Error: {error}", err=True)
-        raise typer.Exit(1) from error
+        raise SystemExit(1) from None

--- a/.claude/skills/frb-dev-env/test_frb_dev_env.py
+++ b/.claude/skills/frb-dev-env/test_frb_dev_env.py
@@ -43,8 +43,10 @@ def test_validate_publish_credentials_rejects_missing_credentials(tmp_path: Path
     assert "Dart pub credentials file" in message
 
 
-def test_build_publish_container_command_mounts_credentials(tmp_path: Path) -> None:
-    """Publish mode runs a temporary container with read-only credential mounts."""
+def test_build_docker_run_rm_command_mounts_publish_credentials(
+    tmp_path: Path,
+) -> None:
+    """Publish credential mode adds read-only credential mounts."""
 
     cargo_home = tmp_path / "cargo"
     cargo_home.mkdir()
@@ -66,13 +68,13 @@ def test_build_publish_container_command_mounts_credentials(tmp_path: Path) -> N
         dart_config_dir=None,
     )
 
-    command = frb_dev_env.build_publish_container_command(
+    command = frb_dev_env.build_docker_run_rm_command(
         worktree_root=Path("/repo/flutter_rust_bridge"),
         git_common_root=Path("/repo/flutter_rust_bridge"),
         image="example/frb-dev:latest",
         command=["./frb_internal", "release"],
-        preflight_only=False,
-        paths=paths,
+        with_publish_credentials=True,
+        publish_credential_paths=paths,
     )
 
     assert command[:4] == ["docker", "run", "--rm", "-i"]
@@ -85,37 +87,35 @@ def test_build_publish_container_command_mounts_credentials(tmp_path: Path) -> N
     assert f"{git_config}:/frb-publish-host-credentials/gitconfig:ro" in command
 
     script = command[command.index("bash") + 2]
+    assert "GitHub CLI (gh) is required in the Docker image" in script
     assert "gh auth status --hostname github.com" in script
     assert "gh auth setup-git --hostname github.com" in script
     assert 'test -s "$CARGO_HOME/credentials.toml"' in script
     assert 'test -s "$PUB_CACHE/credentials.json"' in script
 
 
-def test_build_publish_preflight_command_does_not_append_release_command(
-    tmp_path: Path,
-) -> None:
-    """Publish preflight only checks credentials and exits without release work."""
+def test_build_docker_run_rm_command_without_credentials_is_plain() -> None:
+    """Plain run-rm mode does not add publish credential bootstrap."""
 
-    paths = frb_dev_env.PublishCredentialPaths(
-        cargo_home=tmp_path / "cargo",
-        gh_config_dir=tmp_path / "gh",
-        git_config=None,
-        git_config_dir=None,
-        pub_cache_dir=None,
-        dart_config_dir=None,
-    )
-
-    command = frb_dev_env.build_publish_container_command(
+    command = frb_dev_env.build_docker_run_rm_command(
         worktree_root=Path("/repo/flutter_rust_bridge"),
         git_common_root=Path("/repo/flutter_rust_bridge"),
         image="example/frb-dev:latest",
-        command=["./frb_internal", "release"],
-        preflight_only=True,
-        paths=paths,
+        command=["./frb_internal", "--help"],
+        with_publish_credentials=False,
+        publish_credential_paths=None,
     )
 
-    assert command[-1] == "frb-publish-container"
-    assert "./frb_internal" not in command
-    assert "release" not in command
-    script = command[command.index("bash") + 2]
-    assert script.endswith("exit 0")
+    assert command == [
+        "docker",
+        "run",
+        "--rm",
+        "-i",
+        "--volume",
+        "/repo/flutter_rust_bridge:/repo/flutter_rust_bridge",
+        "--workdir",
+        "/repo/flutter_rust_bridge",
+        "example/frb-dev:latest",
+        "./frb_internal",
+        "--help",
+    ]

--- a/.claude/skills/frb-dev-env/test_frb_dev_env.py
+++ b/.claude/skills/frb-dev-env/test_frb_dev_env.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def load_frb_dev_env_module() -> Any:
+    module_path = Path(__file__).with_name("frb_dev_env.py")
+    spec = importlib.util.spec_from_file_location("frb_dev_env", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+frb_dev_env = load_frb_dev_env_module()
+
+
+def test_validate_publish_credentials_rejects_missing_credentials(tmp_path: Path) -> None:
+    """Publish preflight fails before Docker when required credential files are absent."""
+
+    paths = frb_dev_env.PublishCredentialPaths(
+        cargo_home=tmp_path / "cargo",
+        gh_config_dir=tmp_path / "gh",
+        git_config=None,
+        git_config_dir=None,
+        pub_cache_dir=None,
+        dart_config_dir=None,
+    )
+
+    with pytest.raises(frb_dev_env.CommandError) as error:
+        frb_dev_env.validate_publish_credentials(paths)
+
+    message = str(error.value)
+    assert "GitHub CLI config directory" in message
+    assert "Cargo credentials file" in message
+    assert "Dart pub credentials file" in message
+
+
+def test_build_publish_container_command_mounts_credentials(tmp_path: Path) -> None:
+    """Publish mode runs a temporary container with read-only credential mounts."""
+
+    cargo_home = tmp_path / "cargo"
+    cargo_home.mkdir()
+    (cargo_home / "credentials").write_text("token = 'dummy'\n")
+    gh_config_dir = tmp_path / "gh"
+    gh_config_dir.mkdir()
+    pub_cache_dir = tmp_path / "pub-cache"
+    pub_cache_dir.mkdir()
+    (pub_cache_dir / "credentials.json").write_text("{}\n")
+    git_config = tmp_path / ".gitconfig"
+    git_config.write_text("[user]\n  name = Test\n")
+
+    paths = frb_dev_env.PublishCredentialPaths(
+        cargo_home=cargo_home,
+        gh_config_dir=gh_config_dir,
+        git_config=git_config,
+        git_config_dir=None,
+        pub_cache_dir=pub_cache_dir,
+        dart_config_dir=None,
+    )
+
+    command = frb_dev_env.build_publish_container_command(
+        worktree_root=Path("/repo/flutter_rust_bridge"),
+        git_common_root=Path("/repo/flutter_rust_bridge"),
+        image="example/frb-dev:latest",
+        command=["./frb_internal", "release"],
+        preflight_only=False,
+        paths=paths,
+    )
+
+    assert command[:4] == ["docker", "run", "--rm", "-i"]
+    assert "example/frb-dev:latest" in command
+    assert "./frb_internal" in command
+    assert "release" in command
+    assert f"{cargo_home}:/frb-publish-host-credentials/cargo:ro" in command
+    assert f"{gh_config_dir}:/frb-publish-host-credentials/gh:ro" in command
+    assert f"{pub_cache_dir}:/frb-publish-host-credentials/pub-cache:ro" in command
+    assert f"{git_config}:/frb-publish-host-credentials/gitconfig:ro" in command
+
+    script = command[command.index("bash") + 2]
+    assert "gh auth status --hostname github.com" in script
+    assert "gh auth setup-git --hostname github.com" in script
+    assert 'test -s "$CARGO_HOME/credentials.toml"' in script
+    assert 'test -s "$PUB_CACHE/credentials.json"' in script
+
+
+def test_build_publish_preflight_command_does_not_append_release_command(
+    tmp_path: Path,
+) -> None:
+    """Publish preflight only checks credentials and exits without release work."""
+
+    paths = frb_dev_env.PublishCredentialPaths(
+        cargo_home=tmp_path / "cargo",
+        gh_config_dir=tmp_path / "gh",
+        git_config=None,
+        git_config_dir=None,
+        pub_cache_dir=None,
+        dart_config_dir=None,
+    )
+
+    command = frb_dev_env.build_publish_container_command(
+        worktree_root=Path("/repo/flutter_rust_bridge"),
+        git_common_root=Path("/repo/flutter_rust_bridge"),
+        image="example/frb-dev:latest",
+        command=["./frb_internal", "release"],
+        preflight_only=True,
+        paths=paths,
+    )
+
+    assert command[-1] == "frb-publish-container"
+    assert "./frb_internal" not in command
+    assert "release" not in command
+    script = command[command.index("bash") + 2]
+    assert script.endswith("exit 0")

--- a/.claude/skills/frb-publish-release/SKILL.md
+++ b/.claude/skills/frb-publish-release/SKILL.md
@@ -21,10 +21,10 @@ Use this skill when preparing, publishing, or babysitting a `flutter_rust_bridge
 - Run the publish container credential preflight before starting irreversible publish steps:
 
   ```bash
-  .claude/skills/frb-dev-env/frb_dev_env.py docker publish-preflight
+  .claude/skills/frb-dev-env/frb_dev_env.py docker-run-rm --with-publish-credentials -- true
   ```
 
-  Stop if the preflight fails. It checks GitHub CLI auth, Cargo credentials, and Dart pub credentials inside the same temporary credential layout used by publish mode.
+  Stop if the preflight fails. It checks GitHub CLI auth, Cargo credentials, and Dart pub credentials inside the same temporary credential layout used by release publishing.
 - Confirm normal CI is green for the release commit before publishing.
 
 ### 2. Write Changelog
@@ -35,16 +35,16 @@ Use this skill when preparing, publishing, or babysitting a `flutter_rust_bridge
 
 ### 3. Publish
 
-Use the repository release command through Docker publish mode as the normal publishing path:
+Use the repository release command through a temporary Docker container with publish credentials as the normal publishing path:
 
 ```bash
-.claude/skills/frb-dev-env/frb_dev_env.py docker publish -- ./frb_internal release
+.claude/skills/frb-dev-env/frb_dev_env.py docker-run-rm --with-publish-credentials -- ./frb_internal release
 ```
 
 Do not split the normal release into separate `release-update-*` or publish commands. The one-shot command is the source of truth for release sequencing: it computes old/new versions from `CHANGELOG.md`, updates checked-in versions and generated version text, updates Scoop metadata, commits and pushes the version bump, creates a draft GitHub release, then runs the registry publisher:
 
 ```bash
-.claude/skills/frb-dev-env/frb_dev_env.py docker publish -- ./frb_internal release-publish-all
+.claude/skills/frb-dev-env/frb_dev_env.py docker-run-rm --with-publish-credentials -- ./frb_internal release-publish-all
 ```
 
 `release-publish-all` publishes these packages:
@@ -54,7 +54,7 @@ Do not split the normal release into separate `release-update-*` or publish comm
 - `frb_rust` -> crates.io package `flutter_rust_bridge`
 - `frb_dart` -> pub.dev package `flutter_rust_bridge`
 
-Only use a split subcommand as a recovery path after confirming which one-shot step already completed. For example, if the version bump and GitHub draft already exist and only registry publication is needed, use `.claude/skills/frb-dev-env/frb_dev_env.py docker publish -- ./frb_internal release-publish-all` directly.
+Only use a split subcommand as a recovery path after confirming which one-shot step already completed. For example, if the version bump and GitHub draft already exist and only registry publication is needed, use `.claude/skills/frb-dev-env/frb_dev_env.py docker-run-rm --with-publish-credentials -- ./frb_internal release-publish-all` directly.
 
 ### 4. Check Released Versions
 

--- a/.claude/skills/frb-publish-release/SKILL.md
+++ b/.claude/skills/frb-publish-release/SKILL.md
@@ -18,7 +18,13 @@ Use this skill when preparing, publishing, or babysitting a `flutter_rust_bridge
 - Verify both old and new versions are legal before running any mutating release command. The only allowed shapes are stable SemVer `MAJOR.MINOR.PATCH` such as `2.0.0`, or beta SemVer `MAJOR.MINOR.PATCH-beta.N` such as `2.0.0-beta.1`. Use exactly `^\d+\.\d+\.\d+(-beta\.\d+)?$`.
 - Reject versions with any other prerelease label, build metadata, missing numeric components, leading `v`, or loose text. Stop if either old or new version fails this check.
 - Confirm the new version is different from the old version.
-- Confirm GitHub, crates.io, and pub.dev credentials are available before starting irreversible publish steps.
+- Run the publish container credential preflight before starting irreversible publish steps:
+
+  ```bash
+  .claude/skills/frb-dev-env/frb_dev_env.py docker publish-preflight
+  ```
+
+  Stop if the preflight fails. It checks GitHub CLI auth, Cargo credentials, and Dart pub credentials inside the same temporary credential layout used by publish mode.
 - Confirm normal CI is green for the release commit before publishing.
 
 ### 2. Write Changelog
@@ -29,16 +35,16 @@ Use this skill when preparing, publishing, or babysitting a `flutter_rust_bridge
 
 ### 3. Publish
 
-Use the repository release command as the normal publishing path:
+Use the repository release command through Docker publish mode as the normal publishing path:
 
 ```bash
-./frb_internal release
+.claude/skills/frb-dev-env/frb_dev_env.py docker publish -- ./frb_internal release
 ```
 
 Do not split the normal release into separate `release-update-*` or publish commands. The one-shot command is the source of truth for release sequencing: it computes old/new versions from `CHANGELOG.md`, updates checked-in versions and generated version text, updates Scoop metadata, commits and pushes the version bump, creates a draft GitHub release, then runs the registry publisher:
 
 ```bash
-./frb_internal release-publish-all
+.claude/skills/frb-dev-env/frb_dev_env.py docker publish -- ./frb_internal release-publish-all
 ```
 
 `release-publish-all` publishes these packages:
@@ -48,7 +54,7 @@ Do not split the normal release into separate `release-update-*` or publish comm
 - `frb_rust` -> crates.io package `flutter_rust_bridge`
 - `frb_dart` -> pub.dev package `flutter_rust_bridge`
 
-Only use a split subcommand as a recovery path after confirming which one-shot step already completed. For example, if the version bump and GitHub draft already exist and only registry publication is needed, use `./frb_internal release-publish-all` directly.
+Only use a split subcommand as a recovery path after confirming which one-shot step already completed. For example, if the version bump and GitHub draft already exist and only registry publication is needed, use `.claude/skills/frb-dev-env/frb_dev_env.py docker publish -- ./frb_internal release-publish-all` directly.
 
 ### 4. Check Released Versions
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     clang \
     cmake \
+    gh \
     ninja-build \
     pkg-config \
     libclang-dev \
@@ -137,6 +138,7 @@ RUN flutter --version && \
     rustup component list --toolchain "nightly-${RUST_NIGHTLY_VERSION}" --installed | grep rust-src && \
     cargo expand --version && \
     cargo llvm-cov --version && \
+    gh --version && \
     wasm-pack --version && \
     all-contributors --version && \
     "${CHROME_BIN}" --version && \


### PR DESCRIPTION
Summary:
- Add a top-level temporary Docker runner: \.claude/skills/frb-dev-env/frb_dev_env.py docker-run-rm --with-publish-credentials -- <command>.
- Mount host GitHub, Cargo, Git, and Dart pub credentials read-only, copy them into container-local homes, check auth, and run release commands with docker run --rm.
- Install GitHub CLI in the FRB dev image and smoke-check gh --version.
- Update FRB release skills to require the temporary publish-credential runner for release publishing.

Tests:
- python3 -m py_compile .claude/skills/frb-dev-env/frb_dev_env.py .claude/skills/frb-dev-env/test_frb_dev_env.py
- uv run --with pytest --with typer pytest .claude/skills/frb-dev-env/test_frb_dev_env.py
- .claude/skills/frb-dev-env/frb_dev_env.py docker-run-rm --help
- .claude/skills/frb-dev-env/frb_dev_env.py docker-run-rm --with-publish-credentials -- true (expected failure against current published image: gh is not installed yet)
- docker run --rm fzyzcjy/flutter_rust_bridge_dev:latest bash -lc 'apt-cache policy gh || true'

Not yet run:
- ./frb_internal lint --fix (no existing dev container for this worktree; PR remains draft)
- Full publish preflight against a rebuilt dev image containing gh