### PR TITLE
Reproduce Valgrind stderr false green with intentional red CI

### DIFF
--- a/tools/frb_internal/test/makefile_dart_test.dart
+++ b/tools/frb_internal/test/makefile_dart_test.dart
@@ -35,6 +35,17 @@ void main() {
     );
   });
 
+  test('dart valgrind rejects diagnostics emitted only on stderr', () {
+    const stdout = 'All tests passed!';
+    const stderr = 'definitely lost: 1 bytes';
+
+    expect(
+      () => checkValgrindOutput(stdout),
+      throwsException,
+      reason: 'Valgrind reported an error on stderr: $stderr',
+    );
+  });
+
   test('linux build bundle path follows the current machine architecture', () {
     expect(
       linuxBuildBundlePathForTesting(machineArchitecture: 'x86_64'),


### PR DESCRIPTION
## Reproduction

Baseline commit: `a294881305`

Steps:
1. Add the focused regression in `tools/frb_internal/test/makefile_dart_test.dart`.
2. Run:

```bash
cd tools/frb_internal
dart test test/makefile_dart_test.dart
```

Observed:
```text
Expected: throws <Instance of Exception>
Actual: returned <null>
Valgrind reported an error on stderr: definitely lost: 1 bytes
```

Expected:
The Valgrind wrapper must fail when Valgrind reports an error only on stderr.

## Intentional red CI

- Filter: `test_dart_native[image=ubuntu-24.04,package=tools--frb_internal]`
- Expected failing test: `dart valgrind rejects diagnostics emitted only on stderr`
- This PR is a reproducer, not a fix.