### PR TITLE
Reproduce freezed prerelease caret dependency with intentional red CI

### DIFF
--- a/frb_codegen/src/library/utils/dart_repository/version_converter.rs
+++ b/frb_codegen/src/library/utils/dart_repository/version_converter.rs
@@ -98,4 +98,17 @@ mod tests {
             DartPackageVersion::Range(VersionReq::parse(">=1.2.3").unwrap())
         );
     }
+
+    #[test]
+    fn test_dart_prerelease_caret_version_satisfies_stable_requirement() {
+        let version =
+            DartPackageVersion::try_from(&DartDependencyVersion("^4.0.0-dev.3".to_owned()))
+                .unwrap();
+        let requirement = VersionReq::parse(">=1.0.0").unwrap();
+
+        assert!(matches!(
+            version,
+            DartPackageVersion::Exact(version) if requirement.matches(&version)
+        ));
+    }
 }


### PR DESCRIPTION
## Intentional reproduction

This PR intentionally adds a failing regression test for #3241. It is not a fix PR.

Focused CI filter to run:

```text
test_rust[image=ubuntu-latest,version=1.85.0]
```

Expected failure text:

```text
assertion failed: matches!(version, DartPackageVersion::Exact(version) if requirement.matches(&version))
```

Local reproduction command:

```bash
.claude/skills/frb-dev-env/frb_dev_env.py docker exec -- bash -lc 'cargo test -p flutter_rust_bridge_codegen dart_repository::version_converter::tests::test_dart_prerelease_caret_version_satisfies_stable_requirement -- --nocapture'
```

Observed: the test fails because `^4.0.0-dev.3` is converted to an exact prerelease version that Cargo semver does not match against `>=1.0.0`.