### PR TITLE
Pin Flutter version in Tart base provisioning

### DIFF
--- a/tools/tart_macos/README.md
+++ b/tools/tart_macos/README.md
@@ -43,6 +43,7 @@ packer init .
 packer build \
   -var 'source_vm=ghcr.io/cirruslabs/macos-sonoma-xcode:16.1' \
   -var 'target_vm=frb-tart-base-candidate' \
+  -var 'flutter_version=3.44.0' \
   -var 'allow_insecure=false' \
   .
 ```
@@ -147,11 +148,14 @@ packer init .
 packer build \
   -var 'source_vm=127.0.0.1:5000/cirruslabs/macos-sonoma-xcode:16.1' \
   -var 'target_vm=frb-tart-base-candidate' \
+  -var 'flutter_version=3.44.0' \
   -var 'allow_insecure=true' \
   .
 ```
 
-The Packer template clones the raw source VM, boots it as `admin/admin`, runs `scripts/provision-frb-tart-base.sh`, and leaves a stopped local VM named by `target_vm`. The current provision step initializes Xcode, uses the Flutter SDK already present in the source Tart image, installs CocoaPods with Homebrew, installs Rust matching the devcontainer, adds the `aarch64-apple-ios-sim` and `x86_64-apple-ios` Rust targets for both the pinned toolchain and the `stable-aarch64-apple-darwin` toolchain used by CargoKit, and pre-caches Flutter iOS artifacts. It also verifies the image contains Xcode and simulator tooling.
+The Packer template clones the raw source VM, boots it as `admin/admin`, runs `scripts/provision-frb-tart-base.sh`, and leaves a stopped local VM named by `target_vm`. The current provision step initializes Xcode, checks out the requested Flutter SDK version, installs CocoaPods with Homebrew, installs Rust matching the devcontainer, adds the `aarch64-apple-ios-sim` and `x86_64-apple-ios` Rust targets for both the pinned toolchain and the `stable-aarch64-apple-darwin` toolchain used by CargoKit, and pre-caches Flutter iOS and macOS artifacts. It also verifies the image contains Xcode and simulator tooling.
+
+Keep `flutter_version` in sync with `FRB_MAIN_FLUTTER_VERSION` in `.github/workflows/ci.yaml` and the Flutter version in `.devcontainer/Dockerfile`. Do not rely on the source Tart OCI image's preinstalled Flutter version, because Flutter template drift can change generated scaffold files.
 
 Verify the candidate:
 
@@ -166,7 +170,7 @@ Do not boot and mutate `frb-tart-base` during verification. If you need to inspe
 tart clone frb-tart-base-candidate frb-tart-probe
 tart run --no-graphics frb-tart-probe
 tart ip frb-tart-probe --wait 180
-tart exec frb-tart-probe /bin/zsh -lc 'sw_vers && xcodebuild -version && flutter --version && pod --version && rustc --version && cargo --version && rustup target list --installed | grep aarch64-apple-ios-sim && rustup target list --installed | grep x86_64-apple-ios && rustup target list --toolchain stable-aarch64-apple-darwin --installed | grep aarch64-apple-ios-sim && rustup target list --toolchain stable-aarch64-apple-darwin --installed | grep x86_64-apple-ios'
+tart exec frb-tart-probe /bin/zsh -lc 'sw_vers && xcodebuild -version && flutter --version && flutter --version --machine | python3 -c '"'"'import json,sys; assert json.load(sys.stdin)["frameworkVersion"] == "3.44.0"'"'"' && pod --version && rustc --version && cargo --version && rustup target list --installed | grep aarch64-apple-ios-sim && rustup target list --installed | grep x86_64-apple-ios && rustup target list --toolchain stable-aarch64-apple-darwin --installed | grep aarch64-apple-ios-sim && rustup target list --toolchain stable-aarch64-apple-darwin --installed | grep x86_64-apple-ios'
 tart stop frb-tart-probe
 tart delete frb-tart-probe
 ```

--- a/tools/tart_macos/packer/frb-tart-base.pkr.hcl
+++ b/tools/tart_macos/packer/frb-tart-base.pkr.hcl
@@ -25,6 +25,12 @@ variable "allow_insecure" {
   default     = true
 }
 
+variable "flutter_version" {
+  type        = string
+  description = "Flutter SDK version to install in the Tart base. Keep this in sync with FRB_MAIN_FLUTTER_VERSION in CI."
+  default     = "3.44.0"
+}
+
 source "tart-cli" "frb_tart_base" {
   vm_base_name   = var.source_vm
   vm_name        = var.target_vm
@@ -44,7 +50,10 @@ build {
   sources = ["source.tart-cli.frb_tart_base"]
 
   provisioner "shell" {
-    script          = "scripts/provision-frb-tart-base.sh"
+    script = "scripts/provision-frb-tart-base.sh"
+    environment_vars = [
+      "FRB_TART_FLUTTER_VERSION=${var.flutter_version}",
+    ]
     execute_command = "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}"
   }
 }

--- a/tools/tart_macos/packer/scripts/provision-frb-tart-base.sh
+++ b/tools/tart_macos/packer/scripts/provision-frb-tart-base.sh
@@ -5,6 +5,8 @@ export PATH="/opt/homebrew/bin:/usr/local/bin:$HOME/.cargo/bin:$PATH"
 export LANG="en_US.UTF-8"
 
 RUST_VERSION="1.93.1"
+FLUTTER_VERSION="${FRB_TART_FLUTTER_VERSION:-3.44.0}"
+FLUTTER_ROOT="$HOME/flutter"
 
 log() {
   printf '[frb-tart-base] %s\n' "$*"
@@ -37,18 +39,47 @@ configure_xcode() {
   sudo xcodebuild -runFirstLaunch
 }
 
-install_flutter_if_needed() {
+ensure_flutter_root() {
   if command -v flutter >/dev/null 2>&1; then
     return
   fi
 
-  if [ -x "$HOME/flutter/bin/flutter" ]; then
-    export PATH="$HOME/flutter/bin:$PATH"
+  if [ -x "$FLUTTER_ROOT/bin/flutter" ]; then
+    export PATH="$FLUTTER_ROOT/bin:$PATH"
     return
   fi
 
   printf 'Flutter was not found in the source Tart image. Use a source image with Flutter preinstalled, or extend this Packer template with a fast local Flutter archive upload.\n' >&2
   exit 1
+}
+
+ensure_flutter_version() {
+  require_command git
+
+  if [ ! -d "$FLUTTER_ROOT/.git" ]; then
+    printf 'Flutter root is not a git checkout: %s\n' "$FLUTTER_ROOT" >&2
+    exit 1
+  fi
+
+  export PATH="$FLUTTER_ROOT/bin:$PATH"
+  export FLUTTER_GIT_URL="file://$FLUTTER_ROOT"
+
+  local current_version
+  current_version="$(flutter --version --machine | python3 -c 'import json,sys; print(json.load(sys.stdin)["frameworkVersion"])')"
+  if [ "$current_version" = "$FLUTTER_VERSION" ]; then
+    log "Flutter is already ${FLUTTER_VERSION}"
+    return
+  fi
+
+  log "Switching Flutter from ${current_version} to ${FLUTTER_VERSION}"
+  git -C "$FLUTTER_ROOT" fetch origin "refs/tags/${FLUTTER_VERSION}:refs/tags/${FLUTTER_VERSION}"
+  git -C "$FLUTTER_ROOT" checkout --detach "$FLUTTER_VERSION"
+
+  current_version="$(flutter --version --machine | python3 -c 'import json,sys; print(json.load(sys.stdin)["frameworkVersion"])')"
+  if [ "$current_version" != "$FLUTTER_VERSION" ]; then
+    printf 'Expected Flutter %s, but found %s after checkout.\n' "$FLUTTER_VERSION" "$current_version" >&2
+    exit 1
+  fi
 }
 
 install_cocoapods_if_needed() {
@@ -81,9 +112,11 @@ log "Checking source image tools"
 require_command xcodebuild
 require_command xcrun
 require_command curl
+require_command python3
 
 configure_xcode
-install_flutter_if_needed
+ensure_flutter_root
+ensure_flutter_version
 install_cocoapods_if_needed
 install_rustup_if_needed
 persist_shell_path
@@ -100,9 +133,9 @@ rustup target add x86_64-apple-ios
 rustup target add --toolchain stable-aarch64-apple-darwin aarch64-apple-ios-sim
 rustup target add --toolchain stable-aarch64-apple-darwin x86_64-apple-ios
 
-log "Pre-caching Flutter iOS artifacts"
+log "Pre-caching Flutter iOS and macOS artifacts"
 flutter config --no-analytics
-flutter precache --ios
+flutter precache --ios --macos
 
 log "Disabling Spotlight indexing inside the VM"
 sudo mdutil -a -i off
@@ -111,6 +144,7 @@ log "Printing tool versions"
 sw_vers
 xcodebuild -version
 flutter --version
+flutter --version --machine | python3 -c 'import json,os,sys; version=json.load(sys.stdin)["frameworkVersion"]; expected=os.environ.get("FRB_TART_FLUTTER_VERSION", "3.44.0"); assert version == expected, f"Expected Flutter {expected}, found {version}"'
 pod --version
 rustc --version
 cargo --version


### PR DESCRIPTION
## Summary
- pin the Tart base Packer provisioner to the FRB Flutter version instead of relying on the source Tart image
- verify the provisioned Flutter version and pre-cache both iOS and macOS artifacts
- update Tart base rebuild and smoke-test docs

## Testing
- zsh -n tools/tart_macos/packer/scripts/provision-frb-tart-base.sh
- packer fmt -check tools/tart_macos/packer
- git diff --check
- packer validate tools/tart_macos/packer (fails locally: Tart Packer plugin exits before connecting)