### PR TITLE
Remove Gemini from PR workflows

### DIFF
--- a/.claude/skills/frb-issue-to-green-pr/SKILL.md
+++ b/.claude/skills/frb-issue-to-green-pr/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: frb-issue-to-green-pr
-description: "Use when implementing a GitHub issue, bug fix, or feature in flutter_rust_bridge end-to-end: develop the change, add regression coverage, prepare and open a PR, monitor CI until green, request and resolve Gemini review, and keep following up on a 5 minute cadence until the PR is ready."
+description: "Use when implementing a GitHub issue, bug fix, or feature in flutter_rust_bridge end-to-end: develop the change, add regression coverage, prepare and open a PR, monitor CI until green, and keep following up on a 5 minute cadence until the PR is ready."
 ---
 
 # FRB Issue to Green PR
 
-Use this skill as the top-level workflow when the user asks you to implement an issue, fix a bug, add a feature, or otherwise "handle it end to end" in `flutter_rust_bridge`, especially when they ask for an automatic PR, CI monitoring, or Gemini review.
+Use this skill as the top-level workflow when the user asks you to implement an issue, fix a bug, add a feature, or otherwise "handle it end to end" in `flutter_rust_bridge`, especially when they ask for an automatic PR or CI monitoring.
 
 This skill orchestrates the narrower FRB skills. Do not duplicate their detailed instructions in memory; read them when their phase begins.
 
@@ -74,15 +74,9 @@ Read these when entering the matching phase:
 - Create the PR according to the active PR workflow and repository/user PR body rules.
 - If the work comes from a GitHub issue, ensure the PR body includes the appropriate closing keyword such as `Close #1234`, unless the active PR workflow explicitly requires an empty body.
 
-### 6. Handle Gemini review
+### 6. Run the review gate
 
-- Follow `frb-pr-review` for the full PR review gate, including correctness review, test-weakening review, and Gemini.
-- After pushing the PR and once you believe the code is reasonably ready, post a PR comment containing exactly `/gemini review` to request a Gemini pass; do not wait for CI to be green before requesting this first self-initiated review.
-- Wait for Gemini's GitHub review or comments if the repository automation posts them.
-- Treat actionable Gemini feedback like review comments: inspect, fix if valid, commit, push, and reply or otherwise make the resolution visible.
-- If feedback is incorrect or not actionable, leave a concise PR comment explaining why.
-- After substantial follow-up fixes, request another Gemini pass when you again believe the code is reasonably ready.
-- Wait for each new Gemini response on GitHub, then resolve any actionable follow-up feedback.
+- Follow `frb-pr-review` for the full PR review gate, including correctness review and test-weakening review.
 
 ### 7. Monitor CI until terminal
 
@@ -96,13 +90,12 @@ Read these when entering the matching phase:
 ### 8. Stop only when ready
 
 - The PR checks are green or all remaining non-green checks are clearly unrelated and explained.
-- Gemini has no unresolved actionable feedback after the latest self-initiated `/gemini review` pass.
 - The branch is pushed, commits are present on the PR, and the final status is reported to the user with the PR URL.
 
 ## Automation Rules
 
 - Prefer a heartbeat attached to the current thread for short follow-up intervals such as every 5 minutes.
-- The heartbeat prompt must be self-contained: include the PR URL/number, branch, repository, and the requirement to inspect CI and Gemini review state, fix issues, commit, push, and continue until ready.
+- The heartbeat prompt must be self-contained: include the PR URL/number, branch, repository, and the requirement to inspect CI and review state, fix issues, commit, push, and continue until ready.
 - Do not create a duplicate heartbeat if one already exists for the same PR; update the existing automation instead.
 - Cancel or leave inactive any PR-specific heartbeat once the stop conditions are met.
 

--- a/.claude/skills/frb-pr-review/SKILL.md
+++ b/.claude/skills/frb-pr-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frb-pr-review
-description: Review a flutter_rust_bridge PR before treating it as ready, including subagent checks for correctness and test weakening plus Gemini review.
+description: Review a flutter_rust_bridge PR before treating it as ready, including subagent checks for correctness and test weakening.
 ---
 
 # FRB PR Review
@@ -21,15 +21,9 @@ Run independent review before final readiness:
    - Do not duplicate that workflow here; read `sdev-pass-test` for detection, classification, and restoration details.
    - Treat unjustified skipped tests, weaker assertions, broader ignores, fake timeouts, and coverage hiding as blockers.
 
-3. Ask Gemini for an external review.
-   - Post `/gemini review` when the PR is reasonably ready.
-   - Inspect Gemini's review/comments.
-   - Fix valid feedback, commit, push, and explain invalid feedback in a concise PR comment.
-   - Request another Gemini pass after substantial follow-up fixes.
-
-4. Write a concise review conclusion.
+3. Write a concise review conclusion.
    - Put the conclusion in the PR description or an agent-context draft when the user asks for a Markdown artifact.
-   - Include the subagents used, Gemini status, accepted findings, dismissed findings, fixes made, and remaining risks.
+   - Include the subagents used, accepted findings, dismissed findings, fixes made, and remaining risks.
 
 ## Stop Condition
 
@@ -37,5 +31,4 @@ Do not call the PR ready until:
 
 - Correctness review has no unresolved actionable findings.
 - Test-weakening review has no unjustified weakening.
-- Gemini has no unresolved actionable feedback after the latest requested pass.
 - CI status is green, or remaining non-green checks are clearly unrelated and explained.

--- a/.claude/skills/frb-test/SKILL.md
+++ b/.claude/skills/frb-test/SKILL.md
@@ -61,4 +61,4 @@ Choose tests by blast radius:
 
 After pushing to a PR branch, monitor GitHub Actions until the run reaches a terminal state. If CI fails, inspect the failing job logs and either fix the issue or clearly report why it is unrelated or flaky. Do not leave a PR in an unknown queued or in-progress state when the user asked for CI validation.
 
-Before treating a non-trivial PR as ready, run the review gate in `frb-pr-review`; local tests alone do not check correctness review, test weakening, or Gemini feedback.
+Before treating a non-trivial PR as ready, run the review gate in `frb-pr-review`; local tests alone do not check correctness review or test weakening.


### PR DESCRIPTION
## Changes

- Remove Gemini review requests and response handling from the end-to-end PR workflow.
- Remove Gemini from the PR review gate and readiness conditions.
- Keep correctness, test-weakening, and CI gates unchanged.

## Validation

- Repository-wide case-insensitive search for `gemini` returns no matches.
- `git diff --check` passes.