### PR TITLE
Update iOS CI simulator device

### DIFF
--- a/tools/frb_internal/lib/src/makefile_dart/ci_plan/full_jobs.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/ci_plan/full_jobs.dart
@@ -185,7 +185,7 @@ final kCiJobs = [
     'test_flutter_native_ios',
     matrix: CiMatrix([
       for (final package in _flutterNativePackages)
-        {'package': package, 'device': 'iPhone 16 Pro Max Simulator (18.6)'},
+        {'package': package, 'device': 'iPhone 17 Pro Max Simulator (26.5)'},
     ]),
   ),
   CiJob(
@@ -287,7 +287,7 @@ List<Map<String, Object?>> _quickstartSmokeEntries(String package) {
       'image': 'macos-latest',
       'platform': 'ios',
       'target': 'ios',
-      'device': 'iPhone 16 Pro Max Simulator (18.6)',
+      'device': 'iPhone 17 Pro Max Simulator (26.5)',
       'package': package,
       'package_path': packagePath,
     },

--- a/tools/frb_internal/test/ci_plan_test.dart
+++ b/tools/frb_internal/test/ci_plan_test.dart
@@ -251,7 +251,7 @@ void main() {
     test('values containing spaces are accepted verbatim', () {
       final plan = buildCiPlan(
         filter:
-            'test_flutter_native_ios[device=iPhone 16 Pro Max Simulator (18.6),package=frb_example--rust_ui_counter--ui]',
+            'test_flutter_native_ios[device=iPhone 17 Pro Max Simulator (26.5),package=frb_example--rust_ui_counter--ui]',
         automaticCiDisabled: false,
       );
 
@@ -260,7 +260,7 @@ void main() {
         'include': [
           {
             'package': 'frb_example--rust_ui_counter--ui',
-            'device': 'iPhone 16 Pro Max Simulator (18.6)',
+            'device': 'iPhone 17 Pro Max Simulator (26.5)',
           },
         ],
       });
@@ -499,14 +499,14 @@ void main() {
       ),
       const _CiFilterExample(
         filter:
-            'test_flutter_native_ios[device=iPhone 16 Pro Max Simulator (18.6),package=frb_example--rust_ui_counter--ui]',
+            'test_flutter_native_ios[device=iPhone 17 Pro Max Simulator (26.5),package=frb_example--rust_ui_counter--ui]',
         enabledJobs: {'test_flutter_native_ios'},
         matrixByJob: {
           'test_flutter_native_ios': {
             'include': [
               {
                 'package': 'frb_example--rust_ui_counter--ui',
-                'device': 'iPhone 16 Pro Max Simulator (18.6)',
+                'device': 'iPhone 17 Pro Max Simulator (26.5)',
               },
             ],
           },

--- a/tools/frb_internal/test/ci_plan_test_snapshot_full.json
+++ b/tools/frb_internal/test/ci_plan_test_snapshot_full.json
@@ -646,27 +646,27 @@
       "matrix": [
         {
           "package": "frb_example--flutter_via_create",
-          "device": "iPhone 16 Pro Max Simulator (18.6)"
+          "device": "iPhone 17 Pro Max Simulator (26.5)"
         },
         {
           "package": "frb_example--flutter_via_create_native_assets",
-          "device": "iPhone 16 Pro Max Simulator (18.6)"
+          "device": "iPhone 17 Pro Max Simulator (26.5)"
         },
         {
           "package": "frb_example--flutter_package--example",
-          "device": "iPhone 16 Pro Max Simulator (18.6)"
+          "device": "iPhone 17 Pro Max Simulator (26.5)"
         },
         {
           "package": "frb_example--flutter_package_native_assets--example",
-          "device": "iPhone 16 Pro Max Simulator (18.6)"
+          "device": "iPhone 17 Pro Max Simulator (26.5)"
         },
         {
           "package": "frb_example--rust_ui_counter--ui",
-          "device": "iPhone 16 Pro Max Simulator (18.6)"
+          "device": "iPhone 17 Pro Max Simulator (26.5)"
         },
         {
           "package": "frb_example--rust_ui_todo_list--ui",
-          "device": "iPhone 16 Pro Max Simulator (18.6)"
+          "device": "iPhone 17 Pro Max Simulator (26.5)"
         }
       ]
     },
@@ -872,7 +872,7 @@
             "image": "macos-latest",
             "platform": "ios",
             "target": "ios",
-            "device": "iPhone 16 Pro Max Simulator (18.6)",
+            "device": "iPhone 17 Pro Max Simulator (26.5)",
             "package": "frb_example--flutter_via_create",
             "package_path": "frb_example/flutter_via_create"
           }
@@ -933,7 +933,7 @@
             "image": "macos-latest",
             "platform": "ios",
             "target": "ios",
-            "device": "iPhone 16 Pro Max Simulator (18.6)",
+            "device": "iPhone 17 Pro Max Simulator (26.5)",
             "package": "frb_example--flutter_via_create_native_assets",
             "package_path": "frb_example/flutter_via_create_native_assets"
           }


### PR DESCRIPTION
## Summary

Update the iOS CI simulator device from:

```text
iPhone 16 Pro Max Simulator (18.6)
```

to:

```text
iPhone 17 Pro Max Simulator (26.5)
```

## Why

After #3282 was merged, the `master` CI run reached the iOS native jobs on GitHub's current `macos-latest` image.

Those jobs now run on a macOS 26 arm64 image. The runner's simulator list no longer contains `iPhone 16 Pro Max Simulator (18.6)`. The available iPhone Pro Max simulator in the logs is `iPhone 17 Pro Max Simulator (26.5)`.

Because the simulator lookup script now uses structured `simctl` data and requires an exact match, it correctly failed early with:

```text
Expected exactly one simulator for iPhone 16 Pro Max Simulator (18.6), found 0
```

## What changed

- Updated the iOS device in `tools/frb_internal/lib/src/makefile_dart/ci_plan/full_jobs.dart`.
- Updated the CI plan tests that reference the device value.
- Updated the full CI plan snapshot.

## Validation

- `git diff --check`
- Verified from `master` CI logs that `iPhone 17 Pro Max Simulator (26.5)` is present on the current runner image.
