### PR TITLE
Sync native assets lockfile versions

### DIFF
--- a/frb_example/flutter_package_native_assets/example/pubspec.lock
+++ b/frb_example/flutter_package_native_assets/example/pubspec.lock
@@ -128,7 +128,7 @@ packages:
       path: "../../../frb_dart"
       relative: true
     source: path
-    version: "2.12.0"
+    version: "2.13.0-beta.1"
   flutter_rust_bridge_hooks:
     dependency: transitive
     description:

--- a/frb_example/flutter_via_create_native_assets/pubspec.lock
+++ b/frb_example/flutter_via_create_native_assets/pubspec.lock
@@ -121,7 +121,7 @@ packages:
       path: "../../frb_dart"
       relative: true
     source: path
-    version: "2.12.0"
+    version: "2.13.0-beta.1"
   flutter_rust_bridge_hooks:
     dependency: "direct main"
     description:

--- a/frb_example/flutter_via_integrate_native_assets/pubspec.lock
+++ b/frb_example/flutter_via_integrate_native_assets/pubspec.lock
@@ -121,7 +121,7 @@ packages:
       path: "../../frb_dart"
       relative: true
     source: path
-    version: "2.12.0"
+    version: "2.13.0-beta.1"
   flutter_rust_bridge_hooks:
     dependency: "direct main"
     description:


### PR DESCRIPTION
Fixes the current default-branch CI failure in `Generate :: Internal` by committing the generated lockfile version updates for the native-assets examples.\n\nFailing evidence:\n- Run: https://github.com/fzyzcjy/flutter_rust_bridge/actions/runs/27490330603\n- Job: https://github.com/fzyzcjy/flutter_rust_bridge/actions/runs/27490330603/job/81254091521\n- Failure: `./frb_internal generate-internal --set-exit-if-changed --coverage` reported dirty `pubspec.lock` files where `flutter_rust_bridge` changed from `2.12.0` to `2.13.0-beta.1`.\n\nChanged files:\n- `frb_example/flutter_package_native_assets/example/pubspec.lock`\n- `frb_example/flutter_via_create_native_assets/pubspec.lock`\n- `frb_example/flutter_via_integrate_native_assets/pubspec.lock`\n\nVerification:\n- `.claude/skills/frb-dev-env/frb_dev_env.py docker exec -- bash -lc './frb_internal generate-internal --set-exit-if-changed --coverage'`\n