### PR TITLE
Reproduce ffigen 21 struct removal failure with intentional red CI

### DIFF
--- a/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/wire_class/io/via_ffigen.rs
+++ b/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/wire_class/io/via_ffigen.rs
@@ -81,3 +81,46 @@ fn sanity_check(
     );
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn postpare_modify_removes_ffigen_21_wire_sync_struct() {
+        let output = postpare_modify(
+            r#"
+class RustLibWire {
+}
+
+final class WireSyncRust2DartSse extends ffi.Struct {
+  external ffi.Pointer<ffi.Uint8> ptr;
+
+  @ffi.Int32()
+  external int len;
+
+  static ffi.Pointer<WireSyncRust2DartSse> $allocate(
+    ffi.Allocator $allocator, {
+    required ffi.Pointer<ffi.Uint8> ptr,
+    required int len,
+  }) => $allocator<WireSyncRust2DartSse>()
+    ..ref.ptr = ptr
+    ..ref.len = len;
+}
+"#,
+            &DartOutputClassNamePack {
+                entrypoint_class_name: "RustLib".to_owned(),
+                api_class_name: "RustLibApi".to_owned(),
+                api_impl_class_name: "RustLibApiImpl".to_owned(),
+                api_impl_platform_class_name: "RustLibApiImplPlatform".to_owned(),
+                wire_class_name: "RustLibWire".to_owned(),
+                wasm_module_name: "RustLibWasmModule".to_owned(),
+            },
+        );
+
+        assert!(
+            !output.contains("..ref.ptr = ptr"),
+            "ffigen 21 class fragment remains and causes expected_executable parser errors:\n{output}"
+        );
+    }
+}


### PR DESCRIPTION
## Purpose

- This is an intentional reproduction PR for #3350, not a fix.
- It adds the ffigen 21 `WireSyncRust2DartSse` class shape as a generator unit test.
- The test must remain red on the unfixed baseline.

## Reproduction

Baseline commit: `0ac5759ee323e981abc2585743934fbd77b78e5a`

Steps:

1. Apply commit `50bfa9758190c0edcd11ed3119eb3b99d66caae9`.
2. Run:

   ```bash
   .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- bash -lc './frb_internal test-rust-package --package frb_codegen'
   ```

Observed:

```text
ffigen 21 class fragment remains and causes expected_executable parser errors:
) => $allocator<WireSyncRust2DartSse>()
    ..ref.ptr = ptr
    ..ref.len = len;
}

test result: FAILED. 177 passed; 1 failed
```

Expected:

- FRB removes the entire ffigen-generated `WireSyncRust2DartSse` class, including the ffigen 21 `$allocate` constructor.
- No dangling expression body remains in generated Dart.

## Intentional red CI

- **Filter**: `test_rust[image=ubuntu-latest,version=nightly]`
- **Expected failing test**: `postpare_modify_removes_ffigen_21_wire_sync_struct`
- **Expected failure text**: `ffigen 21 class fragment remains and causes expected_executable parser errors`
