### PR TITLE
Improve Flutter upgrade workflow

### DIFF
--- a/.claude/skills/frb-upgrade-flutter/SKILL.md
+++ b/.claude/skills/frb-upgrade-flutter/SKILL.md
@@ -5,236 +5,151 @@ description: >-
   devcontainer Docker images, CI/post-release pins, generated Flutter scaffolds, or platform compatibility.
 ---
 
-# FRB Upgrade Flutter
+# 1 Start here
 
-Use this as the single-file workflow for Flutter stable bumps in `flutter_rust_bridge`.
+- Confirm the target Flutter stable release from official Flutter sources.
+- Read `frb-dev-env` before running setup, generation, lint, or tests. Use its per-worktree local Docker workflow.
+- Read `frb-docker` before changing `.devcontainer/**` or publishing the dev image.
+- Read `frb-code-generation` before accepting generated or scaffold drift.
+- Read `frb-cargokit` before changing any copied CargoKit file. Read `frb-cargokit-dev` only when the source
+  change belongs in the external CargoKit repository.
+- Read `frb-pr-chain-split` as soon as an independently landable prerequisite or cleanup appears.
+- Read `frb-prepare-pr` and then `frb-pr-review` before treating the upgrade PR as ready.
+- Read `frb-fix-ci` when CI starts failing.
 
-## Start Here
+# 2 Establish the version contract
 
-1. Confirm the target Flutter stable release from official Flutter sources.
-2. Also read:
-   - `frb-docker` before changing `.devcontainer/**` or publishing the dev image.
-   - `frb-code-generation` before accepting generated or scaffold drift.
-   - `frb-cargokit` or `frb-cargokit-dev` before changing copied `cargokit` files.
-   - `frb-pr-review` before treating the upgrade PR as ready.
-   - `frb-fix-ci` when CI starts failing.
-
-## Non-Negotiables
-
-- Keep `.github/workflows/ci.yaml` and `.github/workflows/post_release.yaml` toolchain env values in sync.
-- Treat `.devcontainer/Dockerfile` `ARG` values as the source of truth for dev image tags.
-- Dry-run the dev Docker image before depending on a new derived image tag in the PR.
-- After changing `.devcontainer/Dockerfile`, build a fresh local image from that Dockerfile and use a
-  container based on that fresh image for local validation. Do not keep using an older per-worktree
-  container whose Flutter, Dart, Rust, Android, or browser tooling may still be stale.
-- After the upgrade PR merges, trigger the dev Docker image publish workflow on `master`.
-- Do not hand-edit generated files as the final state.
-- Classify scaffold drift by source: integration template, Apple scaffold, Cargokit, or example output.
-
-## Workflow
-
-### Step 1: Review the Flutter Release
-
-Use official Flutter sources. Record the target Flutter version, bundled Dart version, release date,
-and release-note items likely to affect FRB.
-
-Scan for:
-
-- Dart SDK constraint changes
-- Android Gradle Plugin, Kotlin, Java, Android SDK, or NDK changes
-- iOS/macOS project generation changes, especially Swift Package Manager or CocoaPods defaults
-- Web renderer, Chrome, DevTools, or test-driver changes
-- Host architecture changes such as Apple Silicon or Windows ARM support
-
-### Step 2: Plan the Single Upgrade PR
-
-Plan one PR for the Flutter upgrade. Keep the PR internally organized by logical commits or phases,
-but do not split the upgrade across multiple PRs unless Tom explicitly asks.
-
-Use this order inside the single PR:
-
-1. Upgrade the dev Docker image inputs and derived metadata tests.
-2. Sync CI and post-release version pins.
-3. Regenerate and classify scaffold drift.
-4. Fix real compatibility failures.
-5. Update workflow docs or skills only if the process changed.
-
-### Step 3: Inventory Current Pins
-
-Run these before planning the bump:
+- Record the target Flutter version, bundled Dart version, release date, and relevant release-note changes.
+- Distinguish the primary Dart version from the minimum supported Dart SDK floor.
+  - Upgrade the primary Dart pin with Flutter.
+  - Do not raise package SDK constraints merely because the primary toolchain is newer.
+  - When retaining an older SDK floor, run dependency resolution, analysis, and tests on that floor in CI.
+- Inventory version-like values without assuming the target Dart major or minor:
 
 ```shell
-rg -n \
-  "FRB_MAIN_|FLUTTER_VERSION|DART_VERSION|RUST_VERSION|setup-flutter|setup-dart|cirruslabs/flutter"
-rg -n "flutter_rust_bridge_dev|3\\.[0-9]+"
+rg -n "FRB_MAIN_|FLUTTER_VERSION|DART_VERSION|RUST_VERSION|setup-flutter|setup-dart|cirruslabs/flutter"
+rg -n "flutter_rust_bridge_dev|stable|nightly|minimum.*version|deployment.*target" \
+  .devcontainer .github tools frb_codegen frb_example
 ```
 
-Inspect at least:
+- Inspect at least:
+  - `.devcontainer/Dockerfile`;
+  - `.github/workflows/ci.yaml` and `.github/workflows/post_release.yaml`;
+  - `.github/workflows/publish_dev_docker.yaml`;
+  - `tools/frb_internal/test/src/makefile_dart/test_dev_docker_metadata.dart`;
+  - package `pubspec.yaml` and checked-in `pubspec.lock` files;
+  - `frb_codegen/assets/integration_template/**`;
+  - `tools/frb_internal/assets/apple_scaffold/**`;
+  - `tools/tart_macos/**`;
+  - `frb_example/**`.
 
-- `.devcontainer/Dockerfile`
-- `.github/workflows/ci.yaml`
-- `.github/workflows/post_release.yaml`
-- `.github/workflows/publish_dev_docker.yaml`
-- `tools/frb_internal/test/src/makefile_dart/test_dev_docker_metadata.dart`
-- `pubspec.yaml`, package `pubspec.yaml` files, and checked-in `pubspec.lock` files
-- `frb_codegen/assets/integration_template/**`
-- `tools/frb_internal/assets/apple_scaffold/**`
-- `frb_example/**`
+# 3 Choose PR boundaries before implementation
 
-### Step 4: Upgrade the Devcontainer First
+- Keep generated snapshots, their generator changes, required tests, and upgrade-specific compatibility migrations in
+  the main upgrade PR.
+- Split independent bug fixes, hardening, and reusable prerequisites into predecessor PRs according to
+  `frb-pr-chain-split`.
+- Build and maintain any predecessor chain exclusively with the official `gh stack` workflow described there.
+- Put `ci-manual-dispatch` on dormant predecessors unless a predecessor specifically needs GitHub-only validation.
+- Do not move incidental skill or workflow cleanup into the upgrade PR when it can stand alone against `master`.
 
-Update `.devcontainer/Dockerfile`:
+# 4 Upgrade the development toolchain
 
-- `ARG FLUTTER_VERSION`
-- Required Rust, Rust nightly, Node, Playwright, Chrome, system package, Java, or Android tooling changes
+- Update `.devcontainer/Dockerfile` inputs, including Flutter and any required Rust, Rust nightly, Node, Playwright,
+  Chrome, system package, Java, or Android changes.
+- Update tests that assert the derived dev image tag.
+- Use `frb-dev-env` and `frb-docker` to build a fresh image and recreate the per-worktree container. Do not validate
+  the upgrade in a stale container or use ad hoc bind mounts that bypass the worktree-aware environment.
+- Dry-run the publish workflow before depending on a new derived image tag.
+- If Apple pins, simulators, or host tooling change, continue with the Tart workflow routed by `frb-dev-env` and
+  read `frb-tart-prepare` before provisioning or validation.
 
-Update metadata tests that assert the derived dev image tag.
+# 5 Synchronize CI and post-release pins
 
-Build and smoke-test locally when practical. If an old per-worktree container already exists, do not
-use it for this step; create a fresh container from the newly built image, or rebuild/recreate the
-per-worktree container so it uses the updated Dockerfile contents.
+- Update the top-level toolchain values together in `.github/workflows/ci.yaml` and
+  `.github/workflows/post_release.yaml`:
+  - `FRB_MAIN_FLUTTER_VERSION`;
+  - `FRB_MAIN_DART_VERSION`;
+  - `FRB_MAIN_RUST_VERSION` when the upgraded tooling requires it;
+  - `FRB_RUSTFMT_NIGHTLY_VERSION` only when formatting or nightly `rust-src` behavior requires it.
+- Keep a retained minimum Dart floor explicit and independently exercised; do not substitute the primary Dart pin for
+  that compatibility lane.
+- Review Java, Android SDK/NDK, Chrome/chromedriver, macOS runner, simulator, Windows ARM, and post-release install-mode
+  assumptions.
 
-```shell
-docker build -f .devcontainer/Dockerfile -t frb-dev .devcontainer
-docker run --rm -v "$PWD:/workspace" -w /workspace frb-dev bash -lc './frb_internal --help'
-docker run --rm -v "$PWD:/workspace" -w /workspace frb-dev bash -lc '
-set -euo pipefail
-flutter --version
-dart --version
-node --version
-npm --version
-cargo --version
-wasm-pack --version
-"${CHROME_BIN}" --version
-'
-```
+# 6 Regenerate to convergence
 
-If local build is too expensive, dry-run the workflow:
+- Read `frb-code-generation` and run the narrowest owning generator before broad generation.
+- Normalize the intended source inputs, resolve dependencies, run final code generation, and format with the target
+  toolchain. Do not hand formatter-unstable intermediate text to a different generation lane.
+- Run the owning generation command a second time and require a clean diff. A single successful run is not convergence.
+- Preserve semantic equivalence in templates. Do not move construction, scope, lifetime, or callback boundaries merely
+  to make new formatter output look smaller.
+- Classify every changed path by provenance:
 
-```shell
-gh workflow run publish_dev_docker.yaml --ref <branch> -f publish=false
-```
+| Provenance | Required action |
+| --- | --- |
+| Integration template | Change the template source and regenerate consumers |
+| Apple scaffold asset | Refresh through the owning scaffold workflow |
+| CargoKit copy | Follow the CargoKit ownership rules below |
+| Generated example output | Keep the generator and snapshot together |
+| Flutter migrator edit in a legacy example | Apply the exact current scaffold migration and record it as direct |
+| Unexplained manual edit | Revert it or identify its owning source before proceeding |
 
-### Step 5: Sync CI and Post-Release Pins
+- When an old example has no supported regeneration entry point, compare it with a fresh target-Flutter scaffold and
+  directly apply only required tool-defined migrations. Record those files separately from automatic output.
 
-Update top-level env values together in `.github/workflows/ci.yaml` and
-`.github/workflows/post_release.yaml`:
+# 7 Preserve the OHOS composition contract
 
-- `FRB_MAIN_FLUTTER_VERSION`
-- `FRB_MAIN_DART_VERSION`
-- `FRB_MAIN_RUST_VERSION` if the Flutter or tooling bump requires newer Rust
-- `FRB_RUSTFMT_NIGHTLY_VERSION` only if formatting or nightly-only `rust-src` behavior requires it
+- Treat the checked-in package and the older OHOS Flutter fork as two distinct sources of truth:
+  - generic Flutter scaffold files come from the target stable Flutter package;
+  - overlay only explicit OHOS-owned paths from the OHOS fork;
+  - include `ohos` and, when required by the package, `rust_builder/ohos` and `rust_builder/pubspec.yaml`;
+  - exclude transient trees such as `node_modules`;
+  - preserve intentional deletions instead of silently resurrecting stale files.
+- Make preservation transactional. Stage and validate the composed result before replacing the canonical package, and
+  restore the original package if create, dependency resolution, code generation, formatting, or the final swap fails.
+- Test both success and failure paths. Do not add production APIs whose only purpose is exposing internals to tests.
 
-`post_release.yaml` intentionally says it should stay in sync with `ci.yaml`. It verifies released
-quickstart and codegen installation modes, so do not leave it pinned to old Flutter/Dart versions.
+# 8 Route CargoKit changes correctly
 
-Scan workflow assumptions:
+- Use `frb-cargokit` to determine whether a diff is an upstream source change, an FRB copy-sync change, or generated
+  integration output.
+- Use `frb-cargokit-dev` and a separate upstream change only when behavior belongs in the external CargoKit repository.
+- Use the owning sync command for source-copy updates; do not manually patch every copied CargoKit tree.
+- Keep `precommit-integrate` and CargoKit copy synchronization conceptually separate.
+- Treat nested `cargokit/build_tool` packages according to their own Dart package metadata even when the parent package
+  is a Flutter package.
 
-- `flutter-actions/setup-flutter`
-- `dart-lang/setup-dart`
-- Java setup for Android jobs
-- Linux desktop package prerequisites
-- iOS simulator names and macOS runner labels
-- Windows ARM runner coverage
-- Chrome/chromedriver setup for web jobs
-- Post-release `codegen_install_mode` coverage for `cargo-install`, `cargo-binstall`, `scoop`, and
-  `homebrew`
-- Any commented job that says it was waiting for a CI Flutter upgrade
+# 9 Validate in dependency order
 
-### Step 6: Regenerate and Classify Drift
+- Use the fresh local Docker environment from `frb-dev-env`.
+- Read `frb-lint` and `frb-test` for exact commands.
+- Validate in this order:
+  1. dev-image metadata and tool versions;
+  2. Dart analysis, tests, and the retained minimum-SDK lane;
+  3. internal generation and second-pass cleanliness;
+  4. integration generation and CargoKit synchronization;
+  5. focused legacy Android and Apple platform builds affected by migrations;
+  6. representative native and web examples.
+- Before creating or updating the PR, run `frb-prepare-pr`.
+- Before declaring it ready, run the independent review gate in `frb-pr-review`.
 
-Read `frb-code-generation` first.
+# 10 Triage CI and finish
 
-Expect drift in:
+- Read `frb-fix-ci` before deep CI debugging.
+- Triage failures in dependency order: environment setup, generation, integration, platform builds, post-release,
+  then coverage or uploads.
+- Compare platform failures with target-Flutter release notes and fresh scaffold output before adding workarounds.
+- Keep full CI on the top upgrade PR. Follow `frb-pr-chain-split` for filtered or deferred predecessor CI.
+- After the upgrade merges, publish the dev Docker image from `master` when `.devcontainer/Dockerfile` changed, then
+  verify the expected `linux/amd64` and `linux/arm64` manifests.
 
-- `pubspec.lock` Dart SDK constraints
-- `flutter create` / `flutter integrate` scaffold output
-- Android Gradle, Kotlin, Java, NDK, and manifest files
-- iOS/macOS Xcode project files, CocoaPods files, or SwiftPM package files
-- Windows/Linux desktop scaffold files
-- Generated `frb_generated.*` files if Dart formatting, analyzer behavior, or codegen dependencies changed
+# 11 PR notes
 
-Classify by source:
-
-- Template-driven drift belongs in `frb_codegen/assets/integration_template/**`.
-- Apple scaffold drift may belong in `tools/frb_internal/assets/apple_scaffold/**`.
-- Cargokit drift may belong in the upstream Cargokit repo.
-- Example-only drift should come from the relevant `./frb_internal generate-*` or `precommit-*` command.
-
-Run focused generation first when possible, then broaden:
-
-```shell
-./frb_internal precommit-generate
-./frb_internal precommit-integrate
-```
-
-If multiple generated-output CI failures rotate across packages, stop package-by-package fixes and run
-a clean full `./frb_internal precommit-generate`.
-
-### Step 7: Validate Locally
-
-Read `frb-lint` and `frb-test` for exact command guidance. Tom's FRB environment runs tests locally,
-usually through the per-worktree Docker container.
-
-If the Flutter upgrade changed `.devcontainer/Dockerfile`, first ensure local validation is running
-inside the fresh image built in Step 4. Seeing an old Dart or Flutter version locally means the
-container is stale; recreate it before trusting any validation result.
-
-Recommended minimum validation:
-
-```shell
-./frb_internal lint --fix
-./frb_internal test-dart-native --package frb_example/pure_dart
-./frb_internal test-dart-native --package frb_example/pure_dart_pde
-./frb_internal test-flutter-native --package frb_example/flutter_via_create
-./frb_internal test-flutter-web --package frb_example/gallery
-```
-
-For CI or Docker plumbing-only changes, dev image dry-run and focused metadata tests may be enough
-before opening the PR. Let CI cover the full matrix.
-
-Before treating the upgrade PR as ready, run the review gate in `frb-pr-review`.
-
-### Step 8: Triage CI in Dependency Order
-
-Read `frb-fix-ci` before deep debugging.
-
-1. Dev Docker publish or dry-run failures
-2. Lint/setup failures caused by incompatible tool versions
-3. Generate and Generate Internal failures
-4. Integrate scaffold failures
-5. Build and platform tests
-6. Post-release quickstart failures
-7. Coverage, benchmark, website, and upload jobs
-
-When a platform starts failing after the Flutter bump, compare against release notes before patching
-symptoms. Flutter stable bumps often intentionally change generated platform projects.
-
-### Step 9: Publish the Dev Docker Image After Merge
-
-After the single upgrade PR is merged into `master`, trigger the publish workflow from `master` so the
-new derived dev image tag exists for future CI and developer workflows:
-
-```shell
-gh workflow run publish_dev_docker.yaml --ref master
-```
-
-After it completes, verify both `linux/amd64` and `linux/arm64`:
-
-```shell
-docker buildx imagetools inspect fzyzcjy/flutter_rust_bridge_dev:latest
-docker buildx imagetools inspect fzyzcjy/flutter_rust_bridge_dev:flutter-<flutter>-rust-<rust>-nightly-<nightly>
-```
-
-BuildKit attestation manifests can appear as `unknown/unknown`; those are not platform images.
-
-## PR Notes
-
-For the single upgrade PR, include:
-
-- Old and new Flutter/Dart versions
-- Whether the dev image was dry-run or published
-- Exact version tag of the dev image
-- Generated/scaffold sources that changed
-- Local validation commands and CI status
-- Any known remaining platform-specific follow-up
+- Record old and new Flutter and primary Dart versions.
+- Record the retained or raised minimum Dart SDK floor and its validation lane.
+- List generated files, direct Flutter migrator edits, CargoKit changes, and OHOS overlays by provenance.
+- Link predecessor PRs and identify which ones intentionally use manual CI.
+- Record the fresh dev-image tag, exact local validations, generation convergence result, and CI status.
+- Call out any platform-specific follow-up that remains intentionally out of scope.


### PR DESCRIPTION
## Summary

- make independent prerequisite splitting part of the Flutter upgrade workflow
- distinguish the primary Dart toolchain from the supported SDK floor
- require convergent generation and semantic template preservation
- document OHOS composition, CargoKit ownership, legacy scaffold migrations, and preparation/review gates

## Validation

- `quick_validate.py .claude/skills/frb-upgrade-flutter`
- `git diff --check`

This is a skill-only change and does not require the full CI matrix.