### PR TITLE
Avoid waiting for opaque streams to close

### DIFF
--- a/frb_example/pure_dart/test/api/pseudo_manual/rust_auto_opaque_twin_moi_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/rust_auto_opaque_twin_moi_test.dart
@@ -306,7 +306,7 @@ Future<void> main({bool skipRustLibInit = false}) async {
 
   test('stream sink', () async {
     final stream = rustAutoOpaqueStreamSinkTwinMoi();
-    final obj = (await stream.toList()).single;
+    final obj = await stream.first;
     await futurizeVoidTwinMoi(
       rustAutoOpaqueArgBorrowTwinMoi(arg: obj, expect: 42),
     );

--- a/frb_example/pure_dart/test/api/pseudo_manual/rust_auto_opaque_twin_rust_async_moi_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/rust_auto_opaque_twin_rust_async_moi_test.dart
@@ -321,7 +321,7 @@ Future<void> main({bool skipRustLibInit = false}) async {
 
   test('stream sink', () async {
     final stream = rustAutoOpaqueStreamSinkTwinRustAsyncMoi();
-    final obj = (await stream.toList()).single;
+    final obj = await stream.first;
     await futurizeVoidTwinRustAsyncMoi(
       rustAutoOpaqueArgBorrowTwinRustAsyncMoi(arg: obj, expect: 42),
     );

--- a/frb_example/pure_dart/test/api/pseudo_manual/rust_auto_opaque_twin_rust_async_sse_moi_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/rust_auto_opaque_twin_rust_async_sse_moi_test.dart
@@ -334,7 +334,7 @@ Future<void> main({bool skipRustLibInit = false}) async {
 
   test('stream sink', () async {
     final stream = rustAutoOpaqueStreamSinkTwinRustAsyncSseMoi();
-    final obj = (await stream.toList()).single;
+    final obj = await stream.first;
     await futurizeVoidTwinRustAsyncSseMoi(
       rustAutoOpaqueArgBorrowTwinRustAsyncSseMoi(arg: obj, expect: 42),
     );

--- a/frb_example/pure_dart/test/api/pseudo_manual/rust_auto_opaque_twin_rust_async_sse_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/rust_auto_opaque_twin_rust_async_sse_test.dart
@@ -321,7 +321,7 @@ Future<void> main({bool skipRustLibInit = false}) async {
 
   test('stream sink', () async {
     final stream = rustAutoOpaqueStreamSinkTwinRustAsyncSse();
-    final obj = (await stream.toList()).single;
+    final obj = await stream.first;
     await futurizeVoidTwinRustAsyncSse(
       rustAutoOpaqueArgBorrowTwinRustAsyncSse(arg: obj, expect: 42),
     );

--- a/frb_example/pure_dart/test/api/pseudo_manual/rust_auto_opaque_twin_rust_async_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/rust_auto_opaque_twin_rust_async_test.dart
@@ -313,7 +313,7 @@ Future<void> main({bool skipRustLibInit = false}) async {
 
   test('stream sink', () async {
     final stream = rustAutoOpaqueStreamSinkTwinRustAsync();
-    final obj = (await stream.toList()).single;
+    final obj = await stream.first;
     await futurizeVoidTwinRustAsync(
       rustAutoOpaqueArgBorrowTwinRustAsync(arg: obj, expect: 42),
     );

--- a/frb_example/pure_dart/test/api/pseudo_manual/rust_auto_opaque_twin_sse_moi_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/rust_auto_opaque_twin_sse_moi_test.dart
@@ -307,7 +307,7 @@ Future<void> main({bool skipRustLibInit = false}) async {
 
   test('stream sink', () async {
     final stream = rustAutoOpaqueStreamSinkTwinSseMoi();
-    final obj = (await stream.toList()).single;
+    final obj = await stream.first;
     await futurizeVoidTwinSseMoi(
       rustAutoOpaqueArgBorrowTwinSseMoi(arg: obj, expect: 42),
     );

--- a/frb_example/pure_dart/test/api/pseudo_manual/rust_auto_opaque_twin_sse_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/rust_auto_opaque_twin_sse_test.dart
@@ -306,7 +306,7 @@ Future<void> main({bool skipRustLibInit = false}) async {
 
   test('stream sink', () async {
     final stream = rustAutoOpaqueStreamSinkTwinSse();
-    final obj = (await stream.toList()).single;
+    final obj = await stream.first;
     await futurizeVoidTwinSse(
       rustAutoOpaqueArgBorrowTwinSse(arg: obj, expect: 42),
     );

--- a/frb_example/pure_dart/test/api/pseudo_manual/rust_auto_opaque_twin_sync_moi_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/rust_auto_opaque_twin_sync_moi_test.dart
@@ -311,7 +311,7 @@ Future<void> main({bool skipRustLibInit = false}) async {
 
   test('stream sink', () async {
     final stream = rustAutoOpaqueStreamSinkTwinSyncMoi();
-    final obj = (await stream.toList()).single;
+    final obj = await stream.first;
     await futurizeVoidTwinSyncMoi(
       rustAutoOpaqueArgBorrowTwinSyncMoi(arg: obj, expect: 42),
     );

--- a/frb_example/pure_dart/test/api/pseudo_manual/rust_auto_opaque_twin_sync_sse_moi_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/rust_auto_opaque_twin_sync_sse_moi_test.dart
@@ -318,7 +318,7 @@ Future<void> main({bool skipRustLibInit = false}) async {
 
   test('stream sink', () async {
     final stream = rustAutoOpaqueStreamSinkTwinSyncSseMoi();
-    final obj = (await stream.toList()).single;
+    final obj = await stream.first;
     await futurizeVoidTwinSyncSseMoi(
       rustAutoOpaqueArgBorrowTwinSyncSseMoi(arg: obj, expect: 42),
     );

--- a/frb_example/pure_dart/test/api/pseudo_manual/rust_auto_opaque_twin_sync_sse_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/rust_auto_opaque_twin_sync_sse_test.dart
@@ -311,7 +311,7 @@ Future<void> main({bool skipRustLibInit = false}) async {
 
   test('stream sink', () async {
     final stream = rustAutoOpaqueStreamSinkTwinSyncSse();
-    final obj = (await stream.toList()).single;
+    final obj = await stream.first;
     await futurizeVoidTwinSyncSse(
       rustAutoOpaqueArgBorrowTwinSyncSse(arg: obj, expect: 42),
     );

--- a/frb_example/pure_dart/test/api/pseudo_manual/rust_auto_opaque_twin_sync_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/rust_auto_opaque_twin_sync_test.dart
@@ -306,7 +306,7 @@ Future<void> main({bool skipRustLibInit = false}) async {
 
   test('stream sink', () async {
     final stream = rustAutoOpaqueStreamSinkTwinSync();
-    final obj = (await stream.toList()).single;
+    final obj = await stream.first;
     await futurizeVoidTwinSync(
       rustAutoOpaqueArgBorrowTwinSync(arg: obj, expect: 42),
     );

--- a/frb_example/pure_dart/test/api/rust_auto_opaque_test.dart
+++ b/frb_example/pure_dart/test/api/rust_auto_opaque_test.dart
@@ -303,7 +303,7 @@ Future<void> main({bool skipRustLibInit = false}) async {
 
   test('stream sink', () async {
     final stream = rustAutoOpaqueStreamSinkTwinNormal();
-    final obj = (await stream.toList()).single;
+    final obj = await stream.first;
     await futurizeVoidTwinNormal(
       rustAutoOpaqueArgBorrowTwinNormal(arg: obj, expect: 42),
     );

--- a/frb_example/pure_dart_pde/test/api/pseudo_manual/rust_auto_opaque_twin_rust_async_test.dart
+++ b/frb_example/pure_dart_pde/test/api/pseudo_manual/rust_auto_opaque_twin_rust_async_test.dart
@@ -315,7 +315,7 @@ Future<void> main({bool skipRustLibInit = false}) async {
 
   test('stream sink', () async {
     final stream = rustAutoOpaqueStreamSinkTwinRustAsync();
-    final obj = (await stream.toList()).single;
+    final obj = await stream.first;
     await futurizeVoidTwinRustAsync(
       rustAutoOpaqueArgBorrowTwinRustAsync(arg: obj, expect: 42),
     );

--- a/frb_example/pure_dart_pde/test/api/pseudo_manual/rust_auto_opaque_twin_sync_test.dart
+++ b/frb_example/pure_dart_pde/test/api/pseudo_manual/rust_auto_opaque_twin_sync_test.dart
@@ -308,7 +308,7 @@ Future<void> main({bool skipRustLibInit = false}) async {
 
   test('stream sink', () async {
     final stream = rustAutoOpaqueStreamSinkTwinSync();
-    final obj = (await stream.toList()).single;
+    final obj = await stream.first;
     await futurizeVoidTwinSync(
       rustAutoOpaqueArgBorrowTwinSync(arg: obj, expect: 42),
     );

--- a/frb_example/pure_dart_pde/test/api/rust_auto_opaque_test.dart
+++ b/frb_example/pure_dart_pde/test/api/rust_auto_opaque_test.dart
@@ -305,7 +305,7 @@ Future<void> main({bool skipRustLibInit = false}) async {
 
   test('stream sink', () async {
     final stream = rustAutoOpaqueStreamSinkTwinNormal();
-    final obj = (await stream.toList()).single;
+    final obj = await stream.first;
     await futurizeVoidTwinNormal(
       rustAutoOpaqueArgBorrowTwinNormal(arg: obj, expect: 42),
     );


### PR DESCRIPTION
## Context

Master run [31252039186](https://github.com/fzyzcjy/flutter_rust_bridge/actions/runs/31252039186) timed out in both Web variants:

- `Test :: Dart :: Web (frb_example--pure_dart)`
- `Test :: Dart :: Web (frb_example--pure_dart_pde)`

The failing generated test was:

```dart
final stream = rustAutoOpaqueStreamSinkTwinNormal();
final obj = (await stream.toList()).single;
```

The Rust function adds one opaque object and then drops its `StreamSink`. The test received the object, but one generated Web twin did not observe the close message and timed out after 30 seconds while awaiting `toList()`.

## Proposed workaround

This PR changes `stream.toList()` to `stream.first` in the source test and its generated twin/PDE variants. That preserves the opaque-object roundtrip assertion and avoids waiting for stream closure.

Both focused Web suites passed locally, and both corresponding PR CI jobs passed.

## Why this is being closed

Further comparison showed that the last successful master Web run and the failing runs used the same pinned Dart, Rust, wasm-bindgen, and wasm-pack versions. Relevant stream code and this test also did not change between those revisions. Several generated twins completed successfully in the failing run before one twin timed out, which points to a latent Web stream close/order race rather than a deterministic change from the triggering PR.

Using `stream.first` makes the test stable, but it no longer verifies that dropping the Rust `StreamSink` closes the Dart stream. If stream closure is part of the bridge contract, this workaround could hide a runtime bug. The PR is therefore closed without merging while the new master CI is observed; a runtime ordering fix should be preferred if the failure recurs.

## Validation performed

- `./frb_internal test-dart-web --package frb_example/pure_dart`
- `./frb_internal test-dart-web --package frb_example/pure_dart_pde`
- `./frb_internal generate-internal-frb-example-pure-dart --set-exit-if-changed`
- `git diff --check`
