### PR TITLE
Sync Flutter integrate lockfiles

### DIFF
--- a/frb_example/flutter_package/example/pubspec.lock
+++ b/frb_example/flutter_package/example/pubspec.lock
@@ -297,10 +297,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
+      sha256: "5f37239c4851efcef929cea7824e76df7f2f0970aef85d66bbc430afa40e72f0"
       url: "https://pub.dev"
     source: hosted
-    version: "15.2.0"
+    version: "15.3.0"
   web:
     dependency: transitive
     description:

--- a/frb_example/flutter_package_native_assets/example/pubspec.lock
+++ b/frb_example/flutter_package_native_assets/example/pubspec.lock
@@ -368,10 +368,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
+      sha256: "5f37239c4851efcef929cea7824e76df7f2f0970aef85d66bbc430afa40e72f0"
       url: "https://pub.dev"
     source: hosted
-    version: "15.2.0"
+    version: "15.3.0"
   web:
     dependency: transitive
     description:

--- a/frb_example/flutter_via_create/pubspec.lock
+++ b/frb_example/flutter_via_create/pubspec.lock
@@ -297,10 +297,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
+      sha256: "5f37239c4851efcef929cea7824e76df7f2f0970aef85d66bbc430afa40e72f0"
       url: "https://pub.dev"
     source: hosted
-    version: "15.2.0"
+    version: "15.3.0"
   web:
     dependency: transitive
     description:

--- a/frb_example/flutter_via_create_native_assets/pubspec.lock
+++ b/frb_example/flutter_via_create_native_assets/pubspec.lock
@@ -361,10 +361,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
+      sha256: "5f37239c4851efcef929cea7824e76df7f2f0970aef85d66bbc430afa40e72f0"
       url: "https://pub.dev"
     source: hosted
-    version: "15.2.0"
+    version: "15.3.0"
   web:
     dependency: transitive
     description:

--- a/frb_example/flutter_via_integrate/pubspec.lock
+++ b/frb_example/flutter_via_integrate/pubspec.lock
@@ -297,10 +297,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
+      sha256: "5f37239c4851efcef929cea7824e76df7f2f0970aef85d66bbc430afa40e72f0"
       url: "https://pub.dev"
     source: hosted
-    version: "15.2.0"
+    version: "15.3.0"
   web:
     dependency: transitive
     description:

--- a/frb_example/flutter_via_integrate_native_assets/pubspec.lock
+++ b/frb_example/flutter_via_integrate_native_assets/pubspec.lock
@@ -361,10 +361,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
+      sha256: "5f37239c4851efcef929cea7824e76df7f2f0970aef85d66bbc430afa40e72f0"
       url: "https://pub.dev"
     source: hosted
-    version: "15.2.0"
+    version: "15.3.0"
   web:
     dependency: transitive
     description:


### PR DESCRIPTION
## Reproduction

Baseline commit: `a2948813056be8ac219cfce8fc05ad87874e9577`

Steps:

1. Initialize the CargoKit submodules:

   ```bash
   git submodule update --init --recursive
   ```

2. Run the command from the failing CI job:

   ```bash
   ./frb_internal generate-run-frb-codegen-command-integrate --set-exit-if-changed --package frb_example--flutter_package_native_assets --coverage
   ```

Observed:

```text
frb_example/flutter_package_native_assets/example/pubspec.lock changes vm_service from 15.2.0 to 15.3.0, then the final git diff check fails.
```

Expected: the committed lockfiles match the current Flutter integrate output, so the command leaves no tracked diff and exits successfully.

The failure was observed in [PR #3353's generate job](https://github.com/fzyzcjy/flutter_rust_bridge/actions/runs/32559016556/job/96997636923?pr=3353). It is unrelated to that PR's implementation. The latest green workflow on `master` was created on August 16, while current `master` still contains the same stale lockfiles, so a fresh run is expected to reproduce the failure.

## Changes

- Regenerate the Flutter integrate fixtures with `./frb_internal precommit-integrate`.
- Sync `vm_service` from 15.2.0 to 15.3.0 in all six affected example lockfiles.
- Exclude the known platform xcconfig generation noise, matching the CI command.

## Validation

- `./frb_internal precommit-integrate`
- `./frb_internal generate-run-frb-codegen-command-integrate --set-exit-if-changed --package frb_example--flutter_package_native_assets --coverage`
- `./frb_internal lint --fix`
- `git diff --check origin/master...HEAD`

## Review

Reviewed the complete diff for correctness, dependency consistency, accidental test weakening, and unrelated generated changes. All six files contain the same valid `vm_service` version/checksum transition produced by the authoritative generation command; no findings.
