### PR TITLE
Upload coverage artifacts after failed gates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -348,6 +348,7 @@ jobs:
 
       # report
       - uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: ${{ github.job }}--${{ matrix.image }}--${{ matrix.package }}--coverage
           path: target/coverage
@@ -415,6 +416,7 @@ jobs:
 
       # report
       - uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: ${{ github.job }}--${{ matrix.image }}--${{ matrix.package }}--${{ matrix.platforms }}--coverage
           path: target/coverage
@@ -486,6 +488,7 @@ jobs:
 
       # report
       - uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: ${{ github.job }}--coverage
           path: target/coverage
@@ -758,6 +761,7 @@ jobs:
 
       # report
       - uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: ${{ github.job }}--${{ matrix.info.image }}--${{ matrix.info.version }}--coverage
           path: target/coverage
@@ -799,6 +803,7 @@ jobs:
 
       # report
       - uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: ${{ github.job }}--${{ matrix.image }}--${{ matrix.package }}--coverage
           path: target/coverage
@@ -1118,6 +1123,7 @@ jobs:
 
       # report
       - uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: ${{ github.job }}--${{ matrix.package }}--coverage
           path: target/coverage


### PR DESCRIPTION
## Summary
- Upload coverage artifacts with `if: always()` for coverage-producing CI jobs.
- Prevent Codecov aggregation from missing shards when a job writes coverage and then fails a later gate such as `--set-exit-if-changed`.

## Investigation
- Last green master report `57d5373`: Codecov total 98.56%.
- Failed master report `cf573f3`: Codecov total 97.94%.
- The drop was dominated by missing `GenerateInternalRust` coverage: `frb_dart_source_code.rs`, `frb_rust_source_code.rs`, and `internal/mod.rs` added 117 missing lines after `Generate :: Internal` wrote `target/coverage/GenerateInternalRust/codecov.json` but failed the git diff gate before artifact upload.

## Verification
- `git diff --check HEAD~1..HEAD`
- `actionlint` is not installed locally; CI will validate the workflow.