### PR TITLE
Include hooks in release readiness checks

### DIFF
--- a/.claude/skills/frb-publish-release/SKILL.md
+++ b/.claude/skills/frb-publish-release/SKILL.md
@@ -93,6 +93,7 @@ For beta versions such as `2.13.0-beta.1`, do not require the GitHub release to 
 - `frb_macros` -> crates.io package `flutter_rust_bridge_macros`
 - `frb_rust` -> crates.io package `flutter_rust_bridge`
 - `frb_dart` -> pub.dev package `flutter_rust_bridge`
+- `frb_hooks` -> pub.dev package `flutter_rust_bridge_hooks`
 
 Only use a split subcommand as a recovery path after confirming which one-shot step already completed. For example, if the version bump and GitHub release already exist and only registry publication is needed, use `.claude/skills/frb-dev-env/frb_dev_env.py docker-run-rm --with-publish-credentials -- ./frb_internal release-publish-all` directly.
 

--- a/tools/frb_internal/lib/src/makefile_dart/release.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/release.dart
@@ -188,13 +188,19 @@ Future<void> releasePublishAll() async {
   await exec('cd frb_codegen && cargo publish');
   await exec('cd frb_macros && cargo publish');
   await exec('cd frb_rust && cargo publish');
-  await exec(
-    'cd frb_dart && flutter pub publish --force --server=https://pub.dartlang.org',
-  );
-  await exec(
-    'cd frb_hooks && dart pub publish --force --server=https://pub.dartlang.org',
-  );
+  for (final package in kDartPublishedPackages) {
+    await exec(dartPublishCommand(package));
+  }
 }
+
+@visibleForTesting
+String dartPublishCommand(String package) => switch (package) {
+  'frb_dart' =>
+    'cd frb_dart && flutter pub publish --force --server=https://pub.dartlang.org',
+  'frb_hooks' =>
+    'cd frb_hooks && dart pub publish --force --server=https://pub.dartlang.org',
+  _ => throw ArgumentError.value(package, 'package'),
+};
 
 void verifyReleaseSubmodules({String? repoRoot, String? submoduleStatus}) {
   final status =

--- a/tools/frb_internal/lib/src/makefile_dart/released_version.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/released_version.dart
@@ -7,10 +7,9 @@ import 'package:args/command_runner.dart';
 import 'package:build_cli_annotations/build_cli_annotations.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_rust_bridge_internal/src/makefile_dart/consts.dart';
-import 'package:flutter_rust_bridge_internal/src/makefile_dart/release.dart'
-    show getFrbDartVersion;
 import 'package:flutter_rust_bridge_internal/src/utils/makefile_dart_infra.dart';
 import 'package:toml/toml.dart';
+import 'package:yaml/yaml.dart';
 
 part 'released_version.g.dart';
 
@@ -68,13 +67,19 @@ class ReleasePackageStatus {
 }
 
 typedef ReleaseMetadataFetcher = Future<Map<String, dynamic>> Function(Uri uri);
+typedef DartPackageManifestFetcher = String Function(String package);
 
 Future<List<ReleasePackageStatus>> fetchReleasePackageStatuses({
   String? targetVersion,
   ReleaseMetadataFetcher fetcher = _defaultReleaseMetadataFetcher,
+  DartPackageManifestFetcher dartPackageManifestFetcher =
+      _defaultDartPackageManifestFetcher,
 }) async {
   final rustVersion = targetVersion ?? getWorkspaceRustVersion();
-  final dartVersion = targetVersion ?? getFrbDartVersion();
+  final dartPackages = [
+    for (final package in kDartPublishedPackages)
+      parseDartPackageManifest(dartPackageManifestFetcher(package)),
+  ];
 
   return [
     for (final package in [
@@ -91,14 +96,14 @@ Future<List<ReleasePackageStatus>> fetchReleasePackageStatuses({
           fetcher: fetcher,
         ),
       ),
-    for (final package in ['flutter_rust_bridge', 'flutter_rust_bridge_hooks'])
+    for (final package in dartPackages)
       ReleasePackageStatus(
         registry: 'pub.dev',
-        name: package,
-        manifestVersion: dartVersion,
+        name: package.name,
+        manifestVersion: targetVersion ?? package.version,
         releasedVersion: await fetchPubDevReleasedVersion(
-          package,
-          targetVersion: dartVersion,
+          package.name,
+          targetVersion: targetVersion ?? package.version,
           fetcher: fetcher,
         ),
       ),
@@ -149,6 +154,14 @@ Set<String> pubDevVersions(Map<String, dynamic> json) =>
         .map((version) => version['version'])
         .whereType<String>()
         .toSet();
+
+({String name, String version}) parseDartPackageManifest(String raw) {
+  final yaml = loadYaml(raw) as Map<Object?, Object?>;
+  return (name: yaml['name'] as String, version: yaml['version'] as String);
+}
+
+String _defaultDartPackageManifestFetcher(String package) =>
+    File('${exec.pwd}$package/pubspec.yaml').readAsStringSync();
 
 Future<Map<String, dynamic>> _defaultReleaseMetadataFetcher(Uri uri) async {
   final response = await Dio().getUri<Map<String, dynamic>>(uri);

--- a/tools/frb_internal/lib/src/makefile_dart/released_version.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/released_version.dart
@@ -91,16 +91,17 @@ Future<List<ReleasePackageStatus>> fetchReleasePackageStatuses({
           fetcher: fetcher,
         ),
       ),
-    ReleasePackageStatus(
-      registry: 'pub.dev',
-      name: 'flutter_rust_bridge',
-      manifestVersion: dartVersion,
-      releasedVersion: await fetchPubDevReleasedVersion(
-        'flutter_rust_bridge',
-        targetVersion: dartVersion,
-        fetcher: fetcher,
+    for (final package in ['flutter_rust_bridge', 'flutter_rust_bridge_hooks'])
+      ReleasePackageStatus(
+        registry: 'pub.dev',
+        name: package,
+        manifestVersion: dartVersion,
+        releasedVersion: await fetchPubDevReleasedVersion(
+          package,
+          targetVersion: dartVersion,
+          fetcher: fetcher,
+        ),
       ),
-    ),
   ];
 }
 

--- a/tools/frb_internal/test/makefile_dart_test.dart
+++ b/tools/frb_internal/test/makefile_dart_test.dart
@@ -82,6 +82,13 @@ void main() {
     expect(File(releaseCargoLockTemplatePathForTesting()).existsSync(), true);
   });
 
+  test('release publishes every shared Dart package', () {
+    expect(kDartPublishedPackages.map(dartPublishCommand), [
+      'cd frb_dart && flutter pub publish --force --server=https://pub.dartlang.org',
+      'cd frb_hooks && dart pub publish --force --server=https://pub.dartlang.org',
+    ]);
+  });
+
   test('release guard rejects uninitialized submodules', () {
     expect(
       () => verifyReleaseSubmodules(

--- a/tools/frb_internal/test/makefile_dart_test.dart
+++ b/tools/frb_internal/test/makefile_dart_test.dart
@@ -631,8 +631,80 @@ plain
         statuses.map((status) => status.manifestVersion),
         everyElement('9.9.9'),
       );
+      expect(statuses.map((status) => (status.registry, status.name)), [
+        ('crates.io', 'flutter_rust_bridge_codegen'),
+        ('crates.io', 'flutter_rust_bridge_macros'),
+        ('crates.io', 'flutter_rust_bridge'),
+        ('pub.dev', 'flutter_rust_bridge'),
+        ('pub.dev', 'flutter_rust_bridge_hooks'),
+      ]);
       expect(statuses.map((status) => status.isReleased), everyElement(true));
     });
+
+    test(
+      'reports hooks as unreleased when its target version is absent',
+      () async {
+        final statuses = await fetchReleasePackageStatuses(
+          targetVersion: '9.9.9',
+          fetcher: (uri) async {
+            if (uri.host == 'crates.io') {
+              return {
+                'crate': {'max_version': '9.9.9'},
+              };
+            }
+            if (uri.path.endsWith('/flutter_rust_bridge_hooks')) {
+              return {'versions': <Map<String, String>>[]};
+            }
+            return {
+              'versions': [
+                {'version': '9.9.9'},
+              ],
+            };
+          },
+        );
+
+        final output = buildReleasePackageStatusOutput(statuses);
+        final hooksStatus = statuses.singleWhere(
+          (status) => status.name == 'flutter_rust_bridge_hooks',
+        );
+        expect(output['allReleased'], false);
+        expect(hooksStatus.releasedVersion, isNull);
+        expect(hooksStatus.isReleased, false);
+      },
+    );
+
+    test(
+      'reports hooks as unreleased when only another version exists',
+      () async {
+        final statuses = await fetchReleasePackageStatuses(
+          targetVersion: '9.9.9',
+          fetcher: (uri) async {
+            if (uri.host == 'crates.io') {
+              return {
+                'crate': {'max_version': '9.9.9'},
+              };
+            }
+            final version = uri.path.endsWith('/flutter_rust_bridge_hooks')
+                ? '9.9.8'
+                : '9.9.9';
+            return {
+              'latest': {'version': version},
+              'versions': [
+                {'version': version},
+              ],
+            };
+          },
+        );
+
+        final output = buildReleasePackageStatusOutput(statuses);
+        final hooksStatus = statuses.singleWhere(
+          (status) => status.name == 'flutter_rust_bridge_hooks',
+        );
+        expect(output['allReleased'], false);
+        expect(hooksStatus.releasedVersion, '9.9.8');
+        expect(hooksStatus.isReleased, false);
+      },
+    );
 
     test(
       'uses local Dart manifest version as pub.dev target version',
@@ -656,11 +728,18 @@ plain
           },
         );
 
-        final pubDevStatus = statuses.singleWhere(
+        final pubDevStatuses = statuses.where(
           (status) => status.registry == 'pub.dev',
         );
-        expect(pubDevStatus.releasedVersion, dartVersion);
-        expect(pubDevStatus.isReleased, true);
+        expect(pubDevStatuses, hasLength(2));
+        expect(
+          pubDevStatuses.map((status) => status.releasedVersion),
+          everyElement(dartVersion),
+        );
+        expect(
+          pubDevStatuses.map((status) => status.isReleased),
+          everyElement(true),
+        );
       },
     );
   });

--- a/tools/frb_internal/test/makefile_dart_test.dart
+++ b/tools/frb_internal/test/makefile_dart_test.dart
@@ -707,22 +707,36 @@ plain
     );
 
     test(
-      'uses local Dart manifest version as pub.dev target version',
+      'uses each local Dart manifest version as its pub.dev target',
       () async {
         final rustVersion = getWorkspaceRustVersion();
-        final dartVersion = getFrbDartVersion();
 
         final statuses = await fetchReleasePackageStatuses(
+          dartPackageManifestFetcher: (package) => switch (package) {
+            'frb_dart' =>
+              '''
+name: flutter_rust_bridge
+version: 9.9.9
+''',
+            'frb_hooks' =>
+              '''
+name: flutter_rust_bridge_hooks
+version: 9.9.8
+''',
+            _ => throw StateError('Unexpected Dart package: $package'),
+          },
           fetcher: (uri) async {
             if (uri.host == 'crates.io') {
               return {
                 'crate': {'max_version': rustVersion},
               };
             }
+            final version = uri.path.endsWith('/flutter_rust_bridge_hooks')
+                ? '9.9.8'
+                : '9.9.9';
             return {
-              'latest': {'version': '2.12.0'},
               'versions': [
-                {'version': dartVersion},
+                {'version': version},
               ],
             };
           },
@@ -733,8 +747,11 @@ plain
         );
         expect(pubDevStatuses, hasLength(2));
         expect(
-          pubDevStatuses.map((status) => status.releasedVersion),
-          everyElement(dartVersion),
+          pubDevStatuses.map((status) => (status.name, status.manifestVersion)),
+          [
+            ('flutter_rust_bridge', '9.9.9'),
+            ('flutter_rust_bridge_hooks', '9.9.8'),
+          ],
         );
         expect(
           pubDevStatuses.map((status) => status.isReleased),


### PR DESCRIPTION
## Summary

- include `flutter_rust_bridge_hooks` in release readiness checks
- read each published Dart package manifest independently
- share the published Dart package list between publishing, linting, and readiness checks
- cover missing, mismatched, manifest-specific, and fully released package states

## Reproduction

Baseline: `1cc235f8917f5169fdcfa754f7de7c05d847638b`

1. Check out the baseline commit.
2. Run:

   ```bash
   ./frb_internal get-released-version --version 2.13.0-beta.6
   ```

3. Inspect the JSON package statuses.

Observed: the result contains the three Rust crates and `flutter_rust_bridge`, but omits `flutter_rust_bridge_hooks`. Therefore `allReleased` can become true before the hooks package is available.

Expected: the result contains all five published packages, and `allReleased` remains false when the hooks target version is absent or mismatched.

## Testing

- `dart test test/makefile_dart_test.dart` (58 passed)
- `dart analyze --fatal-infos`
- `./frb_internal lint --fix`
- `frb_dart` pana: 160/160
- `frb_hooks` pana: 160/160

No code generation is required because this change only touches internal release tooling, tests, and release workflow documentation.

## Review

- adversarial correctness review: no findings
- release contract review: no findings
- architecture review: no findings after sharing the release package list
