### PR TITLE
Stabilize master CI workflow dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -403,9 +403,8 @@ jobs:
       - if: matrix.platforms == 'ohos'
         name: Setup flutter-ohos
         run: |
-          git init $GITHUB_WORKSPACE/flutter
-          git -C $GITHUB_WORKSPACE/flutter fetch --depth 1 https://gitcode.com/CPF-Flutter/flutter_flutter.git $FRB_OHOS_FLUTTER_REF
-          git -C $GITHUB_WORKSPACE/flutter checkout FETCH_HEAD
+          git clone -b oh-3.41.9-dev --single-branch https://gitcode.com/CPF-Flutter/flutter_flutter.git $GITHUB_WORKSPACE/flutter
+          git -C $GITHUB_WORKSPACE/flutter checkout -B oh-3.41.9-dev $FRB_OHOS_FLUTTER_REF
           echo "$GITHUB_WORKSPACE/flutter/bin" >> $GITHUB_PATH
       - if: matrix.platforms == 'ohos'
         name: Export OHOS_SDK_HOME
@@ -623,9 +622,8 @@ jobs:
       - if: matrix.info.target == 'ohos'
         name: Setup flutter-ohos
         run: |
-          git init $GITHUB_WORKSPACE/flutter
-          git -C $GITHUB_WORKSPACE/flutter fetch --depth 1 https://gitcode.com/CPF-Flutter/flutter_flutter.git $FRB_OHOS_FLUTTER_REF
-          git -C $GITHUB_WORKSPACE/flutter checkout FETCH_HEAD
+          git clone -b oh-3.41.9-dev --single-branch https://gitcode.com/CPF-Flutter/flutter_flutter.git $GITHUB_WORKSPACE/flutter
+          git -C $GITHUB_WORKSPACE/flutter checkout -B oh-3.41.9-dev $FRB_OHOS_FLUTTER_REF
           echo "$GITHUB_WORKSPACE/flutter/bin" >> $GITHUB_PATH
       - if: matrix.info.target == 'ohos'
         name: Export OHOS_SDK_HOME

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,7 @@ env:
   FRB_MAIN_DART_VERSION: 3.11.0
   FRB_MAIN_FLUTTER_VERSION: 3.44.0
   FRB_RUSTFMT_NIGHTLY_VERSION: nightly-2025-02-01
+  FRB_OHOS_FLUTTER_REF: 6d7e5b43fb43bb85ba0a59e3469299ebcf45a637
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -402,7 +403,8 @@ jobs:
       - if: matrix.platforms == 'ohos'
         name: Setup flutter-ohos
         run: |
-          git clone -b oh-3.41.9-dev https://gitcode.com/CPF-Flutter/flutter_flutter.git $GITHUB_WORKSPACE/flutter
+          git clone https://gitcode.com/CPF-Flutter/flutter_flutter.git $GITHUB_WORKSPACE/flutter
+          git -C $GITHUB_WORKSPACE/flutter checkout $FRB_OHOS_FLUTTER_REF
           echo "$GITHUB_WORKSPACE/flutter/bin" >> $GITHUB_PATH
       - if: matrix.platforms == 'ohos'
         name: Export OHOS_SDK_HOME
@@ -620,7 +622,8 @@ jobs:
       - if: matrix.info.target == 'ohos'
         name: Setup flutter-ohos
         run: |
-          git clone -b oh-3.41.9-dev https://gitcode.com/CPF-Flutter/flutter_flutter.git $GITHUB_WORKSPACE/flutter
+          git clone https://gitcode.com/CPF-Flutter/flutter_flutter.git $GITHUB_WORKSPACE/flutter
+          git -C $GITHUB_WORKSPACE/flutter checkout $FRB_OHOS_FLUTTER_REF
           echo "$GITHUB_WORKSPACE/flutter/bin" >> $GITHUB_PATH
       - if: matrix.info.target == 'ohos'
         name: Export OHOS_SDK_HOME
@@ -1023,10 +1026,35 @@ jobs:
           submodules: recursive
       - name: "Start Simulator"
         run: |
-          # list all devices
           xcrun xctrace list devices
-          # the extra "(" is to avoid matching things like "iPhone 12 Pro Max Simulator (16.2) + Apple Watch Series 5 - 44mm (8.0)"
-          UDID=$(xcrun xctrace list devices | grep '${{ matrix.device }} (' | awk '{print $NF}' | tr -d '()')
+          UDID=$(DEVICE='${{ matrix.device }}' /usr/bin/python3 - <<'PY'
+          import json
+          import os
+          import re
+          import subprocess
+          import sys
+
+          device = os.environ['DEVICE']
+          match = re.fullmatch(r'(.+) Simulator \(([^()]+)\)', device)
+          name = match.group(1) if match else device
+          version = match.group(2) if match else None
+          devices = json.loads(subprocess.check_output(
+              ['xcrun', 'simctl', 'list', 'devices', 'available', '-j'],
+              text=True,
+          ))
+          matches = []
+          for runtime, runtime_devices in devices.get('devices', {}).items():
+              if version and not runtime.endswith(f'iOS-{version.replace(".", "-")}'):
+                  continue
+              for runtime_device in runtime_devices:
+                  if runtime_device.get('name') == name:
+                      matches.append(runtime_device['udid'])
+          if len(matches) != 1:
+              print(f'Expected exactly one simulator for {device}, found {len(matches)}', file=sys.stderr)
+              sys.exit(1)
+          print(matches[0])
+          PY
+          )
           echo UDID=$UDID
           xcrun simctl boot "${UDID:?No Simulator with this name found}"
       - uses: flutter-actions/setup-flutter@v4
@@ -1195,7 +1223,34 @@ jobs:
         name: Start Simulator
         run: |
           xcrun xctrace list devices
-          UDID=$(xcrun xctrace list devices | grep '${{ matrix.info.device }} (' | awk '{print $NF}' | tr -d '()')
+          UDID=$(DEVICE='${{ matrix.info.device }}' /usr/bin/python3 - <<'PY'
+          import json
+          import os
+          import re
+          import subprocess
+          import sys
+
+          device = os.environ['DEVICE']
+          match = re.fullmatch(r'(.+) Simulator \(([^()]+)\)', device)
+          name = match.group(1) if match else device
+          version = match.group(2) if match else None
+          devices = json.loads(subprocess.check_output(
+              ['xcrun', 'simctl', 'list', 'devices', 'available', '-j'],
+              text=True,
+          ))
+          matches = []
+          for runtime, runtime_devices in devices.get('devices', {}).items():
+              if version and not runtime.endswith(f'iOS-{version.replace(".", "-")}'):
+                  continue
+              for runtime_device in runtime_devices:
+                  if runtime_device.get('name') == name:
+                      matches.append(runtime_device['udid'])
+          if len(matches) != 1:
+              print(f'Expected exactly one simulator for {device}, found {len(matches)}', file=sys.stderr)
+              sys.exit(1)
+          print(matches[0])
+          PY
+          )
           echo UDID=$UDID
           echo "UDID=$UDID" >> "$GITHUB_ENV"
           echo "QUICKSTART_SMOKE_DEVICE_ID=$UDID" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1027,34 +1027,7 @@ jobs:
       - name: "Start Simulator"
         run: |
           xcrun xctrace list devices
-          UDID=$(DEVICE='${{ matrix.device }}' /usr/bin/python3 - <<'PY'
-          import json
-          import os
-          import re
-          import subprocess
-          import sys
-
-          device = os.environ['DEVICE']
-          match = re.fullmatch(r'(.+) Simulator \(([^()]+)\)', device)
-          name = match.group(1) if match else device
-          version = match.group(2) if match else None
-          devices = json.loads(subprocess.check_output(
-              ['xcrun', 'simctl', 'list', 'devices', 'available', '-j'],
-              text=True,
-          ))
-          matches = []
-          for runtime, runtime_devices in devices.get('devices', {}).items():
-              if version and not runtime.endswith(f'iOS-{version.replace(".", "-")}'):
-                  continue
-              for runtime_device in runtime_devices:
-                  if runtime_device.get('name') == name:
-                      matches.append(runtime_device['udid'])
-          if len(matches) != 1:
-              print(f'Expected exactly one simulator for {device}, found {len(matches)}', file=sys.stderr)
-              sys.exit(1)
-          print(matches[0])
-          PY
-          )
+          UDID=$(/usr/bin/python3 tools/find_ios_simulator_udid.py '${{ matrix.device }}')
           echo UDID=$UDID
           xcrun simctl boot "${UDID:?No Simulator with this name found}"
       - uses: flutter-actions/setup-flutter@v4
@@ -1223,34 +1196,7 @@ jobs:
         name: Start Simulator
         run: |
           xcrun xctrace list devices
-          UDID=$(DEVICE='${{ matrix.info.device }}' /usr/bin/python3 - <<'PY'
-          import json
-          import os
-          import re
-          import subprocess
-          import sys
-
-          device = os.environ['DEVICE']
-          match = re.fullmatch(r'(.+) Simulator \(([^()]+)\)', device)
-          name = match.group(1) if match else device
-          version = match.group(2) if match else None
-          devices = json.loads(subprocess.check_output(
-              ['xcrun', 'simctl', 'list', 'devices', 'available', '-j'],
-              text=True,
-          ))
-          matches = []
-          for runtime, runtime_devices in devices.get('devices', {}).items():
-              if version and not runtime.endswith(f'iOS-{version.replace(".", "-")}'):
-                  continue
-              for runtime_device in runtime_devices:
-                  if runtime_device.get('name') == name:
-                      matches.append(runtime_device['udid'])
-          if len(matches) != 1:
-              print(f'Expected exactly one simulator for {device}, found {len(matches)}', file=sys.stderr)
-              sys.exit(1)
-          print(matches[0])
-          PY
-          )
+          UDID=$(/usr/bin/python3 tools/find_ios_simulator_udid.py '${{ matrix.info.device }}')
           echo UDID=$UDID
           echo "UDID=$UDID" >> "$GITHUB_ENV"
           echo "QUICKSTART_SMOKE_DEVICE_ID=$UDID" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -403,8 +403,9 @@ jobs:
       - if: matrix.platforms == 'ohos'
         name: Setup flutter-ohos
         run: |
-          git clone https://gitcode.com/CPF-Flutter/flutter_flutter.git $GITHUB_WORKSPACE/flutter
-          git -C $GITHUB_WORKSPACE/flutter checkout $FRB_OHOS_FLUTTER_REF
+          git init $GITHUB_WORKSPACE/flutter
+          git -C $GITHUB_WORKSPACE/flutter fetch --depth 1 https://gitcode.com/CPF-Flutter/flutter_flutter.git $FRB_OHOS_FLUTTER_REF
+          git -C $GITHUB_WORKSPACE/flutter checkout FETCH_HEAD
           echo "$GITHUB_WORKSPACE/flutter/bin" >> $GITHUB_PATH
       - if: matrix.platforms == 'ohos'
         name: Export OHOS_SDK_HOME
@@ -622,8 +623,9 @@ jobs:
       - if: matrix.info.target == 'ohos'
         name: Setup flutter-ohos
         run: |
-          git clone https://gitcode.com/CPF-Flutter/flutter_flutter.git $GITHUB_WORKSPACE/flutter
-          git -C $GITHUB_WORKSPACE/flutter checkout $FRB_OHOS_FLUTTER_REF
+          git init $GITHUB_WORKSPACE/flutter
+          git -C $GITHUB_WORKSPACE/flutter fetch --depth 1 https://gitcode.com/CPF-Flutter/flutter_flutter.git $FRB_OHOS_FLUTTER_REF
+          git -C $GITHUB_WORKSPACE/flutter checkout FETCH_HEAD
           echo "$GITHUB_WORKSPACE/flutter/bin" >> $GITHUB_PATH
       - if: matrix.info.target == 'ohos'
         name: Export OHOS_SDK_HOME

--- a/frb_example/deliberate_bad/rust/Cargo.toml
+++ b/frb_example/deliberate_bad/rust/Cargo.toml
@@ -6,6 +6,10 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib"]
 
+[[bin]]
+name = "frb_example_deliberate_bad_bin"
+path = "src/main.rs"
+
 [dependencies]
 anyhow = { version = "1.0.64", features = ["backtrace"] }
 flutter_rust_bridge = { path = "../../../frb_rust" }

--- a/tools/find_ios_simulator_udid.py
+++ b/tools/find_ios_simulator_udid.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+
+@dataclass(frozen=True)
+class DeviceQuery:
+    label: str
+    name: str
+    version: Optional[str]
+
+
+def main() -> int:
+    device_label, simctl_json_path = _parse_args(args=sys.argv[1:])
+    query = _parse_device_label(label=device_label)
+    devices = _load_simctl_devices(simctl_json_path=simctl_json_path)
+    matches = _find_matching_udids(query=query, devices=devices)
+
+    if len(matches) != 1:
+        print(
+            f"Expected exactly one simulator for {query.label}, found {len(matches)}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(matches[0])
+    return 0
+
+
+def _parse_args(args: list[str]) -> tuple[str, Optional[Path]]:
+    if not args or len(args) not in {1, 3}:
+        _print_usage()
+        raise SystemExit(2)
+
+    if len(args) == 1:
+        return args[0], None
+
+    if args[1] != "--simctl-json":
+        _print_usage()
+        raise SystemExit(2)
+
+    return args[0], Path(args[2])
+
+
+def _print_usage() -> None:
+    print(
+        "Usage: find_ios_simulator_udid.py '<device label>' "
+        "[--simctl-json path]",
+        file=sys.stderr,
+    )
+
+
+def _parse_device_label(label: str) -> DeviceQuery:
+    match = re.fullmatch(r"(.+) Simulator \(([^()]+)\)", label)
+    if match is None:
+        return DeviceQuery(label=label, name=label, version=None)
+
+    return DeviceQuery(label=label, name=match.group(1), version=match.group(2))
+
+
+def _load_simctl_devices(simctl_json_path: Optional[Path]) -> dict[str, Any]:
+    if simctl_json_path is not None:
+        return json.loads(simctl_json_path.read_text())
+
+    output = subprocess.check_output(
+        ["xcrun", "simctl", "list", "devices", "available", "-j"],
+        text=True,
+    )
+    return json.loads(output)
+
+
+def _find_matching_udids(
+    query: DeviceQuery,
+    devices: dict[str, Any],
+) -> list[str]:
+    matches: list[str] = []
+    for runtime, runtime_devices in devices.get("devices", {}).items():
+        if query.version is not None and not runtime.endswith(
+            f"iOS-{query.version.replace('.', '-')}"
+        ):
+            continue
+
+        for runtime_device in runtime_devices:
+            if runtime_device.get("name") == query.name:
+                matches.append(runtime_device["udid"])
+
+    return matches
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR stabilizes CI around three independent failures that surfaced while babysitting the current master/PR CI surface:

- iOS simulator jobs could fail with an empty or wrong UDID because the workflow parsed human-oriented `xctrace list devices` output.
- OHOS jobs followed the floating Flutter-OHOS `oh-3.41.9-dev` branch, whose latest head stopped compiling against the SDK that CI installs.
- Windows Rust jobs can fail when MSVC writes PDB files for the deliberate-bad example because Cargo gives the implicit bin target and cdylib target the same output name.

## Problem 1: iOS simulator UDID lookup

### Symptom

The iOS workflow could fail before the Flutter test actually started with:

```text
UDID: No Simulator with this name found
```

The failing workflow step was selecting the simulator for labels such as:

```text
iPhone 16 Pro Max Simulator (18.6)
```

### Root cause

The old workflow selected the simulator by parsing `xcrun xctrace list devices` with `grep`, `awk`, and `tr`.

That was fragile for a few reasons:

- `xctrace list devices` is human-oriented text, not a stable machine-readable API.
- The CI matrix label contains both a logical device name and a runtime version, but the old shell pipeline did not structurally parse either of them.
- If the text format changed or did not match the exact grep expression, `UDID` became empty and the later `simctl boot` command reported the generic "No Simulator with this name found" message.

### Fix

The workflow now uses `tools/find_ios_simulator_udid.py`.

The script:

- Parses labels like `iPhone 16 Pro Max Simulator (18.6)` into device name `iPhone 16 Pro Max` and runtime version `18.6`.
- Reads `xcrun simctl list devices available -j`, which is structured JSON.
- Matches the device name and runtime suffix exactly.
- Requires exactly one match and fails early with a clear diagnostic if there are zero or multiple matches.

The two iOS simulator-starting workflow steps are now short calls to this script instead of duplicated inline parsing logic.

### Validation

The script was checked locally with a fixture containing both `iOS-18-5` and `iOS-18-6` runtimes to ensure the `18.6` matrix label selects the expected UDID. The actual macOS runner validation is still pending on the latest PR CI run because the iOS jobs are queued behind runner availability.

## Problem 2: OHOS Flutter branch drift

### Symptom

The OHOS build job failed in `flutter build hap --no-codesign --verbose` with ArkTS compiler errors inside Flutter-OHOS code, for example missing `autoFillManager` API members such as `AutoFillType`.

The failing file was in Flutter-OHOS internals rather than this repository's code:

```text
@ohos/flutter_ohos/src/main/ets/plugin/editing/OhosAutoFillHelper.ets
```

### Root cause

FRB CI installed the OpenHarmony SDK with API23, but the workflow cloned the floating Flutter-OHOS branch:

```bash
git clone -b oh-3.41.9-dev https://gitcode.com/CPF-Flutter/flutter_flutter.git
```

Recent commits on that branch introduced Flutter-OHOS code that no longer compiled against the SDK/API combination used by FRB CI. A green baseline and the failing run both installed SDK `6.1.0.105` with API23, so the difference was the floating Flutter-OHOS branch head rather than the SDK setup action.

### Fix

The workflow now pins Flutter-OHOS with:

```yaml
FRB_OHOS_FLUTTER_REF: 6d7e5b43fb43bb85ba0a59e3469299ebcf45a637
```

The checkout still creates a local `oh-3.41.9-dev` branch:

```bash
git clone -b oh-3.41.9-dev --single-branch https://gitcode.com/CPF-Flutter/flutter_flutter.git $GITHUB_WORKSPACE/flutter
git -C $GITHUB_WORKSPACE/flutter checkout -B oh-3.41.9-dev $FRB_OHOS_FLUTTER_REF
```

This keeps CI on the known-good Flutter-OHOS code while preserving enough branch/history context for Flutter's version logic.

### Follow-up discovered during CI

The first pinning attempt used a detached single-commit shallow checkout. That removed enough version metadata that Flutter reported:

```text
The current Flutter SDK version is 0.0.0-unknown.
```

That made pub version solving fail even though the code was otherwise the intended older Flutter-OHOS revision. The current checkout form keeps a local branch and avoids that problem.

### Validation

On PR CI, after switching away from detached single-commit checkout, the OHOS integrate job passed. The OHOS build job was still being re-run on the latest pushed commit at the time this description was updated.

## Problem 3: Windows Rust PDB collision

### Symptom

The Windows Rust job failed while building `frb_example/deliberate_bad/rust` with MSVC:

```text
LINK : fatal error LNK1201: error writing to program database
frb_example_deliberate_bad.pdb
```

Immediately before the failure, Cargo warned that the bin target and lib target had the same output filename.

### Root cause

`frb_example/deliberate_bad/rust` has both:

- A cdylib lib target named from the package: `frb_example_deliberate_bad`.
- A `src/main.rs`, which causes Cargo to create an implicit bin target with the same name.

On Windows/MSVC, both targets attempted to write debug information using the same PDB output name. That can fail nondeterministically or with newer runner/toolchain behavior when the linker cannot write the shared PDB.

### Fix

The crate now declares an explicit bin target with a unique name:

```toml
[[bin]]
name = "frb_example_deliberate_bad_bin"
path = "src/main.rs"
```

This keeps the package and cdylib names unchanged, so generated FRB library loading still uses the same native library stem. Only the Rust executable target receives a unique name to avoid the PDB collision.

### Validation

Local Cargo metadata confirms the target split:

- lib target: `frb_example_deliberate_bad`
- bin target: `frb_example_deliberate_bad_bin`

The Windows Rust job is being re-run on the latest pushed commit.

## Validation so far

- Parsed `.github/workflows/ci.yaml` locally with Ruby YAML loading.
- Ran `git diff --check`.
- Checked `tools/find_ios_simulator_udid.py` with local Python syntax/fixture validation before pushing the helper extraction.
- Confirmed OHOS integrate passed on PR CI after preserving Flutter-OHOS branch/version metadata.
- Latest full PR CI is still in progress after the final helper extraction commit.
