### PR TITLE
Fix released version Dart lint

### DIFF
--- a/tools/frb_internal/lib/src/makefile_dart/released_version.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/released_version.dart
@@ -7,9 +7,10 @@ import 'package:args/command_runner.dart';
 import 'package:build_cli_annotations/build_cli_annotations.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_rust_bridge_internal/src/makefile_dart/consts.dart';
+import 'package:flutter_rust_bridge_internal/src/makefile_dart/release.dart'
+    show getFrbDartVersion;
 import 'package:flutter_rust_bridge_internal/src/utils/makefile_dart_infra.dart';
 import 'package:toml/toml.dart';
-import 'package:yaml/yaml.dart';
 
 part 'released_version.g.dart';
 
@@ -163,7 +164,3 @@ String getWorkspaceRustVersion() =>
 String parseWorkspaceRustVersion(String raw) =>
     TomlDocument.parse(raw).toMap()['workspace']['package']['version']
         as String;
-
-String getFrbDartVersion() => loadYaml(
-  File('${exec.pwd}frb_dart/pubspec.yaml').readAsStringSync(),
-)['version'];


### PR DESCRIPTION
## Summary

Fix the default-branch Dart lint failure by removing the duplicate `getFrbDartVersion` implementation from `released_version.dart` and reusing the existing helper from `release.dart`.

## Main CI Failure

- Failing commit: `17e7a04aadc6104e61888a8a8cb818a3bd5090d1`
- Failing run: https://github.com/fzyzcjy/flutter_rust_bridge/actions/runs/27461074552
- Failing job: `Lint :: Dart :: Primary` / job `81174905235`
- First useful error: `test/makefile_dart_test.dart:466:29` ambiguous import for `getFrbDartVersion`, defined by both `release.dart` and `released_version.dart`.
- Nearest green baseline: no completed green `CI` run was available among the latest default-branch runs inspected; several intervening push runs were cancelled by newer pushes. The failure was isolated from the latest active run logs.

## Verification

Ran inside FRB Docker dev container `frb-5942459189e4` using image `fzyzcjy/flutter_rust_bridge_dev:latest`:

```bash
./frb_internal lint-dart
cd tools/frb_internal && dart test test/makefile_dart_test.dart
```

Both passed. The focused test file reported 43 passing tests.