### PR TITLE
Require explicit changelog text confirmation

### DIFF
--- a/.claude/skills/frb-publish-release/SKILL.md
+++ b/.claude/skills/frb-publish-release/SKILL.md
@@ -64,7 +64,8 @@ Use this skill when preparing, publishing, or babysitting a `flutter_rust_bridge
 - Use `frb-write-changelog` to create or refresh the target release section in `CHANGELOG.md`.
 - When reviewing the release section, explicitly check every third-party human-authored PR in the release range, including docs, CI, chore, and tooling PRs. Each must either have `(thanks @username)` in the matching changelog entry or a documented reason for omission.
 - Be careful with grouped entries: if a local maintainer PR and a third-party PR are summarized together, the grouped entry still needs the third-party thanks attribution.
-- Review the release section manually before publishing. The top `CHANGELOG.md` version is the source used by `frb_internal release`.
+- If `CHANGELOG.md` changed for the release, stop and ask a human to review the actual release-section text. Do not publish until the human explicitly confirms that text; approval of the file change, PR, CI result, or release process does not count as confirmation of the changelog text.
+- The top `CHANGELOG.md` version is the source used by `frb_internal release`.
 - If changelog or version files changed, commit that release preparation before publishing.
 - Land contributor and changelog preparation commits on `origin/master` before publishing. Do not leave release preparation only on a side branch.
 


### PR DESCRIPTION
## Summary

- require a human to review the actual release-section text when CHANGELOG.md changes
- require explicit confirmation of that text before publishing
- clarify that PR, CI, file-change, or process approval is not sufficient

## Testing

- git diff --check