### PR TITLE
Reproduce pure Dart native asset loading failure with intentional red CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1105,6 +1105,9 @@ jobs:
 
       # execute
       - run: ./frb_internal test-flutter-native --flutter-test-args '--device-id ${{ matrix.info.platform }}' --package ${{ matrix.info.package }}
+      - if: matrix.info.platform == 'linux' && matrix.info.package == 'frb_example--flutter_package_native_assets--example'
+        working-directory: frb_example/flutter_package_native_assets
+        run: dart run bin/pure_dart_smoke.dart
 
   test_flutter_web:
     needs: plan_ci

--- a/frb_example/flutter_package_native_assets/bin/pure_dart_smoke.dart
+++ b/frb_example/flutter_package_native_assets/bin/pure_dart_smoke.dart
@@ -1,0 +1,10 @@
+import 'package:flutter_package_native_assets/flutter_package_native_assets.dart';
+
+Future<void> main() async {
+  await RustLib.init();
+
+  final result = greet(name: 'Tom');
+  if (result != 'Hello, Tom!') {
+    throw StateError('Unexpected greeting: $result');
+  }
+}


### PR DESCRIPTION
## Purpose

- Intentionally reproduce #3379 in a repository-owned example.
- This is not a fix PR and its focused CI is expected to fail.

## Reproduction

Baseline commit: `a2948813055d8353f142d56dea8663d655f11a7c`

Steps:

1. Add `frb_example/flutter_package_native_assets/bin/pure_dart_smoke.dart` from this PR.
2. Run:

```bash
cd frb_example/flutter_package_native_assets
dart run bin/pure_dart_smoke.dart
```

Observed:

```text
Invalid argument(s): Failed to load dynamic library 'libflutter_package_native_assets.so': libflutter_package_native_assets.so: cannot open shared object file: No such file or directory
```

Expected:

- `RustLib.init()` loads the code asset produced by the package build hook.
- `greet(name: 'Tom')` returns `Hello, Tom!`.

## Focused CI

```text
test_flutter_native_desktop[platform=linux,package=frb_example--flutter_package_native_assets--example]
```

The existing Flutter integration test should pass first. The subsequent standalone `dart run` step should fail with the dynamic-library error above.