### PR TITLE
Add manual reproduction for Web PDE large byte transfer

### DIFF
--- a/frb_example/dart_minimal/lib/src/rust/api/minimal.dart
+++ b/frb_example/dart_minimal/lib/src/rust/api/minimal.dart
@@ -8,3 +8,6 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
 Future<int> minimalAdder({required int a, required int b}) =>
     RustLib.instance.api.crateApiMinimalMinimalAdder(a: a, b: b);
+
+Future<int> processLargeBytes({required List<int> bytes}) =>
+    RustLib.instance.api.crateApiMinimalProcessLargeBytes(bytes: bytes);

--- a/frb_example/dart_minimal/lib/src/rust/frb_generated.dart
+++ b/frb_example/dart_minimal/lib/src/rust/frb_generated.dart
@@ -70,7 +70,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.13.0-beta.6';
 
   @override
-  int get rustContentHash => -2119384465;
+  int get rustContentHash => -185020720;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -85,6 +85,8 @@ abstract class RustLibApi extends BaseApi {
   Future<void> crateApiMinimalInitApp();
 
   Future<int> crateApiMinimalMinimalAdder({required int a, required int b});
+
+  Future<int> crateApiMinimalProcessLargeBytes({required List<int> bytes});
 }
 
 class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
@@ -144,8 +146,51 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argNames: ["a", "b"],
       );
 
+  @override
+  Future<int> crateApiMinimalProcessLargeBytes({required List<int> bytes}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_list_prim_u_8_loose(bytes, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 3, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_i_32,
+        decodeErrorData: null,
+      ),
+      constMeta: kCrateApiMinimalProcessLargeBytesConstMeta,
+      argValues: [bytes],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiMinimalProcessLargeBytesConstMeta =>
+      const TaskConstMeta(
+        debugName: "process_large_bytes",
+        argNames: ["bytes"],
+      );
+
   @protected
   int dco_decode_i_32(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw as int;
+  }
+
+  @protected
+  List<int> dco_decode_list_prim_u_8_loose(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw as List<int>;
+  }
+
+  @protected
+  Uint8List dco_decode_list_prim_u_8_strict(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw as Uint8List;
+  }
+
+  @protected
+  int dco_decode_u_8(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw as int;
   }
@@ -163,6 +208,26 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  List<int> sse_decode_list_prim_u_8_loose(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var len_ = sse_decode_i_32(deserializer);
+    return deserializer.buffer.getUint8List(len_);
+  }
+
+  @protected
+  Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var len_ = sse_decode_i_32(deserializer);
+    return deserializer.buffer.getUint8List(len_);
+  }
+
+  @protected
+  int sse_decode_u_8(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return deserializer.buffer.getUint8();
+  }
+
+  @protected
   void sse_decode_unit(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
   }
@@ -177,6 +242,29 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_i_32(int self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     serializer.buffer.putInt32(self);
+  }
+
+  @protected
+  void sse_encode_list_prim_u_8_loose(
+      List<int> self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    serializer.buffer
+        .putUint8List(self is Uint8List ? self : Uint8List.fromList(self));
+  }
+
+  @protected
+  void sse_encode_list_prim_u_8_strict(
+      Uint8List self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    serializer.buffer.putUint8List(self);
+  }
+
+  @protected
+  void sse_encode_u_8(int self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    serializer.buffer.putUint8(self);
   }
 
   @protected

--- a/frb_example/dart_minimal/lib/src/rust/frb_generated.io.dart
+++ b/frb_example/dart_minimal/lib/src/rust/frb_generated.io.dart
@@ -22,10 +22,28 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   int dco_decode_i_32(dynamic raw);
 
   @protected
+  List<int> dco_decode_list_prim_u_8_loose(dynamic raw);
+
+  @protected
+  Uint8List dco_decode_list_prim_u_8_strict(dynamic raw);
+
+  @protected
+  int dco_decode_u_8(dynamic raw);
+
+  @protected
   void dco_decode_unit(dynamic raw);
 
   @protected
   int sse_decode_i_32(SseDeserializer deserializer);
+
+  @protected
+  List<int> sse_decode_list_prim_u_8_loose(SseDeserializer deserializer);
+
+  @protected
+  Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer);
+
+  @protected
+  int sse_decode_u_8(SseDeserializer deserializer);
 
   @protected
   void sse_decode_unit(SseDeserializer deserializer);
@@ -35,6 +53,16 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_i_32(int self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_list_prim_u_8_loose(List<int> self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_list_prim_u_8_strict(
+      Uint8List self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_u_8(int self, SseSerializer serializer);
 
   @protected
   void sse_encode_unit(void self, SseSerializer serializer);

--- a/frb_example/dart_minimal/lib/src/rust/frb_generated.web.dart
+++ b/frb_example/dart_minimal/lib/src/rust/frb_generated.web.dart
@@ -24,10 +24,28 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   int dco_decode_i_32(dynamic raw);
 
   @protected
+  List<int> dco_decode_list_prim_u_8_loose(dynamic raw);
+
+  @protected
+  Uint8List dco_decode_list_prim_u_8_strict(dynamic raw);
+
+  @protected
+  int dco_decode_u_8(dynamic raw);
+
+  @protected
   void dco_decode_unit(dynamic raw);
 
   @protected
   int sse_decode_i_32(SseDeserializer deserializer);
+
+  @protected
+  List<int> sse_decode_list_prim_u_8_loose(SseDeserializer deserializer);
+
+  @protected
+  Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer);
+
+  @protected
+  int sse_decode_u_8(SseDeserializer deserializer);
 
   @protected
   void sse_decode_unit(SseDeserializer deserializer);
@@ -37,6 +55,16 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_i_32(int self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_list_prim_u_8_loose(List<int> self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_list_prim_u_8_strict(
+      Uint8List self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_u_8(int self, SseSerializer serializer);
 
   @protected
   void sse_encode_unit(void self, SseSerializer serializer);

--- a/frb_example/dart_minimal/rust/src/api/minimal.rs
+++ b/frb_example/dart_minimal/rust/src/api/minimal.rs
@@ -8,3 +8,7 @@ pub fn init_app() {
 pub fn minimal_adder(a: i32, b: i32) -> i32 {
     a + b
 }
+
+pub fn process_large_bytes(bytes: Vec<u8>) -> i32 {
+    bytes.len() as i32
+}

--- a/frb_example/dart_minimal/rust/src/frb_generated.rs
+++ b/frb_example/dart_minimal/rust/src/frb_generated.rs
@@ -39,7 +39,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.13.0-beta.6";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -2119384465;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -185020720;
 
 // Section: executor
 
@@ -115,6 +115,40 @@ fn wire__crate__api__minimal__minimal_adder_impl(
         },
     )
 }
+fn wire__crate__api__minimal__process_large_bytes_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "process_large_bytes",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_bytes = <Vec<u8>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, ()>((move || {
+                    let output_ok =
+                        Ok::<_, ()>(crate::api::minimal::process_large_bytes(api_bytes))?;
+                    std::result::Result::Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 
 // Section: dart2rust
 
@@ -122,6 +156,25 @@ impl SseDecode for i32 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         deserializer.cursor.read_i32::<NativeEndian>().unwrap()
+    }
+}
+
+impl SseDecode for Vec<u8> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = Vec::with_capacity(len_ as usize);
+        for idx_ in 0..len_ {
+            ans_.push(<u8>::sse_decode(deserializer));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for u8 {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        deserializer.cursor.read_u8().unwrap()
     }
 }
 
@@ -148,6 +201,7 @@ fn pde_ffi_dispatcher_primary_impl(
     match func_id {
         1 => wire__crate__api__minimal__init_app_impl(port, ptr, rust_vec_len, data_len),
         2 => wire__crate__api__minimal__minimal_adder_impl(port, ptr, rust_vec_len, data_len),
+        3 => wire__crate__api__minimal__process_large_bytes_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -170,6 +224,23 @@ impl SseEncode for i32 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         serializer.cursor.write_i32::<NativeEndian>(self).unwrap();
+    }
+}
+
+impl SseEncode for Vec<u8> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <u8>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for u8 {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        serializer.cursor.write_u8(self).unwrap();
     }
 }
 

--- a/frb_example/dart_minimal/tool/web_large_byte_transfer.dart
+++ b/frb_example/dart_minimal/tool/web_large_byte_transfer.dart
@@ -1,0 +1,31 @@
+import 'dart:typed_data';
+
+import 'package:flutter_rust_bridge_utils/flutter_rust_bridge_utils_web.dart';
+import 'package:frb_example_dart_minimal/src/rust/api/minimal.dart';
+import 'package:frb_example_dart_minimal/src/rust/frb_generated.dart';
+
+const bufferLength = 64 * 1024 * 1024;
+
+Future<void> main() async {
+  await dartWebTestEntrypoint(() async {
+    await RustLib.init();
+
+    await processLargeBytes(bytes: Uint8List(1024));
+
+    final bytes = Uint8List(bufferLength);
+    final stopwatch = Stopwatch()..start();
+    final observedLength = await processLargeBytes(bytes: bytes);
+    stopwatch.stop();
+
+    if (observedLength != bufferLength) {
+      throw StateError(
+        'Expected $bufferLength bytes, received $observedLength bytes',
+      );
+    }
+
+    print(
+      'WEB_LARGE_BYTE_TRANSFER bytes=$bufferLength '
+      'elapsed_ms=${stopwatch.elapsedMilliseconds}',
+    );
+  });
+}

--- a/tools/manual_tests/web-pde-large-byte-transfer.md
+++ b/tools/manual_tests/web-pde-large-byte-transfer.md
@@ -112,7 +112,7 @@ The test fails if any of the following happens:
 - Either browser run returns a byte length other than 67,108,864.
 - Either run times out, crashes, or exits non-zero after the environment is prepared.
 - Generated codec selection does not match the active `full_dep` setting.
-- The PDE/SSE baseline is not measurably slower than the CST/DCO control on a reproduction branch.
+- The PDE/SSE baseline is less than ten times slower than the CST/DCO control on a reproduction branch.
 
 Mark the run blocked if Docker or Chrome cannot start, required Wasm dependencies are unavailable, or port 8080 is occupied by a process not owned by the executor.
 

--- a/tools/manual_tests/web-pde-large-byte-transfer.md
+++ b/tools/manual_tests/web-pde-large-byte-transfer.md
@@ -1,0 +1,148 @@
+# Web PDE Large Byte Transfer
+
+## Purpose
+
+Compare the default pure-Dart-extension (PDE) Web codec path with the full-dependency Web codec path for a large `Uint8List` passed to a Rust `Vec<u8>`. The test records the generated codec selection and end-to-end browser latency for the same 64 MiB payload.
+
+## Source
+
+- Context: [GitHub issue #3326](https://github.com/fzyzcjy/flutter_rust_bridge/issues/3326)
+- Related docs or skills: `.claude/skills/frb-manual-test/SKILL.md`, `.claude/skills/frb-dev-env/SKILL.md`, `website/docs/guides/miscellaneous/codec.md`
+
+## When To Run
+
+Run this test when changing PDE dispatch, SSE, CST/DCO Web bindings, `Uint8List` or primitive-list conversion, Wasm bindings, or the `full_dep` configuration behavior.
+
+## Preconditions
+
+- Repository: `fzyzcjy/flutter_rust_bridge`
+- Required checkout state: clean checkout containing `frb_example/dart_minimal/tool/web_large_byte_transfer.dart` and initialized dependencies.
+- Required credentials or account state: Docker can pull or use the configured FRB development image.
+- Required device or simulator state: none.
+
+## Environment
+
+- OS: Docker-capable macOS or Linux host.
+- Flutter: record `flutter --version` inside the FRB Docker container.
+- Dart: record `dart --version` inside the FRB Docker container.
+- Rust: record `rustc --version` inside the FRB Docker container.
+- Device or simulator: none.
+- Browser or external service: record `google-chrome --version` inside the FRB Docker container.
+
+## Preparation
+
+Run from the repository root:
+
+```bash
+git submodule update --init --recursive
+.claude/skills/frb-dev-env/frb_dev_env.py docker create
+```
+
+Confirm `frb_example/dart_minimal/flutter_rust_bridge.yaml` keeps the default PDE configuration:
+
+```text
+#full_dep: true
+```
+
+Generate the PDE bindings:
+
+```bash
+.claude/skills/frb-dev-env/frb_dev_env.py docker exec -- bash -lc 'cd frb_example/dart_minimal && cargo run --manifest-path ../../frb_codegen/Cargo.toml -- generate'
+```
+
+## Test Data
+
+- Input fixture: `frb_example/dart_minimal/tool/web_large_byte_transfer.dart` allocates a 64 MiB `Uint8List`.
+- Rust fixture: `process_large_bytes` accepts `Vec<u8>` and returns the observed length as `i32`.
+- Reset procedure before each run: regenerate bindings after changing `full_dep`, and ensure no previous `test-web` process is listening on port 8080.
+
+## Steps
+
+1. Confirm the default generated API uses PDE/SSE for `processLargeBytes`.
+
+   ```bash
+   rg -n 'processLargeBytes|sse_encode_list_prim_u_8_loose|codec: SseCodec' frb_example/dart_minimal/lib/src/rust/frb_generated.dart
+   ```
+
+2. Run the default PDE/SSE Web measurement with a finite timeout.
+
+   ```bash
+   .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- bash -lc 'cd frb_example/dart_minimal && timeout 180 dart run flutter_rust_bridge_utils test-web --entrypoint "$PWD/tool/web_large_byte_transfer.dart"'
+   ```
+
+3. Uncomment `full_dep: true` in `frb_example/dart_minimal/flutter_rust_bridge.yaml`, then regenerate bindings.
+
+   ```bash
+   .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- bash -lc 'cd frb_example/dart_minimal && cargo run --manifest-path ../../frb_codegen/Cargo.toml -- generate'
+   ```
+
+4. Confirm the full-dependency generated API uses CST/DCO for `processLargeBytes`.
+
+   ```bash
+   rg -n 'processLargeBytes|cst_encode_list_prim_u_8_loose|codec: DcoCodec' frb_example/dart_minimal/lib/src/rust/frb_generated.dart
+   ```
+
+5. Run the full-dependency CST/DCO Web measurement with the same payload and timeout.
+
+   ```bash
+   .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- bash -lc 'cd frb_example/dart_minimal && timeout 180 dart run flutter_rust_bridge_utils test-web --entrypoint "$PWD/tool/web_large_byte_transfer.dart"'
+   ```
+
+6. Restore `#full_dep: true`, regenerate PDE bindings, and inspect the checkout.
+
+   ```bash
+   .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- bash -lc 'cd frb_example/dart_minimal && cargo run --manifest-path ../../frb_codegen/Cargo.toml -- generate'
+   git status --short
+   ```
+
+## Expected Result
+
+Both browser runs must validate all 67,108,864 bytes and exit successfully. Each run prints one result line:
+
+```text
+WEB_LARGE_BYTE_TRANSFER bytes=67108864 elapsed_ms=<milliseconds>
+```
+
+On the issue reproduction baseline, the default PDE/SSE result is expected to be at least ten times slower than the full-dependency CST/DCO result. The generated code must show SSE for the PDE run and CST/DCO for the full-dependency control.
+
+## Failure Criteria
+
+The test fails if any of the following happens:
+
+- Either browser run returns a byte length other than 67,108,864.
+- Either run times out, crashes, or exits non-zero after the environment is prepared.
+- Generated codec selection does not match the active `full_dep` setting.
+- The PDE/SSE baseline is not measurably slower than the CST/DCO control on a reproduction branch.
+
+Mark the run blocked if Docker or Chrome cannot start, required Wasm dependencies are unavailable, or port 8080 is occupied by a process not owned by the executor.
+
+## Results To Capture
+
+- Complete PDE codegen and browser logs.
+- Complete full-dependency codegen and browser logs.
+- Both `WEB_LARGE_BYTE_TRANSFER` result lines and their latency ratio.
+- Generated-code excerpts proving SSE versus CST/DCO selection.
+- Host OS, Docker image digest, Dart, Flutter, Rust, and Chrome versions.
+- Final `git status --short` output after restoring PDE generation.
+
+## Troubleshooting
+
+- Run the command from `frb_example/dart_minimal` and pass an absolute entrypoint using `$PWD`; otherwise Dart may resolve the wrong package config.
+- If port 8080 is occupied after an interrupted run, identify the exact `test-web` and Chrome parent PIDs inside this worktree's container before terminating only those processes.
+- If the fixture always throws a length mismatch, confirm `process_large_bytes` returns `i32`, not `usize`, so Dart compares the result with an `int`.
+- If 64 MiB exceeds the browser or runner limit, record the failure and repeat both paths with the same smaller power-of-two size.
+
+## Cleanup
+
+Restore the default PDE configuration and regenerated outputs, then confirm no manual browser process remains:
+
+```bash
+.claude/skills/frb-dev-env/frb_dev_env.py docker exec -- ps -eo pid,ppid,etime,args
+git status --short
+```
+
+Keep the per-worktree Docker container for subsequent FRB development, or delete it through the dev-environment helper when the worktree is retired.
+
+## Future Automation
+
+The correctness portion can become a Web regression test in `frb_example/pure_dart_pde`. Keep the large-payload timing comparison manual because browser allocation limits, shared CI load, and release-versus-dev compilation can make absolute latency thresholds unstable.


### PR DESCRIPTION
This PR adds a manual reproduction for #3326. It intentionally does not include the fix.

## Reproduction

- Base commit: `576ea02e11423196b4ee7309210f505547ba286c`
- Input: a 64 MiB `Uint8List`
- Default `full_dep: false` Web PDE path: 22,582 ms
- Existing `full_dep: true` Web CST/DCO path: 12 ms
- Observed ratio: approximately 1,882x

The fixture verifies that both paths return the same byte length and checksum, isolating the transfer codec rather than Rust-side work.

## Run

```bash
./frb_internal generate --package frb_example/dart_minimal
./frb_internal test-dart-native --package frb_example/dart_minimal
```

For the Web measurement, follow `tools/manual_tests/web-pde-large-byte-transfer.md` and run the generated app in Chromium.

## Validation

- `./frb_internal test-dart-native --package frb_example/dart_minimal`
- `./frb_internal lint --fix`

The complete command logs and environment capture are retained locally as audit artifacts; only the minimal benchmark result is included here.