### PR TITLE
Add Yarn to dev Docker image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,6 +5,7 @@ FROM ghcr.io/cirruslabs/flutter:${FLUTTER_VERSION}
 ARG RUST_VERSION=1.93.1
 ARG RUST_NIGHTLY_VERSION=2025-02-01
 ARG NODE_VERSION=22.11.0
+ARG YARN_VERSION=1.22.22
 
 # Environment variables
 ENV DEBIAN_FRONTEND=noninteractive
@@ -99,7 +100,7 @@ RUN cargo install wasm-pack
 # Install extra CLI tools used by internal generation and coverage workflows
 RUN cargo install cargo-expand && \
     cargo install cargo-llvm-cov && \
-    npm install -g all-contributors-cli
+    npm install -g all-contributors-cli "yarn@${YARN_VERSION}"
 
 # Install Chromium for web tests (headless testing). Google Chrome does not
 # provide Linux arm64 builds yet, and Ubuntu's chromium-browser package is snap.
@@ -130,6 +131,7 @@ RUN flutter --version && \
     dart --version && \
     node --version && \
     npm --version && \
+    yarn --version && \
     cargo --version && \
     rustup toolchain list | grep "nightly-${RUST_NIGHTLY_VERSION}" && \
     rustup target list --installed | grep wasm32-unknown-unknown && \

--- a/.github/workflows/publish_dev_docker.yaml
+++ b/.github/workflows/publish_dev_docker.yaml
@@ -124,6 +124,7 @@ jobs:
             set -euo pipefail
             flutter --version
             dart --version
+            yarn --version
             cargo --version
             rustup show
             rustup target list --toolchain nightly-${{ needs.metadata.outputs.rust_nightly_version }} --installed


### PR DESCRIPTION
## Summary
- install Yarn classic in the dev Docker image
- verify yarn in Dockerfile and publish-dev-image smoke tests

## Context
The local FRB Docker container could run Node/npm but not `yarn`, so `./frb_internal generate-website` failed at `yarn install --frozen-lockfile` with exit 127 before reaching the website build itself.

## Testing
- Not run locally; this changes the Docker image definition and is covered by the publish dev Docker smoke test.