### PR TITLE
Reproduce Native Assets Android 16 KB page size with intentional red CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1272,6 +1272,21 @@ jobs:
           arch: x86_64
           profile: ${{ matrix.info.device }}
           script: ./frb_internal test-flutter-quickstart-smoke --package ${{ matrix.info.package }} --target android --device-id emulator-5554
+      - if: ${{ matrix.info.target == 'android' && matrix.info.package == 'frb_example--flutter_via_create_native_assets' }}
+        name: Verify Android 16 KB ELF alignment
+        shell: bash
+        run: |-
+          native_library="${{ matrix.info.package_path }}/build/app/intermediates/flutter/debug/native_assets/jniLibs/lib/x86_64/librust_lib_flutter_via_create_native_assets.so"
+          readelf="$ANDROID_HOME/ndk/27.2.12479018/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-readelf"
+          program_headers="$("$readelf" -lW "$native_library")"
+          printf '%s\n' "$program_headers"
+          printf '%s\n' "$program_headers" | awk -v library="$native_library" '
+            $1 == "LOAD" && $NF != "0x4000" {
+              printf "ELF LOAD segment alignment is %s, expected 0x4000: %s\n", $NF, library
+              failed = 1
+            }
+            END { exit failed }
+          '
       - if: ${{ matrix.info.platform == 'nixos' }}
         shell: bash
         run: |-

--- a/frb_example/flutter_via_create_native_assets/android/app/build.gradle.kts
+++ b/frb_example/flutter_via_create_native_assets/android/app/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 android {
     namespace = "com.example.flutter_via_create_native_assets"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = flutter.ndkVersion
+    ndkVersion = "27.2.12479018"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17


### PR DESCRIPTION
This is an intentional reproduction PR for #3421. It is expected to fail and is not the fix.

## Reproduction

- Pin the Native Assets Android example to NDK r27.2.12479018, where 16 KB ELF alignment is not enabled by default.
- Build the existing Android Native Assets quickstart path.
- Inspect the generated x86_64 Rust shared library with llvm-readelf.
- Fail when any LOAD segment is not aligned to 0x4000.

Expected: every LOAD segment reports 0x4000 alignment.

Observed locally: every LOAD segment reports 0x1000, and the focused check exits with:

```text
ELF LOAD segment alignment is 0x1000, expected 0x4000: .../librust_lib_flutter_via_create_native_assets.so
```

Focused CI filter:

```text
test_flutter_quickstart_smoke[platform=android,package=frb_example--flutter_via_create_native_assets]
```

The fix will be submitted independently from the current master branch.