### PR TITLE
Update cargo-llvm-cov for nightly tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -342,7 +342,7 @@ jobs:
         with:
           cache: true
           version: ${{ env.FRB_MAIN_FLUTTER_VERSION }}
-      - run: cargo install cargo-llvm-cov --version ${{ matrix.info.version == '1.85.0' && '0.6.21' || matrix.info.version == 'nightly' && '0.8.6' || '0.6.24' }} --locked
+      - run: cargo install cargo-llvm-cov --version ${{ matrix.info.version == '1.85.0' && '0.6.21' || '0.6.24' }} --locked
 
       # execute
       - run: ./frb_internal generate-run-frb-codegen-command-generate --set-exit-if-changed --package ${{ matrix.package }} --coverage
@@ -757,7 +757,7 @@ jobs:
         with:
           sdk: ${{ env.FRB_MAIN_DART_VERSION }}
           architecture: x64
-      - run: cargo install cargo-llvm-cov --version ${{ matrix.info.version == '1.85.0' && '0.6.21' || '0.6.24' }} --locked
+      - run: cargo install cargo-llvm-cov --version ${{ matrix.info.version == '1.85.0' && '0.6.21' || matrix.info.version == 'nightly' && '0.8.6' || '0.6.24' }} --locked
 
       # execute
       - run: ./frb_internal test-rust --coverage

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -342,7 +342,7 @@ jobs:
         with:
           cache: true
           version: ${{ env.FRB_MAIN_FLUTTER_VERSION }}
-      - run: cargo install cargo-llvm-cov --version ${{ matrix.info.version == '1.85.0' && '0.6.21' || '0.6.24' }} --locked
+      - run: cargo install cargo-llvm-cov --version ${{ matrix.info.version == '1.85.0' && '0.6.21' || matrix.info.version == 'nightly' && '0.8.6' || '0.6.24' }} --locked
 
       # execute
       - run: ./frb_internal generate-run-frb-codegen-command-generate --set-exit-if-changed --package ${{ matrix.package }} --coverage


### PR DESCRIPTION
## Reproduction

Baseline commit: `576ea02e11423196b4ee7309210f505547ba286c`

Steps:
1. Run the `Test :: Rust (ubuntu-latest, nightly)` coverage matrix entry.
2. Let `./frb_internal test-rust --coverage` execute with `cargo-llvm-cov 0.6.24`.

Observed:
```text
test result: ok. 36 passed; 0 failed
test result: ok. 3 passed; 0 failed
error: failed to collect object files: not found object files
```

The same failure reproduced in three consecutive CI runs, including master run 31252039186 job 93089799066.

Expected:
The nightly coverage job collects the instrumented objects and writes its Codecov report after the tests pass.

## Changes

- Use `cargo-llvm-cov 0.8.6` only for the nightly Rust test matrix entry.
- Keep Rust 1.85 on 0.6.21 and all other Rust coverage entries on 0.6.24, avoiding changes to legacy and Web/WASM coverage behavior.

## Validation

- Ran the `frb_rust` package with the current nightly toolchain and `cargo-llvm-cov 0.8.6` in the FRB Docker environment.
- All 39 tests passed and a 22 KB Codecov JSON report was generated.
- `.github/workflows/ci.yaml` parses as valid YAML.
- `git diff --check` passes.

Upstream release: https://github.com/taiki-e/cargo-llvm-cov/releases/tag/v0.8.6