### PR TITLE
Allow fallback iOS simulator runtime

### DIFF
--- a/tools/find_ios_simulator_udid.py
+++ b/tools/find_ios_simulator_udid.py
@@ -16,11 +16,17 @@ class DeviceQuery:
     version: Optional[str]
 
 
+@dataclass(frozen=True)
+class DeviceMatch:
+    udid: str
+    version: str
+
+
 def main() -> int:
     device_label, simctl_json_path = _parse_args(args=sys.argv[1:])
     query = _parse_device_label(label=device_label)
     devices = _load_simctl_devices(simctl_json_path=simctl_json_path)
-    matches = _find_matching_udids(query=query, devices=devices)
+    matches = _find_matching_devices(query=query, devices=devices)
 
     if len(matches) != 1:
         print(
@@ -29,7 +35,15 @@ def main() -> int:
         )
         return 1
 
-    print(matches[0])
+    match = matches[0]
+    if query.version is not None and query.version != match.version:
+        print(
+            f"Simulator {query.label} is unavailable; using {query.name} "
+            f"Simulator ({match.version})",
+            file=sys.stderr,
+        )
+
+    print(match.udid)
     return 0
 
 
@@ -75,22 +89,54 @@ def _load_simctl_devices(simctl_json_path: Optional[Path]) -> dict[str, Any]:
     return json.loads(output)
 
 
-def _find_matching_udids(
+def _find_matching_devices(
     query: DeviceQuery,
     devices: dict[str, Any],
-) -> list[str]:
-    matches: list[str] = []
+) -> list[DeviceMatch]:
+    matches: list[DeviceMatch] = []
     for runtime, runtime_devices in devices.get("devices", {}).items():
-        if query.version is not None and not runtime.endswith(
-            f"iOS-{query.version.replace('.', '-')}"
-        ):
+        runtime_version = _parse_ios_runtime_version(runtime=runtime)
+        if runtime_version is None:
             continue
 
         for runtime_device in runtime_devices:
             if runtime_device.get("name") == query.name:
-                matches.append(runtime_device["udid"])
+                matches.append(
+                    DeviceMatch(
+                        udid=runtime_device["udid"],
+                        version=runtime_version,
+                    )
+                )
 
-    return matches
+    if not matches:
+        return []
+
+    exact_matches = [
+        match
+        for match in matches
+        if query.version is None or match.version == query.version
+    ]
+    if exact_matches or query.version is None:
+        return exact_matches
+
+    latest_version = max(_version_key(match.version) for match in matches)
+    return [
+        match
+        for match in matches
+        if _version_key(match.version) == latest_version
+    ]
+
+
+def _parse_ios_runtime_version(runtime: str) -> Optional[str]:
+    prefix = "com.apple.CoreSimulator.SimRuntime.iOS-"
+    if not runtime.startswith(prefix):
+        return None
+
+    return runtime.removeprefix(prefix).replace("-", ".")
+
+
+def _version_key(version: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in version.split("."))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem: hosted macOS images expose different iOS runtime patch versions

The post-merge master CI run for #3283 still failed in the first iOS native job:

- Run: https://github.com/fzyzcjy/flutter_rust_bridge/actions/runs/28288297751
- Job: `Test :: Flutter :: Native:: iOS (frb_example--flutter_via_create_native_assets, iPhone 17 Pro Max...)`
- Job id: `83816097861`
- Runner image: `macos-15-arm64`, version `20260623.0190.1`

The CI matrix requested `iPhone 17 Pro Max Simulator (26.5)`, but this runner image only had:

- `iPhone 17 Pro Max Simulator (26.1)`
- `iPhone 17 Pro Max Simulator (26.2)`

So the helper correctly failed with:

```text
Expected exactly one simulator for iPhone 17 Pro Max Simulator (26.5), found 0
```

This shows that updating the hard-coded simulator label from `16 Pro Max / 18.6` to `17 Pro Max / 26.5` is still brittle: GitHub-hosted macOS images may differ by installed iOS runtime minor/patch version.

## Fix: keep exact matching, then fall back within the requested device family

This PR updates `tools/find_ios_simulator_udid.py` so it now:

1. Parses the requested device label exactly as before.
2. Returns an exact runtime match when one exists.
3. If the exact runtime is unavailable, searches simulators with the same device name.
4. Selects the highest installed iOS runtime for that device.
5. Prints only the UDID to stdout, so existing `UDID=$(...)` shell usage remains safe.
6. Prints the fallback explanation to stderr, so the CI log still records which runtime was actually used.

For the failing runner above, `iPhone 17 Pro Max Simulator (26.5)` should therefore fall back to `iPhone 17 Pro Max Simulator (26.2)`.

## Non-goal: change the generated CI plan again

This PR intentionally does not keep chasing the matrix string to `26.2`. That would likely pass this specific runner image but would leave the next image update as another deterministic failure. The helper script is the right place for this compatibility behavior because the available simulator list is only known on the selected runner.

## Validation

Validated after pushing and writing the initial PR text, per request:

- `PYTHONPYCACHEPREFIX=/private/tmp/frb-pycache /usr/bin/python3 -m py_compile tools/find_ios_simulator_udid.py`
- In-memory fixture matching job `83816097861`: requested `iPhone 17 Pro Max Simulator (26.5)`, available `26.1` and `26.2`, selected `26.2`.

Still watching PR CI and then master CI after merge.

## Related previous fixes already confirmed on the new master run

The same post-merge master run already confirmed the earlier fixes are working:

- OHOS build: green.
- OHOS integrate: green.
- Windows Rust: green.

The remaining blocker is the iOS simulator runtime selection handled here.