### PR TITLE
Support host proxy for Tart commands

### DIFF
--- a/.claude/skills/frb-dev-env/SKILL.md
+++ b/.claude/skills/frb-dev-env/SKILL.md
@@ -227,7 +227,7 @@ Inspect, create, start, and run light commands in the per-worktree VM:
 
 ### Tart Guest Network Proxy
 
-When the Tart guest needs outbound network access through the host proxy, make the proxy listen on the host's Tart bridge address and pass that URL through the helper. For Clash Verge, enable the Clash setting named "LAN connections" / `allow-lan`, keep the mixed port at `7897`, and verify the host listens on `*:7897` rather than only `127.0.0.1:7897`.
+When the Tart guest needs outbound network access through the host proxy, make the proxy listen on the host's Tart bridge address and pass that URL through the helper. Enable LAN access for the host proxy, keep the mixed proxy port at `7897`, and verify the host listens on `*:7897` rather than only `127.0.0.1:7897`.
 
 Tart guests normally reach the host on `192.168.64.1`, so the usual proxy URL is:
 

--- a/.claude/skills/frb-dev-env/SKILL.md
+++ b/.claude/skills/frb-dev-env/SKILL.md
@@ -225,6 +225,25 @@ Inspect, create, start, and run light commands in the per-worktree VM:
 .claude/skills/frb-dev-env/frb_dev_env.py tart exec -- sw_vers
 ```
 
+### Tart Guest Network Proxy
+
+When the Tart guest needs outbound network access through the host proxy, make the proxy listen on the host's Tart bridge address and pass that URL through the helper. For Clash Verge, enable the Clash setting named "LAN connections" / `allow-lan`, keep the mixed port at `7897`, and verify the host listens on `*:7897` rather than only `127.0.0.1:7897`.
+
+Tart guests normally reach the host on `192.168.64.1`, so the usual proxy URL is:
+
+```bash
+export FRB_TART_HOST_PROXY_URL=http://192.168.64.1:7897
+.claude/skills/frb-dev-env/frb_dev_env.py tart exec -- curl -I https://pub.dev
+```
+
+You can also pass the proxy for a single command:
+
+```bash
+.claude/skills/frb-dev-env/frb_dev_env.py tart exec \
+  --host-proxy-url http://192.168.64.1:7897 \
+  -- curl -I https://pub.dev
+```
+
 Delete the worktree VM when it is no longer needed:
 
 ```bash

--- a/.claude/skills/frb-dev-env/frb_dev_env.py
+++ b/.claude/skills/frb-dev-env/frb_dev_env.py
@@ -43,6 +43,17 @@ REPO_LABEL_VALUE = "flutter_rust_bridge"
 LAYOUT_VERSION_VALUE = "3"
 TART_WORKSPACE_SHARE_NAME = "workspace"
 TART_HOST_MAIN_SHARE_NAME = "main"
+TART_HOST_PROXY_ENV_VAR = "FRB_TART_HOST_PROXY_URL"
+TART_PROXY_ENV_NAMES = [
+    "http_proxy",
+    "https_proxy",
+    "all_proxy",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "CARGO_HTTP_PROXY",
+]
+TART_NO_PROXY_VALUE = "localhost,127.0.0.1,::1"
 TART_LOCAL_COPY_ROOT = Path("/Users/admin/frb-dev-env-local-copies")
 TART_LOCAL_COPY_EXCLUDES = [
     ".dart_tool",
@@ -710,12 +721,56 @@ def ensure_tart_vm(*, worktree_root: Path, base_vm: str, min_free_gb: int) -> st
     return vm_name
 
 
-def tart_shell_command(command: list[str], *, worktree_root: Path) -> list[str]:
+def get_tart_host_proxy_url(host_proxy_url: str | None) -> str | None:
+    if host_proxy_url:
+        return host_proxy_url
+
+    return os.environ.get(TART_HOST_PROXY_ENV_VAR)
+
+
+def build_tart_guest_proxy_env(host_proxy_url: str | None) -> dict[str, str]:
+    resolved_host_proxy_url = get_tart_host_proxy_url(host_proxy_url=host_proxy_url)
+    if not resolved_host_proxy_url:
+        return {}
+
+    parsed = urlsplit(resolved_host_proxy_url)
+    if not parsed.scheme or not parsed.netloc:
+        raise CommandError(
+            "Tart host proxy URL must include scheme and host, for example "
+            "http://192.168.64.1:7897"
+        )
+
+    return {
+        **{name: resolved_host_proxy_url for name in TART_PROXY_ENV_NAMES},
+        "NO_PROXY": TART_NO_PROXY_VALUE,
+        "no_proxy": TART_NO_PROXY_VALUE,
+    }
+
+
+def shell_export_lines(env: dict[str, str]) -> list[str]:
+    return [
+        f"export {key}={shlex.quote(value)}"
+        for key, value in sorted(env.items())
+    ]
+
+
+def tart_shell_command(
+    command: list[str],
+    *,
+    worktree_root: Path,
+    env: dict[str, str] | None = None,
+) -> list[str]:
     quoted_command = " ".join(shlex.quote(part) for part in command)
+    script = "\n".join(
+        [
+            *shell_export_lines(env or {}),
+            f"cd {shlex.quote(str(worktree_root))} && exec {quoted_command}",
+        ]
+    )
     return [
         "/bin/zsh",
         "-lc",
-        f"cd {shlex.quote(str(worktree_root))} && exec {quoted_command}",
+        script,
     ]
 
 
@@ -860,12 +915,19 @@ def tart_prepare_ios_integration_test(
     *,
     vm_name: str,
     flutter_root: Path,
+    env: dict[str, str] | None = None,
 ) -> None:
+    command = ["tart", "exec", vm_name]
+    if env:
+        command.extend(
+            [
+                "/usr/bin/env",
+                *[f"{key}={value}" for key, value in sorted(env.items())],
+            ]
+        )
     exec_command(
         [
-            "tart",
-            "exec",
-            vm_name,
+            *command,
             "/usr/bin/python3",
             "-c",
             build_tart_prepare_ios_integration_test_script(flutter_root=flutter_root),
@@ -1647,6 +1709,13 @@ def tart_prepare_ios_integration_test_command(
         Path,
         typer.Option("--flutter-root", help="Flutter SDK root inside the Tart VM."),
     ] = DEFAULT_TART_FLUTTER_ROOT,
+    host_proxy_url: Annotated[
+        str | None,
+        typer.Option(
+            "--host-proxy-url",
+            help=f"Host proxy URL reachable from the Tart VM. Defaults to {TART_HOST_PROXY_ENV_VAR}.",
+        ),
+    ] = None,
 ) -> None:
     """Prepare the Tart VM Flutter SDK for iOS integration tests."""
 
@@ -1661,6 +1730,7 @@ def tart_prepare_ios_integration_test_command(
     tart_prepare_ios_integration_test(
         vm_name=vm_name,
         flutter_root=flutter_root,
+        env=build_tart_guest_proxy_env(host_proxy_url=host_proxy_url),
     )
 
 
@@ -1698,6 +1768,13 @@ def tart_exec(
         Path,
         typer.Option("--local-copy-root", help="VM-local root for uploaded worktree copies."),
     ] = TART_LOCAL_COPY_ROOT,
+    host_proxy_url: Annotated[
+        str | None,
+        typer.Option(
+            "--host-proxy-url",
+            help=f"Host proxy URL reachable from the Tart VM. Defaults to {TART_HOST_PROXY_ENV_VAR}.",
+        ),
+    ] = None,
 ) -> None:
     """Ensure the Tart VM is running, then execute a command inside it."""
 
@@ -1725,7 +1802,11 @@ def tart_exec(
             "tart",
             "exec",
             vm_name,
-            *tart_shell_command(command, worktree_root=command_worktree_root),
+            *tart_shell_command(
+                command,
+                worktree_root=command_worktree_root,
+                env=build_tart_guest_proxy_env(host_proxy_url=host_proxy_url),
+            ),
         ]
     )
 

--- a/.claude/skills/frb-dev-env/test_frb_dev_env.py
+++ b/.claude/skills/frb-dev-env/test_frb_dev_env.py
@@ -171,3 +171,57 @@ def test_build_docker_run_rm_command_without_credentials_is_plain() -> None:
         "./frb_internal",
         "--help",
     ]
+
+
+def test_build_tart_guest_proxy_env_from_argument(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tart proxy env uses the explicit host proxy URL when provided."""
+
+    monkeypatch.setenv("FRB_TART_HOST_PROXY_URL", "http://ignored.example:7897")
+
+    env = frb_dev_env.build_tart_guest_proxy_env(
+        host_proxy_url="http://192.168.64.1:7897"
+    )
+
+    assert env["HTTP_PROXY"] == "http://192.168.64.1:7897"
+    assert env["http_proxy"] == "http://192.168.64.1:7897"
+    assert env["CARGO_HTTP_PROXY"] == "http://192.168.64.1:7897"
+    assert env["NO_PROXY"] == "localhost,127.0.0.1,::1"
+    assert env["no_proxy"] == "localhost,127.0.0.1,::1"
+
+
+def test_build_tart_guest_proxy_env_from_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tart proxy env falls back to FRB_TART_HOST_PROXY_URL."""
+
+    monkeypatch.setenv("FRB_TART_HOST_PROXY_URL", "http://192.168.64.1:7897")
+
+    env = frb_dev_env.build_tart_guest_proxy_env(host_proxy_url=None)
+
+    assert env["HTTPS_PROXY"] == "http://192.168.64.1:7897"
+
+
+def test_build_tart_guest_proxy_env_rejects_host_without_scheme() -> None:
+    """Tart proxy env rejects ambiguous host proxy URLs."""
+
+    with pytest.raises(frb_dev_env.CommandError) as error:
+        frb_dev_env.build_tart_guest_proxy_env(host_proxy_url="192.168.64.1:7897")
+
+    assert "must include scheme and host" in str(error.value)
+
+
+def test_tart_shell_command_exports_proxy_env() -> None:
+    """Tart shell command exports guest env before running the command."""
+
+    command = frb_dev_env.tart_shell_command(
+        ["curl", "-I", "https://pub.dev"],
+        worktree_root=Path("/repo/flutter_rust_bridge"),
+        env={"HTTP_PROXY": "http://192.168.64.1:7897"},
+    )
+
+    assert command[:2] == ["/bin/zsh", "-lc"]
+    script = command[2]
+    assert "export HTTP_PROXY=http://192.168.64.1:7897" in script
+    assert "cd /repo/flutter_rust_bridge && exec curl -I https://pub.dev" in script

--- a/tools/tart_macos/README.md
+++ b/tools/tart_macos/README.md
@@ -51,7 +51,7 @@ packer build \
 
 Use this only when the direct download path is acceptable. Packer delegates the source VM clone to Tart, so shell proxy environment variables may not control it the way they control CLI tools like `curl` or `crane`.
 
-Leave `host_proxy_url` empty when the Tart guest has reliable direct network access. On macOS hosts running Clash Verge, enable the Clash setting named "LAN connections" so the mixed port listens on `*:7897`, then use `http://192.168.64.1:7897` from Tart guests. Verify it from a running Tart VM before a long base build:
+Leave `host_proxy_url` empty when the Tart guest has reliable direct network access. When using a host proxy, enable LAN access so the mixed proxy port listens on `*:7897`, then use `http://192.168.64.1:7897` from Tart guests. Verify it from a running Tart VM before a long base build:
 
 ```bash
 tart exec <vm-name> /bin/zsh -lc 'curl -I --proxy http://192.168.64.1:7897 --max-time 10 https://pub.dev'

--- a/tools/tart_macos/README.md
+++ b/tools/tart_macos/README.md
@@ -44,11 +44,18 @@ packer build \
   -var 'source_vm=ghcr.io/cirruslabs/macos-sonoma-xcode:16.1' \
   -var 'target_vm=frb-tart-base-candidate' \
   -var 'flutter_version=3.44.0' \
+  -var 'host_proxy_url=http://192.168.64.1:7897' \
   -var 'allow_insecure=false' \
   .
 ```
 
 Use this only when the direct download path is acceptable. Packer delegates the source VM clone to Tart, so shell proxy environment variables may not control it the way they control CLI tools like `curl` or `crane`.
+
+Leave `host_proxy_url` empty when the Tart guest has reliable direct network access. On macOS hosts running Clash Verge, enable the Clash setting named "LAN connections" so the mixed port listens on `*:7897`, then use `http://192.168.64.1:7897` from Tart guests. Verify it from a running Tart VM before a long base build:
+
+```bash
+tart exec <vm-name> /bin/zsh -lc 'curl -I --proxy http://192.168.64.1:7897 --max-time 10 https://pub.dev'
+```
 
 ## Controlled Local Registry Path
 
@@ -149,11 +156,12 @@ packer build \
   -var 'source_vm=127.0.0.1:5000/cirruslabs/macos-sonoma-xcode:16.1' \
   -var 'target_vm=frb-tart-base-candidate' \
   -var 'flutter_version=3.44.0' \
+  -var 'host_proxy_url=http://192.168.64.1:7897' \
   -var 'allow_insecure=true' \
   .
 ```
 
-The Packer template clones the raw source VM, boots it as `admin/admin`, runs `scripts/provision-frb-tart-base.sh`, and leaves a stopped local VM named by `target_vm`. The current provision step initializes Xcode, checks out the requested Flutter SDK version, installs CocoaPods with Homebrew, installs Rust matching the devcontainer, adds the `aarch64-apple-ios-sim` and `x86_64-apple-ios` Rust targets for both the pinned toolchain and the `stable-aarch64-apple-darwin` toolchain used by CargoKit, and pre-caches Flutter iOS and macOS artifacts. It also verifies the image contains Xcode and simulator tooling.
+The Packer template clones the raw source VM, boots it as `admin/admin`, runs `scripts/provision-frb-tart-base.sh`, and leaves a stopped local VM named by `target_vm`. The current provision step initializes Xcode, checks out the requested Flutter SDK version, installs CocoaPods with Homebrew, installs Rust matching the devcontainer, adds the `aarch64-apple-ios-sim` and `x86_64-apple-ios` Rust targets for both the pinned toolchain and the `stable-aarch64-apple-darwin` toolchain used by CargoKit, and pre-caches Flutter iOS and macOS artifacts. If `host_proxy_url` is set, the provision step receives standard `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` / `CARGO_HTTP_PROXY` environment variables. It also verifies the image contains Xcode and simulator tooling.
 
 Keep `flutter_version` in sync with `FRB_MAIN_FLUTTER_VERSION` in `.github/workflows/ci.yaml` and the Flutter version in `.devcontainer/Dockerfile`. Do not rely on the source Tart OCI image's preinstalled Flutter version, because Flutter template drift can change generated scaffold files.
 

--- a/tools/tart_macos/packer/frb-tart-base.pkr.hcl
+++ b/tools/tart_macos/packer/frb-tart-base.pkr.hcl
@@ -31,6 +31,12 @@ variable "flutter_version" {
   default     = "3.44.0"
 }
 
+variable "host_proxy_url" {
+  type        = string
+  description = "Optional host proxy URL reachable from the Tart VM, for example http://192.168.64.1:7897."
+  default     = ""
+}
+
 source "tart-cli" "frb_tart_base" {
   vm_base_name   = var.source_vm
   vm_name        = var.target_vm
@@ -51,9 +57,22 @@ build {
 
   provisioner "shell" {
     script = "scripts/provision-frb-tart-base.sh"
-    environment_vars = [
-      "FRB_TART_FLUTTER_VERSION=${var.flutter_version}",
-    ]
+    environment_vars = concat(
+      [
+        "FRB_TART_FLUTTER_VERSION=${var.flutter_version}",
+      ],
+      var.host_proxy_url == "" ? [] : [
+        "http_proxy=${var.host_proxy_url}",
+        "https_proxy=${var.host_proxy_url}",
+        "all_proxy=${var.host_proxy_url}",
+        "HTTP_PROXY=${var.host_proxy_url}",
+        "HTTPS_PROXY=${var.host_proxy_url}",
+        "ALL_PROXY=${var.host_proxy_url}",
+        "CARGO_HTTP_PROXY=${var.host_proxy_url}",
+        "NO_PROXY=localhost,127.0.0.1,::1",
+        "no_proxy=localhost,127.0.0.1,::1",
+      ],
+    )
     execute_command = "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}"
   }
 }


### PR DESCRIPTION
## Summary
- add Tart guest proxy support to frb_dev_env.py via --host-proxy-url or FRB_TART_HOST_PROXY_URL
- pass optional host_proxy_url through Tart base Packer provisioning
- document generic host proxy setup for Tart guests

## Testing
- uv run --with pytest --with 'typer>=0.12' pytest .claude/skills/frb-dev-env/test_frb_dev_env.py
- packer fmt -check tools/tart_macos/packer
- zsh -n tools/tart_macos/packer/scripts/provision-frb-tart-base.sh
- git diff --check
- .claude/skills/frb-dev-env/frb_dev_env.py tart exec --host-proxy-url http://192.168.64.1:7897 -- /bin/zsh -lc 'test $HTTP_PROXY = http://192.168.64.1:7897 && curl -I --max-time 10 https://pub.dev 2>&1 | head -12'
- packer validate tools/tart_macos/packer (fails locally: Tart Packer plugin exits before connecting)