### PR TITLE
Add 2.13.0-beta.1 changelog

### DIFF
--- a/.claude/skills/frb-write-changelog/SKILL.md
+++ b/.claude/skills/frb-write-changelog/SKILL.md
@@ -69,14 +69,27 @@ Review the final diff.
 - Confirm wording and ordering match nearby release sections.
 - Create a small atomic commit after finishing the edit.
 
-## Step 7: Verify with a subagent
+## Step 7: Run mechanical verification
 
-Launch a separate subagent after finishing the changelog draft.
+Run the changelog verifier after finishing the draft.
 
-- Ask the subagent to independently collect the merged PR list for the same release range.
-- Ask the subagent to compare that list against `CHANGELOG.md`.
-- Ask the subagent to report missing PRs, suspicious duplicates, and formatting inconsistencies.
-- Apply any confirmed fixes, then re-check the final diff.
+```bash
+gh pr list --state merged --limit 200 --json number,title,author,mergedAt,baseRefName,url > /tmp/frb-merged-prs.json
+uv run --script .claude/skills/frb-write-changelog/verify_changelog.py \
+  --version <VERSION> \
+  --previous-release-time <PREVIOUS_RELEASE_TIMESTAMP> \
+  --merged-prs-json /tmp/frb-merged-prs.json
+```
+
+The verifier checks that:
+
+- PR numbers in the target section are complete, not duplicated, and not unexpected.
+- Third-party thanks authors are complete, not duplicated, and not unexpected.
+- `docs: add <name> as a contributor ...` all-contributors PRs are ignored.
+
+Use `--ignore-pr <NUMBER>` only for a documented intentional exclusion. Use `--extra-local-pr <NUMBER>` for a stacked local maintainer PR that belongs in the changelog but is not present in the merged PR JSON yet.
+
+Apply any confirmed fixes, then re-run the verifier.
 
 ## Step 8: Ask the user to review ordering
 
@@ -88,9 +101,10 @@ Tell the user the changelog draft is complete and ask for a manual review.
 
 ## Step 9: Re-verify after human edits
 
-Launch a separate subagent after the user finishes manual edits.
+Run the mechanical verifier again after the user finishes manual edits.
 
-- Ask the subagent to independently inspect the final `CHANGELOG.md`.
-- Ask the subagent to compare the final text against the merged PR list for the same release range.
-- Ask the subagent to specifically report any missing PR numbers.
+- Confirm there are no missing, duplicated, or extra PR numbers.
+- Confirm there are no missing, duplicated, or extra third-party thanks authors.
 - Apply any confirmed fixes, then do one final diff check.
+
+If the user explicitly wants an independent review, ask a separate reviewer or subagent to compare the final `CHANGELOG.md` against the same merged PR list.

--- a/.claude/skills/frb-write-changelog/SKILL.md
+++ b/.claude/skills/frb-write-changelog/SKILL.md
@@ -85,7 +85,7 @@ uv run --script .claude/skills/frb-write-changelog/verify_changelog.py \
 The verifier checks that:
 
 - PR numbers in the target section are complete, not duplicated, and not unexpected.
-- Third-party thanks authors are complete, not duplicated, and not unexpected.
+- Third-party thanks authors are complete and not unexpected. The same author may be thanked on multiple entries.
 - Entries with third-party thanks appear before entries without thanks.
 - `docs: add <name> as a contributor ...` all-contributors PRs are ignored.
 
@@ -106,7 +106,7 @@ Tell the user the changelog draft is complete and ask for a manual review.
 Run the mechanical verifier again after the user finishes manual edits.
 
 - Confirm there are no missing, duplicated, or extra PR numbers.
-- Confirm there are no missing, duplicated, or extra third-party thanks authors.
+- Confirm there are no missing or unexpected third-party thanks authors.
 - Confirm entries with third-party thanks appear before entries without thanks.
 - Apply any confirmed fixes, then do one final diff check.
 

--- a/.claude/skills/frb-write-changelog/SKILL.md
+++ b/.claude/skills/frb-write-changelog/SKILL.md
@@ -57,7 +57,8 @@ Match the existing changelog style.
 
 - Write each item as `* Summary #1234`.
 - Append `(thanks @username)` when attribution is appropriate.
-- Keep items in merge order from newest to oldest unless the surrounding section clearly uses another order.
+- Place entries with `(thanks @username)` before entries without thanks.
+- Within the thanks group and the no-thanks group, keep items in merge order from newest to oldest unless the surrounding section clearly uses another order.
 
 Edit only `CHANGELOG.md`. Do not manually edit generated files for this task.
 
@@ -85,6 +86,7 @@ The verifier checks that:
 
 - PR numbers in the target section are complete, not duplicated, and not unexpected.
 - Third-party thanks authors are complete, not duplicated, and not unexpected.
+- Entries with third-party thanks appear before entries without thanks.
 - `docs: add <name> as a contributor ...` all-contributors PRs are ignored.
 
 Use `--ignore-pr <NUMBER>` only for a documented intentional exclusion. Use `--extra-local-pr <NUMBER>` for a stacked local maintainer PR that belongs in the changelog but is not present in the merged PR JSON yet.
@@ -105,6 +107,7 @@ Run the mechanical verifier again after the user finishes manual edits.
 
 - Confirm there are no missing, duplicated, or extra PR numbers.
 - Confirm there are no missing, duplicated, or extra third-party thanks authors.
+- Confirm entries with third-party thanks appear before entries without thanks.
 - Apply any confirmed fixes, then do one final diff check.
 
 If the user explicitly wants an independent review, ask a separate reviewer or subagent to compare the final `CHANGELOG.md` against the same merged PR list.

--- a/.claude/skills/frb-write-changelog/test_verify_changelog.py
+++ b/.claude/skills/frb-write-changelog/test_verify_changelog.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def load_verify_changelog_module() -> Any:
+    module_path = Path(__file__).with_name("verify_changelog.py")
+    spec = importlib.util.spec_from_file_location("verify_changelog", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+verify_changelog = load_verify_changelog_module()
+
+
+def test_verify_changelog_accepts_complete_section_with_grouped_prs() -> None:
+    """Verifier accepts complete PR coverage and third-party thanks attribution."""
+
+    merged_prs = [
+        make_pr(number=3, author_login="external"),
+        make_pr(number=2, author_login="fzyzcjy"),
+        make_pr(number=1, author_login="app/allcontributors", title="docs: add external as a contributor for code"),
+    ]
+    changelog_text = """
+# Changelog
+
+## 2.0.0
+
+* Add feature #3 (thanks @external)
+* Improve CI #2
+
+## 1.0.0
+"""
+
+    result = verify_changelog.verify_changelog(
+        changelog_text=changelog_text,
+        merged_prs=merged_prs,
+        version="2.0.0",
+        previous_release_time=verify_changelog.parse_datetime("2026-01-01T00:00:00Z"),
+        local_authors={"fzyzcjy"},
+        ignored_pr_numbers=set(),
+        extra_local_pr_numbers=set(),
+    )
+
+    assert result.ok is True
+    assert result.expected_pr_numbers == [3, 2]
+    assert result.actual_pr_numbers == [3, 2]
+    assert result.expected_thanks_authors == ["external"]
+    assert result.actual_thanks_authors == ["external"]
+
+
+def test_verify_changelog_reports_missing_extra_and_duplicate_pr_numbers() -> None:
+    """Verifier reports PR number coverage problems."""
+
+    merged_prs = [
+        make_pr(number=3),
+        make_pr(number=2),
+    ]
+    changelog_text = """
+# Changelog
+
+## 2.0.0
+
+* Add feature #3 #3 #99
+
+## 1.0.0
+"""
+
+    result = verify_changelog.verify_changelog(
+        changelog_text=changelog_text,
+        merged_prs=merged_prs,
+        version="2.0.0",
+        previous_release_time=verify_changelog.parse_datetime("2026-01-01T00:00:00Z"),
+        local_authors={"fzyzcjy"},
+        ignored_pr_numbers=set(),
+        extra_local_pr_numbers=set(),
+    )
+
+    assert result.ok is False
+    assert result.duplicate_pr_numbers == [3]
+    assert result.missing_pr_numbers == [2]
+    assert result.extra_pr_numbers == [99]
+
+
+def test_verify_changelog_reports_thanks_attribution_problems() -> None:
+    """Verifier reports missing, extra, and duplicate third-party thanks."""
+
+    merged_prs = [
+        make_pr(number=4, author_login="alice"),
+        make_pr(number=3, author_login="bob"),
+        make_pr(number=2, author_login="fzyzcjy"),
+    ]
+    changelog_text = """
+# Changelog
+
+## 2.0.0
+
+* Add feature #4 #3 #2 (thanks @alice) (thanks @alice) (thanks @carol)
+
+## 1.0.0
+"""
+
+    result = verify_changelog.verify_changelog(
+        changelog_text=changelog_text,
+        merged_prs=merged_prs,
+        version="2.0.0",
+        previous_release_time=verify_changelog.parse_datetime("2026-01-01T00:00:00Z"),
+        local_authors={"fzyzcjy"},
+        ignored_pr_numbers=set(),
+        extra_local_pr_numbers=set(),
+    )
+
+    assert result.ok is False
+    assert result.duplicate_thanks_authors == ["alice"]
+    assert result.missing_thanks_authors == ["bob"]
+    assert result.extra_thanks_authors == ["carol"]
+
+
+def test_verify_changelog_accepts_stacked_local_pr() -> None:
+    """Verifier accepts an explicitly included local PR missing from merged PR JSON."""
+
+    merged_prs = [
+        make_pr(number=3),
+        make_pr(number=2),
+    ]
+    changelog_text = """
+# Changelog
+
+## 2.0.0
+
+* Improve release tooling #4 #3 #2
+
+## 1.0.0
+"""
+
+    result = verify_changelog.verify_changelog(
+        changelog_text=changelog_text,
+        merged_prs=merged_prs,
+        version="2.0.0",
+        previous_release_time=verify_changelog.parse_datetime("2026-01-01T00:00:00Z"),
+        local_authors={"fzyzcjy"},
+        ignored_pr_numbers=set(),
+        extra_local_pr_numbers={4},
+    )
+
+    assert result.ok is True
+    assert result.expected_pr_numbers == [4, 3, 2]
+    assert result.actual_pr_numbers == [4, 3, 2]
+
+
+def make_pr(
+    *,
+    number: int,
+    author_login: str = "fzyzcjy",
+    title: str = "Add feature",
+) -> Any:
+    return verify_changelog.PullRequestInfo(
+        number=number,
+        title=title,
+        author_login=author_login,
+        author_is_bot=author_login.startswith("app/"),
+        merged_at=verify_changelog.parse_datetime("2026-02-01T00:00:00Z"),
+        base_ref_name="master",
+    )

--- a/.claude/skills/frb-write-changelog/test_verify_changelog.py
+++ b/.claude/skills/frb-write-changelog/test_verify_changelog.py
@@ -123,6 +123,41 @@ def test_verify_changelog_reports_thanks_attribution_problems() -> None:
     assert result.extra_thanks_authors == ["carol"]
 
 
+def test_verify_changelog_reports_thanks_order_problems() -> None:
+    """Verifier reports thanks entries placed after entries without thanks."""
+
+    merged_prs = [
+        make_pr(number=4, author_login="alice"),
+        make_pr(number=3),
+        make_pr(number=2, author_login="bob"),
+    ]
+    changelog_text = """
+# Changelog
+
+## 2.0.0
+
+* Please refer to https://example.com for what's changed.
+* Add first feature #4 (thanks @alice)
+* Improve CI #3
+* Add second feature #2 (thanks @bob)
+
+## 1.0.0
+"""
+
+    result = verify_changelog.verify_changelog(
+        changelog_text=changelog_text,
+        merged_prs=merged_prs,
+        version="2.0.0",
+        previous_release_time=verify_changelog.parse_datetime("2026-01-01T00:00:00Z"),
+        local_authors={"fzyzcjy"},
+        ignored_pr_numbers=set(),
+        extra_local_pr_numbers=set(),
+    )
+
+    assert result.ok is False
+    assert result.thanks_order_violations == ["* Add second feature #2 (thanks @bob)"]
+
+
 def test_verify_changelog_accepts_stacked_local_pr() -> None:
     """Verifier accepts an explicitly included local PR missing from merged PR JSON."""
 

--- a/.claude/skills/frb-write-changelog/test_verify_changelog.py
+++ b/.claude/skills/frb-write-changelog/test_verify_changelog.py
@@ -90,7 +90,7 @@ def test_verify_changelog_reports_missing_extra_and_duplicate_pr_numbers() -> No
 
 
 def test_verify_changelog_reports_thanks_attribution_problems() -> None:
-    """Verifier reports missing, extra, and duplicate third-party thanks."""
+    """Verifier reports missing and extra third-party thanks."""
 
     merged_prs = [
         make_pr(number=4, author_login="alice"),
@@ -118,9 +118,43 @@ def test_verify_changelog_reports_thanks_attribution_problems() -> None:
     )
 
     assert result.ok is False
-    assert result.duplicate_thanks_authors == ["alice"]
     assert result.missing_thanks_authors == ["bob"]
     assert result.extra_thanks_authors == ["carol"]
+
+
+def test_verify_changelog_accepts_duplicate_thanks_author() -> None:
+    """Verifier accepts thanking the same third-party author on multiple entries."""
+
+    merged_prs = [
+        make_pr(number=4, author_login="alice"),
+        make_pr(number=3, author_login="alice"),
+        make_pr(number=2),
+    ]
+    changelog_text = """
+# Changelog
+
+## 2.0.0
+
+* Add first feature #4 (thanks @alice)
+* Add second feature #3 (thanks @alice)
+* Improve CI #2
+
+## 1.0.0
+"""
+
+    result = verify_changelog.verify_changelog(
+        changelog_text=changelog_text,
+        merged_prs=merged_prs,
+        version="2.0.0",
+        previous_release_time=verify_changelog.parse_datetime("2026-01-01T00:00:00Z"),
+        local_authors={"fzyzcjy"},
+        ignored_pr_numbers=set(),
+        extra_local_pr_numbers=set(),
+    )
+
+    assert result.ok is True
+    assert result.expected_thanks_authors == ["alice"]
+    assert result.actual_thanks_authors == ["alice", "alice"]
 
 
 def test_verify_changelog_reports_thanks_order_problems() -> None:

--- a/.claude/skills/frb-write-changelog/verify_changelog.py
+++ b/.claude/skills/frb-write-changelog/verify_changelog.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# dependencies = ["typer>=0.12"]
+# ///
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Annotated, Any, TypeVar
+
+import typer
+
+
+app = typer.Typer(add_completion=False)
+DuplicateValue = TypeVar("DuplicateValue", int, str)
+
+
+@dataclass(frozen=True)
+class PullRequestInfo:
+    number: int
+    title: str
+    author_login: str
+    author_is_bot: bool
+    merged_at: datetime
+    base_ref_name: str
+
+
+@dataclass(frozen=True)
+class VerificationResult:
+    version: str
+    expected_pr_numbers: list[int]
+    actual_pr_numbers: list[int]
+    duplicate_pr_numbers: list[int]
+    missing_pr_numbers: list[int]
+    extra_pr_numbers: list[int]
+    expected_thanks_authors: list[str]
+    actual_thanks_authors: list[str]
+    duplicate_thanks_authors: list[str]
+    missing_thanks_authors: list[str]
+    extra_thanks_authors: list[str]
+
+    @property
+    def ok(self) -> bool:
+        return not any(
+            [
+                self.duplicate_pr_numbers,
+                self.missing_pr_numbers,
+                self.extra_pr_numbers,
+                self.duplicate_thanks_authors,
+                self.missing_thanks_authors,
+                self.extra_thanks_authors,
+            ],
+        )
+
+
+def verify_changelog(
+    *,
+    changelog_text: str,
+    merged_prs: list[PullRequestInfo],
+    version: str,
+    previous_release_time: datetime,
+    local_authors: set[str],
+    ignored_pr_numbers: set[int],
+    extra_local_pr_numbers: set[int],
+) -> VerificationResult:
+    section = extract_changelog_section(
+        changelog_text=changelog_text,
+        version=version,
+    )
+    expected_prs = expected_prs_for_release(
+        merged_prs=merged_prs,
+        previous_release_time=previous_release_time,
+        ignored_pr_numbers=ignored_pr_numbers,
+    )
+
+    actual_pr_numbers = extract_pr_numbers(section)
+    expected_pr_numbers = sorted(
+        {pr.number for pr in expected_prs} | extra_local_pr_numbers,
+        reverse=True,
+    )
+
+    actual_thanks_authors = extract_thanks_authors(section)
+    expected_thanks_authors = sorted(
+        {
+            pr.author_login
+            for pr in expected_prs
+            if should_thank_author(pr=pr, local_authors=local_authors)
+        },
+    )
+
+    return VerificationResult(
+        version=version,
+        expected_pr_numbers=expected_pr_numbers,
+        actual_pr_numbers=actual_pr_numbers,
+        duplicate_pr_numbers=find_duplicates(actual_pr_numbers),
+        missing_pr_numbers=sorted(set(expected_pr_numbers) - set(actual_pr_numbers)),
+        extra_pr_numbers=sorted(set(actual_pr_numbers) - set(expected_pr_numbers)),
+        expected_thanks_authors=expected_thanks_authors,
+        actual_thanks_authors=sorted(actual_thanks_authors),
+        duplicate_thanks_authors=find_duplicates(actual_thanks_authors),
+        missing_thanks_authors=sorted(
+            set(expected_thanks_authors) - set(actual_thanks_authors),
+        ),
+        extra_thanks_authors=sorted(
+            set(actual_thanks_authors) - set(expected_thanks_authors),
+        ),
+    )
+
+
+def extract_changelog_section(*, changelog_text: str, version: str) -> str:
+    match = re.search(
+        rf"^## {re.escape(version)}\n(?P<section>.*?)(?=^## |\Z)",
+        changelog_text,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    if match is None:
+        raise ValueError(f"Could not find changelog section for {version}")
+
+    return match.group("section")
+
+
+def expected_prs_for_release(
+    *,
+    merged_prs: list[PullRequestInfo],
+    previous_release_time: datetime,
+    ignored_pr_numbers: set[int],
+) -> list[PullRequestInfo]:
+    return [
+        pr
+        for pr in merged_prs
+        if pr.merged_at > previous_release_time
+        and pr.number not in ignored_pr_numbers
+        and not is_all_contributors_pr(pr)
+    ]
+
+
+def should_thank_author(
+    *,
+    pr: PullRequestInfo,
+    local_authors: set[str],
+) -> bool:
+    return not pr.author_is_bot and pr.author_login not in local_authors
+
+
+def is_all_contributors_pr(pr: PullRequestInfo) -> bool:
+    return pr.author_login == "app/allcontributors" or pr.title.startswith(
+        "docs: add ",
+    )
+
+
+def extract_pr_numbers(section: str) -> list[int]:
+    return [int(raw_number) for raw_number in re.findall(r"#(\d+)", section)]
+
+
+def extract_thanks_authors(section: str) -> list[str]:
+    return re.findall(r"\(thanks @([A-Za-z0-9-]+)\)", section)
+
+
+def find_duplicates(values: list[DuplicateValue]) -> list[DuplicateValue]:
+    seen: set[DuplicateValue] = set()
+    duplicates: set[DuplicateValue] = set()
+    for value in values:
+        if value in seen:
+            duplicates.add(value)
+        else:
+            seen.add(value)
+
+    return sorted(duplicates)
+
+
+def load_merged_prs(path: Path) -> list[PullRequestInfo]:
+    raw_data = json.loads(path.read_text())
+    if not isinstance(raw_data, list):
+        raise ValueError("Merged PR JSON must contain a list")
+
+    return [parse_pr(raw_pr) for raw_pr in raw_data]
+
+
+def parse_pr(raw_pr: Any) -> PullRequestInfo:
+    if not isinstance(raw_pr, dict):
+        raise ValueError(f"PR entry must be an object: {raw_pr!r}")
+    author = raw_pr.get("author")
+    if not isinstance(author, dict):
+        raise ValueError(f"PR author must be an object: {raw_pr!r}")
+
+    return PullRequestInfo(
+        number=int(raw_pr["number"]),
+        title=str(raw_pr["title"]),
+        author_login=str(author["login"]),
+        author_is_bot=bool(author.get("is_bot", False)),
+        merged_at=parse_datetime(str(raw_pr["mergedAt"])),
+        base_ref_name=str(raw_pr.get("baseRefName", "")),
+    )
+
+
+def parse_datetime(raw_value: str) -> datetime:
+    return datetime.fromisoformat(raw_value.replace("Z", "+00:00"))
+
+
+def format_result(result: VerificationResult) -> str:
+    status = "OK" if result.ok else "FAILED"
+    return "\n".join(
+        [
+            f"Changelog verification: {status}",
+            f"Version: {result.version}",
+            f"Expected PR numbers: {len(result.expected_pr_numbers)}",
+            f"Actual PR numbers: {len(result.actual_pr_numbers)}",
+            f"Duplicate PR numbers: {result.duplicate_pr_numbers}",
+            f"Missing PR numbers: {result.missing_pr_numbers}",
+            f"Extra PR numbers: {result.extra_pr_numbers}",
+            f"Expected third-party thanks authors: {result.expected_thanks_authors}",
+            f"Actual third-party thanks authors: {result.actual_thanks_authors}",
+            f"Duplicate thanks authors: {result.duplicate_thanks_authors}",
+            f"Missing thanks authors: {result.missing_thanks_authors}",
+            f"Extra thanks authors: {result.extra_thanks_authors}",
+        ],
+    )
+
+
+@app.command()
+def main(
+    version: Annotated[
+        str,
+        typer.Option("--version", help="Changelog section version to verify."),
+    ],
+    previous_release_time: Annotated[
+        str,
+        typer.Option(
+            "--previous-release-time",
+            help="Previous release timestamp, for example 2026-03-29T21:34:04+08:00.",
+        ),
+    ],
+    merged_prs_json: Annotated[
+        Path,
+        typer.Option(
+            "--merged-prs-json",
+            help="Path to gh pr list JSON output.",
+        ),
+    ],
+    changelog_path: Annotated[
+        Path,
+        typer.Option("--changelog", help="Path to CHANGELOG.md."),
+    ] = Path("CHANGELOG.md"),
+    local_author: Annotated[
+        list[str],
+        typer.Option(
+            "--local-author",
+            help="Author login that should not receive thanks attribution.",
+        ),
+    ] = ["fzyzcjy"],
+    ignore_pr: Annotated[
+        list[int],
+        typer.Option(
+            "--ignore-pr",
+            help="Merged PR number intentionally excluded from the changelog.",
+        ),
+    ] = [],
+    extra_local_pr: Annotated[
+        list[int],
+        typer.Option(
+            "--extra-local-pr",
+            help="PR number expected in the changelog but absent from the merged PR JSON, authored by a local maintainer.",
+        ),
+    ] = [],
+) -> None:
+    result = verify_changelog(
+        changelog_text=changelog_path.read_text(),
+        merged_prs=load_merged_prs(merged_prs_json),
+        version=version,
+        previous_release_time=parse_datetime(previous_release_time),
+        local_authors=set(local_author),
+        ignored_pr_numbers=set(ignore_pr),
+        extra_local_pr_numbers=set(extra_local_pr),
+    )
+
+    typer.echo(format_result(result))
+    if not result.ok:
+        raise typer.Exit(code=1)
+
+
+if __name__ == "__main__":
+    app()

--- a/.claude/skills/frb-write-changelog/verify_changelog.py
+++ b/.claude/skills/frb-write-changelog/verify_changelog.py
@@ -41,6 +41,7 @@ class VerificationResult:
     duplicate_thanks_authors: list[str]
     missing_thanks_authors: list[str]
     extra_thanks_authors: list[str]
+    thanks_order_violations: list[str]
 
     @property
     def ok(self) -> bool:
@@ -52,6 +53,7 @@ class VerificationResult:
                 self.duplicate_thanks_authors,
                 self.missing_thanks_authors,
                 self.extra_thanks_authors,
+                self.thanks_order_violations,
             ],
         )
 
@@ -107,6 +109,7 @@ def verify_changelog(
         extra_thanks_authors=sorted(
             set(actual_thanks_authors) - set(expected_thanks_authors),
         ),
+        thanks_order_violations=find_thanks_order_violations(section),
     )
 
 
@@ -157,6 +160,27 @@ def extract_pr_numbers(section: str) -> list[int]:
 
 def extract_thanks_authors(section: str) -> list[str]:
     return re.findall(r"\(thanks @([A-Za-z0-9-]+)\)", section)
+
+
+def find_thanks_order_violations(section: str) -> list[str]:
+    seen_entry_without_thanks = False
+    violations: list[str] = []
+    for entry in extract_pr_entry_lines(section):
+        if "(thanks @" in entry:
+            if seen_entry_without_thanks:
+                violations.append(entry)
+        else:
+            seen_entry_without_thanks = True
+
+    return violations
+
+
+def extract_pr_entry_lines(section: str) -> list[str]:
+    return [
+        line.strip()
+        for line in section.splitlines()
+        if line.startswith("* ") and re.search(r"#\d+", line) is not None
+    ]
 
 
 def find_duplicates(values: list[DuplicateValue]) -> list[DuplicateValue]:
@@ -216,6 +240,7 @@ def format_result(result: VerificationResult) -> str:
             f"Duplicate thanks authors: {result.duplicate_thanks_authors}",
             f"Missing thanks authors: {result.missing_thanks_authors}",
             f"Extra thanks authors: {result.extra_thanks_authors}",
+            f"Thanks ordering violations: {result.thanks_order_violations}",
         ],
     )
 

--- a/.claude/skills/frb-write-changelog/verify_changelog.py
+++ b/.claude/skills/frb-write-changelog/verify_changelog.py
@@ -38,7 +38,6 @@ class VerificationResult:
     extra_pr_numbers: list[int]
     expected_thanks_authors: list[str]
     actual_thanks_authors: list[str]
-    duplicate_thanks_authors: list[str]
     missing_thanks_authors: list[str]
     extra_thanks_authors: list[str]
     thanks_order_violations: list[str]
@@ -50,7 +49,6 @@ class VerificationResult:
                 self.duplicate_pr_numbers,
                 self.missing_pr_numbers,
                 self.extra_pr_numbers,
-                self.duplicate_thanks_authors,
                 self.missing_thanks_authors,
                 self.extra_thanks_authors,
                 self.thanks_order_violations,
@@ -102,7 +100,6 @@ def verify_changelog(
         extra_pr_numbers=sorted(set(actual_pr_numbers) - set(expected_pr_numbers)),
         expected_thanks_authors=expected_thanks_authors,
         actual_thanks_authors=sorted(actual_thanks_authors),
-        duplicate_thanks_authors=find_duplicates(actual_thanks_authors),
         missing_thanks_authors=sorted(
             set(expected_thanks_authors) - set(actual_thanks_authors),
         ),
@@ -237,7 +234,6 @@ def format_result(result: VerificationResult) -> str:
             f"Extra PR numbers: {result.extra_pr_numbers}",
             f"Expected third-party thanks authors: {result.expected_thanks_authors}",
             f"Actual third-party thanks authors: {result.actual_thanks_authors}",
-            f"Duplicate thanks authors: {result.duplicate_thanks_authors}",
             f"Missing thanks authors: {result.missing_thanks_authors}",
             f"Extra thanks authors: {result.extra_thanks_authors}",
             f"Thanks ordering violations: {result.thanks_order_violations}",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,8 @@
 * Pass platforms through create and integrate commands #3129
 * Support skipping FVM installation #3126
 * Fix macOS xcconfig drift #3118
-* Restore Rust-to-Dart logging bridge #3114
+* Add Rust-to-Dart logging bridge #3114 #3111 #3079 #2766 (thanks @patmuk)
 * Upgrade Flutter to 3.44 #3112
-* Revert Rust-to-Dart logging bridge #3111
 * Rename `ObjectId` to `MoiObjectId` in `frb_generated_moi_arc_def!` #3106 (thanks @ganeshrvel)
 * Fix Dart native test hangs after logging bridge #3103
 * Fix generated fixed array equality #3093
@@ -19,7 +18,6 @@
 * Fix concurrent cargo-expand auto install #3090
 * Add generic Dart initializer hook #3083
 * Allow frb_internal clean checks without git metadata #3082
-* Add Rust-to-Dart logging bridge #3079
 * Split out @rlch's serde_json Value support #3077
 * Support multi-arch Docker development on Apple Silicon #3070
 * Remove outdated Dockerfile in favor of devcontainer up-to-date Dockerfile #3069
@@ -27,7 +25,6 @@
 * Fix threaded WASM build-web defaults for the website demo #3052
 * Introduce conversion between chrono::NaiveDate and DateTime avoiding RustOpaque #2968 (thanks @TrackerSB)
 * Fix Map/List/Set equality in generated Dart structs #2956 (thanks @nightscape)
-* Re-apply Rust-to-Dart logging overhaul #2766 (thanks @patmuk)
 * Improve release publishing and post-release validation tooling #3221 #3220 #3219 #3218 #3217 #3216 #3215 #3214 #3211 #3210
 * Improve CI, workflow dispatch, and precommit automation #3195 #3193 #3189 #3178 #3175 #3174 #3172 #3166 #3160 #3143 #3137 #3135 #3134 #3132 #3131 #3115 #3099 #3096 #3076 #3072 #3051 #2990
 * Improve local dev, Docker, Tart, Android, and manual-test tooling #3197 #3196 #3192 #3191 #3188 #3187 #3186 #3185 #3184 #3183 #3180 #3179 #3176 #3150 #3149 #3147 #3146 #3144 #3142 #3113

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,101 +3,38 @@
 ## 2.13.0-beta.1
 
 * Please refer to https://fzyzcjy.github.io/flutter_rust_bridge/guides/miscellaneous/whats-new for what's changed in V2.
-* Allow changelog release gate updates #3221
-* Document release CI gate exception #3220
-* Fix release publish skill frontmatter #3219
-* Support token-based publish credentials #3218
-* Add release publish container mode #3217
-* Skip stale unstable post-release versions #3216
-* Test stable and unstable post-release channels #3215
-* Clarify one-shot FRB release publishing #3214
-* Guard FRB release version formats #3211
-* Add FRB release publishing workflow #3210
-* Document feature flag test coverage rules #3201
-* Fix macOS quickstart smoke capture #3197
-* Fix quickstart smoke screenshots on selected devices #3196
-* Comment on manual CI dispatch runs #3195
-* Add CI filter manual test #3193
-* Add Linux Flutter Docker manual coverage #3192
-* Move Tart prepare guide into README #3191
-* Support manual CI dispatch filters #3189
-* Support Tart iOS integration test preparation #3188
-* Require precise manual test evidence #3187
-* Add online demo gallery manual test #3186
-* Fix arm64 dev Docker ChromeDriver support #3185
-* Tag dev Docker images with source revision #3184
-* Pull FRB dev Docker image before container create #3183
-* Support Android host emulator workflow #3180
-* Add manual tests for local FRB dev environments #3179
-* Require narrow CI for reproduction PRs #3178
-* Add quickstart GUI smoke on all platforms #3176
-* Document CI-backed bug reproduction workflow #3175
-* Document temporary CI narrowing tip #3174
-* Stop CI for closed PRs #3172
 * Fix web worker wasm initialization #3171
 * Bump CargoKit to latest and update it for Android 16KB pages #3170
-* Exclude CargoKit from generated analyzer options #3168
-* Timeout Flutter integration test commands #3167
-* Avoid CI reruns on PR metadata edits #3166
-* Fix main CI failures #3160
-* Add main CI regression skill #3159
 * Update git clone URL for flutter-ohos setup #3157 (thanks @star4277)
-* Support Tart local code uploads #3150
-* Add Packer workflow for Tart iOS test base VM #3149
-* Mount git worktree paths in dev env helpers #3147
-* Add FRB development environment skill #3146
-* Add CargoKit copy sync gate #3144
-* Respect browser executable environment for web tests #3143
-* Update commented workflow telemetry references #3142
-* Add FRB PR review gate #3138
-* Add precommit autofix devcontainer fallback #3137
-* Install devcontainer validation dependencies #3135
-* Make workflow telemetry optional #3134
-* Remove commented precommit check job #3132
-* Re-enable Android native Flutter CI #3131
-* Add coverage tests for existing helpers #3130
 * Pass platforms through create and integrate commands #3129
 * Support skipping FVM installation #3126
 * Fix macOS xcconfig drift #3118
-* Update Flutter upgrade skill for fresh Docker validation #3116
-* Run CI for stacked PRs #3115
 * Restore Rust-to-Dart logging bridge #3114
-* Document iOS Simulator validation with Tart #3113
-* Upgrade CI's Flutter version to 3.44 #3112
+* Upgrade Flutter to 3.44 #3112
 * Revert Rust-to-Dart logging bridge #3111
-* Add FRB Codecov fix skill #3110
-* Add Flutter upgrade workflow skill #3109
 * Rename `ObjectId` to `MoiObjectId` in `frb_generated_moi_arc_def!` #3106 (thanks @ganeshrvel)
 * Fix Dart native test hangs after logging bridge #3103
-* Require pure_dart final regression coverage in skills #3102
-* Add FRB issue-to-green-PR skill #3100
-* Fix precommit autofix comments for fork PRs #3099
-* Add Windows ARM Flutter build CI #3096
-* Add CargoKit development skill #3095
-* Require bug reproduction reports in skills #3094
 * Fix generated fixed array equality #3093
 * Fix DCO boxed record decoding #3092
-* Update feature workflow for bug fixes #3091
 * Fix concurrent cargo-expand auto install #3090
-* Update integrate template guidance #3089
-* Add merge conflict resolution skill #3087
 * Add generic Dart initializer hook #3083
 * Allow frb_internal clean checks without git metadata #3082
 * Add Rust-to-Dart logging bridge #3079
 * Split out @rlch's serde_json Value support #3077
-* Fix Codecov project coverage #3076
-* Fix main CI generated drift and threaded wasm build #3072
 * Support multi-arch Docker development on Apple Silicon #3070
 * Remove outdated Dockerfile in favor of devcontainer up-to-date Dockerfile #3069
 * Support HarmonyOS #3065 (thanks @star4277)
 * Fix threaded WASM build-web defaults for the website demo #3052
-* Add precommit autofix workflow and patch artifact #3051
-* Bump lodash from 4.17.21 to 4.18.1 in /website #3047
-* Bump lodash-es from 4.17.21 to 4.18.1 in /website #3046
-* Upgrade Flutter and Rust version in CI #2990
 * Introduce conversion between chrono::NaiveDate and DateTime avoiding RustOpaque #2968 (thanks @TrackerSB)
 * Fix Map/List/Set equality in generated Dart structs #2956 (thanks @nightscape)
 * Re-apply Rust-to-Dart logging overhaul #2766 (thanks @patmuk)
+* Improve release publishing and post-release validation tooling #3221 #3220 #3219 #3218 #3217 #3216 #3215 #3214 #3211 #3210
+* Improve CI, workflow dispatch, and precommit automation #3195 #3193 #3189 #3178 #3175 #3174 #3172 #3166 #3160 #3143 #3137 #3135 #3134 #3132 #3131 #3115 #3099 #3096 #3076 #3072 #3051 #2990
+* Improve local dev, Docker, Tart, Android, and manual-test tooling #3197 #3196 #3192 #3191 #3188 #3187 #3186 #3185 #3184 #3183 #3180 #3179 #3176 #3150 #3149 #3147 #3146 #3144 #3142 #3113
+* Update agent development skills and internal workflow documentation #3201 #3159 #3138 #3116 #3110 #3109 #3102 #3100 #3095 #3094 #3091 #3089 #3087
+* Exclude CargoKit from generated analyzer options and improve Flutter integration test timeouts #3168 #3167
+* Add coverage tests for existing helpers #3130
+* Bump website dependencies #3047 #3046
 
 ## 2.12.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,104 @@
 # Changelog
 
+## 2.13.0-beta.1
+
+* Please refer to https://fzyzcjy.github.io/flutter_rust_bridge/guides/miscellaneous/whats-new for what's changed in V2.
+* Allow changelog release gate updates #3221
+* Document release CI gate exception #3220
+* Fix release publish skill frontmatter #3219
+* Support token-based publish credentials #3218
+* Add release publish container mode #3217
+* Skip stale unstable post-release versions #3216
+* Test stable and unstable post-release channels #3215
+* Clarify one-shot FRB release publishing #3214
+* Guard FRB release version formats #3211
+* Add FRB release publishing workflow #3210
+* Document feature flag test coverage rules #3201
+* Fix macOS quickstart smoke capture #3197
+* Fix quickstart smoke screenshots on selected devices #3196
+* Comment on manual CI dispatch runs #3195
+* Add CI filter manual test #3193
+* Add Linux Flutter Docker manual coverage #3192
+* Move Tart prepare guide into README #3191
+* Support manual CI dispatch filters #3189
+* Support Tart iOS integration test preparation #3188
+* Require precise manual test evidence #3187
+* Add online demo gallery manual test #3186
+* Fix arm64 dev Docker ChromeDriver support #3185
+* Tag dev Docker images with source revision #3184
+* Pull FRB dev Docker image before container create #3183
+* Support Android host emulator workflow #3180
+* Add manual tests for local FRB dev environments #3179
+* Require narrow CI for reproduction PRs #3178
+* Add quickstart GUI smoke on all platforms #3176
+* Document CI-backed bug reproduction workflow #3175
+* Document temporary CI narrowing tip #3174
+* Stop CI for closed PRs #3172
+* Fix web worker wasm initialization #3171
+* Bump CargoKit to latest and update it for Android 16KB pages #3170
+* Exclude CargoKit from generated analyzer options #3168
+* Timeout Flutter integration test commands #3167
+* Avoid CI reruns on PR metadata edits #3166
+* Fix main CI failures #3160
+* Add main CI regression skill #3159
+* Update git clone URL for flutter-ohos setup #3157 (thanks @star4277)
+* Support Tart local code uploads #3150
+* Add Packer workflow for Tart iOS test base VM #3149
+* Mount git worktree paths in dev env helpers #3147
+* Add FRB development environment skill #3146
+* Add CargoKit copy sync gate #3144
+* Respect browser executable environment for web tests #3143
+* Update commented workflow telemetry references #3142
+* Add FRB PR review gate #3138
+* Add precommit autofix devcontainer fallback #3137
+* Install devcontainer validation dependencies #3135
+* Make workflow telemetry optional #3134
+* Remove commented precommit check job #3132
+* Re-enable Android native Flutter CI #3131
+* Add coverage tests for existing helpers #3130
+* Pass platforms through create and integrate commands #3129
+* Support skipping FVM installation #3126
+* Fix macOS xcconfig drift #3118
+* Update Flutter upgrade skill for fresh Docker validation #3116
+* Run CI for stacked PRs #3115
+* Restore Rust-to-Dart logging bridge #3114
+* Document iOS Simulator validation with Tart #3113
+* Upgrade CI's Flutter version to 3.44 #3112
+* Revert Rust-to-Dart logging bridge #3111
+* Add FRB Codecov fix skill #3110
+* Add Flutter upgrade workflow skill #3109
+* Rename `ObjectId` to `MoiObjectId` in `frb_generated_moi_arc_def!` #3106 (thanks @ganeshrvel)
+* Fix Dart native test hangs after logging bridge #3103
+* Require pure_dart final regression coverage in skills #3102
+* Add FRB issue-to-green-PR skill #3100
+* Fix precommit autofix comments for fork PRs #3099
+* Add Windows ARM Flutter build CI #3096
+* Add CargoKit development skill #3095
+* Require bug reproduction reports in skills #3094
+* Fix generated fixed array equality #3093
+* Fix DCO boxed record decoding #3092
+* Update feature workflow for bug fixes #3091
+* Fix concurrent cargo-expand auto install #3090
+* Update integrate template guidance #3089
+* Add merge conflict resolution skill #3087
+* Add generic Dart initializer hook #3083
+* Allow frb_internal clean checks without git metadata #3082
+* Add Rust-to-Dart logging bridge #3079
+* Split out @rlch's serde_json Value support #3077
+* Fix Codecov project coverage #3076
+* Fix main CI generated drift and threaded wasm build #3072
+* Support multi-arch Docker development on Apple Silicon #3070
+* Remove outdated Dockerfile in favor of devcontainer up-to-date Dockerfile #3069
+* Support HarmonyOS #3065 (thanks @star4277)
+* Fix threaded WASM build-web defaults for the website demo #3052
+* Add precommit autofix workflow and patch artifact #3051
+* Bump lodash from 4.17.21 to 4.18.1 in /website #3047
+* Bump lodash-es from 4.17.21 to 4.18.1 in /website #3046
+* Upgrade Flutter and Rust version in CI #2990
+* Introduce conversion between chrono::NaiveDate and DateTime avoiding RustOpaque #2968 (thanks @TrackerSB)
+* Fix Map/List/Set equality in generated Dart structs #2956 (thanks @nightscape)
+* Re-apply Rust-to-Dart logging overhaul #2766 (thanks @patmuk)
+
 ## 2.12.0
 
 * Please refer to https://fzyzcjy.github.io/flutter_rust_bridge/guides/miscellaneous/whats-new for what's changed in V2.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,14 @@
 ## 2.13.0-beta.1
 
 * Please refer to https://fzyzcjy.github.io/flutter_rust_bridge/guides/miscellaneous/whats-new for what's changed in V2.
-* Update git clone URL for flutter-ohos setup #3157 (thanks @star4277)
 * Add Rust-to-Dart logging bridge #3114 #3111 #3079 #2766 (thanks @patmuk)
 * Rename `ObjectId` to `MoiObjectId` in `frb_generated_moi_arc_def!` #3106 (thanks @ganeshrvel)
+* Support HarmonyOS #3065 (thanks @star4277)
 * Introduce conversion between chrono::NaiveDate and DateTime avoiding RustOpaque #2968 (thanks @TrackerSB)
 * Fix Map/List/Set equality in generated Dart structs #2956 (thanks @nightscape)
 * Fix web worker wasm initialization #3171
 * Bump CargoKit to latest and update it for Android 16KB pages #3170
+* Update git clone URL for flutter-ohos setup #3157
 * Pass platforms through create and integrate commands #3129
 * Support skipping FVM installation #3126
 * Fix macOS xcconfig drift #3118
@@ -23,7 +24,6 @@
 * Split out @rlch's serde_json Value support #3077
 * Support multi-arch Docker development on Apple Silicon #3070
 * Remove outdated Dockerfile in favor of devcontainer up-to-date Dockerfile #3069
-* Support HarmonyOS #3065
 * Fix threaded WASM build-web defaults for the website demo #3052
 * Improve release publishing and post-release validation tooling #3221 #3220 #3219 #3218 #3217 #3216 #3215 #3214 #3211 #3210
 * Improve CI, workflow dispatch, and precommit automation #3195 #3193 #3189 #3178 #3175 #3174 #3172 #3166 #3160 #3143 #3137 #3135 #3134 #3132 #3131 #3115 #3099 #3096 #3076 #3072 #3051 #2990

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,17 @@
 ## 2.13.0-beta.1
 
 * Please refer to https://fzyzcjy.github.io/flutter_rust_bridge/guides/miscellaneous/whats-new for what's changed in V2.
+* Update git clone URL for flutter-ohos setup #3157 (thanks @star4277)
+* Add Rust-to-Dart logging bridge #3114 #3111 #3079 #2766 (thanks @patmuk)
+* Rename `ObjectId` to `MoiObjectId` in `frb_generated_moi_arc_def!` #3106 (thanks @ganeshrvel)
+* Introduce conversion between chrono::NaiveDate and DateTime avoiding RustOpaque #2968 (thanks @TrackerSB)
+* Fix Map/List/Set equality in generated Dart structs #2956 (thanks @nightscape)
 * Fix web worker wasm initialization #3171
 * Bump CargoKit to latest and update it for Android 16KB pages #3170
-* Update git clone URL for flutter-ohos setup #3157 (thanks @star4277)
 * Pass platforms through create and integrate commands #3129
 * Support skipping FVM installation #3126
 * Fix macOS xcconfig drift #3118
-* Add Rust-to-Dart logging bridge #3114 #3111 #3079 #2766 (thanks @patmuk)
 * Upgrade Flutter to 3.44 #3112
-* Rename `ObjectId` to `MoiObjectId` in `frb_generated_moi_arc_def!` #3106 (thanks @ganeshrvel)
 * Fix Dart native test hangs after logging bridge #3103
 * Fix generated fixed array equality #3093
 * Fix DCO boxed record decoding #3092
@@ -23,8 +25,6 @@
 * Remove outdated Dockerfile in favor of devcontainer up-to-date Dockerfile #3069
 * Support HarmonyOS #3065
 * Fix threaded WASM build-web defaults for the website demo #3052
-* Introduce conversion between chrono::NaiveDate and DateTime avoiding RustOpaque #2968 (thanks @TrackerSB)
-* Fix Map/List/Set equality in generated Dart structs #2956 (thanks @nightscape)
 * Improve release publishing and post-release validation tooling #3221 #3220 #3219 #3218 #3217 #3216 #3215 #3214 #3211 #3210
 * Improve CI, workflow dispatch, and precommit automation #3195 #3193 #3189 #3178 #3175 #3174 #3172 #3166 #3160 #3143 #3137 #3135 #3134 #3132 #3131 #3115 #3099 #3096 #3076 #3072 #3051 #2990
 * Improve local dev, Docker, Tart, Android, and manual-test tooling #3197 #3196 #3192 #3191 #3188 #3187 #3186 #3185 #3184 #3183 #3180 #3179 #3176 #3150 #3149 #3147 #3146 #3144 #3142 #3113

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.13.0-beta.1
 
 * Please refer to https://fzyzcjy.github.io/flutter_rust_bridge/guides/miscellaneous/whats-new for what's changed in V2.
+* Update git clone URL for flutter-ohos setup #3157 (thanks @star4277)
 * Add Rust-to-Dart logging bridge #3114 #3111 #3079 #2766 (thanks @patmuk)
 * Rename `ObjectId` to `MoiObjectId` in `frb_generated_moi_arc_def!` #3106 (thanks @ganeshrvel)
 * Support HarmonyOS #3065 (thanks @star4277)
@@ -10,7 +11,6 @@
 * Fix Map/List/Set equality in generated Dart structs #2956 (thanks @nightscape)
 * Fix web worker wasm initialization #3171
 * Bump CargoKit to latest and update it for Android 16KB pages #3170
-* Update git clone URL for flutter-ohos setup #3157
 * Pass platforms through create and integrate commands #3129
 * Support skipping FVM installation #3126
 * Fix macOS xcconfig drift #3118

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 * Split out @rlch's serde_json Value support #3077
 * Support multi-arch Docker development on Apple Silicon #3070
 * Remove outdated Dockerfile in favor of devcontainer up-to-date Dockerfile #3069
-* Support HarmonyOS #3065 (thanks @star4277)
+* Support HarmonyOS #3065
 * Fix threaded WASM build-web defaults for the website demo #3052
 * Introduce conversion between chrono::NaiveDate and DateTime avoiding RustOpaque #2968 (thanks @TrackerSB)
 * Fix Map/List/Set equality in generated Dart structs #2956 (thanks @nightscape)


### PR DESCRIPTION
## Summary
- Add the 2.13.0-beta.1 CHANGELOG.md section.
- Group pure release/CI/dev-environment maintenance PRs into compact entries.
- Add frb-write-changelog mechanical verification for PR-number coverage, third-party thanks coverage, and thanks-first ordering.

## Context
Replacement PR for #3222, reopened against master because #3222 was merged into codex/release-gate-allow-changelog.

## Verification
- python3 -m py_compile .claude/skills/frb-write-changelog/verify_changelog.py .claude/skills/frb-write-changelog/test_verify_changelog.py
- uv run --with pytest --with typer pytest .claude/skills/frb-write-changelog/test_verify_changelog.py
- uv run --script .claude/skills/frb-write-changelog/verify_changelog.py --version 2.13.0-beta.1 --previous-release-time 2026-03-29T21:34:04+08:00 --merged-prs-json /tmp/frb-merged-prs.json --ignore-pr 3140 --ignore-pr 3141 --extra-local-pr 3221
- uv run --script .claude/skills/frb-publish-release/release_ci_gate.py --base-green-ref codex/release-gate-allow-changelog --release-ref HEAD
- git diff HEAD~1..HEAD --check