### PR TITLE
Stabilize macOS CI smoke and logging tests

### DIFF
--- a/frb_example/pure_dart/test/multi_initialization_test.dart
+++ b/frb_example/pure_dart/test/multi_initialization_test.dart
@@ -33,7 +33,7 @@ Future<void> main() async {
     expect(simpleAdderTwinSync(a: 42, b: 100), 142);
 
     await emitLogMessage(message: firstMessage);
-    await pumpEventQueue();
+    await _waitForLogMessage(receivedRecords, firstMessage);
 
     expect(_countLogMessage(receivedRecords, firstMessage), 1);
     expect(_countLogMessage(receivedRecords, secondMessage), 0);
@@ -48,7 +48,7 @@ Future<void> main() async {
     expect(simpleAdderTwinSync(a: 42, b: 100), 142);
 
     await emitLogMessage(message: secondMessage);
-    await pumpEventQueue();
+    await _waitForLogMessage(receivedRecords, secondMessage);
 
     // Step 4: Exercise the platform console fallback path without asserting
     // platform-specific output capture.
@@ -66,3 +66,14 @@ int _countLogMessage(List<LogRecord> records, String message) =>
 
 bool _hasLogRecord(List<LogRecord> records, String message, Level level) =>
     records.any((record) => record.message == message && record.level == level);
+
+Future<void> _waitForLogMessage(
+  List<LogRecord> records,
+  String message,
+) async {
+  final deadline = DateTime.now().add(const Duration(seconds: 5));
+  while (DateTime.now().isBefore(deadline)) {
+    if (_countLogMessage(records, message) > 0) return;
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+  }
+}

--- a/frb_example/pure_dart_pde/test/multi_initialization_test.dart
+++ b/frb_example/pure_dart_pde/test/multi_initialization_test.dart
@@ -35,7 +35,7 @@ Future<void> main() async {
     expect(simpleAdderTwinSync(a: 42, b: 100), 142);
 
     await emitLogMessage(message: firstMessage);
-    await pumpEventQueue();
+    await _waitForLogMessage(receivedRecords, firstMessage);
 
     expect(_countLogMessage(receivedRecords, firstMessage), 1);
     expect(_countLogMessage(receivedRecords, secondMessage), 0);
@@ -50,7 +50,7 @@ Future<void> main() async {
     expect(simpleAdderTwinSync(a: 42, b: 100), 142);
 
     await emitLogMessage(message: secondMessage);
-    await pumpEventQueue();
+    await _waitForLogMessage(receivedRecords, secondMessage);
 
     // Step 4: Exercise the platform console fallback path without asserting
     // platform-specific output capture.
@@ -68,3 +68,14 @@ int _countLogMessage(List<LogRecord> records, String message) =>
 
 bool _hasLogRecord(List<LogRecord> records, String message, Level level) =>
     records.any((record) => record.message == message && record.level == level);
+
+Future<void> _waitForLogMessage(
+  List<LogRecord> records,
+  String message,
+) async {
+  final deadline = DateTime.now().add(const Duration(seconds: 5));
+  while (DateTime.now().isBefore(deadline)) {
+    if (_countLogMessage(records, message) > 0) return;
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+  }
+}

--- a/tools/frb_internal/lib/src/makefile_dart/quickstart_smoke.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/quickstart_smoke.dart
@@ -229,13 +229,20 @@ String quickstartSmokeDefaultDeviceIdForTesting(QuickstartSmokeTarget target) {
 
 @visibleForTesting
 Duration quickstartSmokeFlutterRunReadyTimeoutForTesting(
-  QuickstartSmokeTarget target,
-) => switch (target) {
-  QuickstartSmokeTarget.web => const Duration(seconds: 120),
-  QuickstartSmokeTarget.desktop ||
-  QuickstartSmokeTarget.android => const Duration(minutes: 5),
-  QuickstartSmokeTarget.ios => const Duration(minutes: 10),
-};
+  QuickstartSmokeTarget target, {
+  bool? isMacOS,
+}) {
+  final effectiveIsMacOS = isMacOS ?? Platform.isMacOS;
+  return switch (target) {
+    QuickstartSmokeTarget.web => const Duration(seconds: 120),
+    QuickstartSmokeTarget.desktop when effectiveIsMacOS => const Duration(
+      minutes: 10,
+    ),
+    QuickstartSmokeTarget.desktop ||
+    QuickstartSmokeTarget.android => const Duration(minutes: 5),
+    QuickstartSmokeTarget.ios => const Duration(minutes: 10),
+  };
+}
 
 @visibleForTesting
 Duration quickstartSmokeVisibleTextTimeoutForTesting(
@@ -331,6 +338,7 @@ Future<bool> _waitForQuickstartSmokeFlutterRunReady({
 }) async {
   final timeout = quickstartSmokeFlutterRunReadyTimeoutForTesting(
     context.target,
+    isMacOS: Platform.isMacOS,
   );
   final deadline = DateTime.now().add(timeout);
   print('Waiting up to $timeout for flutter run readiness');

--- a/tools/frb_internal/test/makefile_dart_test.dart
+++ b/tools/frb_internal/test/makefile_dart_test.dart
@@ -284,6 +284,26 @@ plain
     );
   });
 
+  test(
+    'quickstart smoke gives macOS desktop cold builds more readiness time',
+    () {
+      expect(
+        quickstartSmokeFlutterRunReadyTimeoutForTesting(
+          QuickstartSmokeTarget.desktop,
+          isMacOS: true,
+        ),
+        const Duration(minutes: 10),
+      );
+      expect(
+        quickstartSmokeFlutterRunReadyTimeoutForTesting(
+          QuickstartSmokeTarget.desktop,
+          isMacOS: false,
+        ),
+        const Duration(minutes: 5),
+      );
+    },
+  );
+
   test('quickstart smoke does not capture while Flutter is still building', () {
     expect(
       quickstartSmokeFlutterRunIsReadyForTesting(


### PR DESCRIPTION
Fixes master CI failures on run 27868087817 (head 595f8891c42047379910af80c8a7aabc9c0ed1ac):

- Test :: Flutter :: Quickstart Smoke:: macos timed out waiting 5 minutes for flutter run readiness, while the app finished building shortly after the timeout.
- Test :: Dart :: Native (macos-15-intel, frb_example--pure_dart_pde) observed zero matching log records immediately after emitting the second Rust log message.

Changes:

- Give macOS desktop quickstart smoke the same 10-minute readiness window as iOS cold builds.
- Wait briefly for the expected logging bridge record in the multi-initialization hot-restart test before asserting counts.
- Regenerated the pure_dart_pde copy from pure_dart.

Validation:

- ./frb_internal generate-internal-frb-example-pure-dart
- dart test test/makefile_dart_test.dart (from tools/frb_internal)
- dart test test/multi_initialization_test.dart (from frb_example/pure_dart)
- dart test test/multi_initialization_test.dart (from frb_example/pure_dart_pde)
- git diff --check

Also attempted ./frb_internal lint --fix; it progressed through many Rust crates but stopped on a rustup TLS EOF while fetching Rust 1.93.1 channel metadata. Attempted ./frb_internal lint-dart after formatting; it reached integrate_third_party and stopped because this local shell lacks flutter on PATH.