### PR TITLE
Fix generated BigInt parse input type

### DIFF
--- a/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/codec/dco/decoder/ty/delegate.rs
+++ b/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/codec/dco/decoder/ty/delegate.rs
@@ -86,7 +86,7 @@ impl WireDartCodecDcoGeneratorDecoderTrait for DelegateWireDartCodecDcoGenerator
             ),
             MirTypeDelegate::StreamSink(_) | MirTypeDelegate::DynTrait(_) => "throw UnimplementedError();".to_owned(),
             MirTypeDelegate::BigPrimitive(_) => {
-                "return BigInt.parse(raw);".to_owned()
+                "return BigInt.parse(raw as String);".to_owned()
             }
             MirTypeDelegate::RustAutoOpaqueExplicit(mir) => format!(r"return dco_decode_{}(raw);", mir.inner.safe_ident()),
             MirTypeDelegate::CustomSerDes(inner) => {

--- a/frb_example/pure_dart_pde/lib/src/rust/frb_generated.dart
+++ b/frb_example/pure_dart_pde/lib/src/rust/frb_generated.dart
@@ -45796,7 +45796,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BigInt dco_decode_I128(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BigInt.parse(raw);
+    return BigInt.parse(raw as String);
   }
 
   @protected
@@ -47366,7 +47366,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BigInt dco_decode_U128(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BigInt.parse(raw);
+    return BigInt.parse(raw as String);
   }
 
   @protected


### PR DESCRIPTION
Fixes #3273.

## Reproduction report

Baseline: `origin/master` at the branch point.

Steps:

1. Generate the bindings for the existing `frb_example/pure_dart` BigInt coverage.
2. Inspect the generated DCO decoders for `i128` / `u128`.
3. Run strict Dart analysis over the generated code.

Observed:

Generated code called `BigInt.parse(raw)` inside `dco_decode_I128` / `dco_decode_U128`, where `raw` has static type `dynamic`. Strict analysis reports `argument_type_not_assignable` because `BigInt.parse` expects a `String`.

Expected:

Generated code should reflect the DCO wire shape and pass a statically typed `String` to `BigInt.parse`.

## Changes

- Generate DCO big primitive decoders as `BigInt.parse(raw as String)`.
- Regenerate the affected `pure_dart` and `pure_dart_pde` bindings.

## Validation

- `./frb_internal precommit-generate`
- `./frb_internal generate-internal-rust`
- `./frb_internal lint --fix`
- `git diff --check`

Notes:

- `frb_hooks` pana still reports the existing dartdoc `RangeError` and scores `150/160`, while static analysis remains `50/50`; the lint command exits successfully.
