### PR TITLE
Clarify uninitialized RustStreamSink stream error

### DIFF
--- a/frb_dart/lib/src/stream/stream_sink.dart
+++ b/frb_dart/lib/src/stream/stream_sink.dart
@@ -16,7 +16,17 @@ class RustStreamSink<T> {
   }
 
   /// The Dart stream for the Rust sink
-  Stream<T> get stream => _state!.stream;
+  Stream<T> get stream {
+    final state = _state;
+    if (state == null) {
+      throw StateError(
+        'RustStreamSink.stream is not ready yet. Pass this RustStreamSink to a '
+        'generated flutter_rust_bridge API before accessing stream. Listening '
+        'before setup is not supported yet.',
+      );
+    }
+    return state.stream;
+  }
 }
 
 class _State<T> {

--- a/frb_dart/test/stream_sink_test.dart
+++ b/frb_dart/test/stream_sink_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('RustStreamSink stream before setup throws actionable StateError', () {
+    expect(
+      () => RustStreamSink<int>().stream,
+      throwsA(
+        isA<StateError>().having(
+          (error) => error.message,
+          'message',
+          allOf(
+            contains('RustStreamSink.stream is not ready yet'),
+            contains('generated flutter_rust_bridge API'),
+          ),
+        ),
+      ),
+    );
+  });
+}


### PR DESCRIPTION
## Reproduction

Baseline commit: `0917013e70d4db46352e1c3d78911271bec46c87`

Steps:
1. Create a `RustStreamSink<int>`.
2. Access `sink.stream` before the sink has been passed to a generated flutter_rust_bridge API.

Observed:
```text
Null check operator used on a null value
```

Expected:
A clear `StateError` explaining that `RustStreamSink.stream` is not ready until generated setup has run.

## Changes

- Add ShuttleSpace as a contributor for reporting the RustStreamSink readiness issue.
- Replace the null-check crash with an actionable `StateError`.
- Add a focused Dart runtime regression test for accessing `RustStreamSink.stream` before setup.

## Verification

- `dart test test/stream_sink_test.dart` in `frb_dart`
- `./frb_internal lint-dart` in the FRB Docker container