### PR TITLE
Reproduce FRB logging with build.rs codegen with intentional red CI

### DIFF
--- a/frb_example/dart_build_rs/rust/src/api/minimal.rs
+++ b/frb_example/dart_build_rs/rust/src/api/minimal.rs
@@ -1,5 +1,7 @@
 use flutter_rust_bridge::frb;
 
+flutter_rust_bridge::enable_frb_rust_to_dart_logging!();
+
 #[frb(init)]
 pub fn init_app() {
     flutter_rust_bridge::setup_default_user_utils();


### PR DESCRIPTION
## Purpose

- Intentionally reproduce #3402 without any fix.
- Keep this PR red as evidence for the separate fix PR.

## Reproduction

Baseline commit: `8631db91a90c699439c9ce2a1fb4164ae8661da9`

Steps:

1. Add `flutter_rust_bridge::enable_frb_rust_to_dart_logging!();` to `frb_example/dart_build_rs/rust/src/api/minimal.rs`.
2. Run `cd frb_example/dart_build_rs/rust && cargo clean && cargo build`.

Observed:

```text
error[E0599]: the method `add` exists for struct `Arc<StreamSink<FrbLogRecord>>`, but its trait bounds were not satisfied
...
doesn't satisfy `FrbLogRecord: SseEncode`
```

Expected:

- The build.rs codegen path generates the `SseEncode` implementation for `FrbLogRecord`.
- The crate compiles successfully.

## Intentional red CI

- Filter: `test_dart_native[image=ubuntu-24.04,package=frb_example--dart_build_rs]`
- Expected failure: `FrbLogRecord: SseEncode` is not satisfied.