### PR TITLE
Support token-based publish credentials

### DIFF
--- a/.claude/skills/frb-dev-env/SKILL.md
+++ b/.claude/skills/frb-dev-env/SKILL.md
@@ -79,9 +79,10 @@ Use `docker-run-rm --with-publish-credentials` only for release publishing comma
 The publish credential flag mounts these host credential sources when present:
 
 - GitHub CLI config from `GH_CONFIG_DIR` or `~/.config/gh`
+- GitHub token env vars from `GH_TOKEN` or `GITHUB_TOKEN`, forwarded without printing token values
 - Cargo credentials and config from `CARGO_HOME` or `~/.cargo`
 - Git config from `~/.gitconfig` and `~/.config/git`
-- Dart pub credentials from `~/.pub-cache`, `~/.config/dart`, or `~/Library/Application Support/dart`
+- Dart pub credentials from `PUB_CACHE`, `~/.pub-cache`, `~/.config/dart`, or `~/Library/Application Support/dart`
 
 Run the credential preflight before any irreversible release step:
 

--- a/.claude/skills/frb-dev-env/frb_dev_env.py
+++ b/.claude/skills/frb-dev-env/frb_dev_env.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import os
 import shlex
+import shutil
 import subprocess
 import sys
 import time
@@ -57,6 +58,7 @@ PUBLISH_CARGO_HOME = Path("/tmp/frb-publish-cargo-home")
 PUBLISH_PUB_CACHE = Path("/tmp/frb-publish-pub-cache")
 PUBLISH_XDG_CONFIG_HOME = Path("/tmp/frb-publish-config")
 PUBLISH_GH_HOST = "github.com"
+PUBLISH_GH_TOKEN_ENV_NAMES = ["GH_TOKEN", "GITHUB_TOKEN"]
 
 
 # ========== Common ==========
@@ -150,7 +152,7 @@ def docker_volume_args_for_roots(*, worktree_root: Path, git_common_root: Path) 
 @dataclass(frozen=True)
 class PublishCredentialPaths:
     cargo_home: Path
-    gh_config_dir: Path
+    gh_config_dir: Path | None
     git_config: Path | None
     git_config_dir: Path | None
     pub_cache_dir: Path | None
@@ -160,10 +162,12 @@ class PublishCredentialPaths:
 def resolve_publish_credential_paths(*, home: Path | None = None) -> PublishCredentialPaths:
     resolved_home = (home or Path.home()).expanduser().resolve()
     cargo_home = env_path("CARGO_HOME") or resolved_home / ".cargo"
-    gh_config_dir = env_path("GH_CONFIG_DIR") or resolved_home / ".config" / "gh"
+    gh_config_dir = _existing_dir(
+        env_path("GH_CONFIG_DIR") or resolved_home / ".config" / "gh"
+    )
     git_config = _existing_file(resolved_home / ".gitconfig")
     git_config_dir = _existing_dir(resolved_home / ".config" / "git")
-    pub_cache_dir = _existing_dir(resolved_home / ".pub-cache")
+    pub_cache_dir = _existing_dir(env_path("PUB_CACHE") or resolved_home / ".pub-cache")
     dart_config_dir = _first_existing_dir(
         [
             resolved_home / ".config" / "dart",
@@ -196,8 +200,11 @@ def _first_existing_dir(paths: list[Path]) -> Path | None:
 def validate_publish_credentials(paths: PublishCredentialPaths) -> None:
     missing = []
 
-    if not paths.gh_config_dir.is_dir():
-        missing.append(f"GitHub CLI config directory: {paths.gh_config_dir}")
+    if not _has_github_token_env() and paths.gh_config_dir is None:
+        missing.append(
+            "GitHub CLI config directory in GH_CONFIG_DIR or ~/.config/gh, "
+            "or GH_TOKEN/GITHUB_TOKEN env var"
+        )
     if not _has_cargo_credentials(paths.cargo_home):
         missing.append(f"Cargo credentials file in: {paths.cargo_home}")
     if not _has_pub_credentials(paths):
@@ -214,7 +221,14 @@ def validate_publish_credentials(paths: PublishCredentialPaths) -> None:
 
 
 def check_publish_host_login_status() -> None:
+    if shutil.which("gh") is None:
+        return
+
     exec_command(["gh", "auth", "status", "--hostname", PUBLISH_GH_HOST])
+
+
+def _has_github_token_env() -> bool:
+    return any(os.environ.get(name) for name in PUBLISH_GH_TOKEN_ENV_NAMES)
 
 
 def _has_cargo_credentials(cargo_home: Path) -> bool:
@@ -243,9 +257,14 @@ def publish_credential_volume_args(paths: PublishCredentialPaths) -> list[str]:
     volumes = [
         "--volume",
         f"{paths.cargo_home}:{PUBLISH_CREDENTIAL_ROOT / 'cargo'}:ro",
-        "--volume",
-        f"{paths.gh_config_dir}:{PUBLISH_CREDENTIAL_ROOT / 'gh'}:ro",
     ]
+    if paths.gh_config_dir is not None:
+        volumes.extend(
+            [
+                "--volume",
+                f"{paths.gh_config_dir}:{PUBLISH_CREDENTIAL_ROOT / 'gh'}:ro",
+            ]
+        )
 
     optional_volumes = [
         (paths.git_config, PUBLISH_CREDENTIAL_ROOT / "gitconfig"),
@@ -268,7 +287,19 @@ def publish_container_environment_args() -> list[str]:
         "XDG_CONFIG_HOME": str(PUBLISH_XDG_CONFIG_HOME),
         "GH_CONFIG_DIR": str(PUBLISH_HOME / ".config" / "gh"),
     }
-    return docker_exec_env_args(env)
+    return [
+        *docker_exec_env_args(env),
+        *docker_env_passthrough_args(PUBLISH_GH_TOKEN_ENV_NAMES),
+    ]
+
+
+def docker_env_passthrough_args(names: list[str]) -> list[str]:
+    result = []
+    for name in names:
+        if os.environ.get(name):
+            result.extend(["--env", name])
+
+    return result
 
 
 def publish_container_bootstrap_script() -> str:
@@ -287,7 +318,7 @@ def publish_container_bootstrap_script() -> str:
             f"export XDG_CONFIG_HOME={shlex.quote(str(PUBLISH_XDG_CONFIG_HOME))}",
             f"export GH_CONFIG_DIR={shlex.quote(str(PUBLISH_HOME / '.config' / 'gh'))}",
             'mkdir -p "$HOME/.config" "$CARGO_HOME" "$PUB_CACHE" "$XDG_CONFIG_HOME/dart"',
-            f"cp -a {gh_credential_root} \"$HOME/.config/gh\"",
+            f"if [ -d {gh_credential_root} ]; then cp -a {gh_credential_root} \"$HOME/.config/gh\"; fi",
             f"if [ -f {gitconfig_path} ]; then cp {gitconfig_path} \"$HOME/.gitconfig\"; fi",
             f"if [ -d {git_config_root} ]; then mkdir -p \"$HOME/.config\" && cp -a {git_config_root} \"$HOME/.config/git\"; fi",
             f"for name in credentials.toml credentials config.toml config; do if [ -f {cargo_credential_root}/$name ]; then cp {cargo_credential_root}/$name \"$CARGO_HOME/$name\"; fi; done",

--- a/.claude/skills/frb-dev-env/test_frb_dev_env.py
+++ b/.claude/skills/frb-dev-env/test_frb_dev_env.py
@@ -22,12 +22,18 @@ def load_frb_dev_env_module() -> Any:
 frb_dev_env = load_frb_dev_env_module()
 
 
-def test_validate_publish_credentials_rejects_missing_credentials(tmp_path: Path) -> None:
+def test_validate_publish_credentials_rejects_missing_credentials(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Publish preflight fails before Docker when required credential files are absent."""
+
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
 
     paths = frb_dev_env.PublishCredentialPaths(
         cargo_home=tmp_path / "cargo",
-        gh_config_dir=tmp_path / "gh",
+        gh_config_dir=None,
         git_config=None,
         git_config_dir=None,
         pub_cache_dir=None,
@@ -43,11 +49,54 @@ def test_validate_publish_credentials_rejects_missing_credentials(tmp_path: Path
     assert "Dart pub credentials file" in message
 
 
+def test_resolve_publish_credential_paths_respects_pub_cache(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Credential discovery respects a custom PUB_CACHE directory."""
+
+    custom_pub_cache = tmp_path / "custom-pub-cache"
+    custom_pub_cache.mkdir()
+    monkeypatch.setenv("PUB_CACHE", str(custom_pub_cache))
+
+    paths = frb_dev_env.resolve_publish_credential_paths(home=tmp_path)
+
+    assert paths.pub_cache_dir == custom_pub_cache
+
+
+def test_validate_publish_credentials_accepts_github_token(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GitHub token env vars can replace a local gh config directory."""
+
+    cargo_home = tmp_path / "cargo"
+    cargo_home.mkdir()
+    (cargo_home / "credentials").write_text("token = 'dummy'\n")
+    pub_cache_dir = tmp_path / "pub-cache"
+    pub_cache_dir.mkdir()
+    (pub_cache_dir / "credentials.json").write_text("{}\n")
+    monkeypatch.setenv("GH_TOKEN", "dummy-token")
+
+    paths = frb_dev_env.PublishCredentialPaths(
+        cargo_home=cargo_home,
+        gh_config_dir=None,
+        git_config=None,
+        git_config_dir=None,
+        pub_cache_dir=pub_cache_dir,
+        dart_config_dir=None,
+    )
+
+    frb_dev_env.validate_publish_credentials(paths)
+
+
 def test_build_docker_run_rm_command_mounts_publish_credentials(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Publish credential mode adds read-only credential mounts."""
 
+    monkeypatch.setenv("GH_TOKEN", "dummy-token")
     cargo_home = tmp_path / "cargo"
     cargo_home.mkdir()
     (cargo_home / "credentials").write_text("token = 'dummy'\n")
@@ -85,6 +134,9 @@ def test_build_docker_run_rm_command_mounts_publish_credentials(
     assert f"{gh_config_dir}:/frb-publish-host-credentials/gh:ro" in command
     assert f"{pub_cache_dir}:/frb-publish-host-credentials/pub-cache:ro" in command
     assert f"{git_config}:/frb-publish-host-credentials/gitconfig:ro" in command
+    assert "--env" in command
+    assert "GH_TOKEN" in command
+    assert "dummy-token" not in command
 
     script = command[command.index("bash") + 2]
     assert "GitHub CLI (gh) is required in the Docker image" in script


### PR DESCRIPTION
Summary:
- Respect PUB_CACHE when discovering Dart pub credentials for the release publish container.
- Allow GH_TOKEN/GITHUB_TOKEN to replace a local gh config directory, and pass token env names through Docker without printing token values.
- Avoid crashing when gh is missing on the host; the container-side gh check remains authoritative.
- Add regression tests for custom PUB_CACHE, GitHub token auth, and token-value redaction in generated docker args.

Context:
- Follow-up to #3217 based on Gemini review feedback.

Tests:
- python3 -m py_compile .claude/skills/frb-dev-env/frb_dev_env.py .claude/skills/frb-dev-env/test_frb_dev_env.py
- uv run --with pytest --with typer pytest .claude/skills/frb-dev-env/test_frb_dev_env.py
- .claude/skills/frb-dev-env/frb_dev_env.py docker-run-rm --help
- git diff --check

Not yet run:
- Full publish preflight against a rebuilt dev image containing gh