### PR TITLE
Await stream assertions in Dart tests

### DIFF
--- a/frb_example/pure_dart/test/api/pseudo_manual/stream_twin_rust_async_sse_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/stream_twin_rust_async_sse_test.dart
@@ -65,16 +65,16 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(cnt, max);
   }
 
-  test('dart call handle_stream_sink_at_1', () {
-    testHandleStream(handleStreamSinkAt1TwinRustAsyncSse);
+  test('dart call handle_stream_sink_at_1', () async {
+    await testHandleStream(handleStreamSinkAt1TwinRustAsyncSse);
   });
 
-  test('dart call handle_stream_sink_at_2', () {
-    testHandleStream(handleStreamSinkAt2TwinRustAsyncSse);
+  test('dart call handle_stream_sink_at_2', () async {
+    await testHandleStream(handleStreamSinkAt2TwinRustAsyncSse);
   });
 
-  test('dart call handle_stream_sink_at_3', () {
-    testHandleStream(handleStreamSinkAt3TwinRustAsyncSse);
+  test('dart call handle_stream_sink_at_3', () async {
+    await testHandleStream(handleStreamSinkAt3TwinRustAsyncSse);
   });
 
   test('stream_sink_fixed_sized_primitive_array_twin_normal', () async {

--- a/frb_example/pure_dart/test/api/pseudo_manual/stream_twin_rust_async_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/stream_twin_rust_async_test.dart
@@ -65,16 +65,16 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(cnt, max);
   }
 
-  test('dart call handle_stream_sink_at_1', () {
-    testHandleStream(handleStreamSinkAt1TwinRustAsync);
+  test('dart call handle_stream_sink_at_1', () async {
+    await testHandleStream(handleStreamSinkAt1TwinRustAsync);
   });
 
-  test('dart call handle_stream_sink_at_2', () {
-    testHandleStream(handleStreamSinkAt2TwinRustAsync);
+  test('dart call handle_stream_sink_at_2', () async {
+    await testHandleStream(handleStreamSinkAt2TwinRustAsync);
   });
 
-  test('dart call handle_stream_sink_at_3', () {
-    testHandleStream(handleStreamSinkAt3TwinRustAsync);
+  test('dart call handle_stream_sink_at_3', () async {
+    await testHandleStream(handleStreamSinkAt3TwinRustAsync);
   });
 
   test('stream_sink_fixed_sized_primitive_array_twin_normal', () async {

--- a/frb_example/pure_dart/test/api/pseudo_manual/stream_twin_sse_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/stream_twin_sse_test.dart
@@ -65,16 +65,16 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(cnt, max);
   }
 
-  test('dart call handle_stream_sink_at_1', () {
-    testHandleStream(handleStreamSinkAt1TwinSse);
+  test('dart call handle_stream_sink_at_1', () async {
+    await testHandleStream(handleStreamSinkAt1TwinSse);
   });
 
-  test('dart call handle_stream_sink_at_2', () {
-    testHandleStream(handleStreamSinkAt2TwinSse);
+  test('dart call handle_stream_sink_at_2', () async {
+    await testHandleStream(handleStreamSinkAt2TwinSse);
   });
 
-  test('dart call handle_stream_sink_at_3', () {
-    testHandleStream(handleStreamSinkAt3TwinSse);
+  test('dart call handle_stream_sink_at_3', () async {
+    await testHandleStream(handleStreamSinkAt3TwinSse);
   });
 
   test('stream_sink_fixed_sized_primitive_array_twin_normal', () async {

--- a/frb_example/pure_dart/test/api/stream_test.dart
+++ b/frb_example/pure_dart/test/api/stream_test.dart
@@ -61,16 +61,16 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(cnt, max);
   }
 
-  test('dart call handle_stream_sink_at_1', () {
-    testHandleStream(handleStreamSinkAt1TwinNormal);
+  test('dart call handle_stream_sink_at_1', () async {
+    await testHandleStream(handleStreamSinkAt1TwinNormal);
   });
 
-  test('dart call handle_stream_sink_at_2', () {
-    testHandleStream(handleStreamSinkAt2TwinNormal);
+  test('dart call handle_stream_sink_at_2', () async {
+    await testHandleStream(handleStreamSinkAt2TwinNormal);
   });
 
-  test('dart call handle_stream_sink_at_3', () {
-    testHandleStream(handleStreamSinkAt3TwinNormal);
+  test('dart call handle_stream_sink_at_3', () async {
+    await testHandleStream(handleStreamSinkAt3TwinNormal);
   });
 
   test('stream_sink_fixed_sized_primitive_array_twin_normal', () async {

--- a/frb_example/pure_dart_pde/test/api/pseudo_manual/stream_twin_rust_async_test.dart
+++ b/frb_example/pure_dart_pde/test/api/pseudo_manual/stream_twin_rust_async_test.dart
@@ -67,16 +67,16 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(cnt, max);
   }
 
-  test('dart call handle_stream_sink_at_1', () {
-    testHandleStream(handleStreamSinkAt1TwinRustAsync);
+  test('dart call handle_stream_sink_at_1', () async {
+    await testHandleStream(handleStreamSinkAt1TwinRustAsync);
   });
 
-  test('dart call handle_stream_sink_at_2', () {
-    testHandleStream(handleStreamSinkAt2TwinRustAsync);
+  test('dart call handle_stream_sink_at_2', () async {
+    await testHandleStream(handleStreamSinkAt2TwinRustAsync);
   });
 
-  test('dart call handle_stream_sink_at_3', () {
-    testHandleStream(handleStreamSinkAt3TwinRustAsync);
+  test('dart call handle_stream_sink_at_3', () async {
+    await testHandleStream(handleStreamSinkAt3TwinRustAsync);
   });
 
   test('stream_sink_fixed_sized_primitive_array_twin_normal', () async {

--- a/frb_example/pure_dart_pde/test/api/stream_test.dart
+++ b/frb_example/pure_dart_pde/test/api/stream_test.dart
@@ -63,16 +63,16 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(cnt, max);
   }
 
-  test('dart call handle_stream_sink_at_1', () {
-    testHandleStream(handleStreamSinkAt1TwinNormal);
+  test('dart call handle_stream_sink_at_1', () async {
+    await testHandleStream(handleStreamSinkAt1TwinNormal);
   });
 
-  test('dart call handle_stream_sink_at_2', () {
-    testHandleStream(handleStreamSinkAt2TwinNormal);
+  test('dart call handle_stream_sink_at_2', () async {
+    await testHandleStream(handleStreamSinkAt2TwinNormal);
   });
 
-  test('dart call handle_stream_sink_at_3', () {
-    testHandleStream(handleStreamSinkAt3TwinNormal);
+  test('dart call handle_stream_sink_at_3', () async {
+    await testHandleStream(handleStreamSinkAt3TwinNormal);
   });
 
   test('stream_sink_fixed_sized_primitive_array_twin_normal', () async {


### PR DESCRIPTION
## Reproduction

Baseline commit: `9a76fe46bb2d840794fe5a17d276e5d719d8471c`

Steps:
1. Run `./frb_internal test-dart-web --package frb_example/pure_dart`.
2. Let the three `handle_stream_sink_at_*` tests execute concurrently.

Observed:
```text
Expected: <5>
  Actual: <1>
This test failed after it had already completed.
```

The callbacks start `testHandleStream(...)` without returning or awaiting its future, so the test runner marks each case complete while its stream assertions are still running.

Expected:
Each test remains active until its stream is closed and all five events are asserted.

## Changes

- Make the three origin stream tests asynchronous and await `testHandleStream(...)`.
- Regenerate all pure_dart twin and PDE test variants.

## Validation

- `./frb_internal test-dart-web --package frb_example/pure_dart`
- `./frb_internal generate-internal-frb-example-pure-dart --set-exit-if-changed`