### PR TITLE
Reproduce idle RustStreamSink cancellation hang in E2E tests

### DIFF
--- a/frb_dart/test/stream_sink_test.dart
+++ b/frb_dart/test/stream_sink_test.dart
@@ -1,19 +1,7 @@
 import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
-import 'package:flutter_rust_bridge/src/codec/dco.dart';
 import 'package:test/test.dart';
 
 void main() {
-  RustStreamSink<int> createSink() {
-    final sink = RustStreamSink<int>();
-    sink.setupAndSerialize(
-      codec: DcoCodec<int, Exception>(
-        decodeSuccessData: (raw) => raw as int,
-        decodeErrorData: null,
-      ),
-    );
-    return sink;
-  }
-
   test('RustStreamSink stream before setup throws actionable StateError', () {
     expect(
       () => RustStreamSink<int>().stream,
@@ -29,18 +17,4 @@ void main() {
       ),
     );
   });
-
-  test(
-    'cancelling an idle subscription completes even after it is suspended',
-    () async {
-      final sink = createSink();
-      final subscription = sink.stream.listen((_) {});
-      // Give the underlying port subscription time to settle so it is genuinely
-      // waiting for the next (never arriving) message, which is the scenario that
-      // used to deadlock cancel().
-      await Future<void>.delayed(const Duration(milliseconds: 10));
-
-      await subscription.cancel().timeout(const Duration(seconds: 1));
-    },
-  );
 }

--- a/frb_dart/test/stream_sink_test.dart
+++ b/frb_dart/test/stream_sink_test.dart
@@ -1,7 +1,19 @@
 import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
+import 'package:flutter_rust_bridge/src/codec/dco.dart';
 import 'package:test/test.dart';
 
 void main() {
+  RustStreamSink<int> createSink() {
+    final sink = RustStreamSink<int>();
+    sink.setupAndSerialize(
+      codec: DcoCodec<int, Exception>(
+        decodeSuccessData: (raw) => raw as int,
+        decodeErrorData: null,
+      ),
+    );
+    return sink;
+  }
+
   test('RustStreamSink stream before setup throws actionable StateError', () {
     expect(
       () => RustStreamSink<int>().stream,
@@ -17,4 +29,18 @@ void main() {
       ),
     );
   });
+
+  test(
+    'cancelling an idle subscription completes even after it is suspended',
+    () async {
+      final sink = createSink();
+      final subscription = sink.stream.listen((_) {});
+      // Give the underlying port subscription time to settle so it is genuinely
+      // waiting for the next (never arriving) message, which is the scenario that
+      // used to deadlock cancel().
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      await subscription.cancel().timeout(const Duration(seconds: 1));
+    },
+  );
 }

--- a/frb_example/pure_dart/rust/src/api/event_listener.rs
+++ b/frb_example/pure_dart/rust/src/api/event_listener.rs
@@ -43,7 +43,9 @@ pub fn close_event_listener_twin_normal() {
 pub fn create_event_twin_normal(address: String, payload: String) {
     if let Ok(mut guard) = EVENTS.lock() {
         if let Some(sink) = guard.as_mut() {
-            sink.add(EventTwinNormal { address, payload }).unwrap();
+            // The Dart subscription may already be cancelled (which closes the
+            // receive port), so a failed `add` is expected, not a bug.
+            let _ = sink.add(EventTwinNormal { address, payload });
         }
     }
 }
@@ -54,7 +56,9 @@ pub fn create_event_twin_normal(address: String, payload: String) {
 pub fn create_event_sync_twin_normal(address: String, payload: String) {
     if let Ok(mut guard) = EVENTS.lock() {
         if let Some(sink) = guard.as_mut() {
-            sink.add(EventTwinNormal { address, payload }).unwrap();
+            // The Dart subscription may already be cancelled (which closes the
+            // receive port), so a failed `add` is expected, not a bug.
+            let _ = sink.add(EventTwinNormal { address, payload });
         }
     }
 }

--- a/frb_example/pure_dart/rust/src/api/pseudo_manual/event_listener_twin_rust_async.rs
+++ b/frb_example/pure_dart/rust/src/api/pseudo_manual/event_listener_twin_rust_async.rs
@@ -49,7 +49,9 @@ pub async fn close_event_listener_twin_rust_async() {
 pub async fn create_event_twin_rust_async(address: String, payload: String) {
     if let Ok(mut guard) = EVENTS.lock() {
         if let Some(sink) = guard.as_mut() {
-            sink.add(EventTwinRustAsync { address, payload }).unwrap();
+            // The Dart subscription may already be cancelled (which closes the
+            // receive port), so a failed `add` is expected, not a bug.
+            let _ = sink.add(EventTwinRustAsync { address, payload });
         }
     }
 }

--- a/frb_example/pure_dart/rust/src/api/pseudo_manual/event_listener_twin_rust_async_sse.rs
+++ b/frb_example/pure_dart/rust/src/api/pseudo_manual/event_listener_twin_rust_async_sse.rs
@@ -54,8 +54,9 @@ pub async fn close_event_listener_twin_rust_async_sse() {
 pub async fn create_event_twin_rust_async_sse(address: String, payload: String) {
     if let Ok(mut guard) = EVENTS.lock() {
         if let Some(sink) = guard.as_mut() {
-            sink.add(EventTwinRustAsyncSse { address, payload })
-                .unwrap();
+            // The Dart subscription may already be cancelled (which closes the
+            // receive port), so a failed `add` is expected, not a bug.
+            let _ = sink.add(EventTwinRustAsyncSse { address, payload });
         }
     }
 }

--- a/frb_example/pure_dart/rust/src/api/pseudo_manual/event_listener_twin_sse.rs
+++ b/frb_example/pure_dart/rust/src/api/pseudo_manual/event_listener_twin_sse.rs
@@ -54,7 +54,9 @@ pub fn close_event_listener_twin_sse() {
 pub fn create_event_twin_sse(address: String, payload: String) {
     if let Ok(mut guard) = EVENTS.lock() {
         if let Some(sink) = guard.as_mut() {
-            sink.add(EventTwinSse { address, payload }).unwrap();
+            // The Dart subscription may already be cancelled (which closes the
+            // receive port), so a failed `add` is expected, not a bug.
+            let _ = sink.add(EventTwinSse { address, payload });
         }
     }
 }

--- a/frb_example/pure_dart/test/api/event_listener_test.dart
+++ b/frb_example/pure_dart/test/api/event_listener_test.dart
@@ -47,7 +47,10 @@ Future<void> main({bool skipRustLibInit = false}) async {
     await Future.delayed(Duration.zero);
     final subscription = stream.listen((_) {});
     await Future.delayed(Duration.zero);
-    unawaited(subscription.cancel());
+    // Cancelling must complete promptly even though Rust never sends another
+    // event nor closes the stream (regression for the idle-cancel deadlock).
+    await subscription.cancel().timeout(const Duration(seconds: 5));
+    // Rust sending after the Dart side already cancelled must not crash.
     createEventSyncTwinNormal(address: '1', payload: '');
   });
   // FRB_INTERNAL_GENERATOR_DISABLE_DUPLICATOR_END

--- a/frb_example/pure_dart_pde/rust/src/api/event_listener.rs
+++ b/frb_example/pure_dart_pde/rust/src/api/event_listener.rs
@@ -45,7 +45,9 @@ pub fn close_event_listener_twin_normal() {
 pub fn create_event_twin_normal(address: String, payload: String) {
     if let Ok(mut guard) = EVENTS.lock() {
         if let Some(sink) = guard.as_mut() {
-            sink.add(EventTwinNormal { address, payload }).unwrap();
+            // The Dart subscription may already be cancelled (which closes the
+            // receive port), so a failed `add` is expected, not a bug.
+            let _ = sink.add(EventTwinNormal { address, payload });
         }
     }
 }
@@ -56,7 +58,9 @@ pub fn create_event_twin_normal(address: String, payload: String) {
 pub fn create_event_sync_twin_normal(address: String, payload: String) {
     if let Ok(mut guard) = EVENTS.lock() {
         if let Some(sink) = guard.as_mut() {
-            sink.add(EventTwinNormal { address, payload }).unwrap();
+            // The Dart subscription may already be cancelled (which closes the
+            // receive port), so a failed `add` is expected, not a bug.
+            let _ = sink.add(EventTwinNormal { address, payload });
         }
     }
 }

--- a/frb_example/pure_dart_pde/rust/src/api/pseudo_manual/event_listener_twin_rust_async.rs
+++ b/frb_example/pure_dart_pde/rust/src/api/pseudo_manual/event_listener_twin_rust_async.rs
@@ -51,7 +51,9 @@ pub async fn close_event_listener_twin_rust_async() {
 pub async fn create_event_twin_rust_async(address: String, payload: String) {
     if let Ok(mut guard) = EVENTS.lock() {
         if let Some(sink) = guard.as_mut() {
-            sink.add(EventTwinRustAsync { address, payload }).unwrap();
+            // The Dart subscription may already be cancelled (which closes the
+            // receive port), so a failed `add` is expected, not a bug.
+            let _ = sink.add(EventTwinRustAsync { address, payload });
         }
     }
 }

--- a/frb_example/pure_dart_pde/test/api/event_listener_test.dart
+++ b/frb_example/pure_dart_pde/test/api/event_listener_test.dart
@@ -49,7 +49,10 @@ Future<void> main({bool skipRustLibInit = false}) async {
     await Future.delayed(Duration.zero);
     final subscription = stream.listen((_) {});
     await Future.delayed(Duration.zero);
-    unawaited(subscription.cancel());
+    // Cancelling must complete promptly even though Rust never sends another
+    // event nor closes the stream (regression for the idle-cancel deadlock).
+    await subscription.cancel().timeout(const Duration(seconds: 5));
+    // Rust sending after the Dart side already cancelled must not crash.
     createEventSyncTwinNormal(address: '1', payload: '');
   });
   // FRB_INTERNAL_GENERATOR_DISABLE_DUPLICATOR_END


### PR DESCRIPTION
## Purpose

- Isolate the Rust↔Dart end-to-end regression coverage for #3311 against the current `master` implementation.
- Keep the `RustStreamSink` production fix out of this PR.
- Intentionally leave CI red at the idle `StreamSubscription.cancel()` timeout.

## End-to-end reproduction

- Initialize the real generated library with `RustLib.init()`.
- Call the generated `registerEventListenerTwinNormal()` API, backed by a Rust `StreamSink` stored by the example crate.
- Listen without Rust sending an event or closing the stream.
- Await `subscription.cancel()` with a five-second timeout.
- After cancellation succeeds with #3311, call the generated sync Rust API once more; the example fixture treats the closed receive port as expected.

The canonical changes live under `frb_example/pure_dart`; the repository generator produces the matching twin and `pure_dart_pde` variants. The previous `frb_dart`-only unit reproduction is removed from the net diff.

Observed locally with the full native E2E command:

```text
$ ./frb_internal test-dart-native --package frb_example/pure_dart
test/api/event_listener_test.dart: when Rust send event after Dart close stream [E]
TimeoutException after 0:00:05.000000: Future not completed
test/api/event_listener_test.dart 52:5  main.<fn>
+4374 ~4 -1: Some tests failed.
```

This was the suite's only failure. The command compiled and loaded the real `frb_example_pure_dart` Rust crate before running the Dart tests. Both E2E test files pass Dart format/analyze, both Rust fixtures pass `cargo fmt --check`, and a second internal generation produced no diff.

Expected after applying #3311: cancellation completes promptly while the Rust side is idle, then the post-cancel Rust send returns without crashing the fixture.

## CI expectation

This PR is intentionally failing. A `frb_example--pure_dart` or `frb_example--pure_dart_pde` E2E job should fail at `test/api/event_listener_test.dart: when Rust send event after Dart close stream` with the same five-second `TimeoutException`. A `frb_dart` unit-test failure, compilation failure, or unrelated failure is not the intended reproduction.

## Confirmed focused E2E CI reproduction

- Filter: `test_dart_native[image=ubuntu-24.04,package=frb_example--pure_dart]`
- Run: [CI #31298269214](https://github.com/fzyzcjy/flutter_rust_bridge/actions/runs/31298269214)
- Job: [Test :: Dart :: Native (ubuntu-24.04, frb_example--pure_dart)](https://github.com/fzyzcjy/flutter_rust_bridge/actions/runs/31298269214/job/93209655196)
- The job compiled `frb_example_pure_dart` in the optimized release profile and ran the generated Rust↔Dart E2E suite.
- Sole failing test: `test/api/event_listener_test.dart: when Rust send event after Dart close stream`
- Error: `TimeoutException after 0:00:05.000000: Future not completed` at line 52.
- Summary: `4374 tests passed, 1 failed, 4 skipped`.
