### PR TITLE
Reproduce native-assets existing-hook warning with intentional red CI

### DIFF
--- a/frb_codegen/src/library/integration/integrator/overlay.rs
+++ b/frb_codegen/src/library/integration/integrator/overlay.rs
@@ -315,7 +315,7 @@ impl TemplateDirs {
 
 #[cfg(test)]
 mod tests {
-    use super::filter_file;
+    use super::{existing_native_assets_build_hook_warning, filter_file};
     use std::path::Path;
 
     #[test]
@@ -381,5 +381,15 @@ mod tests {
             true,
             true,
         ));
+    }
+
+    #[test]
+    fn existing_native_assets_build_hook_has_actionable_warning() {
+        assert_eq!(
+            existing_native_assets_build_hook_warning(Path::new("hook/build.dart")),
+            Some(
+                "Native Assets integration did not modify the existing hook/build.dart. Add FlutterRustBridgeNativeAssetsBuilder to your build hook manually; see https://cjycode.com/flutter_rust_bridge/manual/integrate/03-native-assets/.".to_owned(),
+            ),
+        );
     }
 }


### PR DESCRIPTION
## Reproduction

Baseline commit: `f0dcf1f38a1b5f8d471f6a8e78771c927a86fbfa`

Steps:
1. Add a unit test asserting that an existing Native Assets `hook/build.dart` emits an actionable instruction to add `FlutterRustBridgeNativeAssetsBuilder`.
2. Run `cargo test -p flutter_rust_bridge_codegen existing_native_assets_build_hook_has_actionable_warning`.

Observed:
```text
error[E0432]: unresolved import `super::existing_native_assets_build_hook_warning`
```

Expected:
The integration code exposes and emits a specific warning for an existing `hook/build.dart`, explaining that it was not modified and must invoke `FlutterRustBridgeNativeAssetsBuilder` manually.

Focused CI: `test_rust[image=ubuntu-latest,version=1.85.0]`

This is an intentional red CI reproduction PR for #3295, not a fix PR.