### PR TITLE
Limit automatic build runner outputs

### DIFF
--- a/frb_codegen/src/library/codegen/polisher/mod.rs
+++ b/frb_codegen/src/library/codegen/polisher/mod.rs
@@ -14,6 +14,11 @@ use log::warn;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+lazy_static! {
+    static ref ANY_REQUIREMENT: VersionReq = VersionReq::parse(">= 1.0.0").unwrap();
+    static ref BUILD_RUNNER_REQUIREMENT: VersionReq = VersionReq::parse(">= 1.7.0").unwrap();
+}
+
 pub(crate) mod add_mod_to_lib;
 mod auto_upgrade;
 pub(crate) mod internal_config;
@@ -67,10 +72,6 @@ fn ensure_dependencies(
     needs_freezed: bool,
     needs_json_serializable: bool,
 ) -> anyhow::Result<()> {
-    lazy_static! {
-        pub(crate) static ref ANY_REQUIREMENT: VersionReq = VersionReq::parse(">= 1.0.0").unwrap();
-    }
-
     if needs_freezed {
         let repo = DartRepository::from_path(&config.dart_root)?;
         repo.has_specified_and_installed("freezed", DartDependencyMode::Dev, &ANY_REQUIREMENT)?;
@@ -82,7 +83,7 @@ fn ensure_dependencies(
         repo.has_specified_and_installed(
             "build_runner",
             DartDependencyMode::Dev,
-            &ANY_REQUIREMENT,
+            &BUILD_RUNNER_REQUIREMENT,
         )?;
     }
 
@@ -185,4 +186,17 @@ fn execute_duplicate_c_output(config: &PolisherInternalConfig) -> anyhow::Result
         )?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BUILD_RUNNER_REQUIREMENT;
+    use cargo_metadata::Version;
+
+    /// Requires the first build_runner release that supports output filters.
+    #[test]
+    fn test_build_runner_requirement_supports_output_filters() {
+        assert!(!BUILD_RUNNER_REQUIREMENT.matches(&Version::parse("1.6.9").unwrap()));
+        assert!(BUILD_RUNNER_REQUIREMENT.matches(&Version::parse("1.7.0").unwrap()));
+    }
 }

--- a/frb_codegen/src/library/codegen/polisher/mod.rs
+++ b/frb_codegen/src/library/codegen/polisher/mod.rs
@@ -126,7 +126,11 @@ fn execute_build_runner(
     }
 
     let _pb = progress_bar_pack.polish_dart_build_runner.start();
-    dart_build_runner(&config.dart_root, config.fvm_install_mode)
+    dart_build_runner(
+        &config.dart_root,
+        &config.dart_output,
+        config.fvm_install_mode,
+    )
 }
 
 fn execute_dart_fix(

--- a/frb_codegen/src/library/codegen/polisher/mod.rs
+++ b/frb_codegen/src/library/codegen/polisher/mod.rs
@@ -35,7 +35,12 @@ pub(super) fn polish(
     ensure_dependencies(config, needs_freezed, needs_json_serializable)?;
 
     warn_if_fail(
-        execute_build_runner(needs_freezed, config, progress_bar_pack),
+        execute_build_runner(
+            needs_freezed,
+            needs_json_serializable,
+            config,
+            progress_bar_pack,
+        ),
         "execute_build_runner",
     );
     if config.dart_fix {
@@ -83,7 +88,7 @@ fn ensure_dependencies(
         repo.has_specified_and_installed(
             "build_runner",
             DartDependencyMode::Dev,
-            &BUILD_RUNNER_REQUIREMENT,
+            build_runner_requirement(config.build_runner),
         )?;
     }
 
@@ -104,6 +109,14 @@ fn ensure_dependencies(
     Ok(())
 }
 
+fn build_runner_requirement(build_runner: bool) -> &'static VersionReq {
+    if build_runner {
+        &BUILD_RUNNER_REQUIREMENT
+    } else {
+        &ANY_REQUIREMENT
+    }
+}
+
 fn warn_if_fail(r: anyhow::Result<()>, debug_name: &str) -> bool {
     match r {
         Ok(_) => true,
@@ -119,6 +132,7 @@ fn warn_if_fail(r: anyhow::Result<()>, debug_name: &str) -> bool {
 
 fn execute_build_runner(
     needs_freezed: bool,
+    needs_json_serializable: bool,
     config: &PolisherInternalConfig,
     progress_bar_pack: &GeneratorProgressBarPack,
 ) -> anyhow::Result<()> {
@@ -130,6 +144,7 @@ fn execute_build_runner(
     dart_build_runner(
         &config.dart_root,
         &config.dart_output,
+        needs_json_serializable,
         config.fvm_install_mode,
     )
 }
@@ -190,7 +205,7 @@ fn execute_duplicate_c_output(config: &PolisherInternalConfig) -> anyhow::Result
 
 #[cfg(test)]
 mod tests {
-    use super::BUILD_RUNNER_REQUIREMENT;
+    use super::{build_runner_requirement, BUILD_RUNNER_REQUIREMENT};
     use cargo_metadata::Version;
 
     /// Requires the first build_runner release that supports output filters.
@@ -198,5 +213,12 @@ mod tests {
     fn test_build_runner_requirement_supports_output_filters() {
         assert!(!BUILD_RUNNER_REQUIREMENT.matches(&Version::parse("1.6.9").unwrap()));
         assert!(BUILD_RUNNER_REQUIREMENT.matches(&Version::parse("1.7.0").unwrap()));
+    }
+
+    /// Keeps the legacy dependency range when automatic build_runner invocation is disabled.
+    #[test]
+    fn test_build_runner_requirement_when_invocation_disabled() {
+        assert!(build_runner_requirement(false).matches(&Version::parse("1.6.9").unwrap()));
+        assert!(!build_runner_requirement(true).matches(&Version::parse("1.6.9").unwrap()));
     }
 }

--- a/frb_codegen/src/library/commands/dart_build_runner.rs
+++ b/frb_codegen/src/library/commands/dart_build_runner.rs
@@ -67,7 +67,11 @@ fn build_runner_output_filters(
         format!("dart_output={dart_output:?} must be within dart_root={dart_root:?}")
     })?;
     let relative_output = path_to_string(relative_output)?.replace(MAIN_SEPARATOR, "/");
-    let output_prefix = build_filter_output_prefix(&relative_output, dart_package_name)?;
+    let Some(output_prefix) = build_filter_output_prefix(&relative_output, dart_package_name)
+    else {
+        debug!("Falling back to unfiltered build_runner for dart_output path {relative_output:?}");
+        return Ok(Vec::new());
+    };
 
     let mut extensions = vec!["freezed.dart"];
     if needs_json_serializable {
@@ -93,34 +97,29 @@ fn build_runner_args(output_filters: Vec<String>) -> Vec<String> {
     .concat()
 }
 
-fn build_filter_output_prefix(
-    relative_output: &str,
-    dart_package_name: &str,
-) -> anyhow::Result<String> {
+fn build_filter_output_prefix(relative_output: &str, dart_package_name: &str) -> Option<String> {
     if relative_output.is_empty() {
-        return Ok(String::new());
+        return Some(String::new());
     }
 
     if let Some(library_output) = relative_output.strip_prefix("lib/") {
-        return Ok(format!(
+        return Some(format!(
             "package:{dart_package_name}/{}/",
             quote_package_glob_uri_path(library_output)
         ));
     }
 
     if relative_output == "lib" {
-        return Ok(format!("package:{dart_package_name}/"));
+        return Some(format!("package:{dart_package_name}/"));
     }
 
     if relative_output.bytes().all(|byte| {
         byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~' | b'/')
     }) {
-        return Ok(format!("{relative_output}/"));
+        return Some(format!("{relative_output}/"));
     }
 
-    bail!(
-        "dart_output path outside lib contains characters that build_runner 1.7 cannot represent safely: {relative_output:?}"
-    )
+    None
 }
 
 fn quote_package_glob_uri_path(path: &str) -> String {
@@ -221,18 +220,34 @@ mod tests {
         assert!(error.to_string().contains("must be within dart_root"));
     }
 
-    /// Rejects an unsafe relative URI when build_runner cannot decode it as a package path.
+    /// Falls back to an unfiltered build when a non-library output path cannot be filtered safely.
     #[test]
     fn test_build_runner_output_filters_metacharacter_output_outside_lib() {
-        let error = build_runner_output_filters(
-            Path::new("/project"),
-            Path::new("/project/generated[foo]"),
-            "example",
-            false,
-        )
-        .unwrap_err();
+        assert_eq!(
+            build_runner_output_filters(
+                Path::new("/project"),
+                Path::new("/project/generated[foo]"),
+                "example",
+                false,
+            )
+            .unwrap(),
+            Vec::<String>::new()
+        );
+    }
 
-        assert!(error.to_string().contains("cannot represent safely"));
+    /// Filters a URI-safe output path outside the package library.
+    #[test]
+    fn test_build_runner_output_filters_safe_output_outside_lib() {
+        assert_eq!(
+            build_runner_output_filters(
+                Path::new("/project"),
+                Path::new("/project/test/generated"),
+                "example",
+                false,
+            )
+            .unwrap(),
+            vec!["--build-filter=test/generated/**.freezed.dart"]
+        );
     }
 
     /// Constructs a build_runner command supported by the declared minimum version.

--- a/frb_codegen/src/library/commands/dart_build_runner.rs
+++ b/frb_codegen/src/library/commands/dart_build_runner.rs
@@ -4,15 +4,21 @@ use crate::library::commands::command_runner::ExecuteCommandOptions;
 use crate::library::commands::fvm::command_arg_maybe_fvm;
 use crate::misc::FvmInstallMode;
 use crate::utils::dart_repository::dart_repo::DartRepository;
-use anyhow::bail;
+use crate::utils::path_utils::path_to_string;
+use anyhow::{bail, Context};
 use log::debug;
 use std::collections::HashMap;
 use std::path::Path;
 
-pub fn dart_build_runner(dart_root: &Path, fvm_install_mode: FvmInstallMode) -> anyhow::Result<()> {
-    debug!("Running build_runner at dart_root={dart_root:?}");
+pub fn dart_build_runner(
+    dart_root: &Path,
+    dart_output: &Path,
+    fvm_install_mode: FvmInstallMode,
+) -> anyhow::Result<()> {
+    debug!("Running build_runner at dart_root={dart_root:?} dart_output={dart_output:?}");
 
     let repo = DartRepository::from_path(dart_root)?;
+    let output_filters = build_runner_output_filters(dart_root, dart_output)?;
     let out = command_run!(
         call_shell[Some(dart_root), Some(ExecuteCommandOptions {
             envs: Some(dart_run_extra_env()),
@@ -25,6 +31,7 @@ pub fn dart_build_runner(dart_root: &Path, fvm_install_mode: FvmInstallMode) -> 
         "build_runner",
         "build",
         "--delete-conflicting-outputs",
+        *output_filters,
         "--enable-experiment=class-modifiers",
     )?;
     if !out.status.success() {
@@ -45,4 +52,63 @@ pub(super) fn dart_run_extra_env() -> HashMap<String, String> {
     // Otherwise every call to `ffigen`, `build_runner`, etc will need to
     // trigger `build.dart`, which takes minutes to compile the `./rust` crate
     [("FRB_SIMPLE_BUILD_SKIP".to_owned(), "1".to_owned())].into()
+}
+
+fn build_runner_output_filters(
+    dart_root: &Path,
+    dart_output: &Path,
+) -> anyhow::Result<Vec<String>> {
+    let relative_output = dart_output.strip_prefix(dart_root).with_context(|| {
+        format!("dart_output={dart_output:?} must be within dart_root={dart_root:?}")
+    })?;
+    let relative_output = path_to_string(relative_output)?.replace('\\', "/");
+    let output_prefix = if relative_output.is_empty() {
+        String::new()
+    } else {
+        format!("{relative_output}/")
+    };
+
+    Ok(["freezed.dart", "g.dart"]
+        .map(|extension| format!("--build-filter={output_prefix}**.{extension}"))
+        .to_vec())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_runner_output_filters;
+    use std::path::Path;
+
+    /// Limits build runner to generated outputs beneath a nested Dart output directory.
+    #[test]
+    fn test_build_runner_output_filters_nested_output() {
+        assert_eq!(
+            build_runner_output_filters(Path::new("/project"), Path::new("/project/lib/src/rust"),)
+                .unwrap(),
+            vec![
+                "--build-filter=lib/src/rust/**.freezed.dart",
+                "--build-filter=lib/src/rust/**.g.dart",
+            ]
+        );
+    }
+
+    /// Supports a Dart output directory at the package root without an absolute filter.
+    #[test]
+    fn test_build_runner_output_filters_root_output() {
+        assert_eq!(
+            build_runner_output_filters(Path::new("/project"), Path::new("/project")).unwrap(),
+            vec!["--build-filter=**.freezed.dart", "--build-filter=**.g.dart"]
+        );
+    }
+
+    /// Rejects output directories that build runner cannot address from the Dart package.
+    #[test]
+    fn test_build_runner_output_filters_outside_dart_root() {
+        let error = build_runner_output_filters(
+            Path::new("/project/dart"),
+            Path::new("/project/generated"),
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("must be within dart_root"));
+    }
 }

--- a/frb_codegen/src/library/commands/dart_build_runner.rs
+++ b/frb_codegen/src/library/commands/dart_build_runner.rs
@@ -4,21 +4,29 @@ use crate::library::commands::command_runner::ExecuteCommandOptions;
 use crate::library::commands::fvm::command_arg_maybe_fvm;
 use crate::misc::FvmInstallMode;
 use crate::utils::dart_repository::dart_repo::DartRepository;
+use crate::utils::dart_repository::get_dart_package_name;
 use crate::utils::path_utils::path_to_string;
 use anyhow::{bail, Context};
 use log::debug;
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, MAIN_SEPARATOR};
 
 pub fn dart_build_runner(
     dart_root: &Path,
     dart_output: &Path,
+    needs_json_serializable: bool,
     fvm_install_mode: FvmInstallMode,
 ) -> anyhow::Result<()> {
     debug!("Running build_runner at dart_root={dart_root:?} dart_output={dart_output:?}");
 
     let repo = DartRepository::from_path(dart_root)?;
-    let output_filters = build_runner_output_filters(dart_root, dart_output)?;
+    let output_filters = build_runner_output_filters(
+        dart_root,
+        dart_output,
+        &get_dart_package_name(dart_root)?,
+        needs_json_serializable,
+    )?;
+    let args = build_runner_args(output_filters);
     let out = command_run!(
         call_shell[Some(dart_root), Some(ExecuteCommandOptions {
             envs: Some(dart_run_extra_env()),
@@ -27,12 +35,7 @@ pub fn dart_build_runner(
         ?command_arg_maybe_fvm(Some(dart_root), fvm_install_mode),
         *repo.toolchain.as_run_command(),
         *repo.command_extra_args(),
-        "run",
-        "build_runner",
-        "build",
-        "--delete-conflicting-outputs",
-        *output_filters,
-        "--enable-experiment=class-modifiers",
+        *args,
     )?;
     if !out.status.success() {
         // This will stop the whole generator and tell the users, so we do not care about testing it
@@ -57,36 +60,119 @@ pub(super) fn dart_run_extra_env() -> HashMap<String, String> {
 fn build_runner_output_filters(
     dart_root: &Path,
     dart_output: &Path,
+    dart_package_name: &str,
+    needs_json_serializable: bool,
 ) -> anyhow::Result<Vec<String>> {
     let relative_output = dart_output.strip_prefix(dart_root).with_context(|| {
         format!("dart_output={dart_output:?} must be within dart_root={dart_root:?}")
     })?;
-    let relative_output = path_to_string(relative_output)?.replace('\\', "/");
-    let output_prefix = if relative_output.is_empty() {
-        String::new()
-    } else {
-        format!("{relative_output}/")
-    };
+    let relative_output = path_to_string(relative_output)?.replace(MAIN_SEPARATOR, "/");
+    let output_prefix = build_filter_output_prefix(&relative_output, dart_package_name)?;
 
-    Ok(["freezed.dart", "g.dart"]
+    let mut extensions = vec!["freezed.dart"];
+    if needs_json_serializable {
+        extensions.push("g.dart");
+    }
+
+    Ok(extensions
+        .into_iter()
         .map(|extension| format!("--build-filter={output_prefix}**.{extension}"))
-        .to_vec())
+        .collect())
+}
+
+fn build_runner_args(output_filters: Vec<String>) -> Vec<String> {
+    [
+        vec![
+            "run".to_owned(),
+            "build_runner".to_owned(),
+            "build".to_owned(),
+            "--delete-conflicting-outputs".to_owned(),
+        ],
+        output_filters,
+    ]
+    .concat()
+}
+
+fn build_filter_output_prefix(
+    relative_output: &str,
+    dart_package_name: &str,
+) -> anyhow::Result<String> {
+    if relative_output.is_empty() {
+        return Ok(String::new());
+    }
+
+    if let Some(library_output) = relative_output.strip_prefix("lib/") {
+        return Ok(format!(
+            "package:{dart_package_name}/{}/",
+            quote_package_glob_uri_path(library_output)
+        ));
+    }
+
+    if relative_output == "lib" {
+        return Ok(format!("package:{dart_package_name}/"));
+    }
+
+    if relative_output.bytes().all(|byte| {
+        byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~' | b'/')
+    }) {
+        return Ok(format!("{relative_output}/"));
+    }
+
+    bail!(
+        "dart_output path outside lib contains characters that build_runner 1.7 cannot represent safely: {relative_output:?}"
+    )
+}
+
+fn quote_package_glob_uri_path(path: &str) -> String {
+    let mut quoted = String::with_capacity(path.len());
+    for character in path.chars() {
+        if matches!(
+            character,
+            '*' | '{' | '[' | '?' | '\\' | '}' | ']' | ',' | '-' | '(' | ')'
+        ) {
+            quoted.push('\\');
+        }
+        quoted.push(character);
+    }
+
+    percent_encode_uri_path(&quoted)
+}
+
+fn percent_encode_uri_path(path: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+
+    let mut encoded = String::with_capacity(path.len());
+    for byte in path.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~' | b'/') {
+            encoded.push(byte as char);
+        } else {
+            encoded.push('%');
+            encoded.push(HEX[(byte >> 4) as usize] as char);
+            encoded.push(HEX[(byte & 0x0f) as usize] as char);
+        }
+    }
+    encoded
 }
 
 #[cfg(test)]
 mod tests {
-    use super::build_runner_output_filters;
+    use super::{build_runner_args, build_runner_output_filters};
     use std::path::Path;
 
     /// Limits build runner to generated outputs beneath a nested Dart output directory.
     #[test]
     fn test_build_runner_output_filters_nested_output() {
         assert_eq!(
-            build_runner_output_filters(Path::new("/project"), Path::new("/project/lib/src/rust"),)
-                .unwrap(),
+            build_runner_output_filters(
+                Path::new("/project"),
+                Path::new("/project/lib/src/rust"),
+                "example",
+                true,
+            )
+            .unwrap(),
             vec![
-                "--build-filter=lib/src/rust/**.freezed.dart",
-                "--build-filter=lib/src/rust/**.g.dart",
+                "--build-filter=package:example/src/rust/**.freezed.dart",
+                "--build-filter=package:example/src/rust/**.g.dart",
             ]
         );
     }
@@ -95,8 +181,29 @@ mod tests {
     #[test]
     fn test_build_runner_output_filters_root_output() {
         assert_eq!(
-            build_runner_output_filters(Path::new("/project"), Path::new("/project")).unwrap(),
-            vec!["--build-filter=**.freezed.dart", "--build-filter=**.g.dart"]
+            build_runner_output_filters(
+                Path::new("/project"),
+                Path::new("/project"),
+                "example",
+                false,
+            )
+            .unwrap(),
+            vec!["--build-filter=**.freezed.dart"]
+        );
+    }
+
+    /// Escapes glob metacharacters and URI delimiters in the literal output directory.
+    #[test]
+    fn test_build_runner_output_filters_metacharacter_output() {
+        assert_eq!(
+            build_runner_output_filters(
+                Path::new("/project"),
+                Path::new("/project/lib/generated[foo] #bar?"),
+                "example",
+                false,
+            )
+            .unwrap(),
+            vec!["--build-filter=package:example/generated%5C%5Bfoo%5C%5D%20%23bar%5C%3F/**.freezed.dart"]
         );
     }
 
@@ -106,9 +213,40 @@ mod tests {
         let error = build_runner_output_filters(
             Path::new("/project/dart"),
             Path::new("/project/generated"),
+            "example",
+            false,
         )
         .unwrap_err();
 
         assert!(error.to_string().contains("must be within dart_root"));
+    }
+
+    /// Rejects an unsafe relative URI when build_runner cannot decode it as a package path.
+    #[test]
+    fn test_build_runner_output_filters_metacharacter_output_outside_lib() {
+        let error = build_runner_output_filters(
+            Path::new("/project"),
+            Path::new("/project/generated[foo]"),
+            "example",
+            false,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("cannot represent safely"));
+    }
+
+    /// Constructs a build_runner command supported by the declared minimum version.
+    #[test]
+    fn test_build_runner_args() {
+        assert_eq!(
+            build_runner_args(vec!["--build-filter=lib/**.freezed.dart".to_owned()]),
+            vec![
+                "run",
+                "build_runner",
+                "build",
+                "--delete-conflicting-outputs",
+                "--build-filter=lib/**.freezed.dart",
+            ]
+        );
     }
 }

--- a/tools/frb_internal/lib/src/makefile_dart/lint.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/lint.dart
@@ -182,7 +182,7 @@ Future<void> lintDartAnalyze(LintConfig config) async {
 }
 
 Future<void> lintDartPana(LintConfig config) async {
-  await exec('flutter pub global activate pana');
+  await exec('flutter pub global activate pana 0.23.17');
   for (final package in kDartPublishedPackages) {
     final exitCodeThreshold = kDartPanaExitCodeThresholdByPackage[package]!;
     await exec(

--- a/tools/frb_internal/lib/src/makefile_dart/lint.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/lint.dart
@@ -182,7 +182,7 @@ Future<void> lintDartAnalyze(LintConfig config) async {
 }
 
 Future<void> lintDartPana(LintConfig config) async {
-  await exec('flutter pub global activate pana 0.23.17');
+  await exec('flutter pub global activate pana');
   for (final package in kDartPublishedPackages) {
     final exitCodeThreshold = kDartPanaExitCodeThresholdByPackage[package]!;
     await exec(

--- a/website/docs/manual/troubleshooting.md
+++ b/website/docs/manual/troubleshooting.md
@@ -68,7 +68,7 @@ You can install llvm using `brew install llvm` and it will be installed at `/usr
 
 With automatic `build_runner` invocation enabled, code generation runs `build_runner` 1.7.0 or newer for required `.freezed.dart` outputs and, when JSON serialization is needed, `.g.dart` outputs under the configured `dart_output` directory. If those files seem outdated, ensure `build_runner`, `freezed`, and the corresponding annotations are installed.
 
-Run `build_runner` separately when the Dart package contains unrelated builders whose outputs live outside `dart_output`. The automatic invocation is intentionally scoped to FRB-generated outputs so unrelated builders do not slow down Rust-to-Dart code generation.
+Run `build_runner` separately when the Dart package contains unrelated builders whose outputs live outside `dart_output`. The automatic invocation uses output filters to scope work to FRB-generated outputs. For non-library output paths that build_runner 1.7 cannot represent safely as filters, it falls back to an unfiltered build to preserve generation correctness.
 
 Related: https://github.com/fzyzcjy/flutter_rust_bridge/issues/330
 

--- a/website/docs/manual/troubleshooting.md
+++ b/website/docs/manual/troubleshooting.md
@@ -66,7 +66,9 @@ You can install llvm using `brew install llvm` and it will be installed at `/usr
 
 ## Freezed file is sometimes not generated when it should be
 
-If your `.freezed.dart` or `.g.dart` seems outdated, ensure you have run the `build_runner`.
+Code generation automatically runs `build_runner` for `.freezed.dart` and `.g.dart` outputs under the configured `dart_output` directory. If those files seem outdated, ensure `build_runner`, `freezed`, and the corresponding annotations are installed.
+
+Run `build_runner` separately when the Dart package contains unrelated builders whose outputs live outside `dart_output`. The automatic invocation is intentionally scoped to FRB-generated outputs so unrelated builders do not slow down Rust-to-Dart code generation.
 
 Related: https://github.com/fzyzcjy/flutter_rust_bridge/issues/330
 

--- a/website/docs/manual/troubleshooting.md
+++ b/website/docs/manual/troubleshooting.md
@@ -66,7 +66,7 @@ You can install llvm using `brew install llvm` and it will be installed at `/usr
 
 ## Freezed file is sometimes not generated when it should be
 
-Code generation automatically runs `build_runner` for `.freezed.dart` and `.g.dart` outputs under the configured `dart_output` directory. If those files seem outdated, ensure `build_runner`, `freezed`, and the corresponding annotations are installed.
+Code generation automatically runs `build_runner` 1.7.0 or newer for `.freezed.dart` and `.g.dart` outputs under the configured `dart_output` directory. If those files seem outdated, ensure `build_runner`, `freezed`, and the corresponding annotations are installed.
 
 Run `build_runner` separately when the Dart package contains unrelated builders whose outputs live outside `dart_output`. The automatic invocation is intentionally scoped to FRB-generated outputs so unrelated builders do not slow down Rust-to-Dart code generation.
 

--- a/website/docs/manual/troubleshooting.md
+++ b/website/docs/manual/troubleshooting.md
@@ -66,7 +66,7 @@ You can install llvm using `brew install llvm` and it will be installed at `/usr
 
 ## Freezed file is sometimes not generated when it should be
 
-Code generation automatically runs `build_runner` 1.7.0 or newer for `.freezed.dart` and `.g.dart` outputs under the configured `dart_output` directory. If those files seem outdated, ensure `build_runner`, `freezed`, and the corresponding annotations are installed.
+With automatic `build_runner` invocation enabled, code generation runs `build_runner` 1.7.0 or newer for required `.freezed.dart` outputs and, when JSON serialization is needed, `.g.dart` outputs under the configured `dart_output` directory. If those files seem outdated, ensure `build_runner`, `freezed`, and the corresponding annotations are installed.
 
 Run `build_runner` separately when the Dart package contains unrelated builders whose outputs live outside `dart_output`. The automatic invocation is intentionally scoped to FRB-generated outputs so unrelated builders do not slow down Rust-to-Dart code generation.
 


### PR DESCRIPTION
Close #3299

## Summary

- Restrict the automatic `build_runner` invocation to `.freezed.dart` and `.g.dart` outputs beneath the configured `dart_output` directory.
- Require `build_runner` 1.7.0 or newer because output filters were introduced in that release.
- Document that unrelated Dart builders must be run separately.

## Reproduction

- Baseline commit: `576ea02e11423196b4ee7309210f505547ba286c`
- Reproduction PR: #3342
- Baseline evidence: https://gist.github.com/fzyzcjy/497aede299e9e81de7648b6a15e31ace
- Steps:
  - Add an FRB complex enum that requires Freezed under `frb_example/dart_minimal`.
  - Add an unrelated JSON-serializable Dart model outside the configured `lib/src/rust` output directory.
  - Run FRB code generation.
- Observed before the fix:
  - The required `minimal.freezed.dart` output was generated.
  - The unrelated `unrelated_model.g.dart` output was also generated, proving that FRB ran builders across the whole Dart package.
  - Direct comparison in the same Docker environment took 20.160 seconds for an unfiltered cold run, 16.931 seconds for an unfiltered cached run, and 1.867 seconds for a filtered cached run.
- Expected after the fix:
  - Required Freezed/JSON outputs beneath `dart_output` are generated.
  - Outputs from unrelated builders outside `dart_output` are not generated by FRB code generation.
- Fix execution evidence: https://gist.github.com/fzyzcjy/1ad1e8593bea4485917227c8b9bc00af

The timing reported in #3299 remains environment- and project-dependent. This change removes the deterministic amplification from unrelated package builders; it does not eliminate `build_runner` cold-start cost.

## Validation

- Manual regression through the real FRB code-generation command: required Freezed output present; unrelated JSON output absent.
- Focused Rust regression: 4 passed, 0 failed.
- `./frb_internal test-rust-package --package frb_codegen`: 181 library tests, 13 binary tests, and 1 doc test passed.
- `./frb_internal test-dart-native --package frb_example/pure_dart`: all tests passed.
- `./frb_internal test-dart-native --package frb_example/pure_dart_pde`: all tests passed.
- `./frb_internal precommit-generate`: passed with no generated drift.
- `./frb_internal generate-internal-rust`: passed with no generated drift.
- `./frb_internal lint --fix`: passed; final worktree remained clean.
- Independent correctness review: no unresolved actionable findings.
- Independent test-weakening review: 0 findings; doc compliance: 4 OK.
