### PR TITLE
Extract Docker publishing workflow skill

### DIFF
--- a/.claude/skills/frb-docker/SKILL.md
+++ b/.claude/skills/frb-docker/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: frb-docker
-description: Use when working with flutter_rust_bridge Docker/devcontainer setup, local Docker usage, Apple Silicon containers, or publishing the dev Docker image
+description: Use for ordinary flutter_rust_bridge Docker/devcontainer setup, local image usage, and Apple Silicon containers; route image upgrades and publishing to frb-upgrade-docker.
 ---
 
 # FRB Docker
 
-Use this skill for FRB Docker/devcontainer work: local container usage, Apple Silicon behavior, Dockerfile validation, and publishing `fzyzcjy/flutter_rust_bridge_dev`.
+Use this skill for ordinary FRB Docker/devcontainer work: local container usage, Apple Silicon behavior, and local Dockerfile validation.
+
+Read `frb-upgrade-docker` before changing toolchain inputs or publishing `fzyzcjy/flutter_rust_bridge_dev`.
 
 ## Source of Truth
 
@@ -100,52 +102,3 @@ docker run --rm -v "$PWD:/workspace" -w /workspace/frb_rust frb-dev bash -lc 'ca
 ```
 
 If generated files drift during lint/codegen, do not manually edit generated files. Restore unrelated generated drift unless the task intentionally changes generation outputs.
-
-### Publish Workflow
-
-Publish the dev image from the workflow:
-
-```shell
-gh workflow run publish_dev_docker.yaml --ref master
-```
-
-Manual dispatch defaults to `publish=true`.
-
-To verify the workflow without publishing:
-
-```shell
-gh workflow run publish_dev_docker.yaml --ref master -f publish=false
-```
-
-The workflow builds and smoke-tests:
-
-- `linux/amd64` on `ubuntu-latest`
-- `linux/arm64` on `ubuntu-24.04-arm`
-
-When publishing, it pushes per-platform images and then creates multi-arch tags:
-
-- `latest`
-- `flutter-<flutter_version>-rust-<rust_version>-nightly-<rust_nightly_version>`
-- `flutter-<flutter_version>-rust-<rust_version>-nightly-<rust_nightly_version>-code-<short_sha>`
-- `sha-<short_sha>`
-
-After publishing, inspect the manifest:
-
-```shell
-docker buildx imagetools inspect fzyzcjy/flutter_rust_bridge_dev:latest
-```
-
-It should include `linux/amd64` and `linux/arm64`. BuildKit attestation manifests may appear as `unknown/unknown`; those are not platform images.
-
-Inspect the image revision label when checking exactly which source commit was published:
-
-```shell
-docker inspect fzyzcjy/flutter_rust_bridge_dev:latest \
-  --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}'
-```
-
-## CI Workflow Guidance
-
-Avoid building the full Rust/Flutter arm64 image under QEMU on an amd64 runner; it is much slower than native arm64 and can make the workflow impractical. Use native arch runners for heavy image builds.
-
-If a dry-run passes but publishing fails, inspect whether Docker Hub login, per-platform push, or manifest creation failed; those are separate phases in the workflow.

--- a/.claude/skills/frb-upgrade-docker/SKILL.md
+++ b/.claude/skills/frb-upgrade-docker/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: frb-upgrade-docker
+description: Upgrade and publish the flutter_rust_bridge development Docker image.
+---
+
+# FRB Upgrade Docker
+
+### Publish Workflow
+
+Publish the dev image from the workflow:
+
+```shell
+gh workflow run publish_dev_docker.yaml --ref master
+```
+
+Manual dispatch defaults to `publish=true`.
+
+To verify the workflow without publishing:
+
+```shell
+gh workflow run publish_dev_docker.yaml --ref master -f publish=false
+```
+
+The workflow builds and smoke-tests:
+
+- `linux/amd64` on `ubuntu-latest`
+- `linux/arm64` on `ubuntu-24.04-arm`
+
+When publishing, it pushes per-platform images and then creates multi-arch tags:
+
+- `latest`
+- `flutter-<flutter_version>-rust-<rust_version>-nightly-<rust_nightly_version>`
+- `flutter-<flutter_version>-rust-<rust_version>-nightly-<rust_nightly_version>-code-<short_sha>`
+- `sha-<short_sha>`
+
+After publishing, inspect the manifest:
+
+```shell
+docker buildx imagetools inspect fzyzcjy/flutter_rust_bridge_dev:latest
+```
+
+It should include `linux/amd64` and `linux/arm64`. BuildKit attestation manifests may appear as `unknown/unknown`; those are not platform images.
+
+Inspect the image revision label when checking exactly which source commit was published:
+
+```shell
+docker inspect fzyzcjy/flutter_rust_bridge_dev:latest \
+  --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}'
+```
+
+## CI Workflow Guidance
+
+Avoid building the full Rust/Flutter arm64 image under QEMU on an amd64 runner; it is much slower than native arm64 and can make the workflow impractical. Use native arch runners for heavy image builds.
+
+If a dry-run passes but publishing fails, inspect whether Docker Hub login, per-platform push, or manifest creation failed; those are separate phases in the workflow.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,4 +26,5 @@ When adding or testing feature flags, read `frb-feature-flag`.
 - `frb-prepare-pr` - PR preparation
 - `frb-fix-ci` - CI fixes
 - `frb-fix-main-ci` - Default-branch CI regression triage
-- `frb-docker` - Docker/devcontainer usage and dev image publishing
+- `frb-docker` - Ordinary Docker/devcontainer usage and local validation
+- `frb-upgrade-docker` - Dev Docker image upgrades and publishing


### PR DESCRIPTION
## Changes

Fixes #the-issue-number-here

## Optional tools

* It is recommended to use the `/frb-develop-feature` skill, which contains detailed guidance for the agent to develop a feature.
* There is a devcontainer and Dockerfile at `.devcontainer`, which optionally helps creating a standardized development environment.