### PR TITLE
Preserve OHOS outputs during precommit autofix

### DIFF
--- a/tools/frb_internal/lib/src/makefile_dart/generate.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/generate.dart
@@ -448,10 +448,11 @@ Future<void> generateRunFrbCodegenCommandIntegrate(
       );
       print('Pick temporary directory: $dirTemp');
       await Directory(dirTemp).create(recursive: true);
+      final dirTempOriginal = path.join(dirTemp, 'original');
 
       // We move instead of delete folder for extra safety of this script
       if (await Directory(dirPackage).exists()) {
-        await Directory(dirPackage).rename(path.join(dirTemp, 'original'));
+        await Directory(dirPackage).rename(dirTempOriginal);
       }
 
       final recipe = _integrateRecipeForPackage(config.package);
@@ -490,6 +491,13 @@ Future<void> generateRunFrbCodegenCommandIntegrate(
       if (!config.skipCheckedInAppleScaffold) {
         await applyCheckedInAppleScaffoldSourceOfTruth(
           package: config.package,
+          generatedPackageDir: dirPackage,
+        );
+      }
+      if (!config.includeOhos) {
+        await preserveCheckedInOhosScaffold(
+          package: config.package,
+          originalPackageDir: dirTempOriginal,
           generatedPackageDir: dirPackage,
         );
       }

--- a/tools/frb_internal/lib/src/makefile_dart/integrate_apple_scaffold.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/integrate_apple_scaffold.dart
@@ -37,6 +37,15 @@ const _kIntegrateAppleScaffoldSourceOfTruthPaths = <String, List<String>>{
   ],
 };
 
+const _kPreservedOhosScaffoldPaths = <String, List<String>>{
+  'frb_example/flutter_via_create': [
+    'ohos',
+    'rust_builder/ohos',
+    'rust_builder/pubspec.yaml',
+  ],
+  'frb_example/flutter_via_create_native_assets': ['ohos'],
+};
+
 List<String> integrateAppleScaffoldSourceOfTruthPackages() =>
     List.unmodifiable(_kIntegrateAppleScaffoldSourceOfTruthPaths.keys);
 
@@ -57,8 +66,24 @@ Future<void> applyCheckedInAppleScaffoldSourceOfTruth({
   }
 }
 
+Future<void> preserveCheckedInOhosScaffold({
+  required String package,
+  required String originalPackageDir,
+  required String generatedPackageDir,
+}) async {
+  for (final relativePath in _preservedOhosScaffoldPaths(package)) {
+    _restorePathIfExists(
+      source: path.join(originalPackageDir, relativePath),
+      destination: path.join(generatedPackageDir, relativePath),
+    );
+  }
+}
+
 List<String> _integrateAppleScaffoldSourceOfTruthPaths(String package) =>
     _kIntegrateAppleScaffoldSourceOfTruthPaths[package] ?? const [];
+
+List<String> _preservedOhosScaffoldPaths(String package) =>
+    _kPreservedOhosScaffoldPaths[package] ?? const [];
 
 String _integrateAppleScaffoldSourceOfTruthAssetPath({
   required String package,
@@ -91,6 +116,10 @@ String _integrateAppleScaffoldSourceOfTruthAssetPathFromRepoRoot({
 List<String> integrateAppleScaffoldSourceOfTruthPathsForTesting(
   String package,
 ) => List.unmodifiable(_integrateAppleScaffoldSourceOfTruthPaths(package));
+
+@visibleForTesting
+List<String> preservedOhosScaffoldPathsForTesting(String package) =>
+    List.unmodifiable(_preservedOhosScaffoldPaths(package));
 
 @visibleForTesting
 List<String> integrateAppleScaffoldSourceOfTruthAssetPathsForTesting({
@@ -132,6 +161,7 @@ void _restorePathIfExists({
 
   switch (sourceEntity) {
     case FileSystemEntityType.file:
+      File(destination).parent.createSync(recursive: true);
       File(source).copySync(destination);
     case FileSystemEntityType.directory:
       _copyDirectoryRecursive(

--- a/tools/frb_internal/test/integrate_apple_scaffold_test.dart
+++ b/tools/frb_internal/test/integrate_apple_scaffold_test.dart
@@ -133,6 +133,67 @@ void main() {
     },
   );
 
+  test('preserved OHOS scaffold paths are explicit', () {
+    expect(
+      preservedOhosScaffoldPathsForTesting('frb_example/flutter_via_create'),
+      ['ohos', 'rust_builder/ohos', 'rust_builder/pubspec.yaml'],
+    );
+    expect(
+      preservedOhosScaffoldPathsForTesting(
+        'frb_example/flutter_via_create_native_assets',
+      ),
+      ['ohos'],
+    );
+    expect(
+      preservedOhosScaffoldPathsForTesting('frb_example/flutter_package'),
+      isEmpty,
+    );
+  });
+
+  test(
+    'preserveCheckedInOhosScaffold restores files and directories',
+    () async {
+      final tempDir = Directory.systemTemp.createTempSync('frb-preserve-ohos-');
+      addTearDown(() => tempDir.deleteSync(recursive: true));
+
+      final original = Directory('${tempDir.path}/original');
+      final generated = Directory('${tempDir.path}/generated');
+      Directory('${original.path}/ohos').createSync(recursive: true);
+      Directory(
+        '${original.path}/rust_builder/ohos',
+      ).createSync(recursive: true);
+      File('${original.path}/ohos/marker.txt').writeAsStringSync('root-ohos');
+      File(
+        '${original.path}/rust_builder/ohos/marker.txt',
+      ).writeAsStringSync('builder-ohos');
+      File(
+        '${original.path}/rust_builder/pubspec.yaml',
+      ).writeAsStringSync('plugin:\n  platforms:\n    ohos:\n');
+      Directory(generated.path).createSync(recursive: true);
+
+      await preserveCheckedInOhosScaffold(
+        package: 'frb_example/flutter_via_create',
+        originalPackageDir: original.path,
+        generatedPackageDir: generated.path,
+      );
+
+      expect(
+        File('${generated.path}/ohos/marker.txt').readAsStringSync(),
+        'root-ohos',
+      );
+      expect(
+        File(
+          '${generated.path}/rust_builder/ohos/marker.txt',
+        ).readAsStringSync(),
+        'builder-ohos',
+      );
+      expect(
+        File('${generated.path}/rust_builder/pubspec.yaml').readAsStringSync(),
+        'plugin:\n  platforms:\n    ohos:\n',
+      );
+    },
+  );
+
   test('copyDirectoryRecursive preserves dotfiles and nested workspace files', () {
     final tempDir = Directory.systemTemp.createTempSync('frb-copy-recursive-');
     addTearDown(() => tempDir.deleteSync(recursive: true));


### PR DESCRIPTION
## Summary
- preserve checked-in OHOS scaffold outputs when non-OHOS integrate generation runs
- keep rust_builder OHOS registration from being exported as a precommit-autofix deletion
- add regression coverage for the preserved paths and restore behavior

## Testing
- .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- dart format tools/frb_internal/lib/src/makefile_dart/generate.dart tools/frb_internal/lib/src/makefile_dart/integrate_apple_scaffold.dart tools/frb_internal/test/integrate_apple_scaffold_test.dart
- .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- bash -lc 'cd tools/frb_internal && dart test test/integrate_apple_scaffold_test.dart'