### PR TITLE
Guard releases against uninitialized submodules

### DIFF
--- a/.claude/skills/frb-publish-release/SKILL.md
+++ b/.claude/skills/frb-publish-release/SKILL.md
@@ -13,6 +13,15 @@ Use this skill when preparing, publishing, or babysitting a `flutter_rust_bridge
 
 - Work from the repository root on the intended release branch, normally fresh `master`. If the checkout is detached but already points at the intended release commit, switch or create a local release branch from that commit before running mutating release commands; do not treat detached HEAD itself as a release blocker.
 - Check `git status --short --branch` and do not start publishing from a dirty tree.
+- Check CargoKit submodules before publishing:
+
+  ```bash
+  git submodule status --recursive
+  git submodule update --init --recursive
+  cd frb_codegen && cargo package --list --allow-dirty | rg 'assets/integration_template/cargokit/.*/build_tool/(pubspec.yaml|bin/build_tool.dart|lib/build_tool.dart)'
+  ```
+
+  Stop if either CargoKit submodule path is uninitialized, if the package list omits the app or plugin CargoKit `build_tool` files, or if the command does not show both `app/rust_builder/cargokit/build_tool` and `plugin/cargokit/build_tool`. A release built without initialized CargoKit submodules publishes a broken `flutter_rust_bridge_codegen` crate.
 - Treat `master` as a moving branch. Before each irreversible release phase, fetch `origin master`, confirm the current release branch or detached checkout still points at the intended latest `origin/master` commit, and re-run `git status --short --branch` to confirm there are no unexpected local changes.
 - Confirm the target version in `CHANGELOG.md`, root `Cargo.toml`, and `frb_dart/pubspec.yaml`.
 - Compute the release versions the same way `./frb_internal release` does: the top `CHANGELOG.md` version is the new version and the next release section is the old version.

--- a/.claude/skills/frb-publish-release/SKILL.md
+++ b/.claude/skills/frb-publish-release/SKILL.md
@@ -13,14 +13,14 @@ Use this skill when preparing, publishing, or babysitting a `flutter_rust_bridge
 
 - Work from the repository root on the intended release branch, normally fresh `master`. If the checkout is detached but already points at the intended release commit, switch or create a local release branch from that commit before running mutating release commands; do not treat detached HEAD itself as a release blocker.
 - Check `git status --short --branch` and do not start publishing from a dirty tree.
-- Check CargoKit submodules before publishing:
+- Check submodules before publishing:
 
   ```bash
   git submodule update --init --recursive
   git submodule status --recursive
   ```
 
-  Stop if either CargoKit submodule path remains uninitialized. A release built without initialized CargoKit submodules publishes a broken `flutter_rust_bridge_codegen` crate. The release script performs the same submodule-status guard before publishing.
+  Stop if any submodule path remains uninitialized. A release built without initialized submodules can publish incomplete package contents. The release script performs the same submodule-status guard before publishing.
 - Treat `master` as a moving branch. Before each irreversible release phase, fetch `origin master`, confirm the current release branch or detached checkout still points at the intended latest `origin/master` commit, and re-run `git status --short --branch` to confirm there are no unexpected local changes.
 - Confirm the target version in `CHANGELOG.md`, root `Cargo.toml`, and `frb_dart/pubspec.yaml`.
 - Compute the release versions the same way `./frb_internal release` does: the top `CHANGELOG.md` version is the new version and the next release section is the old version.

--- a/.claude/skills/frb-publish-release/SKILL.md
+++ b/.claude/skills/frb-publish-release/SKILL.md
@@ -16,12 +16,11 @@ Use this skill when preparing, publishing, or babysitting a `flutter_rust_bridge
 - Check CargoKit submodules before publishing:
 
   ```bash
-  git submodule status --recursive
   git submodule update --init --recursive
-  cd frb_codegen && cargo package --list --allow-dirty | rg 'assets/integration_template/cargokit/.*/build_tool/(pubspec.yaml|bin/build_tool.dart|lib/build_tool.dart)'
+  git submodule status --recursive
   ```
 
-  Stop if either CargoKit submodule path is uninitialized, if the package list omits the app or plugin CargoKit `build_tool` files, or if the command does not show both `app/rust_builder/cargokit/build_tool` and `plugin/cargokit/build_tool`. A release built without initialized CargoKit submodules publishes a broken `flutter_rust_bridge_codegen` crate.
+  Stop if either CargoKit submodule path remains uninitialized. A release built without initialized CargoKit submodules publishes a broken `flutter_rust_bridge_codegen` crate. The release script also verifies the packaged CargoKit files before `cargo publish`, so the skill preflight does not need to enumerate individual files.
 - Treat `master` as a moving branch. Before each irreversible release phase, fetch `origin master`, confirm the current release branch or detached checkout still points at the intended latest `origin/master` commit, and re-run `git status --short --branch` to confirm there are no unexpected local changes.
 - Confirm the target version in `CHANGELOG.md`, root `Cargo.toml`, and `frb_dart/pubspec.yaml`.
 - Compute the release versions the same way `./frb_internal release` does: the top `CHANGELOG.md` version is the new version and the next release section is the old version.

--- a/.claude/skills/frb-publish-release/SKILL.md
+++ b/.claude/skills/frb-publish-release/SKILL.md
@@ -20,7 +20,7 @@ Use this skill when preparing, publishing, or babysitting a `flutter_rust_bridge
   git submodule status --recursive
   ```
 
-  Stop if either CargoKit submodule path remains uninitialized. A release built without initialized CargoKit submodules publishes a broken `flutter_rust_bridge_codegen` crate. The release script also verifies the packaged CargoKit files before `cargo publish`, so the skill preflight does not need to enumerate individual files.
+  Stop if either CargoKit submodule path remains uninitialized. A release built without initialized CargoKit submodules publishes a broken `flutter_rust_bridge_codegen` crate. The release script performs the same submodule-status guard before publishing.
 - Treat `master` as a moving branch. Before each irreversible release phase, fetch `origin master`, confirm the current release branch or detached checkout still points at the intended latest `origin/master` commit, and re-run `git status --short --branch` to confirm there are no unexpected local changes.
 - Confirm the target version in `CHANGELOG.md`, root `Cargo.toml`, and `frb_dart/pubspec.yaml`.
 - Compute the release versions the same way `./frb_internal release` does: the top `CHANGELOG.md` version is the new version and the next release section is the old version.

--- a/tools/frb_internal/lib/src/makefile_dart/release.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/release.dart
@@ -37,6 +37,7 @@ class VersionInfo {
 
 Future<void> release() async {
   print('Version info: ${computeVersionInfo()}');
+  verifyCargokitReleaseInputs();
   await releaseUpdateVersion();
   await releaseUpdateCode();
   await releaseUpdateScoop();
@@ -183,6 +184,8 @@ String releaseCargoLockTemplatePathForTesting() =>
     '${exec.pwd}frb_codegen/assets/integration_template/shared/shared/REPLACE_ME_RUST_CRATE_DIR/Cargo.lock.template';
 
 Future<void> releasePublishAll() async {
+  verifyCargokitReleaseInputs();
+  await verifyCargokitCodegenPackageContents();
   await exec('cd frb_codegen && cargo publish');
   await exec('cd frb_macros && cargo publish');
   await exec('cd frb_rust && cargo publish');
@@ -192,6 +195,46 @@ Future<void> releasePublishAll() async {
   await exec(
     'cd frb_hooks && dart pub publish --force --server=https://pub.dartlang.org',
   );
+}
+
+@visibleForTesting
+List<String> cargokitReleaseRequiredPathsForTesting() =>
+    List.unmodifiable(_kCargokitReleaseRequiredPaths);
+
+void verifyCargokitReleaseInputs({String? repoRoot}) {
+  final root = repoRoot ?? exec.pwd;
+  final missingPaths = _kCargokitReleaseRequiredPaths
+      .where((path) => !File('$root$path').existsSync())
+      .toList();
+
+  if (missingPaths.isNotEmpty) {
+    throw Exception(
+      [
+        'CargoKit release inputs are missing. Run `git submodule update --init --recursive` before publishing.',
+        ...missingPaths.map((path) => '- $path'),
+      ].join('\n'),
+    );
+  }
+}
+
+Future<void> verifyCargokitCodegenPackageContents() async {
+  final output = await exec(
+    'cargo package --list --allow-dirty',
+    relativePwd: 'frb_codegen',
+  );
+  final packageFiles = output.stdout.split('\n').toSet();
+  final missingPaths = _kCargokitCodegenPackageRequiredPaths
+      .where((path) => !packageFiles.contains(path))
+      .toList();
+
+  if (missingPaths.isNotEmpty) {
+    throw Exception(
+      [
+        'CargoKit release files are missing from flutter_rust_bridge_codegen package output.',
+        ...missingPaths.map((path) => '- $path'),
+      ].join('\n'),
+    );
+  }
 }
 
 String getFrbDartVersion() => loadYaml(
@@ -221,6 +264,24 @@ VersionInfo computeVersionInfo() => _extractChangelog().$1;
     lines.sublist(newVersion.$1 + 1, oldVersion.$1).join("\n").trim(),
   );
 }
+
+const _kCargokitCodegenPackageRequiredPaths = [
+  'assets/integration_template/cargokit/app/rust_builder/cargokit/build_tool/bin/build_tool.dart',
+  'assets/integration_template/cargokit/app/rust_builder/cargokit/build_tool/lib/build_tool.dart',
+  'assets/integration_template/cargokit/app/rust_builder/cargokit/build_tool/pubspec.yaml',
+  'assets/integration_template/cargokit/plugin/cargokit/build_tool/bin/build_tool.dart',
+  'assets/integration_template/cargokit/plugin/cargokit/build_tool/lib/build_tool.dart',
+  'assets/integration_template/cargokit/plugin/cargokit/build_tool/pubspec.yaml',
+];
+
+const _kCargokitReleaseRequiredPaths = [
+  'frb_codegen/assets/integration_template/cargokit/app/rust_builder/cargokit/build_tool/bin/build_tool.dart',
+  'frb_codegen/assets/integration_template/cargokit/app/rust_builder/cargokit/build_tool/lib/build_tool.dart',
+  'frb_codegen/assets/integration_template/cargokit/app/rust_builder/cargokit/build_tool/pubspec.yaml',
+  'frb_codegen/assets/integration_template/cargokit/plugin/cargokit/build_tool/bin/build_tool.dart',
+  'frb_codegen/assets/integration_template/cargokit/plugin/cargokit/build_tool/lib/build_tool.dart',
+  'frb_codegen/assets/integration_template/cargokit/plugin/cargokit/build_tool/pubspec.yaml',
+];
 
 String simpleReplaceSection(
   String raw, {

--- a/tools/frb_internal/lib/src/makefile_dart/release.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/release.dart
@@ -185,7 +185,6 @@ String releaseCargoLockTemplatePathForTesting() =>
 
 Future<void> releasePublishAll() async {
   verifyCargokitReleaseInputs();
-  await verifyCargokitCodegenPackageContents();
   await exec('cd frb_codegen && cargo publish');
   await exec('cd frb_macros && cargo publish');
   await exec('cd frb_rust && cargo publish');
@@ -197,45 +196,42 @@ Future<void> releasePublishAll() async {
   );
 }
 
+void verifyCargokitReleaseInputs({String? repoRoot, String? submoduleStatus}) {
+  final status =
+      submoduleStatus ?? _gitSubmoduleStatus(repoRoot ?? '${exec.pwd}');
+  final uninitializedPaths = _uninitializedCargokitSubmodulePaths(status);
+
+  if (uninitializedPaths.isNotEmpty) {
+    throw Exception(
+      [
+        'CargoKit submodules are uninitialized. Run `git submodule update --init --recursive` before publishing.',
+        ...uninitializedPaths.map((path) => '- $path'),
+      ].join('\n'),
+    );
+  }
+}
+
+String _gitSubmoduleStatus(String repoRoot) {
+  final result = Process.runSync('git', [
+    'submodule',
+    'status',
+    '--recursive',
+  ], workingDirectory: repoRoot);
+  if (result.exitCode != 0) {
+    throw Exception('Failed to check git submodule status: ${result.stderr}');
+  }
+  return result.stdout as String;
+}
+
 @visibleForTesting
-List<String> cargokitReleaseRequiredPathsForTesting() =>
-    List.unmodifiable(_kCargokitReleaseRequiredPaths);
+List<String> uninitializedCargokitSubmodulePathsForTesting(String status) =>
+    _uninitializedCargokitSubmodulePaths(status);
 
-void verifyCargokitReleaseInputs({String? repoRoot}) {
-  final root = repoRoot ?? exec.pwd;
-  final missingPaths = _kCargokitReleaseRequiredPaths
-      .where((path) => !File('$root$path').existsSync())
-      .toList();
-
-  if (missingPaths.isNotEmpty) {
-    throw Exception(
-      [
-        'CargoKit release inputs are missing. Run `git submodule update --init --recursive` before publishing.',
-        ...missingPaths.map((path) => '- $path'),
-      ].join('\n'),
-    );
-  }
-}
-
-Future<void> verifyCargokitCodegenPackageContents() async {
-  final output = await exec(
-    'cargo package --list --allow-dirty',
-    relativePwd: 'frb_codegen',
-  );
-  final packageFiles = output.stdout.split('\n').toSet();
-  final missingPaths = _kCargokitCodegenPackageRequiredPaths
-      .where((path) => !packageFiles.contains(path))
-      .toList();
-
-  if (missingPaths.isNotEmpty) {
-    throw Exception(
-      [
-        'CargoKit release files are missing from flutter_rust_bridge_codegen package output.',
-        ...missingPaths.map((path) => '- $path'),
-      ].join('\n'),
-    );
-  }
-}
+List<String> _uninitializedCargokitSubmodulePaths(String status) => status
+    .split('\n')
+    .where((line) => line.startsWith('-') && line.contains('/cargokit'))
+    .map((line) => line.trim().split(RegExp(r'\s+'))[1])
+    .toList();
 
 String getFrbDartVersion() => loadYaml(
   File('${exec.pwd}frb_dart/pubspec.yaml').readAsStringSync(),
@@ -264,24 +260,6 @@ VersionInfo computeVersionInfo() => _extractChangelog().$1;
     lines.sublist(newVersion.$1 + 1, oldVersion.$1).join("\n").trim(),
   );
 }
-
-const _kCargokitCodegenPackageRequiredPaths = [
-  'assets/integration_template/cargokit/app/rust_builder/cargokit/build_tool/bin/build_tool.dart',
-  'assets/integration_template/cargokit/app/rust_builder/cargokit/build_tool/lib/build_tool.dart',
-  'assets/integration_template/cargokit/app/rust_builder/cargokit/build_tool/pubspec.yaml',
-  'assets/integration_template/cargokit/plugin/cargokit/build_tool/bin/build_tool.dart',
-  'assets/integration_template/cargokit/plugin/cargokit/build_tool/lib/build_tool.dart',
-  'assets/integration_template/cargokit/plugin/cargokit/build_tool/pubspec.yaml',
-];
-
-const _kCargokitReleaseRequiredPaths = [
-  'frb_codegen/assets/integration_template/cargokit/app/rust_builder/cargokit/build_tool/bin/build_tool.dart',
-  'frb_codegen/assets/integration_template/cargokit/app/rust_builder/cargokit/build_tool/lib/build_tool.dart',
-  'frb_codegen/assets/integration_template/cargokit/app/rust_builder/cargokit/build_tool/pubspec.yaml',
-  'frb_codegen/assets/integration_template/cargokit/plugin/cargokit/build_tool/bin/build_tool.dart',
-  'frb_codegen/assets/integration_template/cargokit/plugin/cargokit/build_tool/lib/build_tool.dart',
-  'frb_codegen/assets/integration_template/cargokit/plugin/cargokit/build_tool/pubspec.yaml',
-];
 
 String simpleReplaceSection(
   String raw, {

--- a/tools/frb_internal/lib/src/makefile_dart/release.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/release.dart
@@ -37,7 +37,7 @@ class VersionInfo {
 
 Future<void> release() async {
   print('Version info: ${computeVersionInfo()}');
-  verifyCargokitReleaseInputs();
+  verifyReleaseSubmodules();
   await releaseUpdateVersion();
   await releaseUpdateCode();
   await releaseUpdateScoop();
@@ -184,7 +184,7 @@ String releaseCargoLockTemplatePathForTesting() =>
     '${exec.pwd}frb_codegen/assets/integration_template/shared/shared/REPLACE_ME_RUST_CRATE_DIR/Cargo.lock.template';
 
 Future<void> releasePublishAll() async {
-  verifyCargokitReleaseInputs();
+  verifyReleaseSubmodules();
   await exec('cd frb_codegen && cargo publish');
   await exec('cd frb_macros && cargo publish');
   await exec('cd frb_rust && cargo publish');
@@ -196,15 +196,15 @@ Future<void> releasePublishAll() async {
   );
 }
 
-void verifyCargokitReleaseInputs({String? repoRoot, String? submoduleStatus}) {
+void verifyReleaseSubmodules({String? repoRoot, String? submoduleStatus}) {
   final status =
       submoduleStatus ?? _gitSubmoduleStatus(repoRoot ?? '${exec.pwd}');
-  final uninitializedPaths = _uninitializedCargokitSubmodulePaths(status);
+  final uninitializedPaths = _uninitializedSubmodulePaths(status);
 
   if (uninitializedPaths.isNotEmpty) {
     throw Exception(
       [
-        'CargoKit submodules are uninitialized. Run `git submodule update --init --recursive` before publishing.',
+        'Release submodules are uninitialized. Run `git submodule update --init --recursive` before publishing.',
         ...uninitializedPaths.map((path) => '- $path'),
       ].join('\n'),
     );
@@ -224,12 +224,12 @@ String _gitSubmoduleStatus(String repoRoot) {
 }
 
 @visibleForTesting
-List<String> uninitializedCargokitSubmodulePathsForTesting(String status) =>
-    _uninitializedCargokitSubmodulePaths(status);
+List<String> uninitializedSubmodulePathsForTesting(String status) =>
+    _uninitializedSubmodulePaths(status);
 
-List<String> _uninitializedCargokitSubmodulePaths(String status) => status
+List<String> _uninitializedSubmodulePaths(String status) => status
     .split('\n')
-    .where((line) => line.startsWith('-') && line.contains('/cargokit'))
+    .where((line) => line.startsWith('-'))
     .map((line) => line.trim().split(RegExp(r'\s+'))[1])
     .toList();
 

--- a/tools/frb_internal/test/makefile_dart_test.dart
+++ b/tools/frb_internal/test/makefile_dart_test.dart
@@ -81,9 +81,9 @@ void main() {
     expect(File(releaseCargoLockTemplatePathForTesting()).existsSync(), true);
   });
 
-  test('release guard rejects uninitialized CargoKit submodules', () {
+  test('release guard rejects uninitialized submodules', () {
     expect(
-      () => verifyCargokitReleaseInputs(
+      () => verifyReleaseSubmodules(
         submoduleStatus:
             '-6f7144d frb_codegen/assets/integration_template/cargokit/app/rust_builder/cargokit',
       ),
@@ -97,9 +97,9 @@ void main() {
     );
   });
 
-  test('release guard accepts initialized CargoKit submodules', () {
+  test('release guard accepts initialized submodules', () {
     expect(
-      () => verifyCargokitReleaseInputs(
+      () => verifyReleaseSubmodules(
         submoduleStatus:
             ' 6f7144d frb_codegen/assets/integration_template/cargokit/app/rust_builder/cargokit (heads/main)\n'
             ' 6f7144d frb_codegen/assets/integration_template/cargokit/plugin/cargokit (heads/main)',
@@ -108,15 +108,16 @@ void main() {
     );
   });
 
-  test('release guard reports only uninitialized CargoKit submodules', () {
+  test('release guard reports all uninitialized submodules', () {
     expect(
-      uninitializedCargokitSubmodulePathsForTesting(
+      uninitializedSubmodulePathsForTesting(
         '-6f7144d frb_codegen/assets/integration_template/cargokit/app/rust_builder/cargokit\n'
         ' 6f7144d frb_codegen/assets/integration_template/cargokit/plugin/cargokit\n'
         '-1234567 unrelated/submodule',
       ),
       [
         'frb_codegen/assets/integration_template/cargokit/app/rust_builder/cargokit',
+        'unrelated/submodule',
       ],
     );
   });

--- a/tools/frb_internal/test/makefile_dart_test.dart
+++ b/tools/frb_internal/test/makefile_dart_test.dart
@@ -81,6 +81,38 @@ void main() {
     expect(File(releaseCargoLockTemplatePathForTesting()).existsSync(), true);
   });
 
+  test('release guard rejects missing CargoKit submodule files', () {
+    final dir = Directory.systemTemp.createTempSync('frb_release_guard_');
+    addTearDown(() => dir.deleteSync(recursive: true));
+
+    expect(
+      () => verifyCargokitReleaseInputs(repoRoot: '${dir.path}/'),
+      throwsA(
+        isA<Exception>().having(
+          (error) => error.toString(),
+          'message',
+          contains('git submodule update --init --recursive'),
+        ),
+      ),
+    );
+  });
+
+  test('release guard accepts initialized CargoKit submodule files', () {
+    final dir = Directory.systemTemp.createTempSync('frb_release_guard_');
+    addTearDown(() => dir.deleteSync(recursive: true));
+
+    for (final path in cargokitReleaseRequiredPathsForTesting()) {
+      final file = File('${dir.path}/$path');
+      file.parent.createSync(recursive: true);
+      file.writeAsStringSync('content');
+    }
+
+    expect(
+      () => verifyCargokitReleaseInputs(repoRoot: '${dir.path}/'),
+      returnsNormally,
+    );
+  });
+
   test(
     'pure dart generator resolves package from repo root instead of cwd',
     () {

--- a/tools/frb_internal/test/makefile_dart_test.dart
+++ b/tools/frb_internal/test/makefile_dart_test.dart
@@ -81,12 +81,12 @@ void main() {
     expect(File(releaseCargoLockTemplatePathForTesting()).existsSync(), true);
   });
 
-  test('release guard rejects missing CargoKit submodule files', () {
-    final dir = Directory.systemTemp.createTempSync('frb_release_guard_');
-    addTearDown(() => dir.deleteSync(recursive: true));
-
+  test('release guard rejects uninitialized CargoKit submodules', () {
     expect(
-      () => verifyCargokitReleaseInputs(repoRoot: '${dir.path}/'),
+      () => verifyCargokitReleaseInputs(
+        submoduleStatus:
+            '-6f7144d frb_codegen/assets/integration_template/cargokit/app/rust_builder/cargokit',
+      ),
       throwsA(
         isA<Exception>().having(
           (error) => error.toString(),
@@ -97,19 +97,27 @@ void main() {
     );
   });
 
-  test('release guard accepts initialized CargoKit submodule files', () {
-    final dir = Directory.systemTemp.createTempSync('frb_release_guard_');
-    addTearDown(() => dir.deleteSync(recursive: true));
-
-    for (final path in cargokitReleaseRequiredPathsForTesting()) {
-      final file = File('${dir.path}/$path');
-      file.parent.createSync(recursive: true);
-      file.writeAsStringSync('content');
-    }
-
+  test('release guard accepts initialized CargoKit submodules', () {
     expect(
-      () => verifyCargokitReleaseInputs(repoRoot: '${dir.path}/'),
+      () => verifyCargokitReleaseInputs(
+        submoduleStatus:
+            ' 6f7144d frb_codegen/assets/integration_template/cargokit/app/rust_builder/cargokit (heads/main)\n'
+            ' 6f7144d frb_codegen/assets/integration_template/cargokit/plugin/cargokit (heads/main)',
+      ),
       returnsNormally,
+    );
+  });
+
+  test('release guard reports only uninitialized CargoKit submodules', () {
+    expect(
+      uninitializedCargokitSubmodulePathsForTesting(
+        '-6f7144d frb_codegen/assets/integration_template/cargokit/app/rust_builder/cargokit\n'
+        ' 6f7144d frb_codegen/assets/integration_template/cargokit/plugin/cargokit\n'
+        '-1234567 unrelated/submodule',
+      ),
+      [
+        'frb_codegen/assets/integration_template/cargokit/app/rust_builder/cargokit',
+      ],
     );
   });
 


### PR DESCRIPTION
## Summary
- add a release guard that fails when any git submodule is uninitialized
- run the same submodule-status guard from the release skill before publishing
- document the submodule initialization check in the release skill

## Reproduction
- v2.13.0-beta.3 was published from a checkout where submodules were uninitialized
- the published flutter_rust_bridge_codegen crate omitted submodule content
- post-release unstable+cargokit quickstart failed when it tried to use missing files from that submodule content

## Verification
- dart test test/makefile_dart_test.dart -n "release guard"
- git diff --check