### PR TITLE
Remove prerelease flag from GitHub release command

### DIFF
--- a/tools/frb_internal/lib/src/makefile_dart/release.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/release.dart
@@ -10,7 +10,6 @@ import 'package:flutter_rust_bridge_internal/src/utils/makefile_dart_infra.dart'
 import 'package:glob/glob.dart';
 import 'package:glob/list_local_fs.dart';
 import 'package:meta/meta.dart';
-import 'package:pub_semver/pub_semver.dart';
 import 'package:yaml/yaml.dart';
 
 List<Command<void>> createCommands() {
@@ -172,12 +171,9 @@ String githubReleaseCreateCommand({
   required String version,
   required String notesFile,
 }) {
-  final parsedVersion = Version.parse(version);
-
   return [
     'gh release create v$version',
     '--notes-file $notesFile',
-    if (parsedVersion.isPreRelease) '--prerelease',
     '--title v$version',
   ].join(' ');
 }

--- a/tools/frb_internal/test/makefile_dart_test.dart
+++ b/tools/frb_internal/test/makefile_dart_test.dart
@@ -57,13 +57,13 @@ void main() {
     );
   });
 
-  test('GitHub release create command labels prerelease versions', () {
+  test('GitHub release create command does not label prerelease versions', () {
     expect(
       githubReleaseCreateCommand(
         version: '2.13.0-beta.1',
         notesFile: 'temp.txt',
       ),
-      'gh release create v2.13.0-beta.1 --notes-file temp.txt --prerelease --title v2.13.0-beta.1',
+      'gh release create v2.13.0-beta.1 --notes-file temp.txt --title v2.13.0-beta.1',
     );
   });
 


### PR DESCRIPTION
## Summary
- Stop adding --prerelease when creating GitHub releases for prerelease version strings.
- Update the internal release command test to expect the flag-free command.

## Verification
- .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- bash -lc 'cd tools/frb_internal && dart format --set-exit-if-changed lib/src/makefile_dart/release.dart test/makefile_dart_test.dart'
- .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- bash -lc 'cd tools/frb_internal && dart analyze lib/src/makefile_dart/release.dart test/makefile_dart_test.dart'
- .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- bash -lc 'cd tools/frb_internal && dart test test/makefile_dart_test.dart'

Note: ./frb_internal lint --fix progressed through Rust/Dart formatting, fixes, and checks, then failed in pana because it tried to copy the worktree .git fsmonitor IPC socket (.git/worktrees/flutter_rust_bridge12/fsmonitor--daemon.ipc). The lint-created lockfile drift was restored before commit.