### PR TITLE
Normalize web DCO values across Dart compilers

### DIFF
--- a/frb_codegen/assets/integration_template/shared/shared/lib/src/rust/frb_generated.dart
+++ b/frb_codegen/assets/integration_template/shared/shared/lib/src/rust/frb_generated.dart
@@ -144,7 +144,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   String dco_decode_String(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as String;
+    return dcoDecodeString(raw);
   }
 
   @protected
@@ -156,7 +156,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   int dco_decode_u_8(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dcoDecodePrimitiveInt(raw);
   }
 
   @protected

--- a/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/codec/dco/decoder/ty/boxed.rs
+++ b/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/codec/dco/decoder/ty/boxed.rs
@@ -24,7 +24,13 @@ impl WireDartCodecDcoGeneratorDecoderTrait for BoxedWireDartCodecDcoGenerator<'_
                 MirTypePrimitive::I64
                 | MirTypePrimitive::Isize
                 | MirTypePrimitive::U64
-                | MirTypePrimitive::Usize,
+                | MirTypePrimitive::Usize
+                | MirTypePrimitive::U8
+                | MirTypePrimitive::I8
+                | MirTypePrimitive::U16
+                | MirTypePrimitive::I16
+                | MirTypePrimitive::U32
+                | MirTypePrimitive::I32,
             )
             | Delegate(MirTypeDelegate::Array(_) | MirTypeDelegate::PrimitiveEnum { .. }) => {
                 format!("return dco_decode_{}(raw);", self.mir.inner.safe_ident())

--- a/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/codec/dco/decoder/ty/delegate.rs
+++ b/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/codec/dco/decoder/ty/delegate.rs
@@ -1,5 +1,4 @@
 use crate::codegen::generator::wire::dart::spec_generator::codec::dco::base::*;
-use crate::codegen::generator::wire::dart::spec_generator::codec::dco::decoder::misc::gen_decode_simple_type_cast;
 use crate::codegen::generator::wire::dart::spec_generator::codec::dco::decoder::ty::WireDartCodecDcoGeneratorDecoderTrait;
 use crate::codegen::ir::mir::ty::delegate::{
     MirTypeDelegate, MirTypeDelegateArrayMode, MirTypeDelegatePrimitiveEnum, MirTypeDelegateTime,
@@ -13,7 +12,7 @@ impl WireDartCodecDcoGeneratorDecoderTrait for DelegateWireDartCodecDcoGenerator
         match &self.mir {
             MirTypeDelegate::Array(array) => match &array.mode {
                 MirTypeDelegateArrayMode::General(general) => format!(
-                    r"return {}((raw as List<dynamic>).map(dco_decode_{}).toList());",
+                    r"return {}(dcoDecodeList(raw).map(dco_decode_{}).toList());",
                     ApiDartGenerator::new(self.mir.clone(), self.context.as_api_dart_context())
                         .dart_api_type(),
                     general.safe_ident(),
@@ -34,23 +33,20 @@ impl WireDartCodecDcoGeneratorDecoderTrait for DelegateWireDartCodecDcoGenerator
             //         self.mir.get_delegate().safe_ident()
             //     )
             // }
-            MirTypeDelegate::String
-            | MirTypeDelegate::Backtrace
-            /*| MirTypeDelegate::ZeroCopyBufferVecPrimitive(_)*/ => {
-                gen_decode_simple_type_cast(self.mir.clone().into(), self.context)
-            }
+            MirTypeDelegate::String => "return dcoDecodeString(raw);".to_owned(),
+            MirTypeDelegate::Backtrace => "return dcoDecodeString(raw);".to_owned(),
             MirTypeDelegate::Char => {
-                "return String.fromCharCode(raw);".to_owned()
+                "return String.fromCharCode(dcoDecodePrimitiveInt(raw));".to_owned()
             }
             // MirTypeDelegate::StringList => {
             //     "return (raw as List<dynamic>).cast<String>();".to_owned()
             // }
             MirTypeDelegate::PrimitiveEnum(MirTypeDelegatePrimitiveEnum { mir, .. }) => {
                 format!(
-                    "return {}.values[raw as int];",
+                    "return {}.values[dcoDecodePrimitiveInt(raw)];",
                     ApiDartGenerator::new(mir.clone(), self.context.as_api_dart_context())
                         .dart_api_type()
-                ) // here `as int` is neccessary in strict dynamic mode
+                )
             }
             MirTypeDelegate::Time(mir) => {
                 if mir == &MirTypeDelegateTime::Duration {
@@ -72,10 +68,10 @@ impl WireDartCodecDcoGeneratorDecoderTrait for DelegateWireDartCodecDcoGenerator
                 "return UuidValue.fromByteList(dco_decode_list_prim_u_8_strict(raw));".to_owned()
             }
             MirTypeDelegate::SerdeJsonValue => {
-                "return jsonDecode(raw as String);".to_owned()
+                "return jsonDecode(dcoDecodeString(raw));".to_owned()
             }
             // MirTypeDelegate::Uuids => ...,
-            MirTypeDelegate::AnyhowException => "return AnyhowException(raw as String);".to_owned(),
+            MirTypeDelegate::AnyhowException => "return AnyhowException(dcoDecodeString(raw));".to_owned(),
             MirTypeDelegate::Map(_) => format!(
                 "return Map.fromEntries(dco_decode_{}(raw).map((e) => MapEntry(e.$1, e.$2)));",
                 self.mir.get_delegate().safe_ident(),
@@ -86,7 +82,7 @@ impl WireDartCodecDcoGeneratorDecoderTrait for DelegateWireDartCodecDcoGenerator
             ),
             MirTypeDelegate::StreamSink(_) | MirTypeDelegate::DynTrait(_) => "throw UnimplementedError();".to_owned(),
             MirTypeDelegate::BigPrimitive(_) => {
-                "return BigInt.parse(raw as String);".to_owned()
+                "return BigInt.parse(dcoDecodeString(raw));".to_owned()
             }
             MirTypeDelegate::RustAutoOpaqueExplicit(mir) => format!(r"return dco_decode_{}(raw);", mir.inner.safe_ident()),
             MirTypeDelegate::CustomSerDes(inner) => {
@@ -121,8 +117,11 @@ mod tests {
         let context = test_utils::context(&pack, &config);
 
         for (mir, expected) in [
-            (MirTypeDelegate::String, "return raw as String;"),
-            (MirTypeDelegate::Char, "return String.fromCharCode(raw);"),
+            (MirTypeDelegate::String, "return dcoDecodeString(raw);"),
+            (
+                MirTypeDelegate::Char,
+                "return String.fromCharCode(dcoDecodePrimitiveInt(raw));",
+            ),
             (
                 MirTypeDelegate::Time(MirTypeDelegateTime::Duration),
                 "return dcoDecodeDuration(dco_decode_i_64(raw).toInt());",
@@ -137,7 +136,7 @@ mod tests {
             ),
             (
                 MirTypeDelegate::SerdeJsonValue,
-                "return jsonDecode(raw as String);",
+                "return jsonDecode(dcoDecodeString(raw));",
             ),
         ] {
             let generator = DelegateWireDartCodecDcoGenerator::new(mir, context);

--- a/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/codec/dco/decoder/ty/enumeration.rs
+++ b/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/codec/dco/decoder/ty/enumeration.rs
@@ -22,7 +22,7 @@ impl WireDartCodecDcoGeneratorDecoderTrait for EnumRefWireDartCodecDcoGenerator<
                         .enumerate()
                         .map(|(idx, field)| {
                             let val =
-                                format!("dco_decode_{}(raw[{}]),", field.ty.safe_ident(), idx + 1);
+                                format!("dco_decode_{}(arr[{}]),", field.ty.safe_ident(), idx + 1);
                             if st.is_fields_named {
                                 format!("{}: {}", field.name.dart_style(), val)
                             } else {
@@ -36,7 +36,8 @@ impl WireDartCodecDcoGeneratorDecoderTrait for EnumRefWireDartCodecDcoGenerator<
             })
             .collect_vec();
         format!(
-            "switch (raw[0]) {{
+            "final arr = dcoDecodeList(raw);
+            switch (dcoDecodePrimitiveInt(arr[0])) {{
                 {}
                 default: throw Exception(\"unreachable\");
             }}",
@@ -126,7 +127,7 @@ mod tests {
 
         assert_eq!(
             output,
-            "switch (raw[0]) {\n                case 0: return Event.empty();\ncase 1: return Event.value(itemValue: dco_decode_i_32(raw[1]),);\n                default: throw Exception(\"unreachable\");\n            }"
+            "final arr = dcoDecodeList(raw);\n            switch (dcoDecodePrimitiveInt(arr[0])) {\n                case 0: return Event.empty();\ncase 1: return Event.value(itemValue: dco_decode_i_32(arr[1]),);\n                default: throw Exception(\"unreachable\");\n            }"
         );
     }
 }

--- a/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/codec/dco/decoder/ty/general_list.rs
+++ b/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/codec/dco/decoder/ty/general_list.rs
@@ -17,7 +17,7 @@ impl WireDartCodecDcoGeneratorDecoderTrait for GeneralListWireDartCodecDcoGenera
         }
 
         format!(
-            "return (raw as List<dynamic>).map(dco_decode_{}).toList();",
+            "return dcoDecodeList(raw).map(dco_decode_{}).toList();",
             self.mir.inner.safe_ident()
         )
     }
@@ -55,7 +55,7 @@ mod tests {
         );
         assert_eq!(
             generic.generate_impl_decode_body(),
-            "return (raw as List<dynamic>).map(dco_decode_i_32).toList();"
+            "return dcoDecodeList(raw).map(dco_decode_i_32).toList();"
         );
     }
 }

--- a/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/codec/dco/decoder/ty/primitive.rs
+++ b/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/codec/dco/decoder/ty/primitive.rs
@@ -13,6 +13,12 @@ impl WireDartCodecDcoGeneratorDecoderTrait for PrimitiveWireDartCodecDcoGenerato
             MirTypePrimitive::U64 | MirTypePrimitive::Usize => {
                 "return dcoDecodeU64(raw);".to_owned()
             }
+            MirTypePrimitive::U8
+            | MirTypePrimitive::I8
+            | MirTypePrimitive::U16
+            | MirTypePrimitive::I16
+            | MirTypePrimitive::U32
+            | MirTypePrimitive::I32 => "return dcoDecodePrimitiveInt(raw);".to_owned(),
             _ => gen_decode_simple_type_cast(self.mir.clone().into(), self.context),
         }
     }
@@ -36,7 +42,7 @@ mod tests {
             (MirTypePrimitive::Isize, "return dcoDecodeI64(raw);"),
             (MirTypePrimitive::U64, "return dcoDecodeU64(raw);"),
             (MirTypePrimitive::Usize, "return dcoDecodeU64(raw);"),
-            (MirTypePrimitive::I32, "return raw as int;"),
+            (MirTypePrimitive::I32, "return dcoDecodePrimitiveInt(raw);"),
         ] {
             let generator = PrimitiveWireDartCodecDcoGenerator::new(primitive, context);
             assert_eq!(generator.generate_impl_decode_body(), expected);

--- a/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/codec/dco/decoder/ty/record.rs
+++ b/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/codec/dco/decoder/ty/record.rs
@@ -15,7 +15,7 @@ impl WireDartCodecDcoGeneratorDecoderTrait for RecordWireDartCodecDcoGenerator<'
             .collect_vec()
             .join(",");
         format!(
-            "final arr = raw as List<dynamic>;
+            "final arr = dcoDecodeList(raw);
             if (arr.length != {len}) {{
                 throw Exception('Expected {len} elements, got ${{arr.length}}');
             }}
@@ -56,7 +56,7 @@ mod tests {
 
         assert_eq!(
             output,
-            "final arr = raw as List<dynamic>;\n            if (arr.length != 2) {\n                throw Exception('Expected 2 elements, got ${arr.length}');\n            }\n            return (dco_decode_i_32(arr[0]),dco_decode_bool(arr[1]),);"
+            "final arr = dcoDecodeList(raw);\n            if (arr.length != 2) {\n                throw Exception('Expected 2 elements, got ${arr.length}');\n            }\n            return (dco_decode_i_32(arr[0]),dco_decode_bool(arr[1]),);"
         );
     }
 }

--- a/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/codec/dco/decoder/ty/rust_auto_opaque_implicit.rs
+++ b/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/codec/dco/decoder/ty/rust_auto_opaque_implicit.rs
@@ -50,7 +50,7 @@ mod tests {
 
         assert_eq!(
             generator.generate_impl_decode_body(),
-            "return HandleImpl.frbInternalDcoDecode(raw as List<dynamic>);"
+            "return HandleImpl.frbInternalDcoDecode(dcoDecodeList(raw));"
         );
     }
 }

--- a/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/codec/dco/decoder/ty/rust_opaque.rs
+++ b/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/codec/dco/decoder/ty/rust_opaque.rs
@@ -15,7 +15,7 @@ pub(super) fn generalized_rust_opaque_generate_impl_decode_body(
     context: WireDartCodecDcoGeneratorContext,
 ) -> String {
     format!(
-        "return {}Impl.frbInternalDcoDecode(raw as List<dynamic>);",
+        "return {}Impl.frbInternalDcoDecode(dcoDecodeList(raw));",
         ApiDartGenerator::new(mir, context.as_api_dart_context()).dart_api_type()
     )
 }
@@ -52,7 +52,7 @@ mod tests {
 
         assert_eq!(
             output,
-            "return HandleImpl.frbInternalDcoDecode(raw as List<dynamic>);"
+            "return HandleImpl.frbInternalDcoDecode(dcoDecodeList(raw));"
         );
     }
 }

--- a/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/codec/dco/decoder/ty/structure.rs
+++ b/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/codec/dco/decoder/ty/structure.rs
@@ -23,7 +23,7 @@ impl WireDartCodecDcoGeneratorDecoderTrait for StructRefWireDartCodecDcoGenerato
             .collect_vec();
 
         let inner = inner.join("\n");
-        let cast = "final arr = raw as List<dynamic>;".to_string();
+        let cast = "final arr = dcoDecodeList(raw);".to_string();
         let safe_check = format!("if (arr.length != {}) throw Exception('unexpected arr length: expect {} but see ${{arr.length}}');", s.fields.len(), s.fields.len());
         let ctor_postfix = dart_constructor_postfix(
             &s.name.name,
@@ -96,7 +96,7 @@ mod tests {
 
         assert_eq!(
             output,
-            "final arr = raw as List<dynamic>;\n                if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');\n                return Point(xValue: dco_decode_i_32(arr[0]),);"
+            "final arr = dcoDecodeList(raw);\n                if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');\n                return Point(xValue: dco_decode_i_32(arr[0]),);"
         );
     }
 }

--- a/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/codec/dco/entrypoint.rs
+++ b/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/codec/dco/entrypoint.rs
@@ -145,7 +145,7 @@ mod tests {
                 .body
                 .as_deref(),
             Some(
-                "// Codec=Dco (DartCObject based), see doc to use other codecs\nreturn raw as int;"
+                "// Codec=Dco (DartCObject based), see doc to use other codecs\nreturn dcoDecodePrimitiveInt(raw);"
             )
         );
         assert!(entrypoint

--- a/frb_dart/lib/src/codec/dco.dart
+++ b/frb_dart/lib/src/codec/dco.dart
@@ -21,8 +21,11 @@ class DcoCodec<S, E extends Object>
   /// {@macro flutter_rust_bridge.only_for_generated_code}
   @override
   S decodeObject(dynamic raw) {
-    final rawList = raw as List<dynamic>;
-    return _DcoSimpleDecoder(this, rawList).decode(rawList[0]);
+    final rawList = dcoDecodeList(raw);
+    return _DcoSimpleDecoder(
+      this,
+      rawList,
+    ).decode(dcoDecodePrimitiveInt(rawList[0]));
   }
 
   @override

--- a/frb_dart/lib/src/manual_impl/_io.dart
+++ b/frb_dart/lib/src/manual_impl/_io.dart
@@ -12,6 +12,18 @@ List<dynamic> wireSyncRust2DartDcoIntoDart(WireSyncRust2DartDco syncReturn) =>
     dartCObjectIntoDart(syncReturn.ref);
 
 /// {@macro flutter_rust_bridge.only_for_generated_code}
+int dcoDecodePrimitiveInt(Object? raw) => raw as int;
+
+/// {@macro flutter_rust_bridge.only_for_generated_code}
+String dcoDecodeString(Object? raw) {
+  if (raw is String) return raw;
+  return String.fromCharCode(dcoDecodePrimitiveInt(raw));
+}
+
+/// {@macro flutter_rust_bridge.only_for_generated_code}
+List<dynamic> dcoDecodeList(Object? raw) => raw as List<dynamic>;
+
+/// {@macro flutter_rust_bridge.only_for_generated_code}
 int dcoDecodeI64(Object? raw) => raw as int;
 
 /// {@macro flutter_rust_bridge.only_for_generated_code}

--- a/frb_dart/lib/src/manual_impl/_io.dart
+++ b/frb_dart/lib/src/manual_impl/_io.dart
@@ -15,10 +15,7 @@ List<dynamic> wireSyncRust2DartDcoIntoDart(WireSyncRust2DartDco syncReturn) =>
 int dcoDecodePrimitiveInt(Object? raw) => raw as int;
 
 /// {@macro flutter_rust_bridge.only_for_generated_code}
-String dcoDecodeString(Object? raw) {
-  if (raw is String) return raw;
-  return String.fromCharCode(dcoDecodePrimitiveInt(raw));
-}
+String dcoDecodeString(Object? raw) => raw as String;
 
 /// {@macro flutter_rust_bridge.only_for_generated_code}
 List<dynamic> dcoDecodeList(Object? raw) => raw as List<dynamic>;

--- a/frb_dart/lib/src/manual_impl/_web.dart
+++ b/frb_dart/lib/src/manual_impl/_web.dart
@@ -1,10 +1,47 @@
+import 'dart:js_interop';
+
 import 'package:flutter_rust_bridge/src/generalized_typed_data/_web.dart';
 import 'package:flutter_rust_bridge/src/platform_types/_web.dart';
 import 'package:flutter_rust_bridge/src/platform_utils/_web.dart';
 
 /// {@macro flutter_rust_bridge.internal}
 List<dynamic> wireSyncRust2DartDcoIntoDart(WireSyncRust2DartDco syncReturn) =>
-    syncReturn;
+    dcoDecodeList(syncReturn);
+
+/// {@macro flutter_rust_bridge.only_for_generated_code}
+int dcoDecodePrimitiveInt(Object? raw) {
+  if (raw is int) return raw;
+  if (raw is double && raw.isFinite && raw == raw.truncateToDouble()) {
+    return raw.toInt();
+  }
+  throw Exception(
+    'dcoDecodePrimitiveInt see unexpected type=${raw.runtimeType} value=$raw',
+  );
+}
+
+/// {@macro flutter_rust_bridge.only_for_generated_code}
+String dcoDecodeString(Object? raw) {
+  if (raw is String) return raw;
+  if (raw is JSAny) {
+    if (raw.typeofEquals('string')) return (raw as JSString).toDart;
+    final dartified = raw.dartify();
+    if (dartified is String) return dartified;
+    return String.fromCharCode(dcoDecodePrimitiveInt(dartified));
+  }
+  return String.fromCharCode(dcoDecodePrimitiveInt(raw));
+}
+
+/// {@macro flutter_rust_bridge.only_for_generated_code}
+List<dynamic> dcoDecodeList(Object? raw) {
+  if (raw is List<dynamic>) return raw;
+  if (raw is JSAny) {
+    final dartified = raw.dartify();
+    if (dartified is List<dynamic>) return dartified;
+  }
+  throw Exception(
+    'dcoDecodeList see unexpected type=${raw.runtimeType} value=$raw',
+  );
+}
 
 /// {@macro flutter_rust_bridge.only_for_generated_code}
 BigInt dcoDecodeI64(Object? raw) => jsBigIntToDartBigInt(raw);
@@ -13,15 +50,36 @@ BigInt dcoDecodeI64(Object? raw) => jsBigIntToDartBigInt(raw);
 BigInt dcoDecodeU64(Object? raw) => jsBigIntToDartBigInt(raw);
 
 /// {@macro flutter_rust_bridge.only_for_generated_code}
-Int64List dcoDecodeInt64List(List<dynamic> raw) =>
-    Int64List.raw(_toListBigInt(raw));
+Int64List dcoDecodeInt64List(Object? raw) =>
+    Int64List.raw(_toListBigInt(dcoDecodeList(raw)));
 
 /// {@macro flutter_rust_bridge.only_for_generated_code}
-Uint64List dcoDecodeUint64List(List<dynamic> raw) =>
-    Uint64List.raw(_toListBigInt(raw));
+Uint64List dcoDecodeUint64List(Object? raw) =>
+    Uint64List.raw(_toListBigInt(dcoDecodeList(raw)));
 
 List<BigInt> _toListBigInt(List<dynamic> raw) =>
     raw.map((x) => jsBigIntToDartBigInt(x!)).toList();
+
+/// {@macro flutter_rust_bridge.only_for_generated_code}
+JSAny cstEncodeInt64List(List<BigInt> raw) =>
+    _JSBigInt64Array(_cstEncodeBigIntList(raw));
+
+/// {@macro flutter_rust_bridge.only_for_generated_code}
+JSAny cstEncodeUint64List(List<BigInt> raw) =>
+    _JSBigUint64Array(_cstEncodeBigIntList(raw));
+
+JSArray<JSBigInt> _cstEncodeBigIntList(List<BigInt> raw) =>
+    raw.map((value) => castNativeBigInt(value) as JSBigInt).toList().toJS;
+
+@JS('BigInt64Array')
+extension type _JSBigInt64Array._(JSObject _) implements JSObject {
+  external factory _JSBigInt64Array(JSArray<JSBigInt> values);
+}
+
+@JS('BigUint64Array')
+extension type _JSBigUint64Array._(JSObject _) implements JSObject {
+  external factory _JSBigUint64Array(JSArray<JSBigInt> values);
+}
 
 /// {@macro flutter_rust_bridge.only_for_generated_code}
 BigInt sseEncodeCastedPrimitiveI64(int raw) => BigInt.from(raw);

--- a/frb_dart/lib/src/manual_impl/_web.dart
+++ b/frb_dart/lib/src/manual_impl/_web.dart
@@ -26,9 +26,10 @@ String dcoDecodeString(Object? raw) {
     if (raw.typeofEquals('string')) return (raw as JSString).toDart;
     final dartified = raw.dartify();
     if (dartified is String) return dartified;
-    return String.fromCharCode(dcoDecodePrimitiveInt(dartified));
   }
-  return String.fromCharCode(dcoDecodePrimitiveInt(raw));
+  throw Exception(
+    'dcoDecodeString see unexpected type=${raw.runtimeType} value=$raw',
+  );
 }
 
 /// {@macro flutter_rust_bridge.only_for_generated_code}

--- a/frb_dart/lib/src/platform_types/_web.dart
+++ b/frb_dart/lib/src/platform_types/_web.dart
@@ -8,7 +8,7 @@ import 'package:web/web.dart' as web;
 typedef NativePortType = web.EventTarget;
 
 /// {@macro flutter_rust_bridge.only_for_generated_code}
-typedef WireSyncRust2DartDco = List<dynamic>;
+typedef WireSyncRust2DartDco = Object?;
 
 /// {@macro flutter_rust_bridge.only_for_generated_code}
 typedef WireSyncRust2DartSse = JSUint8Array;

--- a/frb_dart/lib/src/platform_utils/_web.dart
+++ b/frb_dart/lib/src/platform_utils/_web.dart
@@ -26,6 +26,9 @@ JSAny castNativeBigInt(BigInt value) => _jsBigInt(value.toString());
 /// {@macro flutter_rust_bridge.only_for_generated_code}
 BigInt jsBigIntToDartBigInt(Object? raw) {
   if (raw is int) return BigInt.from(raw);
+  if (raw is double && raw.isFinite && raw == raw.truncateToDouble()) {
+    return BigInt.from(raw.toInt());
+  }
 
   if (raw is Object) {
     final jsAny = raw.jsify();

--- a/frb_dart/test/js_interop_protocol_test.dart
+++ b/frb_dart/test/js_interop_protocol_test.dart
@@ -1,0 +1,96 @@
+@TestOn('vm')
+import 'package:flutter_rust_bridge/src/dart_opaque/_common.dart';
+import 'package:flutter_rust_bridge/src/generalized_frb_rust_binding/generalized_frb_rust_binding.dart';
+import 'package:flutter_rust_bridge/src/main_components/handler.dart';
+import 'package:flutter_rust_bridge/src/manual_impl/manual_impl.dart';
+import 'package:flutter_rust_bridge/src/platform_types/platform_types.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('Dart opaque decoder accepts integral JavaScript numbers', () {
+    final binding = _FakeGeneralizedFrbRustBinding(
+      values: {7: 'decoded opaque'},
+    );
+
+    expect(decodeDartOpaqueCommon(7.0, binding), 'decoded opaque');
+    expect(binding.lastDecodedPointer, 7);
+  });
+
+  test('Dart opaque decoder reports missing fake pointers in tests', () {
+    final binding = _FakeGeneralizedFrbRustBinding(values: const {});
+
+    expect(
+      () => decodeDartOpaqueCommon(7.0, binding),
+      throwsA(
+        isA<StateError>().having(
+          (error) => error.message,
+          'message',
+          'Missing fake Dart opaque value for pointer 7',
+        ),
+      ),
+    );
+  });
+
+  test('Dart function handler accepts native integer call ids', () {
+    var observedCallId = -1;
+    var observedArgument = '';
+    final binding = _FakeGeneralizedFrbRustBinding(
+      values: {
+        9: (int callId, String argument) {
+          observedCallId = callId;
+          observedArgument = argument;
+        },
+      },
+    );
+
+    BaseHandler().dartFnInvoke([9, 42, 'payload'], binding);
+
+    expect(observedCallId, 42);
+    expect(observedArgument, 'payload');
+  });
+
+  test('Dart function handler rejects non-native call ids', () {
+    final binding = _FakeGeneralizedFrbRustBinding(values: {9: (int _) {}});
+
+    expect(
+      () => BaseHandler().dartFnInvoke([9, 42.5], binding),
+      throwsA(isA<TypeError>()),
+    );
+  });
+
+  test('DCO string decoder accepts integer character codes', () {
+    expect(dcoDecodeString(65), 'A');
+  });
+
+  test('Fake binding encodes Dart opaque values as null pointers', () {
+    final binding = _FakeGeneralizedFrbRustBinding(values: const {});
+
+    final pointer = binding.dartOpaqueDart2RustEncode(Object(), 0);
+
+    expect(PlatformPointerUtil.isNullPtr(pointer), isTrue);
+  });
+}
+
+class _FakeGeneralizedFrbRustBinding extends GeneralizedFrbRustBinding {
+  final Map<int, Object> values;
+  int? lastDecodedPointer;
+
+  _FakeGeneralizedFrbRustBinding({required this.values})
+    : super(ExternalLibrary.process(iKnowHowToUseIt: true));
+
+  @override
+  Object dartOpaqueRust2DartDecode(int ptr) {
+    lastDecodedPointer = ptr;
+    final value = values[ptr];
+    if (value == null) {
+      throw StateError('Missing fake Dart opaque value for pointer $ptr');
+    }
+    return value;
+  }
+
+  @override
+  PlatformPointer dartOpaqueDart2RustEncode(
+    Object object,
+    NativePortType dartHandlerPort,
+  ) => PlatformPointerUtil.nullPtr();
+}

--- a/frb_dart/test/js_interop_protocol_test.dart
+++ b/frb_dart/test/js_interop_protocol_test.dart
@@ -58,8 +58,8 @@ void main() {
     );
   });
 
-  test('DCO string decoder accepts integer character codes', () {
-    expect(dcoDecodeString(65), 'A');
+  test('DCO string decoder rejects integer character codes', () {
+    expect(() => dcoDecodeString(65), throwsA(isA<TypeError>()));
   });
 
   test('Fake binding encodes Dart opaque values as null pointers', () {

--- a/frb_dart/test/js_interop_protocol_web_test.dart
+++ b/frb_dart/test/js_interop_protocol_web_test.dart
@@ -1,0 +1,38 @@
+@TestOn('browser')
+import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated_web.dart';
+import 'package:test/test.dart';
+
+@JS('BigInt64Array')
+extension type _JSBigInt64Array(JSObject _) implements JSObject {}
+
+@JS('BigUint64Array')
+extension type _JSBigUint64Array(JSObject _) implements JSObject {}
+
+void main() {
+  test('DCO primitive integer decoder accepts integral JavaScript numbers', () {
+    expect(dcoDecodePrimitiveInt(42.0), 42);
+  });
+
+  test('DCO string decoder accepts JavaScript strings without dartify', () {
+    expect(dcoDecodeString('hello'.toJS), 'hello');
+  });
+
+  test('DCO string decoder accepts JavaScript integer character codes', () {
+    expect(dcoDecodeString(65.toJS), 'A');
+  });
+
+  test('CST int64 list encoder emits BigInt64Array', () {
+    final encoded = cstEncodeInt64List([BigInt.from(-1), BigInt.zero]);
+
+    expect(encoded.isA<_JSBigInt64Array>(), isTrue);
+  });
+
+  test('CST uint64 list encoder emits BigUint64Array', () {
+    final encoded = cstEncodeUint64List([
+      BigInt.zero,
+      BigInt.parse('18446744073709551615'),
+    ]);
+
+    expect(encoded.isA<_JSBigUint64Array>(), isTrue);
+  });
+}

--- a/frb_dart/test/js_interop_protocol_web_test.dart
+++ b/frb_dart/test/js_interop_protocol_web_test.dart
@@ -17,8 +17,8 @@ void main() {
     expect(dcoDecodeString('hello'.toJS), 'hello');
   });
 
-  test('DCO string decoder accepts JavaScript integer character codes', () {
-    expect(dcoDecodeString(65.toJS), 'A');
+  test('DCO string decoder rejects JavaScript integer character codes', () {
+    expect(() => dcoDecodeString(65.toJS), throwsException);
   });
 
   test('CST int64 list encoder emits BigInt64Array', () {

--- a/frb_example/dart_build_rs/lib/src/rust/frb_generated.dart
+++ b/frb_example/dart_build_rs/lib/src/rust/frb_generated.dart
@@ -147,7 +147,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   int dco_decode_i_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dcoDecodePrimitiveInt(raw);
   }
 
   @protected

--- a/frb_example/dart_minimal/lib/src/rust/frb_generated.dart
+++ b/frb_example/dart_minimal/lib/src/rust/frb_generated.dart
@@ -147,7 +147,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   int dco_decode_i_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dcoDecodePrimitiveInt(raw);
   }
 
   @protected

--- a/frb_example/flutter_package/lib/src/rust/frb_generated.dart
+++ b/frb_example/flutter_package/lib/src/rust/frb_generated.dart
@@ -144,7 +144,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   String dco_decode_String(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as String;
+    return dcoDecodeString(raw);
   }
 
   @protected
@@ -156,7 +156,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   int dco_decode_u_8(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dcoDecodePrimitiveInt(raw);
   }
 
   @protected

--- a/frb_example/flutter_package_native_assets/lib/src/rust/frb_generated.dart
+++ b/frb_example/flutter_package_native_assets/lib/src/rust/frb_generated.dart
@@ -144,7 +144,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   String dco_decode_String(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as String;
+    return dcoDecodeString(raw);
   }
 
   @protected
@@ -156,7 +156,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   int dco_decode_u_8(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dcoDecodePrimitiveInt(raw);
   }
 
   @protected

--- a/frb_example/flutter_via_create/lib/src/rust/frb_generated.dart
+++ b/frb_example/flutter_via_create/lib/src/rust/frb_generated.dart
@@ -144,7 +144,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   String dco_decode_String(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as String;
+    return dcoDecodeString(raw);
   }
 
   @protected
@@ -156,7 +156,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   int dco_decode_u_8(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dcoDecodePrimitiveInt(raw);
   }
 
   @protected

--- a/frb_example/flutter_via_create_native_assets/lib/src/rust/frb_generated.dart
+++ b/frb_example/flutter_via_create_native_assets/lib/src/rust/frb_generated.dart
@@ -144,7 +144,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   String dco_decode_String(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as String;
+    return dcoDecodeString(raw);
   }
 
   @protected
@@ -156,7 +156,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   int dco_decode_u_8(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dcoDecodePrimitiveInt(raw);
   }
 
   @protected

--- a/frb_example/flutter_via_integrate/lib/src/rust/frb_generated.dart
+++ b/frb_example/flutter_via_integrate/lib/src/rust/frb_generated.dart
@@ -144,7 +144,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   String dco_decode_String(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as String;
+    return dcoDecodeString(raw);
   }
 
   @protected
@@ -156,7 +156,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   int dco_decode_u_8(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dcoDecodePrimitiveInt(raw);
   }
 
   @protected

--- a/frb_example/flutter_via_integrate_native_assets/lib/src/rust/frb_generated.dart
+++ b/frb_example/flutter_via_integrate_native_assets/lib/src/rust/frb_generated.dart
@@ -144,7 +144,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   String dco_decode_String(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as String;
+    return dcoDecodeString(raw);
   }
 
   @protected
@@ -156,7 +156,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   int dco_decode_u_8(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dcoDecodePrimitiveInt(raw);
   }
 
   @protected

--- a/frb_example/gallery/lib/src/rust/frb_generated.dart
+++ b/frb_example/gallery/lib/src/rust/frb_generated.dart
@@ -130,13 +130,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   AnyhowException dco_decode_AnyhowException(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AnyhowException(raw as String);
+    return AnyhowException(dcoDecodeString(raw));
   }
 
   @protected
   String dco_decode_String(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as String;
+    return dcoDecodeString(raw);
   }
 
   @protected
@@ -160,7 +160,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   int dco_decode_i_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dcoDecodePrimitiveInt(raw);
   }
 
   @protected
@@ -172,7 +172,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   Point dco_decode_point(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return Point(
@@ -184,7 +184,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   Size dco_decode_size(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return Size(
@@ -196,7 +196,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   int dco_decode_u_8(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dcoDecodePrimitiveInt(raw);
   }
 
   @protected

--- a/frb_example/integrate_third_party/lib/src/rust/frb_generated.dart
+++ b/frb_example/integrate_third_party/lib/src/rust/frb_generated.dart
@@ -17997,7 +17997,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argNames: [],
       );
 
-  Future<void> Function(int, dynamic)
+  Future<void> Function(dynamic, dynamic)
       encode_DartFn_Inputs_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioProcessingEvent_Output_unit_AnyhowException(
           FutureOr<void> Function(AudioProcessingEvent) raw) {
     return (callId, rawArg0) async {
@@ -18025,14 +18025,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       final output = serializer.intoRaw();
 
       generalizedFrbRustBinding.dartFnDeliverOutput(
-          callId: callId,
+          callId: dcoDecodePrimitiveInt(callId),
           ptr: output.ptr,
           rustVecLen: output.rustVecLen,
           dataLen: output.dataLen);
     };
   }
 
-  Future<void> Function(int, dynamic)
+  Future<void> Function(dynamic, dynamic)
       encode_DartFn_Inputs_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEvent_Output_unit_AnyhowException(
           FutureOr<void> Function(Event) raw) {
     return (callId, rawArg0) async {
@@ -18060,14 +18060,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       final output = serializer.intoRaw();
 
       generalizedFrbRustBinding.dartFnDeliverOutput(
-          callId: callId,
+          callId: dcoDecodePrimitiveInt(callId),
           ptr: output.ptr,
           rustVecLen: output.rustVecLen,
           dataLen: output.dataLen);
     };
   }
 
-  Future<void> Function(int, dynamic)
+  Future<void> Function(dynamic, dynamic)
       encode_DartFn_Inputs_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOfflineAudioCompletionEvent_Output_unit_AnyhowException(
           FutureOr<void> Function(OfflineAudioCompletionEvent) raw) {
     return (callId, rawArg0) async {
@@ -18095,14 +18095,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       final output = serializer.intoRaw();
 
       generalizedFrbRustBinding.dartFnDeliverOutput(
-          callId: callId,
+          callId: dcoDecodePrimitiveInt(callId),
           ptr: output.ptr,
           rustVecLen: output.rustVecLen,
           dataLen: output.dataLen);
     };
   }
 
-  Future<void> Function(int, dynamic)
+  Future<void> Function(dynamic, dynamic)
       encode_DartFn_Inputs_String_Output_unit_AnyhowException(
           FutureOr<void> Function(String) raw) {
     return (callId, rawArg0) async {
@@ -18128,7 +18128,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       final output = serializer.intoRaw();
 
       generalizedFrbRustBinding.dartFnDeliverOutput(
-          callId: callId,
+          callId: dcoDecodePrimitiveInt(callId),
           ptr: output.ptr,
           rustVecLen: output.rustVecLen,
           dataLen: output.dataLen);
@@ -18488,7 +18488,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   AnyhowException dco_decode_AnyhowException(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AnyhowException(raw as String);
+    return AnyhowException(dcoDecodeString(raw));
   }
 
   @protected
@@ -18712,7 +18712,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAnalyserNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AnalyserNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return AnalyserNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -18720,7 +18720,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioBuffer(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AudioBufferImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return AudioBufferImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -18728,7 +18728,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioBufferSourceNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AudioBufferSourceNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return AudioBufferSourceNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -18736,7 +18736,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioContext(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AudioContextImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return AudioContextImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -18744,7 +18744,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioDestinationNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AudioDestinationNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return AudioDestinationNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -18752,7 +18752,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioListener(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AudioListenerImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return AudioListenerImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -18760,7 +18760,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioParam(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AudioParamImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return AudioParamImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -18768,7 +18768,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioParamId(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AudioParamIdImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return AudioParamIdImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -18776,7 +18776,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioProcessingEvent(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AudioProcessingEventImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return AudioProcessingEventImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -18784,7 +18784,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioRenderCapacity(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AudioRenderCapacityImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return AudioRenderCapacityImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -18793,7 +18793,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return AudioRenderCapacityEventImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -18801,7 +18801,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioWorkletNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AudioWorkletNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return AudioWorkletNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -18809,7 +18809,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBiquadFilterNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BiquadFilterNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BiquadFilterNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -18817,7 +18817,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBlobEvent(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BlobEventImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BlobEventImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -18825,7 +18825,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChannelConfig(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return ChannelConfigImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return ChannelConfigImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -18833,7 +18833,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChannelMergerNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return ChannelMergerNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return ChannelMergerNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -18841,7 +18841,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChannelSplitterNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return ChannelSplitterNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return ChannelSplitterNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -18850,7 +18850,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return ConcreteBaseAudioContextImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -18858,7 +18858,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerConstantSourceNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return ConstantSourceNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return ConstantSourceNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -18866,7 +18866,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerConvolverNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return ConvolverNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return ConvolverNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -18874,7 +18874,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDelayNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DelayNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return DelayNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -18882,7 +18882,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDummyStruct(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DummyStructImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return DummyStructImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -18890,8 +18890,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDynamicsCompressorNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DynamicsCompressorNodeImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return DynamicsCompressorNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -18899,7 +18898,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEvent(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return EventImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return EventImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -18907,7 +18906,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerGainNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return GainNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return GainNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -18915,7 +18914,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerIIRFilterNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return IirFilterNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return IirFilterNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -18924,7 +18923,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MediaElementAudioSourceNodeImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -18932,7 +18931,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMediaRecorder(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return MediaRecorderImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return MediaRecorderImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -18940,7 +18939,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMediaStream(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return MediaStreamImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return MediaStreamImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -18949,7 +18948,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MediaStreamAudioDestinationNodeImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -18958,7 +18957,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MediaStreamAudioSourceNodeImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -18966,8 +18965,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMediaStreamConstraints(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return MediaStreamConstraintsImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return MediaStreamConstraintsImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -18975,7 +18973,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMediaStreamTrack(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return MediaStreamTrackImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return MediaStreamTrackImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -18984,7 +18982,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MediaStreamTrackAudioSourceNodeImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -18992,7 +18990,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMyMediaElement(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return MediaElementImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return MediaElementImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19001,7 +18999,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return OfflineAudioCompletionEventImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -19009,7 +19007,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOfflineAudioContext(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OfflineAudioContextImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OfflineAudioContextImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19017,7 +19015,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOscillatorNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OscillatorNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OscillatorNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19025,7 +19023,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPannerNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return PannerNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return PannerNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19033,7 +19031,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPeriodicWave(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return PeriodicWaveImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return PeriodicWaveImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19041,7 +19039,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerScriptProcessorNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return ScriptProcessorNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return ScriptProcessorNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19049,7 +19047,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStereoPannerNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return StereoPannerNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return StereoPannerNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19057,7 +19055,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWaveShaperNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return WaveShaperNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return WaveShaperNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19065,7 +19063,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAnalyserNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AnalyserNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return AnalyserNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19073,7 +19071,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioBuffer(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AudioBufferImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return AudioBufferImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19081,7 +19079,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioBufferSourceNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AudioBufferSourceNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return AudioBufferSourceNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19089,7 +19087,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioProcessingEvent(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AudioProcessingEventImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return AudioProcessingEventImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19098,7 +19096,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return AudioRenderCapacityEventImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -19106,7 +19104,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBiquadFilterNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BiquadFilterNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BiquadFilterNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19114,7 +19112,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBlobEvent(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BlobEventImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BlobEventImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19122,7 +19120,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerConstantSourceNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return ConstantSourceNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return ConstantSourceNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19130,7 +19128,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerConvolverNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return ConvolverNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return ConvolverNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19138,7 +19136,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMyMediaElement(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return MediaElementImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return MediaElementImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19147,7 +19145,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return OfflineAudioCompletionEventImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -19155,7 +19153,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOfflineAudioContext(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OfflineAudioContextImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OfflineAudioContextImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19163,7 +19161,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOscillatorNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OscillatorNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OscillatorNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19171,7 +19169,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPannerNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return PannerNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return PannerNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19179,7 +19177,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWaveShaperNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return WaveShaperNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return WaveShaperNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19187,7 +19185,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAnalyserNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AnalyserNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return AnalyserNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19195,7 +19193,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioBuffer(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AudioBufferImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return AudioBufferImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19203,7 +19201,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioBufferSourceNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AudioBufferSourceNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return AudioBufferSourceNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19211,7 +19209,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioContext(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AudioContextImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return AudioContextImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19220,7 +19218,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return AudioContextRegistrationImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -19228,7 +19226,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioDestinationNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AudioDestinationNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return AudioDestinationNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19236,7 +19234,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioListener(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AudioListenerImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return AudioListenerImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19244,7 +19242,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioParam(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AudioParamImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return AudioParamImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19252,7 +19250,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioProcessingEvent(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AudioProcessingEventImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return AudioProcessingEventImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19260,7 +19258,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioRenderCapacity(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AudioRenderCapacityImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return AudioRenderCapacityImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19269,7 +19267,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return AudioRenderCapacityEventImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -19277,7 +19275,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioWorkletNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AudioWorkletNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return AudioWorkletNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19285,7 +19283,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBiquadFilterNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BiquadFilterNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BiquadFilterNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19293,7 +19291,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBlobEvent(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BlobEventImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BlobEventImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19301,7 +19299,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChannelMergerNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return ChannelMergerNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return ChannelMergerNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19309,7 +19307,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChannelSplitterNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return ChannelSplitterNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return ChannelSplitterNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19318,7 +19316,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return ConcreteBaseAudioContextImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -19326,7 +19324,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerConstantSourceNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return ConstantSourceNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return ConstantSourceNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19334,7 +19332,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerConvolverNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return ConvolverNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return ConvolverNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19342,7 +19340,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDelayNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DelayNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return DelayNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19350,8 +19348,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDynamicsCompressorNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DynamicsCompressorNodeImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return DynamicsCompressorNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19359,7 +19356,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEvent(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return EventImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return EventImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19367,7 +19364,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerGainNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return GainNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return GainNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19375,7 +19372,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerIIRFilterNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return IirFilterNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return IirFilterNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19384,7 +19381,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MediaElementAudioSourceNodeImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -19392,7 +19389,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMediaRecorder(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return MediaRecorderImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return MediaRecorderImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19400,7 +19397,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMediaStream(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return MediaStreamImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return MediaStreamImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19409,7 +19406,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MediaStreamAudioDestinationNodeImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -19418,7 +19415,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MediaStreamAudioSourceNodeImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -19426,7 +19423,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMediaStreamTrack(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return MediaStreamTrackImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return MediaStreamTrackImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19435,7 +19432,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MediaStreamTrackAudioSourceNodeImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -19443,7 +19440,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMyMediaElement(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return MediaElementImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return MediaElementImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19452,7 +19449,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return OfflineAudioCompletionEventImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -19460,7 +19457,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOfflineAudioContext(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OfflineAudioContextImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OfflineAudioContextImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19468,7 +19465,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOscillatorNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OscillatorNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OscillatorNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19476,7 +19473,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPannerNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return PannerNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return PannerNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19484,7 +19481,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerScriptProcessorNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return ScriptProcessorNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return ScriptProcessorNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19492,7 +19489,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStereoPannerNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return StereoPannerNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return StereoPannerNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19500,7 +19497,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWaveShaperNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return WaveShaperNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return WaveShaperNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19873,7 +19870,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAnalyserNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AnalyserNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return AnalyserNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19881,7 +19878,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioBuffer(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AudioBufferImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return AudioBufferImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19889,7 +19886,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioBufferSourceNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AudioBufferSourceNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return AudioBufferSourceNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19897,7 +19894,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioContext(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AudioContextImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return AudioContextImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19906,7 +19903,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return AudioContextRegistrationImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -19914,7 +19911,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioDestinationNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AudioDestinationNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return AudioDestinationNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19922,7 +19919,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioListener(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AudioListenerImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return AudioListenerImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19930,7 +19927,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioParam(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AudioParamImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return AudioParamImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19938,7 +19935,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioParamId(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AudioParamIdImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return AudioParamIdImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19946,7 +19943,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioProcessingEvent(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AudioProcessingEventImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return AudioProcessingEventImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19954,7 +19951,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioRenderCapacity(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AudioRenderCapacityImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return AudioRenderCapacityImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19963,7 +19960,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return AudioRenderCapacityEventImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -19971,7 +19968,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioWorkletNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AudioWorkletNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return AudioWorkletNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19979,7 +19976,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBiquadFilterNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BiquadFilterNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BiquadFilterNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19987,7 +19984,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBlobEvent(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BlobEventImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BlobEventImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -19995,7 +19992,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChannelConfig(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return ChannelConfigImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return ChannelConfigImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -20003,7 +20000,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChannelMergerNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return ChannelMergerNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return ChannelMergerNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -20011,7 +20008,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChannelSplitterNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return ChannelSplitterNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return ChannelSplitterNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -20020,7 +20017,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return ConcreteBaseAudioContextImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -20028,7 +20025,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerConstantSourceNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return ConstantSourceNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return ConstantSourceNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -20036,7 +20033,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerConvolverNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return ConvolverNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return ConvolverNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -20044,7 +20041,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDelayNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DelayNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return DelayNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -20052,7 +20049,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDummyStruct(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DummyStructImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return DummyStructImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -20060,8 +20057,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDynamicsCompressorNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DynamicsCompressorNodeImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return DynamicsCompressorNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -20069,7 +20065,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEvent(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return EventImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return EventImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -20077,7 +20073,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerGainNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return GainNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return GainNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -20085,7 +20081,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerIIRFilterNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return IirFilterNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return IirFilterNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -20094,7 +20090,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MediaElementAudioSourceNodeImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -20102,7 +20098,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMediaRecorder(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return MediaRecorderImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return MediaRecorderImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -20110,7 +20106,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMediaStream(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return MediaStreamImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return MediaStreamImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -20119,7 +20115,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MediaStreamAudioDestinationNodeImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -20128,7 +20124,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MediaStreamAudioSourceNodeImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -20136,8 +20132,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMediaStreamConstraints(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return MediaStreamConstraintsImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return MediaStreamConstraintsImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -20145,7 +20140,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMediaStreamTrack(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return MediaStreamTrackImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return MediaStreamTrackImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -20154,7 +20149,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MediaStreamTrackAudioSourceNodeImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -20162,7 +20157,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMyMediaElement(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return MediaElementImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return MediaElementImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -20171,7 +20166,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return OfflineAudioCompletionEventImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -20179,7 +20174,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOfflineAudioContext(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OfflineAudioContextImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OfflineAudioContextImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -20187,7 +20182,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOscillatorNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OscillatorNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OscillatorNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -20195,7 +20190,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPannerNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return PannerNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return PannerNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -20203,7 +20198,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPeriodicWave(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return PeriodicWaveImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return PeriodicWaveImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -20211,7 +20206,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerScriptProcessorNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return ScriptProcessorNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return ScriptProcessorNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -20219,7 +20214,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStereoPannerNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return StereoPannerNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return StereoPannerNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -20227,13 +20222,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWaveShaperNode(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return WaveShaperNodeImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return WaveShaperNodeImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
   String dco_decode_String(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as String;
+    return dcoDecodeString(raw);
   }
 
   @protected
@@ -20480,7 +20475,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   AnalyserOptions dco_decode_analyser_options(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 5)
       throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
     return AnalyserOptions(
@@ -20495,7 +20490,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   AudioBufferOptions dco_decode_audio_buffer_options(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return AudioBufferOptions(
@@ -20508,7 +20503,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   AudioBufferSourceOptions dco_decode_audio_buffer_source_options(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 6)
       throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
     return AudioBufferSourceOptions(
@@ -20527,7 +20522,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   AudioContextLatencyCategory dco_decode_audio_context_latency_category(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return AudioContextLatencyCategory_Balanced();
       case 1:
@@ -20536,7 +20532,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         return AudioContextLatencyCategory_Playback();
       case 3:
         return AudioContextLatencyCategory_Custom(
-          dco_decode_f_64(raw[1]),
+          dco_decode_f_64(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -20546,7 +20542,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   AudioContextOptions dco_decode_audio_context_options(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return AudioContextOptions(
@@ -20561,133 +20557,134 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   AudioContextRenderSizeCategory dco_decode_audio_context_render_size_category(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AudioContextRenderSizeCategory.values[raw as int];
+    return AudioContextRenderSizeCategory.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   AudioContextState dco_decode_audio_context_state(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AudioContextState.values[raw as int];
+    return AudioContextState.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   AudioNodeImplementor dco_decode_audio_node_implementor(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return AudioNodeImplementor_Variant0(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAnalyserNode(
-              raw[1]),
+              arr[1]),
         );
       case 1:
         return AudioNodeImplementor_Variant1(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioBufferSourceNode(
-              raw[1]),
+              arr[1]),
         );
       case 2:
         return AudioNodeImplementor_Variant2(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioDestinationNode(
-              raw[1]),
+              arr[1]),
         );
       case 3:
         return AudioNodeImplementor_Variant3(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioParam(
-              raw[1]),
+              arr[1]),
         );
       case 4:
         return AudioNodeImplementor_Variant4(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioWorkletNode(
-              raw[1]),
+              arr[1]),
         );
       case 5:
         return AudioNodeImplementor_Variant5(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBiquadFilterNode(
-              raw[1]),
+              arr[1]),
         );
       case 6:
         return AudioNodeImplementor_Variant6(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChannelMergerNode(
-              raw[1]),
+              arr[1]),
         );
       case 7:
         return AudioNodeImplementor_Variant7(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChannelSplitterNode(
-              raw[1]),
+              arr[1]),
         );
       case 8:
         return AudioNodeImplementor_Variant8(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerConstantSourceNode(
-              raw[1]),
+              arr[1]),
         );
       case 9:
         return AudioNodeImplementor_Variant9(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerConvolverNode(
-              raw[1]),
+              arr[1]),
         );
       case 10:
         return AudioNodeImplementor_Variant10(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDelayNode(
-              raw[1]),
+              arr[1]),
         );
       case 11:
         return AudioNodeImplementor_Variant11(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDynamicsCompressorNode(
-              raw[1]),
+              arr[1]),
         );
       case 12:
         return AudioNodeImplementor_Variant12(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerGainNode(
-              raw[1]),
+              arr[1]),
         );
       case 13:
         return AudioNodeImplementor_Variant13(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerIIRFilterNode(
-              raw[1]),
+              arr[1]),
         );
       case 14:
         return AudioNodeImplementor_Variant14(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMediaElementAudioSourceNode(
-              raw[1]),
+              arr[1]),
         );
       case 15:
         return AudioNodeImplementor_Variant15(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMediaStreamAudioDestinationNode(
-              raw[1]),
+              arr[1]),
         );
       case 16:
         return AudioNodeImplementor_Variant16(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMediaStreamAudioSourceNode(
-              raw[1]),
+              arr[1]),
         );
       case 17:
         return AudioNodeImplementor_Variant17(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMediaStreamTrackAudioSourceNode(
-              raw[1]),
+              arr[1]),
         );
       case 18:
         return AudioNodeImplementor_Variant18(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOscillatorNode(
-              raw[1]),
+              arr[1]),
         );
       case 19:
         return AudioNodeImplementor_Variant19(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPannerNode(
-              raw[1]),
+              arr[1]),
         );
       case 20:
         return AudioNodeImplementor_Variant20(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerScriptProcessorNode(
-              raw[1]),
+              arr[1]),
         );
       case 21:
         return AudioNodeImplementor_Variant21(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStereoPannerNode(
-              raw[1]),
+              arr[1]),
         );
       case 22:
         return AudioNodeImplementor_Variant22(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWaveShaperNode(
-              raw[1]),
+              arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -20697,7 +20694,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   AudioNodeOptions dco_decode_audio_node_options(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return AudioNodeOptions(
@@ -20710,7 +20707,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   AudioParamDescriptor dco_decode_audio_param_descriptor(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 5)
       throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
     return AudioParamDescriptor(
@@ -20726,7 +20723,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   AudioRenderCapacityOptions dco_decode_audio_render_capacity_options(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return AudioRenderCapacityOptions(
@@ -20739,166 +20736,167 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_auto_ref_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_audio_param_proxy_enum(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioParamProxyEnum_Variant0(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioBufferSourceNode(
-              raw[1]),
+              arr[1]),
         );
       case 1:
         return Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioParamProxyEnum_Variant1(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioBufferSourceNode(
-              raw[1]),
+              arr[1]),
         );
       case 2:
         return Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioParamProxyEnum_Variant2(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioListener(
-              raw[1]),
+              arr[1]),
         );
       case 3:
         return Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioParamProxyEnum_Variant3(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioListener(
-              raw[1]),
+              arr[1]),
         );
       case 4:
         return Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioParamProxyEnum_Variant4(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioListener(
-              raw[1]),
+              arr[1]),
         );
       case 5:
         return Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioParamProxyEnum_Variant5(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioListener(
-              raw[1]),
+              arr[1]),
         );
       case 6:
         return Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioParamProxyEnum_Variant6(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioListener(
-              raw[1]),
+              arr[1]),
         );
       case 7:
         return Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioParamProxyEnum_Variant7(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioListener(
-              raw[1]),
+              arr[1]),
         );
       case 8:
         return Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioParamProxyEnum_Variant8(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioListener(
-              raw[1]),
+              arr[1]),
         );
       case 9:
         return Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioParamProxyEnum_Variant9(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioListener(
-              raw[1]),
+              arr[1]),
         );
       case 10:
         return Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioParamProxyEnum_Variant10(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioListener(
-              raw[1]),
+              arr[1]),
         );
       case 11:
         return Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioParamProxyEnum_Variant11(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBiquadFilterNode(
-              raw[1]),
+              arr[1]),
         );
       case 12:
         return Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioParamProxyEnum_Variant12(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBiquadFilterNode(
-              raw[1]),
+              arr[1]),
         );
       case 13:
         return Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioParamProxyEnum_Variant13(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBiquadFilterNode(
-              raw[1]),
+              arr[1]),
         );
       case 14:
         return Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioParamProxyEnum_Variant14(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBiquadFilterNode(
-              raw[1]),
+              arr[1]),
         );
       case 15:
         return Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioParamProxyEnum_Variant15(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerConstantSourceNode(
-              raw[1]),
+              arr[1]),
         );
       case 16:
         return Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioParamProxyEnum_Variant16(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDelayNode(
-              raw[1]),
+              arr[1]),
         );
       case 17:
         return Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioParamProxyEnum_Variant17(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDynamicsCompressorNode(
-              raw[1]),
+              arr[1]),
         );
       case 18:
         return Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioParamProxyEnum_Variant18(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDynamicsCompressorNode(
-              raw[1]),
+              arr[1]),
         );
       case 19:
         return Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioParamProxyEnum_Variant19(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDynamicsCompressorNode(
-              raw[1]),
+              arr[1]),
         );
       case 20:
         return Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioParamProxyEnum_Variant20(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDynamicsCompressorNode(
-              raw[1]),
+              arr[1]),
         );
       case 21:
         return Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioParamProxyEnum_Variant21(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDynamicsCompressorNode(
-              raw[1]),
+              arr[1]),
         );
       case 22:
         return Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioParamProxyEnum_Variant22(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerGainNode(
-              raw[1]),
+              arr[1]),
         );
       case 23:
         return Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioParamProxyEnum_Variant23(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOscillatorNode(
-              raw[1]),
+              arr[1]),
         );
       case 24:
         return Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioParamProxyEnum_Variant24(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOscillatorNode(
-              raw[1]),
+              arr[1]),
         );
       case 25:
         return Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioParamProxyEnum_Variant25(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPannerNode(
-              raw[1]),
+              arr[1]),
         );
       case 26:
         return Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioParamProxyEnum_Variant26(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPannerNode(
-              raw[1]),
+              arr[1]),
         );
       case 27:
         return Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioParamProxyEnum_Variant27(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPannerNode(
-              raw[1]),
+              arr[1]),
         );
       case 28:
         return Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioParamProxyEnum_Variant28(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPannerNode(
-              raw[1]),
+              arr[1]),
         );
       case 29:
         return Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioParamProxyEnum_Variant29(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPannerNode(
-              raw[1]),
+              arr[1]),
         );
       case 30:
         return Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioParamProxyEnum_Variant30(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPannerNode(
-              raw[1]),
+              arr[1]),
         );
       case 31:
         return Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAudioParamProxyEnum_Variant31(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStereoPannerNode(
-              raw[1]),
+              arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -20910,11 +20908,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_auto_ref_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_media_stream_proxy_enum(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMediaStreamProxyEnum_Variant0(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMediaStreamAudioDestinationNode(
-              raw[1]),
+              arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -20924,13 +20923,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   AutomationRate dco_decode_automation_rate(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AutomationRate.values[raw as int];
+    return AutomationRate.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   BiquadFilterOptions dco_decode_biquad_filter_options(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 6)
       throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
     return BiquadFilterOptions(
@@ -20946,7 +20945,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BiquadFilterType dco_decode_biquad_filter_type(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BiquadFilterType.values[raw as int];
+    return BiquadFilterType.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
@@ -21041,19 +21040,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   ChannelCountMode dco_decode_channel_count_mode(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return ChannelCountMode.values[raw as int];
+    return ChannelCountMode.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   ChannelInterpretation dco_decode_channel_interpretation(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return ChannelInterpretation.values[raw as int];
+    return ChannelInterpretation.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   ChannelMergerOptions dco_decode_channel_merger_options(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return ChannelMergerOptions(
@@ -21065,7 +21064,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   ChannelSplitterOptions dco_decode_channel_splitter_options(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return ChannelSplitterOptions(
@@ -21077,7 +21076,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   ConstantSourceOptions dco_decode_constant_source_options(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return ConstantSourceOptions(
@@ -21088,7 +21087,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   ConvolverOptions dco_decode_convolver_options(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return ConvolverOptions(
@@ -21103,7 +21102,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   DelayOptions dco_decode_delay_options(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return DelayOptions(
@@ -21116,14 +21115,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   DistanceModelType dco_decode_distance_model_type(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DistanceModelType.values[raw as int];
+    return DistanceModelType.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   DynamicsCompressorOptions dco_decode_dynamics_compressor_options(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 6)
       throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
     return DynamicsCompressorOptions(
@@ -21151,7 +21150,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   GainOptions dco_decode_gain_options(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return GainOptions(
@@ -21163,7 +21162,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   int dco_decode_i_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dcoDecodePrimitiveInt(raw);
   }
 
   @protected
@@ -21177,7 +21176,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_list_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMediaStreamTrack(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(
             dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMediaStreamTrack)
         .toList();
@@ -21187,17 +21186,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<AudioParamDescriptor> dco_decode_list_audio_param_descriptor(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_audio_param_descriptor)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_audio_param_descriptor).toList();
   }
 
   @protected
   List<Float32List> dco_decode_list_list_prim_f_32_strict(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_list_prim_f_32_strict)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_list_prim_f_32_strict).toList();
   }
 
   @protected
@@ -21233,7 +21228,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MediaStreamTrackState dco_decode_media_stream_track_state(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return MediaStreamTrackState.values[raw as int];
+    return MediaStreamTrackState.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
@@ -21273,7 +21268,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   OscillatorOptions dco_decode_oscillator_options(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 5)
       throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
     return OscillatorOptions(
@@ -21290,19 +21285,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   OscillatorType dco_decode_oscillator_type(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OscillatorType.values[raw as int];
+    return OscillatorType.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   OverSampleType dco_decode_over_sample_type(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OverSampleType.values[raw as int];
+    return OverSampleType.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   PannerOptions dco_decode_panner_options(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 15)
       throw Exception('unexpected arr length: expect 15 but see ${arr.length}');
     return PannerOptions(
@@ -21327,13 +21322,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PanningModelType dco_decode_panning_model_type(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return PanningModelType.values[raw as int];
+    return PanningModelType.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   PeriodicWaveOptions dco_decode_periodic_wave_options(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return PeriodicWaveOptions(
@@ -21350,7 +21345,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) dco_decode_record_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_audio_param_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_audio_param_id(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -21365,7 +21360,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   StereoPannerOptions dco_decode_stereo_panner_options(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StereoPannerOptions(
@@ -21377,7 +21372,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   int dco_decode_u_8(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dcoDecodePrimitiveInt(raw);
   }
 
   @protected
@@ -21395,7 +21390,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   WaveShaperOptions dco_decode_wave_shaper_options(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return WaveShaperOptions(

--- a/frb_example/pure_dart/lib/src/rust/frb_generated.dart
+++ b/frb_example/pure_dart/lib/src/rust/frb_generated.dart
@@ -101455,7 +101455,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             argNames: ["id"],
           );
 
-  Future<void> Function(int, dynamic)
+  Future<void> Function(dynamic, dynamic)
       encode_DartFn_Inputs_CustomSerializer_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerIpv4Addr_Output_CustomSerializer_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerIpv4Addr_AnyhowException(
           FutureOr<InternetAddress> Function(InternetAddress) raw) {
     return (callId, rawArg0) async {
@@ -101484,14 +101484,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       final output = serializer.intoRaw();
 
       generalizedFrbRustBinding.dartFnDeliverOutput(
-          callId: callId,
+          callId: dcoDecodePrimitiveInt(callId),
           ptr: output.ptr,
           rustVecLen: output.rustVecLen,
           dataLen: output.dataLen);
     };
   }
 
-  Future<void> Function(int, dynamic)
+  Future<void> Function(dynamic, dynamic)
       encode_DartFn_Inputs_DartOpaque_Output_unit_AnyhowException(
           FutureOr<void> Function(Object) raw) {
     return (callId, rawArg0) async {
@@ -101517,14 +101517,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       final output = serializer.intoRaw();
 
       generalizedFrbRustBinding.dartFnDeliverOutput(
-          callId: callId,
+          callId: dcoDecodePrimitiveInt(callId),
           ptr: output.ptr,
           rustVecLen: output.rustVecLen,
           dataLen: output.dataLen);
     };
   }
 
-  Future<void> Function(int, dynamic)
+  Future<void> Function(dynamic, dynamic)
       encode_DartFn_Inputs_String_Output_String_AnyhowException(
           FutureOr<String> Function(String) raw) {
     return (callId, rawArg0) async {
@@ -101550,14 +101550,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       final output = serializer.intoRaw();
 
       generalizedFrbRustBinding.dartFnDeliverOutput(
-          callId: callId,
+          callId: dcoDecodePrimitiveInt(callId),
           ptr: output.ptr,
           rustVecLen: output.rustVecLen,
           dataLen: output.dataLen);
     };
   }
 
-  Future<void> Function(int, dynamic)
+  Future<void> Function(dynamic, dynamic)
       encode_DartFn_Inputs_String_Output_unit_AnyhowException(
           FutureOr<void> Function(String) raw) {
     return (callId, rawArg0) async {
@@ -101583,14 +101583,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       final output = serializer.intoRaw();
 
       generalizedFrbRustBinding.dartFnDeliverOutput(
-          callId: callId,
+          callId: dcoDecodePrimitiveInt(callId),
           ptr: output.ptr,
           rustVecLen: output.rustVecLen,
           dataLen: output.dataLen);
     };
   }
 
-  Future<void> Function(int, dynamic, dynamic)
+  Future<void> Function(dynamic, dynamic, dynamic)
       encode_DartFn_Inputs_String_demo_struct_for_rust_call_dart_twin_normal_Output_unit_AnyhowException(
           FutureOr<void> Function(String, DemoStructForRustCallDartTwinNormal)
               raw) {
@@ -101619,14 +101619,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       final output = serializer.intoRaw();
 
       generalizedFrbRustBinding.dartFnDeliverOutput(
-          callId: callId,
+          callId: dcoDecodePrimitiveInt(callId),
           ptr: output.ptr,
           rustVecLen: output.rustVecLen,
           dataLen: output.dataLen);
     };
   }
 
-  Future<void> Function(int, dynamic, dynamic)
+  Future<void> Function(dynamic, dynamic, dynamic)
       encode_DartFn_Inputs_String_demo_struct_for_rust_call_dart_twin_rust_async_Output_unit_AnyhowException(
           FutureOr<void> Function(
                   String, DemoStructForRustCallDartTwinRustAsync)
@@ -101656,14 +101656,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       final output = serializer.intoRaw();
 
       generalizedFrbRustBinding.dartFnDeliverOutput(
-          callId: callId,
+          callId: dcoDecodePrimitiveInt(callId),
           ptr: output.ptr,
           rustVecLen: output.rustVecLen,
           dataLen: output.dataLen);
     };
   }
 
-  Future<void> Function(int, dynamic, dynamic)
+  Future<void> Function(dynamic, dynamic, dynamic)
       encode_DartFn_Inputs_String_demo_struct_for_rust_call_dart_twin_rust_async_sse_Output_unit_AnyhowException(
           FutureOr<void> Function(
                   String, DemoStructForRustCallDartTwinRustAsyncSse)
@@ -101694,14 +101694,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       final output = serializer.intoRaw();
 
       generalizedFrbRustBinding.dartFnDeliverOutput(
-          callId: callId,
+          callId: dcoDecodePrimitiveInt(callId),
           ptr: output.ptr,
           rustVecLen: output.rustVecLen,
           dataLen: output.dataLen);
     };
   }
 
-  Future<void> Function(int, dynamic, dynamic)
+  Future<void> Function(dynamic, dynamic, dynamic)
       encode_DartFn_Inputs_String_demo_struct_for_rust_call_dart_twin_sse_Output_unit_AnyhowException(
           FutureOr<void> Function(String, DemoStructForRustCallDartTwinSse)
               raw) {
@@ -101729,7 +101729,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       final output = serializer.intoRaw();
 
       generalizedFrbRustBinding.dartFnDeliverOutput(
-          callId: callId,
+          callId: dcoDecodePrimitiveInt(callId),
           ptr: output.ptr,
           rustVecLen: output.rustVecLen,
           dataLen: output.dataLen);
@@ -101737,7 +101737,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   Future<void> Function(
-    int,
+    dynamic,
   ) encode_DartFn_Inputs__Output_DartOpaque_AnyhowException(
       FutureOr<Object> Function() raw) {
     return (
@@ -101763,7 +101763,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       final output = serializer.intoRaw();
 
       generalizedFrbRustBinding.dartFnDeliverOutput(
-          callId: callId,
+          callId: dcoDecodePrimitiveInt(callId),
           ptr: output.ptr,
           rustVecLen: output.rustVecLen,
           dataLen: output.dataLen);
@@ -101771,7 +101771,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   Future<void> Function(
-    int,
+    dynamic,
   ) encode_DartFn_Inputs__Output_String_AnyhowException(
       FutureOr<String> Function() raw) {
     return (
@@ -101797,7 +101797,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       final output = serializer.intoRaw();
 
       generalizedFrbRustBinding.dartFnDeliverOutput(
-          callId: callId,
+          callId: dcoDecodePrimitiveInt(callId),
           ptr: output.ptr,
           rustVecLen: output.rustVecLen,
           dataLen: output.dataLen);
@@ -101805,7 +101805,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   Future<void> Function(
-    int,
+    dynamic,
   ) encode_DartFn_Inputs__Output_unit_AnyhowException(
       FutureOr<void> Function() raw) {
     return (
@@ -101831,14 +101831,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       final output = serializer.intoRaw();
 
       generalizedFrbRustBinding.dartFnDeliverOutput(
-          callId: callId,
+          callId: dcoDecodePrimitiveInt(callId),
           ptr: output.ptr,
           rustVecLen: output.rustVecLen,
           dataLen: output.dataLen);
     };
   }
 
-  Future<void> Function(int, dynamic)
+  Future<void> Function(dynamic, dynamic)
       encode_DartFn_Inputs_demo_struct_for_rust_call_dart_twin_normal_Output_demo_struct_for_rust_call_dart_twin_normal_AnyhowException(
           FutureOr<DemoStructForRustCallDartTwinNormal> Function(
                   DemoStructForRustCallDartTwinNormal)
@@ -101868,14 +101868,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       final output = serializer.intoRaw();
 
       generalizedFrbRustBinding.dartFnDeliverOutput(
-          callId: callId,
+          callId: dcoDecodePrimitiveInt(callId),
           ptr: output.ptr,
           rustVecLen: output.rustVecLen,
           dataLen: output.dataLen);
     };
   }
 
-  Future<void> Function(int, dynamic)
+  Future<void> Function(dynamic, dynamic)
       encode_DartFn_Inputs_demo_struct_for_rust_call_dart_twin_rust_async_Output_demo_struct_for_rust_call_dart_twin_rust_async_AnyhowException(
           FutureOr<DemoStructForRustCallDartTwinRustAsync> Function(
                   DemoStructForRustCallDartTwinRustAsync)
@@ -101905,14 +101905,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       final output = serializer.intoRaw();
 
       generalizedFrbRustBinding.dartFnDeliverOutput(
-          callId: callId,
+          callId: dcoDecodePrimitiveInt(callId),
           ptr: output.ptr,
           rustVecLen: output.rustVecLen,
           dataLen: output.dataLen);
     };
   }
 
-  Future<void> Function(int, dynamic)
+  Future<void> Function(dynamic, dynamic)
       encode_DartFn_Inputs_demo_struct_for_rust_call_dart_twin_rust_async_sse_Output_demo_struct_for_rust_call_dart_twin_rust_async_sse_AnyhowException(
           FutureOr<DemoStructForRustCallDartTwinRustAsyncSse> Function(
                   DemoStructForRustCallDartTwinRustAsyncSse)
@@ -101943,14 +101943,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       final output = serializer.intoRaw();
 
       generalizedFrbRustBinding.dartFnDeliverOutput(
-          callId: callId,
+          callId: dcoDecodePrimitiveInt(callId),
           ptr: output.ptr,
           rustVecLen: output.rustVecLen,
           dataLen: output.dataLen);
     };
   }
 
-  Future<void> Function(int, dynamic)
+  Future<void> Function(dynamic, dynamic)
       encode_DartFn_Inputs_demo_struct_for_rust_call_dart_twin_sse_Output_demo_struct_for_rust_call_dart_twin_sse_AnyhowException(
           FutureOr<DemoStructForRustCallDartTwinSse> Function(
                   DemoStructForRustCallDartTwinSse)
@@ -101979,7 +101979,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       final output = serializer.intoRaw();
 
       generalizedFrbRustBinding.dartFnDeliverOutput(
-          callId: callId,
+          callId: dcoDecodePrimitiveInt(callId),
           ptr: output.ptr,
           rustVecLen: output.rustVecLen,
           dataLen: output.dataLen);
@@ -103849,7 +103849,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   AnyhowException dco_decode_AnyhowException(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AnyhowException(raw as String);
+    return AnyhowException(dcoDecodeString(raw));
   }
 
   @protected
@@ -104091,8 +104091,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBoxdynAnySendSyncstatic(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BoxAnyMyDartTypeRenameImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return BoxAnyMyDartTypeRenameImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104100,7 +104099,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBoxdynFnStringStringSendSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BoxFnStringStringImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BoxFnStringStringImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104108,7 +104107,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBoxdynMyTraitTwinMoiSendSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BoxMyTraitTwinMoiImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BoxMyTraitTwinMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104116,7 +104115,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBoxdynMyTraitTwinNormalSendSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BoxMyTraitTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BoxMyTraitTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104125,7 +104124,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return BoxMyTraitTwinRustAsyncMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104133,8 +104132,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBoxdynMyTraitTwinRustAsyncSendSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BoxMyTraitTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return BoxMyTraitTwinRustAsyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104143,7 +104141,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return BoxMyTraitTwinRustAsyncSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104152,7 +104150,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return BoxMyTraitTwinRustAsyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104160,7 +104158,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBoxdynMyTraitTwinSseMoiSendSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BoxMyTraitTwinSseMoiImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BoxMyTraitTwinSseMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104168,7 +104166,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBoxdynMyTraitTwinSseSendSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BoxMyTraitTwinSseImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BoxMyTraitTwinSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104176,7 +104174,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBoxdynMyTraitTwinSyncMoiSendSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BoxMyTraitTwinSyncMoiImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BoxMyTraitTwinSyncMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104184,7 +104182,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBoxdynMyTraitTwinSyncSendSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BoxMyTraitTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BoxMyTraitTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104193,7 +104191,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return BoxMyTraitTwinSyncSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104201,7 +104199,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBoxdynMyTraitTwinSyncSseSendSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BoxMyTraitTwinSyncSseImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BoxMyTraitTwinSyncSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104210,7 +104208,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return ConstructorOpaqueStructTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104219,7 +104217,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return ConstructorOpaqueSyncStructTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104227,8 +104225,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCustomHasherTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return CustomHasherTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return CustomHasherTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104237,7 +104234,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return CustomHasherTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104246,7 +104243,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return CustomHasherTwinRustAsyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104254,7 +104251,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCustomHasherTwinSse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return CustomHasherTwinSseImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return CustomHasherTwinSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104262,7 +104259,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCustomHasherTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return CustomHasherTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return CustomHasherTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104270,8 +104267,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCustomHasherTwinSyncSse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return CustomHasherTwinSyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return CustomHasherTwinSyncSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104280,7 +104276,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return DeliberateFailSanityCheckTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104288,7 +104284,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDroppableTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DroppableTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return DroppableTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104296,8 +104292,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDroppableTwinRustAsync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DroppableTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return DroppableTwinRustAsyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104306,7 +104301,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return DroppableTwinRustAsyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104314,7 +104309,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDroppableTwinSse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DroppableTwinSseImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return DroppableTwinSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104322,7 +104317,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDroppableTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DroppableTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return DroppableTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104330,7 +104325,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDroppableTwinSyncSse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DroppableTwinSyncSseImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return DroppableTwinSyncSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104339,7 +104334,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return EnumWithGoodAndOpaqueWithoutOptionTwinMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104348,7 +104343,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return EnumWithGoodAndOpaqueWithoutOptionTwinNormalImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104357,7 +104352,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return EnumWithGoodAndOpaqueWithoutOptionTwinRustAsyncImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104366,7 +104361,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return EnumWithGoodAndOpaqueWithoutOptionTwinRustAsyncMoiImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104375,7 +104370,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return EnumWithGoodAndOpaqueWithoutOptionTwinRustAsyncSseImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104384,7 +104379,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return EnumWithGoodAndOpaqueWithoutOptionTwinRustAsyncSseMoiImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104393,7 +104388,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return EnumWithGoodAndOpaqueWithoutOptionTwinSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104402,7 +104397,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return EnumWithGoodAndOpaqueWithoutOptionTwinSseMoiImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104411,7 +104406,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return EnumWithGoodAndOpaqueWithoutOptionTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104420,7 +104415,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return EnumWithGoodAndOpaqueWithoutOptionTwinSyncMoiImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104429,7 +104424,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return EnumWithGoodAndOpaqueWithoutOptionTwinSyncSseImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104438,7 +104433,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return EnumWithGoodAndOpaqueWithoutOptionTwinSyncSseMoiImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104447,7 +104442,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return ItemContainerSolutionOneTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104455,8 +104450,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLtOwnedStructTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return LtOwnedStructTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return LtOwnedStructTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104464,7 +104458,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLtOwnedStructTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return LtOwnedStructTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return LtOwnedStructTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104472,7 +104466,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLtSubStructTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return LtSubStructTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return LtSubStructTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104480,7 +104474,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLtSubStructTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return LtSubStructTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return LtSubStructTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104488,8 +104482,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMyAudioParamTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return MyAudioParamTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return MyAudioParamTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104498,7 +104491,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MyImplTraitWithSelfTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104507,7 +104500,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MyImplTraitWithSelfTwinSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104516,7 +104509,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MyImplTraitWithSelfTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104525,7 +104518,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MyImplTraitWithSelfTwinSyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104533,7 +104526,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMyNodeTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return MyNodeTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return MyNodeTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104542,7 +104535,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MyStructWithTryFromTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104551,7 +104544,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104560,7 +104553,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104569,7 +104562,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104578,7 +104571,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinRustAsyncMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104587,7 +104580,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinRustAsyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104596,7 +104589,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinRustAsyncSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104605,7 +104598,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104614,7 +104607,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104623,7 +104616,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104632,7 +104625,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinSyncMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104641,7 +104634,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinSyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104650,7 +104643,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinSyncSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104658,7 +104651,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinMoi(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return NonCloneSimpleTwinMoiImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return NonCloneSimpleTwinMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104667,7 +104660,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104676,7 +104669,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104685,7 +104678,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinRustAsyncMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104694,7 +104687,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinRustAsyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104703,7 +104696,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinRustAsyncSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104711,7 +104704,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinSse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return NonCloneSimpleTwinSseImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return NonCloneSimpleTwinSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104720,7 +104713,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104728,8 +104721,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return NonCloneSimpleTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return NonCloneSimpleTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104738,7 +104730,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinSyncMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104747,7 +104739,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinSyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104756,7 +104748,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinSyncSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104764,7 +104756,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueItemTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueItemTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueItemTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104772,7 +104764,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueOneTwinMoi(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueOneTwinMoiImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueOneTwinMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104780,7 +104772,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueOneTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueOneTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueOneTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104788,8 +104780,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueOneTwinRustAsync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueOneTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return OpaqueOneTwinRustAsyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104798,7 +104789,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return OpaqueOneTwinRustAsyncMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104807,7 +104798,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return OpaqueOneTwinRustAsyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104816,7 +104807,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return OpaqueOneTwinRustAsyncSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104824,7 +104815,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueOneTwinSse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueOneTwinSseImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueOneTwinSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104832,7 +104823,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueOneTwinSseMoi(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueOneTwinSseMoiImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueOneTwinSseMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104840,7 +104831,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueOneTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueOneTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueOneTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104848,7 +104839,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueOneTwinSyncMoi(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueOneTwinSyncMoiImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueOneTwinSyncMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104856,7 +104847,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueOneTwinSyncSse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueOneTwinSyncSseImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueOneTwinSyncSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104864,8 +104855,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueOneTwinSyncSseMoi(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueOneTwinSyncSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return OpaqueOneTwinSyncSseMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104874,7 +104864,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return OpaqueStructWithDartCodeTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104882,7 +104872,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueTwoTwinMoi(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueTwoTwinMoiImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueTwoTwinMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104890,7 +104880,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueTwoTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueTwoTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueTwoTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104898,8 +104888,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueTwoTwinRustAsync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueTwoTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return OpaqueTwoTwinRustAsyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104908,7 +104897,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return OpaqueTwoTwinRustAsyncMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104917,7 +104906,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return OpaqueTwoTwinRustAsyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104926,7 +104915,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return OpaqueTwoTwinRustAsyncSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104934,7 +104923,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueTwoTwinSse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueTwoTwinSseImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueTwoTwinSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104942,7 +104931,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueTwoTwinSseMoi(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueTwoTwinSseMoiImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueTwoTwinSseMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104950,7 +104939,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueTwoTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueTwoTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueTwoTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104958,7 +104947,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueTwoTwinSyncMoi(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueTwoTwinSyncMoiImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueTwoTwinSyncMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104966,7 +104955,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueTwoTwinSyncSse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueTwoTwinSyncSseImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueTwoTwinSyncSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104974,8 +104963,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueTwoTwinSyncSseMoi(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueTwoTwinSyncSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return OpaqueTwoTwinSyncSseMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -104984,7 +104972,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return RustOpaqueWebLockingDataTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -104993,7 +104981,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return RustOpaqueWebLockingDataTwinSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105001,7 +104989,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerSimpleLogger(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return SimpleLoggerImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return SimpleLoggerImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105010,7 +104998,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return SimpleOpaqueExternalStructWithMethodImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105019,7 +105007,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StaticGetterOnlyTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105028,7 +105016,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StaticGetterOnlyTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105037,7 +105025,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StaticGetterOnlyTwinRustAsyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105045,8 +105033,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStaticGetterOnlyTwinSse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return StaticGetterOnlyTwinSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return StaticGetterOnlyTwinSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105055,7 +105042,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StaticGetterOnlyTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105064,7 +105051,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StaticGetterOnlyTwinSyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105073,7 +105060,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructInMiscNoTwinExampleAImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105082,7 +105069,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructInMiscNoTwinExampleBImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105091,7 +105078,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructOneWithTraitForDynTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105100,7 +105087,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructOneWithTraitTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105109,7 +105096,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructOneWithTraitTwinSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105118,7 +105105,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructOneWithTraitTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105127,7 +105114,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructOneWithTraitTwinSyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105136,7 +105123,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructTwoWithTraitForDynTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105145,7 +105132,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructTwoWithTraitTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105154,7 +105141,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructTwoWithTraitTwinSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105163,7 +105150,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructTwoWithTraitTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105172,7 +105159,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructTwoWithTraitTwinSyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105181,7 +105168,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinMoiImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105190,7 +105177,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinNormalImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105199,7 +105186,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinRustAsyncImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105208,7 +105195,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinRustAsyncMoiImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105217,7 +105204,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinRustAsyncSseImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105226,7 +105213,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinRustAsyncSseMoiImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105235,7 +105222,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinSseImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105244,7 +105231,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinSseMoiImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105253,7 +105240,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinSyncImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105262,7 +105249,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinSyncMoiImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105271,7 +105258,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinSyncSseImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105280,7 +105267,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinSyncSseMoiImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105289,7 +105276,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithImplBlockInMultiFileImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105298,7 +105285,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithRustAutoOpaqueFieldWithManyDeriveInnerImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105307,7 +105294,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithSimpleSetterTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105315,7 +105302,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerTypeForIgnore(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return TypeForIgnoreImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return TypeForIgnoreImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105323,7 +105310,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerTypeForIgnoreAll(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return TypeForIgnoreAllImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return TypeForIgnoreAllImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105332,7 +105319,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return ConstructorOpaqueStructTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105341,7 +105328,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return ConstructorOpaqueSyncStructTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105350,7 +105337,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return DeliberateFailSanityCheckTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105358,7 +105345,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDroppableTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DroppableTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return DroppableTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105366,8 +105353,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDroppableTwinRustAsync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DroppableTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return DroppableTwinRustAsyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105376,7 +105362,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return DroppableTwinRustAsyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105384,7 +105370,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDroppableTwinSse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DroppableTwinSseImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return DroppableTwinSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105392,7 +105378,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDroppableTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DroppableTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return DroppableTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105400,7 +105386,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDroppableTwinSyncSse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DroppableTwinSyncSseImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return DroppableTwinSyncSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105409,7 +105395,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return ItemContainerSolutionOneTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105417,7 +105403,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLtSubStructTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return LtSubStructTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return LtSubStructTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105425,7 +105411,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLtSubStructTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return LtSubStructTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return LtSubStructTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105433,7 +105419,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinMoi(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return NonCloneSimpleTwinMoiImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return NonCloneSimpleTwinMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105442,7 +105428,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105451,7 +105437,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105460,7 +105446,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinRustAsyncMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105469,7 +105455,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinRustAsyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105478,7 +105464,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinRustAsyncSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105486,7 +105472,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinSse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return NonCloneSimpleTwinSseImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return NonCloneSimpleTwinSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105495,7 +105481,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105503,8 +105489,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return NonCloneSimpleTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return NonCloneSimpleTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105513,7 +105498,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinSyncMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105522,7 +105507,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinSyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105531,7 +105516,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinSyncSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105540,7 +105525,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return RustOpaqueWebLockingDataTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105549,7 +105534,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return RustOpaqueWebLockingDataTwinSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105558,7 +105543,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructOneWithTraitForDynTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105567,7 +105552,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructOneWithTraitTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105576,7 +105561,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructOneWithTraitTwinSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105585,7 +105570,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructOneWithTraitTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105594,7 +105579,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructOneWithTraitTwinSyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105603,7 +105588,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructTwoWithTraitForDynTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105612,7 +105597,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructTwoWithTraitTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105621,7 +105606,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructTwoWithTraitTwinSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105630,7 +105615,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructTwoWithTraitTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105639,7 +105624,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructTwoWithTraitTwinSyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105648,7 +105633,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinMoiImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105657,7 +105642,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinNormalImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105666,7 +105651,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinRustAsyncImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105675,7 +105660,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinRustAsyncMoiImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105684,7 +105669,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinRustAsyncSseImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105693,7 +105678,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinRustAsyncSseMoiImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105702,7 +105687,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinSseImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105711,7 +105696,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinSseMoiImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105720,7 +105705,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinSyncImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105729,7 +105714,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinSyncMoiImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105738,7 +105723,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinSyncSseImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105747,7 +105732,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinSyncSseMoiImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105756,7 +105741,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithSimpleSetterTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105764,7 +105749,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerTypeForIgnoreAll(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return TypeForIgnoreAllImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return TypeForIgnoreAllImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105773,7 +105758,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return ConstructorOpaqueStructTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105782,7 +105767,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return ConstructorOpaqueSyncStructTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105791,7 +105776,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return DeliberateFailSanityCheckTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105799,7 +105784,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDroppableTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DroppableTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return DroppableTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105807,8 +105792,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDroppableTwinRustAsync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DroppableTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return DroppableTwinRustAsyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105817,7 +105801,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return DroppableTwinRustAsyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105825,7 +105809,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDroppableTwinSse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DroppableTwinSseImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return DroppableTwinSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105833,7 +105817,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDroppableTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DroppableTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return DroppableTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105841,7 +105825,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDroppableTwinSyncSse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DroppableTwinSyncSseImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return DroppableTwinSyncSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105850,7 +105834,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return ItemContainerSolutionOneTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105858,8 +105842,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLtOwnedStructTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return LtOwnedStructTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return LtOwnedStructTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105867,7 +105850,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLtOwnedStructTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return LtOwnedStructTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return LtOwnedStructTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105875,7 +105858,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLtSubStructTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return LtSubStructTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return LtSubStructTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105883,7 +105866,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLtSubStructTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return LtSubStructTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return LtSubStructTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105891,8 +105874,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMyAudioParamTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return MyAudioParamTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return MyAudioParamTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105901,7 +105883,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MyImplTraitWithSelfTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105910,7 +105892,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MyImplTraitWithSelfTwinSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105919,7 +105901,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MyImplTraitWithSelfTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105928,7 +105910,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MyImplTraitWithSelfTwinSyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105936,7 +105918,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMyNodeTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return MyNodeTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return MyNodeTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -105945,7 +105927,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MyStructWithTryFromTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105954,7 +105936,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105963,7 +105945,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105972,7 +105954,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105981,7 +105963,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinRustAsyncMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105990,7 +105972,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinRustAsyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -105999,7 +105981,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinRustAsyncSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -106008,7 +105990,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -106017,7 +105999,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -106026,7 +106008,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -106035,7 +106017,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinSyncMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -106044,7 +106026,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinSyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -106053,7 +106035,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinSyncSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -106061,7 +106043,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinMoi(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return NonCloneSimpleTwinMoiImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return NonCloneSimpleTwinMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -106070,7 +106052,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -106079,7 +106061,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -106088,7 +106070,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinRustAsyncMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -106097,7 +106079,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinRustAsyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -106106,7 +106088,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinRustAsyncSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -106114,7 +106096,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinSse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return NonCloneSimpleTwinSseImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return NonCloneSimpleTwinSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -106123,7 +106105,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -106131,8 +106113,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return NonCloneSimpleTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return NonCloneSimpleTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -106141,7 +106122,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinSyncMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -106150,7 +106131,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinSyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -106159,7 +106140,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinSyncSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -106168,7 +106149,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return OpaqueStructWithDartCodeTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -106177,7 +106158,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return RustOpaqueWebLockingDataTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -106186,7 +106167,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return RustOpaqueWebLockingDataTwinSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -106194,7 +106175,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerSimpleLogger(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return SimpleLoggerImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return SimpleLoggerImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -106203,7 +106184,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return SimpleOpaqueExternalStructWithMethodImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -106212,7 +106193,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructInMiscNoTwinExampleAImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -106221,7 +106202,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructInMiscNoTwinExampleBImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -106230,7 +106211,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructOneWithTraitForDynTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -106239,7 +106220,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructOneWithTraitTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -106248,7 +106229,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructOneWithTraitTwinSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -106257,7 +106238,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructOneWithTraitTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -106266,7 +106247,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructOneWithTraitTwinSyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -106275,7 +106256,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructTwoWithTraitForDynTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -106284,7 +106265,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructTwoWithTraitTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -106293,7 +106274,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructTwoWithTraitTwinSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -106302,7 +106283,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructTwoWithTraitTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -106311,7 +106292,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructTwoWithTraitTwinSyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -106320,7 +106301,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinMoiImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -106329,7 +106310,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinNormalImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -106338,7 +106319,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinRustAsyncImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -106347,7 +106328,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinRustAsyncMoiImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -106356,7 +106337,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinRustAsyncSseImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -106365,7 +106346,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinRustAsyncSseMoiImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -106374,7 +106355,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinSseImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -106383,7 +106364,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinSseMoiImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -106392,7 +106373,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinSyncImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -106401,7 +106382,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinSyncMoiImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -106410,7 +106391,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinSyncSseImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -106419,7 +106400,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinSyncSseMoiImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -106428,7 +106409,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithImplBlockInMultiFileImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -106437,7 +106418,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithSimpleSetterTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -106445,7 +106426,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerTypeForIgnore(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return TypeForIgnoreImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return TypeForIgnoreImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -106453,13 +106434,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerTypeForIgnoreAll(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return TypeForIgnoreAllImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return TypeForIgnoreAllImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
   String dco_decode_Backtrace(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as String;
+    return dcoDecodeString(raw);
   }
 
   @protected
@@ -106493,7 +106474,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   String dco_decode_Char(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return String.fromCharCode(raw);
+    return String.fromCharCode(dcoDecodePrimitiveInt(raw));
   }
 
   @protected
@@ -106670,8 +106651,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   ObjectArray1 dco_decode_DartOpaque_array_1(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return ObjectArray1(
-        (raw as List<dynamic>).map(dco_decode_DartOpaque).toList());
+    return ObjectArray1(dcoDecodeList(raw).map(dco_decode_DartOpaque).toList());
   }
 
   @protected
@@ -106684,7 +106664,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BigInt dco_decode_I128(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BigInt.parse(raw as String);
+    return BigInt.parse(dcoDecodeString(raw));
   }
 
   @protected
@@ -107320,15 +107300,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   BoxDartDebugTwinMoi dco_decode_RustOpaque_BoxdynDartDebugTwinMoi(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BoxDartDebugTwinMoiImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BoxDartDebugTwinMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
   BoxDartDebugTwinNormal dco_decode_RustOpaque_BoxdynDartDebugTwinNormal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BoxDartDebugTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return BoxDartDebugTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -107336,7 +107315,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return BoxDartDebugTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -107344,7 +107323,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_BoxdynDartDebugTwinRustAsyncMoi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return BoxDartDebugTwinRustAsyncMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -107352,7 +107331,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_BoxdynDartDebugTwinRustAsyncSse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return BoxDartDebugTwinRustAsyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -107360,45 +107339,42 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_BoxdynDartDebugTwinRustAsyncSseMoi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return BoxDartDebugTwinRustAsyncSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
   BoxDartDebugTwinSse dco_decode_RustOpaque_BoxdynDartDebugTwinSse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BoxDartDebugTwinSseImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BoxDartDebugTwinSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
   BoxDartDebugTwinSseMoi dco_decode_RustOpaque_BoxdynDartDebugTwinSseMoi(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BoxDartDebugTwinSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return BoxDartDebugTwinSseMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
   BoxDartDebugTwinSync dco_decode_RustOpaque_BoxdynDartDebugTwinSync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BoxDartDebugTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BoxDartDebugTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
   BoxDartDebugTwinSyncMoi dco_decode_RustOpaque_BoxdynDartDebugTwinSyncMoi(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BoxDartDebugTwinSyncMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return BoxDartDebugTwinSyncMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
   BoxDartDebugTwinSyncSse dco_decode_RustOpaque_BoxdynDartDebugTwinSyncSse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BoxDartDebugTwinSyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return BoxDartDebugTwinSyncSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -107406,15 +107382,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_BoxdynDartDebugTwinSyncSseMoi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return BoxDartDebugTwinSyncSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
   FrbOpaqueReturnTwinMoi dco_decode_RustOpaque_FrbOpaqueReturnTwinMoi(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return FrbOpaqueReturnTwinMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return FrbOpaqueReturnTwinMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -107422,7 +107397,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return FrbOpaqueReturnTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -107430,7 +107405,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_FrbOpaqueReturnTwinRustAsync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return FrbOpaqueReturnTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -107438,7 +107413,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_FrbOpaqueReturnTwinRustAsyncMoi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return FrbOpaqueReturnTwinRustAsyncMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -107446,7 +107421,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_FrbOpaqueReturnTwinRustAsyncSse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return FrbOpaqueReturnTwinRustAsyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -107454,15 +107429,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_FrbOpaqueReturnTwinRustAsyncSseMoi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return FrbOpaqueReturnTwinRustAsyncSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
   FrbOpaqueReturnTwinSse dco_decode_RustOpaque_FrbOpaqueReturnTwinSse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return FrbOpaqueReturnTwinSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return FrbOpaqueReturnTwinSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -107470,15 +107444,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return FrbOpaqueReturnTwinSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
   FrbOpaqueReturnTwinSync dco_decode_RustOpaque_FrbOpaqueReturnTwinSync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return FrbOpaqueReturnTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return FrbOpaqueReturnTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -107486,7 +107459,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return FrbOpaqueReturnTwinSyncMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -107494,7 +107467,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return FrbOpaqueReturnTwinSyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -107502,7 +107475,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_FrbOpaqueReturnTwinSyncSseMoi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return FrbOpaqueReturnTwinSyncSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -107510,7 +107483,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return FrbOpaqueSyncReturnTwinMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -107518,7 +107491,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_FrbOpaqueSyncReturnTwinNormal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return FrbOpaqueSyncReturnTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -107526,7 +107499,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return FrbOpaqueSyncReturnTwinSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -107534,15 +107507,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_FrbOpaqueSyncReturnTwinSseMoi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return FrbOpaqueSyncReturnTwinSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
   HideDataAnotherTwinMoi dco_decode_RustOpaque_HideDataAnotherTwinMoi(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return HideDataAnotherTwinMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return HideDataAnotherTwinMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -107550,15 +107522,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return HideDataAnotherTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
   HideDataAnotherTwinSse dco_decode_RustOpaque_HideDataAnotherTwinSse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return HideDataAnotherTwinSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return HideDataAnotherTwinSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -107566,35 +107537,34 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return HideDataAnotherTwinSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
   HideDataTwinMoi dco_decode_RustOpaque_HideDataTwinMoi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return HideDataTwinMoiImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return HideDataTwinMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
   HideDataTwinMoiArray2 dco_decode_RustOpaque_HideDataTwinMoi_array_2(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return HideDataTwinMoiArray2((raw as List<dynamic>)
-        .map(dco_decode_RustOpaque_HideDataTwinMoi)
-        .toList());
+    return HideDataTwinMoiArray2(
+        dcoDecodeList(raw).map(dco_decode_RustOpaque_HideDataTwinMoi).toList());
   }
 
   @protected
   HideDataTwinNormal dco_decode_RustOpaque_HideDataTwinNormal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return HideDataTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return HideDataTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
   HideDataTwinNormalArray2 dco_decode_RustOpaque_HideDataTwinNormal_array_2(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return HideDataTwinNormalArray2((raw as List<dynamic>)
+    return HideDataTwinNormalArray2(dcoDecodeList(raw)
         .map(dco_decode_RustOpaque_HideDataTwinNormal)
         .toList());
   }
@@ -107603,7 +107573,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   HideDataTwinRustAsync dco_decode_RustOpaque_HideDataTwinRustAsync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return HideDataTwinRustAsyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return HideDataTwinRustAsyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -107611,14 +107581,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return HideDataTwinRustAsyncMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
   HideDataTwinRustAsyncMoiArray2
       dco_decode_RustOpaque_HideDataTwinRustAsyncMoi_array_2(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return HideDataTwinRustAsyncMoiArray2((raw as List<dynamic>)
+    return HideDataTwinRustAsyncMoiArray2(dcoDecodeList(raw)
         .map(dco_decode_RustOpaque_HideDataTwinRustAsyncMoi)
         .toList());
   }
@@ -107628,7 +107598,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return HideDataTwinRustAsyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -107636,14 +107606,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return HideDataTwinRustAsyncSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
   HideDataTwinRustAsyncSseMoiArray2
       dco_decode_RustOpaque_HideDataTwinRustAsyncSseMoi_array_2(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return HideDataTwinRustAsyncSseMoiArray2((raw as List<dynamic>)
+    return HideDataTwinRustAsyncSseMoiArray2(dcoDecodeList(raw)
         .map(dco_decode_RustOpaque_HideDataTwinRustAsyncSseMoi)
         .toList());
   }
@@ -107652,7 +107622,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   HideDataTwinRustAsyncSseArray2
       dco_decode_RustOpaque_HideDataTwinRustAsyncSse_array_2(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return HideDataTwinRustAsyncSseArray2((raw as List<dynamic>)
+    return HideDataTwinRustAsyncSseArray2(dcoDecodeList(raw)
         .map(dco_decode_RustOpaque_HideDataTwinRustAsyncSse)
         .toList());
   }
@@ -107661,7 +107631,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   HideDataTwinRustAsyncArray2
       dco_decode_RustOpaque_HideDataTwinRustAsync_array_2(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return HideDataTwinRustAsyncArray2((raw as List<dynamic>)
+    return HideDataTwinRustAsyncArray2(dcoDecodeList(raw)
         .map(dco_decode_RustOpaque_HideDataTwinRustAsync)
         .toList());
   }
@@ -107669,20 +107639,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   HideDataTwinSse dco_decode_RustOpaque_HideDataTwinSse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return HideDataTwinSseImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return HideDataTwinSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
   HideDataTwinSseMoi dco_decode_RustOpaque_HideDataTwinSseMoi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return HideDataTwinSseMoiImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return HideDataTwinSseMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
   HideDataTwinSseMoiArray2 dco_decode_RustOpaque_HideDataTwinSseMoi_array_2(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return HideDataTwinSseMoiArray2((raw as List<dynamic>)
+    return HideDataTwinSseMoiArray2(dcoDecodeList(raw)
         .map(dco_decode_RustOpaque_HideDataTwinSseMoi)
         .toList());
   }
@@ -107691,28 +107661,27 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   HideDataTwinSseArray2 dco_decode_RustOpaque_HideDataTwinSse_array_2(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return HideDataTwinSseArray2((raw as List<dynamic>)
-        .map(dco_decode_RustOpaque_HideDataTwinSse)
-        .toList());
+    return HideDataTwinSseArray2(
+        dcoDecodeList(raw).map(dco_decode_RustOpaque_HideDataTwinSse).toList());
   }
 
   @protected
   HideDataTwinSync dco_decode_RustOpaque_HideDataTwinSync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return HideDataTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return HideDataTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
   HideDataTwinSyncMoi dco_decode_RustOpaque_HideDataTwinSyncMoi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return HideDataTwinSyncMoiImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return HideDataTwinSyncMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
   HideDataTwinSyncMoiArray2 dco_decode_RustOpaque_HideDataTwinSyncMoi_array_2(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return HideDataTwinSyncMoiArray2((raw as List<dynamic>)
+    return HideDataTwinSyncMoiArray2(dcoDecodeList(raw)
         .map(dco_decode_RustOpaque_HideDataTwinSyncMoi)
         .toList());
   }
@@ -107720,22 +107689,21 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   HideDataTwinSyncSse dco_decode_RustOpaque_HideDataTwinSyncSse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return HideDataTwinSyncSseImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return HideDataTwinSyncSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
   HideDataTwinSyncSseMoi dco_decode_RustOpaque_HideDataTwinSyncSseMoi(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return HideDataTwinSyncSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return HideDataTwinSyncSseMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
   HideDataTwinSyncSseMoiArray2
       dco_decode_RustOpaque_HideDataTwinSyncSseMoi_array_2(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return HideDataTwinSyncSseMoiArray2((raw as List<dynamic>)
+    return HideDataTwinSyncSseMoiArray2(dcoDecodeList(raw)
         .map(dco_decode_RustOpaque_HideDataTwinSyncSseMoi)
         .toList());
   }
@@ -107744,7 +107712,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   HideDataTwinSyncSseArray2 dco_decode_RustOpaque_HideDataTwinSyncSse_array_2(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return HideDataTwinSyncSseArray2((raw as List<dynamic>)
+    return HideDataTwinSyncSseArray2(dcoDecodeList(raw)
         .map(dco_decode_RustOpaque_HideDataTwinSyncSse)
         .toList());
   }
@@ -107753,7 +107721,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   HideDataTwinSyncArray2 dco_decode_RustOpaque_HideDataTwinSync_array_2(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return HideDataTwinSyncArray2((raw as List<dynamic>)
+    return HideDataTwinSyncArray2(dcoDecodeList(raw)
         .map(dco_decode_RustOpaque_HideDataTwinSync)
         .toList());
   }
@@ -107761,15 +107729,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MutexHideDataTwinMoi dco_decode_RustOpaque_MutexHideDataTwinMoi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return MutexHideDataTwinMoiImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return MutexHideDataTwinMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
   MutexHideDataTwinNormal dco_decode_RustOpaque_MutexHideDataTwinNormal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return MutexHideDataTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return MutexHideDataTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -107777,7 +107744,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MutexHideDataTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -107785,7 +107752,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_MutexHideDataTwinRustAsyncMoi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MutexHideDataTwinRustAsyncMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -107793,7 +107760,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_MutexHideDataTwinRustAsyncSse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MutexHideDataTwinRustAsyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -107801,28 +107768,27 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_MutexHideDataTwinRustAsyncSseMoi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MutexHideDataTwinRustAsyncSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
   MutexHideDataTwinSse dco_decode_RustOpaque_MutexHideDataTwinSse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return MutexHideDataTwinSseImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return MutexHideDataTwinSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
   MutexHideDataTwinSseMoi dco_decode_RustOpaque_MutexHideDataTwinSseMoi(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return MutexHideDataTwinSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return MutexHideDataTwinSseMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
   MutexHideDataTwinSync dco_decode_RustOpaque_MutexHideDataTwinSync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return MutexHideDataTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return MutexHideDataTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -107830,7 +107796,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MutexHideDataTwinSyncMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -107838,7 +107804,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MutexHideDataTwinSyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -107846,21 +107812,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MutexHideDataTwinSyncSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
   NonCloneDataTwinMoi dco_decode_RustOpaque_NonCloneDataTwinMoi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return NonCloneDataTwinMoiImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return NonCloneDataTwinMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
   NonCloneDataTwinNormal dco_decode_RustOpaque_NonCloneDataTwinNormal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return NonCloneDataTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return NonCloneDataTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -107868,7 +107833,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneDataTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -107876,7 +107841,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_NonCloneDataTwinRustAsyncMoi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneDataTwinRustAsyncMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -107884,7 +107849,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_NonCloneDataTwinRustAsyncSse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneDataTwinRustAsyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -107892,43 +107857,40 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_NonCloneDataTwinRustAsyncSseMoi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneDataTwinRustAsyncSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
   NonCloneDataTwinSse dco_decode_RustOpaque_NonCloneDataTwinSse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return NonCloneDataTwinSseImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return NonCloneDataTwinSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
   NonCloneDataTwinSseMoi dco_decode_RustOpaque_NonCloneDataTwinSseMoi(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return NonCloneDataTwinSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return NonCloneDataTwinSseMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
   NonCloneDataTwinSync dco_decode_RustOpaque_NonCloneDataTwinSync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return NonCloneDataTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return NonCloneDataTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
   NonCloneDataTwinSyncMoi dco_decode_RustOpaque_NonCloneDataTwinSyncMoi(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return NonCloneDataTwinSyncMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return NonCloneDataTwinSyncMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
   NonCloneDataTwinSyncSse dco_decode_RustOpaque_NonCloneDataTwinSyncSse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return NonCloneDataTwinSyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return NonCloneDataTwinSyncSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -107936,14 +107898,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneDataTwinSyncSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
   RwLockHideDataTwinMoi dco_decode_RustOpaque_RwLockHideDataTwinMoi(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return RwLockHideDataTwinMoiImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return RwLockHideDataTwinMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -107951,7 +107913,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return RwLockHideDataTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -107959,7 +107921,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return RwLockHideDataTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -107967,7 +107929,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_RwLockHideDataTwinRustAsyncMoi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return RwLockHideDataTwinRustAsyncMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -107975,7 +107937,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_RwLockHideDataTwinRustAsyncSse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return RwLockHideDataTwinRustAsyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -107983,14 +107945,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_RwLockHideDataTwinRustAsyncSseMoi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return RwLockHideDataTwinRustAsyncSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
   RwLockHideDataTwinSse dco_decode_RustOpaque_RwLockHideDataTwinSse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return RwLockHideDataTwinSseImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return RwLockHideDataTwinSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -107998,15 +107960,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return RwLockHideDataTwinSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
   RwLockHideDataTwinSync dco_decode_RustOpaque_RwLockHideDataTwinSync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return RwLockHideDataTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return RwLockHideDataTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108014,7 +107975,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return RwLockHideDataTwinSyncMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108022,7 +107983,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return RwLockHideDataTwinSyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108030,7 +107991,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_RwLockHideDataTwinSyncSseMoi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return RwLockHideDataTwinSyncSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108038,8 +107999,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBoxdynAnySendSyncstatic(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BoxAnyMyDartTypeRenameImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return BoxAnyMyDartTypeRenameImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108047,7 +108007,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBoxdynFnStringStringSendSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BoxFnStringStringImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BoxFnStringStringImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108055,7 +108015,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBoxdynMyTraitTwinMoiSendSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BoxMyTraitTwinMoiImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BoxMyTraitTwinMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108063,7 +108023,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBoxdynMyTraitTwinNormalSendSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BoxMyTraitTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BoxMyTraitTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108072,7 +108032,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return BoxMyTraitTwinRustAsyncMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108080,8 +108040,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBoxdynMyTraitTwinRustAsyncSendSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BoxMyTraitTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return BoxMyTraitTwinRustAsyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108090,7 +108049,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return BoxMyTraitTwinRustAsyncSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108099,7 +108058,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return BoxMyTraitTwinRustAsyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108107,7 +108066,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBoxdynMyTraitTwinSseMoiSendSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BoxMyTraitTwinSseMoiImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BoxMyTraitTwinSseMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108115,7 +108074,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBoxdynMyTraitTwinSseSendSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BoxMyTraitTwinSseImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BoxMyTraitTwinSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108123,7 +108082,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBoxdynMyTraitTwinSyncMoiSendSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BoxMyTraitTwinSyncMoiImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BoxMyTraitTwinSyncMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108131,7 +108090,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBoxdynMyTraitTwinSyncSendSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BoxMyTraitTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BoxMyTraitTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108140,7 +108099,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return BoxMyTraitTwinSyncSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108148,7 +108107,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBoxdynMyTraitTwinSyncSseSendSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BoxMyTraitTwinSyncSseImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BoxMyTraitTwinSyncSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108157,7 +108116,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return ConstructorOpaqueStructTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108166,7 +108125,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return ConstructorOpaqueSyncStructTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108174,8 +108133,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCustomHasherTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return CustomHasherTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return CustomHasherTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108184,7 +108142,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return CustomHasherTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108193,7 +108151,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return CustomHasherTwinRustAsyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108201,7 +108159,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCustomHasherTwinSse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return CustomHasherTwinSseImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return CustomHasherTwinSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108209,7 +108167,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCustomHasherTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return CustomHasherTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return CustomHasherTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108217,8 +108175,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCustomHasherTwinSyncSse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return CustomHasherTwinSyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return CustomHasherTwinSyncSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108227,7 +108184,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return DeliberateFailSanityCheckTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108235,7 +108192,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDroppableTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DroppableTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return DroppableTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108243,8 +108200,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDroppableTwinRustAsync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DroppableTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return DroppableTwinRustAsyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108253,7 +108209,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return DroppableTwinRustAsyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108261,7 +108217,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDroppableTwinSse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DroppableTwinSseImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return DroppableTwinSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108269,7 +108225,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDroppableTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DroppableTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return DroppableTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108277,7 +108233,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDroppableTwinSyncSse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DroppableTwinSyncSseImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return DroppableTwinSyncSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108286,7 +108242,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return EnumWithGoodAndOpaqueWithoutOptionTwinMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108295,7 +108251,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return EnumWithGoodAndOpaqueWithoutOptionTwinNormalImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108304,7 +108260,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return EnumWithGoodAndOpaqueWithoutOptionTwinRustAsyncImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108313,7 +108269,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return EnumWithGoodAndOpaqueWithoutOptionTwinRustAsyncMoiImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108322,7 +108278,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return EnumWithGoodAndOpaqueWithoutOptionTwinRustAsyncSseImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108331,7 +108287,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return EnumWithGoodAndOpaqueWithoutOptionTwinRustAsyncSseMoiImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108340,7 +108296,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return EnumWithGoodAndOpaqueWithoutOptionTwinSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108349,7 +108305,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return EnumWithGoodAndOpaqueWithoutOptionTwinSseMoiImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108358,7 +108314,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return EnumWithGoodAndOpaqueWithoutOptionTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108367,7 +108323,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return EnumWithGoodAndOpaqueWithoutOptionTwinSyncMoiImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108376,7 +108332,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return EnumWithGoodAndOpaqueWithoutOptionTwinSyncSseImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108385,7 +108341,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return EnumWithGoodAndOpaqueWithoutOptionTwinSyncSseMoiImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108394,7 +108350,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return ItemContainerSolutionOneTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108403,7 +108359,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return LtNestedTypeWithLifetimeTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108412,7 +108368,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return LtNestedTypeWithLifetimeTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108421,7 +108377,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return LtTypeWithLifetimeTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108430,7 +108386,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return LtTypeWithLifetimeTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108439,7 +108395,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return LtTypeWithMultiDepTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108448,7 +108404,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return LtTypeWithMultiDepTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108456,8 +108412,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLtOwnedStructTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return LtOwnedStructTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return LtOwnedStructTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108465,7 +108420,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLtOwnedStructTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return LtOwnedStructTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return LtOwnedStructTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108473,7 +108428,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLtSubStructTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return LtSubStructTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return LtSubStructTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108481,7 +108436,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLtSubStructTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return LtSubStructTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return LtSubStructTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108489,8 +108444,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMyAudioParamTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return MyAudioParamTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return MyAudioParamTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108499,7 +108453,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MyImplTraitWithSelfTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108508,7 +108462,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MyImplTraitWithSelfTwinSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108517,7 +108471,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MyImplTraitWithSelfTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108526,7 +108480,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MyImplTraitWithSelfTwinSyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108534,7 +108488,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMyNodeTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return MyNodeTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return MyNodeTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108543,7 +108497,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MyStructWithTryFromTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108551,7 +108505,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneDataRaw(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return NonCloneDataRawImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return NonCloneDataRawImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108560,7 +108514,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108569,7 +108523,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108578,7 +108532,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108587,7 +108541,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinRustAsyncMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108596,7 +108550,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinRustAsyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108605,7 +108559,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinRustAsyncSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108614,7 +108568,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108623,7 +108577,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108632,7 +108586,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108641,7 +108595,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinSyncMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108650,7 +108604,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinSyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108659,7 +108613,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinSyncSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108667,7 +108621,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinMoi(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return NonCloneSimpleTwinMoiImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return NonCloneSimpleTwinMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108676,7 +108630,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108685,7 +108639,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108694,7 +108648,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinRustAsyncMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108703,7 +108657,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinRustAsyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108712,7 +108666,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinRustAsyncSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108720,7 +108674,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinSse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return NonCloneSimpleTwinSseImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return NonCloneSimpleTwinSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108729,7 +108683,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108737,8 +108691,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return NonCloneSimpleTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return NonCloneSimpleTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108747,7 +108700,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinSyncMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108756,7 +108709,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinSyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108765,7 +108718,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinSyncSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108773,7 +108726,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueItemTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueItemTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueItemTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108781,7 +108734,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueOneTwinMoi(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueOneTwinMoiImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueOneTwinMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108789,7 +108742,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueOneTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueOneTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueOneTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108797,8 +108750,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueOneTwinRustAsync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueOneTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return OpaqueOneTwinRustAsyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108807,7 +108759,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return OpaqueOneTwinRustAsyncMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108816,7 +108768,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return OpaqueOneTwinRustAsyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108825,7 +108777,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return OpaqueOneTwinRustAsyncSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108833,7 +108785,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueOneTwinSse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueOneTwinSseImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueOneTwinSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108841,7 +108793,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueOneTwinSseMoi(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueOneTwinSseMoiImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueOneTwinSseMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108849,7 +108801,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueOneTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueOneTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueOneTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108857,7 +108809,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueOneTwinSyncMoi(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueOneTwinSyncMoiImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueOneTwinSyncMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108865,7 +108817,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueOneTwinSyncSse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueOneTwinSyncSseImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueOneTwinSyncSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108873,8 +108825,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueOneTwinSyncSseMoi(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueOneTwinSyncSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return OpaqueOneTwinSyncSseMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108883,7 +108834,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return OpaqueStructWithDartCodeTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108891,7 +108842,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueTwoTwinMoi(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueTwoTwinMoiImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueTwoTwinMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108899,7 +108850,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueTwoTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueTwoTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueTwoTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108907,8 +108858,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueTwoTwinRustAsync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueTwoTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return OpaqueTwoTwinRustAsyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108917,7 +108867,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return OpaqueTwoTwinRustAsyncMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108926,7 +108876,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return OpaqueTwoTwinRustAsyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108935,7 +108885,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return OpaqueTwoTwinRustAsyncSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -108943,7 +108893,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueTwoTwinSse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueTwoTwinSseImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueTwoTwinSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108951,7 +108901,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueTwoTwinSseMoi(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueTwoTwinSseMoiImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueTwoTwinSseMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108959,7 +108909,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueTwoTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueTwoTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueTwoTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108967,7 +108917,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueTwoTwinSyncMoi(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueTwoTwinSyncMoiImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueTwoTwinSyncMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108975,7 +108925,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueTwoTwinSyncSse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueTwoTwinSyncSseImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueTwoTwinSyncSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108983,8 +108933,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueTwoTwinSyncSseMoi(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueTwoTwinSyncSseMoiImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return OpaqueTwoTwinSyncSseMoiImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -108993,7 +108942,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return RustAutoOpaqueWebLockingDataTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -109002,7 +108951,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return RustAutoOpaqueWebLockingDataTwinSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -109011,7 +108960,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return RustOpaqueWebLockingDataTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -109020,7 +108969,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return RustOpaqueWebLockingDataTwinSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -109028,7 +108977,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerSimpleLogger(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return SimpleLoggerImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return SimpleLoggerImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -109037,7 +108986,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return SimpleOpaqueExternalStructWithMethodImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -109046,7 +108995,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StaticGetterOnlyTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -109055,7 +109004,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StaticGetterOnlyTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -109064,7 +109013,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StaticGetterOnlyTwinRustAsyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -109072,8 +109021,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStaticGetterOnlyTwinSse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return StaticGetterOnlyTwinSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return StaticGetterOnlyTwinSseImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -109082,7 +109030,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StaticGetterOnlyTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -109091,7 +109039,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StaticGetterOnlyTwinSyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -109100,7 +109048,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructInMiscNoTwinExampleAImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -109109,7 +109057,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructInMiscNoTwinExampleBImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -109118,7 +109066,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructOneWithTraitForDynTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -109127,7 +109075,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructOneWithTraitTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -109136,7 +109084,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructOneWithTraitTwinSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -109145,7 +109093,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructOneWithTraitTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -109154,7 +109102,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructOneWithTraitTwinSyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -109163,7 +109111,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructTwoWithTraitForDynTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -109172,7 +109120,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructTwoWithTraitTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -109181,7 +109129,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructTwoWithTraitTwinSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -109190,7 +109138,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructTwoWithTraitTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -109199,7 +109147,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructTwoWithTraitTwinSyncSseImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -109208,7 +109156,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinMoiImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -109217,7 +109165,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinNormalImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -109226,7 +109174,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinRustAsyncImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -109235,7 +109183,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinRustAsyncMoiImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -109244,7 +109192,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinRustAsyncSseImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -109253,7 +109201,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinRustAsyncSseMoiImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -109262,7 +109210,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinSseImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -109271,7 +109219,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinSseMoiImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -109280,7 +109228,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinSyncImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -109289,7 +109237,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinSyncMoiImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -109298,7 +109246,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinSyncSseImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -109307,7 +109255,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinSyncSseMoiImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -109316,7 +109264,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithImplBlockInMultiFileImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -109325,7 +109273,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithRustAutoOpaqueFieldWithManyDeriveInnerImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -109334,7 +109282,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithSimpleSetterTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -109342,7 +109290,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerTypeForIgnore(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return TypeForIgnoreImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return TypeForIgnoreImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -109350,25 +109298,25 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerTypeForIgnoreAll(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return TypeForIgnoreAllImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return TypeForIgnoreAllImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
   I16 dco_decode_RustOpaque_i16(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return I16Impl.frbInternalDcoDecode(raw as List<dynamic>);
+    return I16Impl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
   I32 dco_decode_RustOpaque_i32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return I32Impl.frbInternalDcoDecode(raw as List<dynamic>);
+    return I32Impl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
   Object? dco_decode_SerdeJsonValue(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return jsonDecode(raw as String);
+    return jsonDecode(dcoDecodeString(raw));
   }
 
   @protected
@@ -109888,7 +109836,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   String dco_decode_String(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as String;
+    return dcoDecodeString(raw);
   }
 
   @protected
@@ -110035,7 +109983,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BigInt dco_decode_U128(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BigInt.parse(raw as String);
+    return BigInt.parse(dcoDecodeString(raw));
   }
 
   @protected
@@ -110047,7 +109995,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   ATwinNormal dco_decode_a_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return ATwinNormal(
@@ -110058,7 +110006,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   ATwinRustAsync dco_decode_a_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return ATwinRustAsync(
@@ -110069,7 +110017,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   ATwinRustAsyncSse dco_decode_a_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return ATwinRustAsyncSse(
@@ -110080,7 +110028,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   ATwinSse dco_decode_a_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return ATwinSse(
@@ -110091,7 +110039,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   ATwinSync dco_decode_a_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return ATwinSync(
@@ -110102,7 +110050,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   ATwinSyncSse dco_decode_a_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return ATwinSyncSse(
@@ -110113,22 +110061,23 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   AbcTwinNormal dco_decode_abc_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return AbcTwinNormal_A(
-          dco_decode_box_autoadd_a_twin_normal(raw[1]),
+          dco_decode_box_autoadd_a_twin_normal(arr[1]),
         );
       case 1:
         return AbcTwinNormal_B(
-          dco_decode_box_autoadd_b_twin_normal(raw[1]),
+          dco_decode_box_autoadd_b_twin_normal(arr[1]),
         );
       case 2:
         return AbcTwinNormal_C(
-          dco_decode_box_autoadd_c_twin_normal(raw[1]),
+          dco_decode_box_autoadd_c_twin_normal(arr[1]),
         );
       case 3:
         return AbcTwinNormal_JustInt(
-          dco_decode_i_32(raw[1]),
+          dco_decode_i_32(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -110138,22 +110087,23 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   AbcTwinRustAsync dco_decode_abc_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return AbcTwinRustAsync_A(
-          dco_decode_box_autoadd_a_twin_rust_async(raw[1]),
+          dco_decode_box_autoadd_a_twin_rust_async(arr[1]),
         );
       case 1:
         return AbcTwinRustAsync_B(
-          dco_decode_box_autoadd_b_twin_rust_async(raw[1]),
+          dco_decode_box_autoadd_b_twin_rust_async(arr[1]),
         );
       case 2:
         return AbcTwinRustAsync_C(
-          dco_decode_box_autoadd_c_twin_rust_async(raw[1]),
+          dco_decode_box_autoadd_c_twin_rust_async(arr[1]),
         );
       case 3:
         return AbcTwinRustAsync_JustInt(
-          dco_decode_i_32(raw[1]),
+          dco_decode_i_32(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -110163,22 +110113,23 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   AbcTwinRustAsyncSse dco_decode_abc_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return AbcTwinRustAsyncSse_A(
-          dco_decode_box_autoadd_a_twin_rust_async_sse(raw[1]),
+          dco_decode_box_autoadd_a_twin_rust_async_sse(arr[1]),
         );
       case 1:
         return AbcTwinRustAsyncSse_B(
-          dco_decode_box_autoadd_b_twin_rust_async_sse(raw[1]),
+          dco_decode_box_autoadd_b_twin_rust_async_sse(arr[1]),
         );
       case 2:
         return AbcTwinRustAsyncSse_C(
-          dco_decode_box_autoadd_c_twin_rust_async_sse(raw[1]),
+          dco_decode_box_autoadd_c_twin_rust_async_sse(arr[1]),
         );
       case 3:
         return AbcTwinRustAsyncSse_JustInt(
-          dco_decode_i_32(raw[1]),
+          dco_decode_i_32(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -110188,22 +110139,23 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   AbcTwinSse dco_decode_abc_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return AbcTwinSse_A(
-          dco_decode_box_autoadd_a_twin_sse(raw[1]),
+          dco_decode_box_autoadd_a_twin_sse(arr[1]),
         );
       case 1:
         return AbcTwinSse_B(
-          dco_decode_box_autoadd_b_twin_sse(raw[1]),
+          dco_decode_box_autoadd_b_twin_sse(arr[1]),
         );
       case 2:
         return AbcTwinSse_C(
-          dco_decode_box_autoadd_c_twin_sse(raw[1]),
+          dco_decode_box_autoadd_c_twin_sse(arr[1]),
         );
       case 3:
         return AbcTwinSse_JustInt(
-          dco_decode_i_32(raw[1]),
+          dco_decode_i_32(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -110213,22 +110165,23 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   AbcTwinSync dco_decode_abc_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return AbcTwinSync_A(
-          dco_decode_box_autoadd_a_twin_sync(raw[1]),
+          dco_decode_box_autoadd_a_twin_sync(arr[1]),
         );
       case 1:
         return AbcTwinSync_B(
-          dco_decode_box_autoadd_b_twin_sync(raw[1]),
+          dco_decode_box_autoadd_b_twin_sync(arr[1]),
         );
       case 2:
         return AbcTwinSync_C(
-          dco_decode_box_autoadd_c_twin_sync(raw[1]),
+          dco_decode_box_autoadd_c_twin_sync(arr[1]),
         );
       case 3:
         return AbcTwinSync_JustInt(
-          dco_decode_i_32(raw[1]),
+          dco_decode_i_32(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -110238,22 +110191,23 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   AbcTwinSyncSse dco_decode_abc_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return AbcTwinSyncSse_A(
-          dco_decode_box_autoadd_a_twin_sync_sse(raw[1]),
+          dco_decode_box_autoadd_a_twin_sync_sse(arr[1]),
         );
       case 1:
         return AbcTwinSyncSse_B(
-          dco_decode_box_autoadd_b_twin_sync_sse(raw[1]),
+          dco_decode_box_autoadd_b_twin_sync_sse(arr[1]),
         );
       case 2:
         return AbcTwinSyncSse_C(
-          dco_decode_box_autoadd_c_twin_sync_sse(raw[1]),
+          dco_decode_box_autoadd_c_twin_sync_sse(arr[1]),
         );
       case 3:
         return AbcTwinSyncSse_JustInt(
-          dco_decode_i_32(raw[1]),
+          dco_decode_i_32(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -110264,7 +110218,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   AnotherMacroStructTwinNormal dco_decode_another_macro_struct_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return AnotherMacroStructTwinNormal(
@@ -110276,7 +110230,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   AnotherTwinNormal dco_decode_another_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return AnotherTwinNormal(
@@ -110287,7 +110241,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   AnotherTwinRustAsync dco_decode_another_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return AnotherTwinRustAsync(
@@ -110298,7 +110252,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   AnotherTwinRustAsyncSse dco_decode_another_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return AnotherTwinRustAsyncSse(
@@ -110309,7 +110263,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   AnotherTwinSse dco_decode_another_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return AnotherTwinSse(
@@ -110320,7 +110274,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   AnotherTwinSync dco_decode_another_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return AnotherTwinSync(
@@ -110331,7 +110285,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   AnotherTwinSyncSse dco_decode_another_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return AnotherTwinSyncSse(
@@ -110342,7 +110296,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   ApplicationEnv dco_decode_application_env(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return ApplicationEnv(
@@ -110353,7 +110307,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   ApplicationEnvVar dco_decode_application_env_var(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return ApplicationEnvVar(
@@ -110365,15 +110319,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   ApplicationMessage dco_decode_application_message(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return ApplicationMessage_DisplayMessage(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return ApplicationMessage_RenderPixel(
-          x: dco_decode_i_32(raw[1]),
-          y: dco_decode_i_32(raw[2]),
+          x: dco_decode_i_32(arr[1]),
+          y: dco_decode_i_32(arr[2]),
         );
       case 2:
         return ApplicationMessage_Exit();
@@ -110385,20 +110340,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   ApplicationMode dco_decode_application_mode(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return ApplicationMode.values[raw as int];
+    return ApplicationMode.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   ApplicationModeArray2 dco_decode_application_mode_array_2(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return ApplicationModeArray2(
-        (raw as List<dynamic>).map(dco_decode_application_mode).toList());
+        dcoDecodeList(raw).map(dco_decode_application_mode).toList());
   }
 
   @protected
   ApplicationSettings dco_decode_application_settings(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 5)
       throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
     return ApplicationSettings(
@@ -110413,7 +110368,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   AttributeTwinNormal dco_decode_attribute_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return AttributeTwinNormal(
@@ -110425,7 +110380,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   AttributeTwinRustAsync dco_decode_attribute_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return AttributeTwinRustAsync(
@@ -110438,7 +110393,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   AttributeTwinRustAsyncSse dco_decode_attribute_twin_rust_async_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return AttributeTwinRustAsyncSse(
@@ -110450,7 +110405,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   AttributeTwinSse dco_decode_attribute_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return AttributeTwinSse(
@@ -110462,7 +110417,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   AttributeTwinSync dco_decode_attribute_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return AttributeTwinSync(
@@ -110474,7 +110429,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   AttributeTwinSyncSse dco_decode_attribute_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return AttributeTwinSyncSse(
@@ -110488,16 +110443,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_auto_ref_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_my_audio_param_twin_normal_proxy_enum(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMyAudioParamTwinNormalProxyEnum_Variant0(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMyNodeTwinNormal(
-              raw[1]),
+              arr[1]),
         );
       case 1:
         return Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMyAudioParamTwinNormalProxyEnum_Variant1(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMyNodeTwinNormal(
-              raw[1]),
+              arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -110507,7 +110463,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BTwinNormal dco_decode_b_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return BTwinNormal(
@@ -110518,7 +110474,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BTwinRustAsync dco_decode_b_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return BTwinRustAsync(
@@ -110529,7 +110485,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BTwinRustAsyncSse dco_decode_b_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return BTwinRustAsyncSse(
@@ -110540,7 +110496,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BTwinSse dco_decode_b_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return BTwinSse(
@@ -110551,7 +110507,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BTwinSync dco_decode_b_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return BTwinSync(
@@ -110562,7 +110518,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BTwinSyncSse dco_decode_b_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return BTwinSyncSse(
@@ -110574,10 +110530,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   BasicGeneralEnumTwinNormal dco_decode_basic_general_enum_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return BasicGeneralEnumTwinNormal_Apple(
-          field: dco_decode_String(raw[1]),
+          field: dco_decode_String(arr[1]),
         );
       case 1:
         return BasicGeneralEnumTwinNormal_Orange();
@@ -110590,10 +110547,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   BasicGeneralEnumTwinRustAsync dco_decode_basic_general_enum_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return BasicGeneralEnumTwinRustAsync_Apple(
-          field: dco_decode_String(raw[1]),
+          field: dco_decode_String(arr[1]),
         );
       case 1:
         return BasicGeneralEnumTwinRustAsync_Orange();
@@ -110606,10 +110564,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   BasicGeneralEnumTwinRustAsyncSse
       dco_decode_basic_general_enum_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return BasicGeneralEnumTwinRustAsyncSse_Apple(
-          field: dco_decode_String(raw[1]),
+          field: dco_decode_String(arr[1]),
         );
       case 1:
         return BasicGeneralEnumTwinRustAsyncSse_Orange();
@@ -110621,10 +110580,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BasicGeneralEnumTwinSse dco_decode_basic_general_enum_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return BasicGeneralEnumTwinSse_Apple(
-          field: dco_decode_String(raw[1]),
+          field: dco_decode_String(arr[1]),
         );
       case 1:
         return BasicGeneralEnumTwinSse_Orange();
@@ -110637,10 +110597,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   BasicGeneralEnumTwinSync dco_decode_basic_general_enum_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return BasicGeneralEnumTwinSync_Apple(
-          field: dco_decode_String(raw[1]),
+          field: dco_decode_String(arr[1]),
         );
       case 1:
         return BasicGeneralEnumTwinSync_Orange();
@@ -110653,10 +110614,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   BasicGeneralEnumTwinSyncSse dco_decode_basic_general_enum_twin_sync_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return BasicGeneralEnumTwinSyncSse_Apple(
-          field: dco_decode_String(raw[1]),
+          field: dco_decode_String(arr[1]),
         );
       case 1:
         return BasicGeneralEnumTwinSyncSse_Orange();
@@ -110669,48 +110631,49 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   BasicPrimitiveEnumTwinNormal dco_decode_basic_primitive_enum_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BasicPrimitiveEnumTwinNormal.values[raw as int];
+    return BasicPrimitiveEnumTwinNormal.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   BasicPrimitiveEnumTwinRustAsync
       dco_decode_basic_primitive_enum_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BasicPrimitiveEnumTwinRustAsync.values[raw as int];
+    return BasicPrimitiveEnumTwinRustAsync.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   BasicPrimitiveEnumTwinRustAsyncSse
       dco_decode_basic_primitive_enum_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BasicPrimitiveEnumTwinRustAsyncSse.values[raw as int];
+    return BasicPrimitiveEnumTwinRustAsyncSse
+        .values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   BasicPrimitiveEnumTwinSse dco_decode_basic_primitive_enum_twin_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BasicPrimitiveEnumTwinSse.values[raw as int];
+    return BasicPrimitiveEnumTwinSse.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   BasicPrimitiveEnumTwinSync dco_decode_basic_primitive_enum_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BasicPrimitiveEnumTwinSync.values[raw as int];
+    return BasicPrimitiveEnumTwinSync.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   BasicPrimitiveEnumTwinSyncSse dco_decode_basic_primitive_enum_twin_sync_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BasicPrimitiveEnumTwinSyncSse.values[raw as int];
+    return BasicPrimitiveEnumTwinSyncSse.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   BasicStructTwinNormal dco_decode_basic_struct_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return BasicStructTwinNormal(
@@ -110723,7 +110686,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   BasicStructTwinRustAsync dco_decode_basic_struct_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return BasicStructTwinRustAsync(
@@ -110736,7 +110699,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   BasicStructTwinRustAsyncSse dco_decode_basic_struct_twin_rust_async_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return BasicStructTwinRustAsyncSse(
@@ -110748,7 +110711,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BasicStructTwinSse dco_decode_basic_struct_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return BasicStructTwinSse(
@@ -110760,7 +110723,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BasicStructTwinSync dco_decode_basic_struct_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return BasicStructTwinSync(
@@ -110772,7 +110735,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BasicStructTwinSyncSse dco_decode_basic_struct_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return BasicStructTwinSyncSse(
@@ -110785,7 +110748,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   BenchmarkBinaryTreeTwinNormal dco_decode_benchmark_binary_tree_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return BenchmarkBinaryTreeTwinNormal(
@@ -110799,7 +110762,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   BenchmarkBinaryTreeTwinRustAsync
       dco_decode_benchmark_binary_tree_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return BenchmarkBinaryTreeTwinRustAsync(
@@ -110813,7 +110776,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   BenchmarkBinaryTreeTwinRustAsyncSse
       dco_decode_benchmark_binary_tree_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return BenchmarkBinaryTreeTwinRustAsyncSse(
@@ -110829,7 +110792,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   BenchmarkBinaryTreeTwinSse dco_decode_benchmark_binary_tree_twin_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return BenchmarkBinaryTreeTwinSse(
@@ -110843,7 +110806,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   BenchmarkBinaryTreeTwinSync dco_decode_benchmark_binary_tree_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return BenchmarkBinaryTreeTwinSync(
@@ -110857,7 +110820,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   BenchmarkBinaryTreeTwinSyncSse dco_decode_benchmark_binary_tree_twin_sync_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return BenchmarkBinaryTreeTwinSyncSse(
@@ -110870,7 +110833,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BenchmarkBlobTwinNormal dco_decode_benchmark_blob_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return BenchmarkBlobTwinNormal(
@@ -110884,7 +110847,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   BenchmarkBlobTwinRustAsync dco_decode_benchmark_blob_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return BenchmarkBlobTwinRustAsync(
@@ -110898,7 +110861,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   BenchmarkBlobTwinRustAsyncSse dco_decode_benchmark_blob_twin_rust_async_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return BenchmarkBlobTwinRustAsyncSse(
@@ -110911,7 +110874,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BenchmarkBlobTwinSse dco_decode_benchmark_blob_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return BenchmarkBlobTwinSse(
@@ -110924,7 +110887,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BenchmarkBlobTwinSync dco_decode_benchmark_blob_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return BenchmarkBlobTwinSync(
@@ -110938,7 +110901,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   BenchmarkBlobTwinSyncSse dco_decode_benchmark_blob_twin_sync_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return BenchmarkBlobTwinSyncSse(
@@ -110951,7 +110914,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BigBuffersTwinNormal dco_decode_big_buffers_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return BigBuffersTwinNormal(
@@ -110963,7 +110926,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BigBuffersTwinRustAsync dco_decode_big_buffers_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return BigBuffersTwinRustAsync(
@@ -110976,7 +110939,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   BigBuffersTwinRustAsyncSse dco_decode_big_buffers_twin_rust_async_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return BigBuffersTwinRustAsyncSse(
@@ -110988,7 +110951,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BigBuffersTwinSse dco_decode_big_buffers_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return BigBuffersTwinSse(
@@ -111000,7 +110963,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BigBuffersTwinSync dco_decode_big_buffers_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return BigBuffersTwinSync(
@@ -111012,7 +110975,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BigBuffersTwinSyncSse dco_decode_big_buffers_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return BigBuffersTwinSyncSse(
@@ -111024,7 +110987,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BlobTwinNormal dco_decode_blob_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return BlobTwinNormal(
@@ -111035,7 +110998,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BlobTwinRustAsync dco_decode_blob_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return BlobTwinRustAsync(
@@ -111046,7 +111009,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BlobTwinRustAsyncSse dco_decode_blob_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return BlobTwinRustAsyncSse(
@@ -111057,7 +111020,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BlobTwinSse dco_decode_blob_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return BlobTwinSse(
@@ -111068,7 +111031,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BlobTwinSync dco_decode_blob_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return BlobTwinSync(
@@ -111079,7 +111042,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BlobTwinSyncSse dco_decode_blob_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return BlobTwinSyncSse(
@@ -112794,13 +112757,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   int dco_decode_box_autoadd_i_16(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dco_decode_i_16(raw);
   }
 
   @protected
   int dco_decode_box_autoadd_i_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dco_decode_i_32(raw);
   }
 
   @protected
@@ -112812,7 +112775,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   int dco_decode_box_autoadd_i_8(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dco_decode_i_8(raw);
   }
 
   @protected
@@ -114418,13 +114381,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   int dco_decode_box_autoadd_u_16(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dco_decode_u_16(raw);
   }
 
   @protected
   int dco_decode_box_autoadd_u_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dco_decode_u_32(raw);
   }
 
   @protected
@@ -114436,7 +114399,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   int dco_decode_box_autoadd_u_8(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dco_decode_u_8(raw);
   }
 
   @protected
@@ -114730,7 +114693,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   int dco_decode_box_i_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dco_decode_i_32(raw);
   }
 
   @protected
@@ -114742,7 +114705,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   int dco_decode_box_i_8(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dco_decode_i_8(raw);
   }
 
   @protected
@@ -114829,7 +114792,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   int dco_decode_box_u_8(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dco_decode_u_8(raw);
   }
 
   @protected
@@ -114884,7 +114847,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   CTwinNormal dco_decode_c_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return CTwinNormal(
@@ -114895,7 +114858,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   CTwinRustAsync dco_decode_c_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return CTwinRustAsync(
@@ -114906,7 +114869,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   CTwinRustAsyncSse dco_decode_c_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return CTwinRustAsyncSse(
@@ -114917,7 +114880,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   CTwinSse dco_decode_c_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return CTwinSse(
@@ -114928,7 +114891,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   CTwinSync dco_decode_c_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return CTwinSync(
@@ -114939,7 +114902,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   CTwinSyncSse dco_decode_c_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return CTwinSyncSse(
@@ -114951,7 +114914,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ConcatenateWithTwinNormal dco_decode_concatenate_with_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return ConcatenateWithTwinNormal(
@@ -114963,7 +114926,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ConcatenateWithTwinRustAsync dco_decode_concatenate_with_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return ConcatenateWithTwinRustAsync(
@@ -114975,7 +114938,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ConcatenateWithTwinRustAsyncSse
       dco_decode_concatenate_with_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return ConcatenateWithTwinRustAsyncSse(
@@ -114986,7 +114949,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   ConcatenateWithTwinSse dco_decode_concatenate_with_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return ConcatenateWithTwinSse(
@@ -114997,7 +114960,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   ConcatenateWithTwinSync dco_decode_concatenate_with_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return ConcatenateWithTwinSync(
@@ -115009,7 +114972,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ConcatenateWithTwinSyncSse dco_decode_concatenate_with_twin_sync_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return ConcatenateWithTwinSyncSse(
@@ -115021,7 +114984,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ConstructorTranslatableStructTwinNormal
       dco_decode_constructor_translatable_struct_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return ConstructorTranslatableStructTwinNormal(
@@ -115033,7 +114996,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ConstructorTranslatableSyncStructTwinNormal
       dco_decode_constructor_translatable_sync_struct_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return ConstructorTranslatableSyncStructTwinNormal.raw(
@@ -115045,7 +115008,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ContainsMirroredSubStructTwinNormal
       dco_decode_contains_mirrored_sub_struct_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return ContainsMirroredSubStructTwinNormal(
@@ -115058,7 +115021,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ContainsMirroredSubStructTwinRustAsync
       dco_decode_contains_mirrored_sub_struct_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return ContainsMirroredSubStructTwinRustAsync(
@@ -115071,7 +115034,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ContainsMirroredSubStructTwinRustAsyncSse
       dco_decode_contains_mirrored_sub_struct_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return ContainsMirroredSubStructTwinRustAsyncSse(
@@ -115084,7 +115047,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ContainsMirroredSubStructTwinSse
       dco_decode_contains_mirrored_sub_struct_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return ContainsMirroredSubStructTwinSse(
@@ -115097,7 +115060,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ContainsMirroredSubStructTwinSync
       dco_decode_contains_mirrored_sub_struct_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return ContainsMirroredSubStructTwinSync(
@@ -115110,7 +115073,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ContainsMirroredSubStructTwinSyncSse
       dco_decode_contains_mirrored_sub_struct_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return ContainsMirroredSubStructTwinSyncSse(
@@ -115123,16 +115086,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomEnumErrorTwinNormal dco_decode_custom_enum_error_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomEnumErrorTwinNormal_One(
-          message: dco_decode_String(raw[1]),
-          backtrace: dco_decode_Backtrace(raw[2]),
+          message: dco_decode_String(arr[1]),
+          backtrace: dco_decode_Backtrace(arr[2]),
         );
       case 1:
         return CustomEnumErrorTwinNormal_Two(
-          message: dco_decode_u_32(raw[1]),
-          backtrace: dco_decode_Backtrace(raw[2]),
+          message: dco_decode_u_32(arr[1]),
+          backtrace: dco_decode_Backtrace(arr[2]),
         );
       default:
         throw Exception("unreachable");
@@ -115143,16 +115107,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomEnumErrorTwinRustAsync dco_decode_custom_enum_error_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomEnumErrorTwinRustAsync_One(
-          message: dco_decode_String(raw[1]),
-          backtrace: dco_decode_Backtrace(raw[2]),
+          message: dco_decode_String(arr[1]),
+          backtrace: dco_decode_Backtrace(arr[2]),
         );
       case 1:
         return CustomEnumErrorTwinRustAsync_Two(
-          message: dco_decode_u_32(raw[1]),
-          backtrace: dco_decode_Backtrace(raw[2]),
+          message: dco_decode_u_32(arr[1]),
+          backtrace: dco_decode_Backtrace(arr[2]),
         );
       default:
         throw Exception("unreachable");
@@ -115163,16 +115128,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomEnumErrorTwinRustAsyncSse
       dco_decode_custom_enum_error_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomEnumErrorTwinRustAsyncSse_One(
-          message: dco_decode_String(raw[1]),
-          backtrace: dco_decode_Backtrace(raw[2]),
+          message: dco_decode_String(arr[1]),
+          backtrace: dco_decode_Backtrace(arr[2]),
         );
       case 1:
         return CustomEnumErrorTwinRustAsyncSse_Two(
-          message: dco_decode_u_32(raw[1]),
-          backtrace: dco_decode_Backtrace(raw[2]),
+          message: dco_decode_u_32(arr[1]),
+          backtrace: dco_decode_Backtrace(arr[2]),
         );
       default:
         throw Exception("unreachable");
@@ -115182,16 +115148,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   CustomEnumErrorTwinSse dco_decode_custom_enum_error_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomEnumErrorTwinSse_One(
-          message: dco_decode_String(raw[1]),
-          backtrace: dco_decode_Backtrace(raw[2]),
+          message: dco_decode_String(arr[1]),
+          backtrace: dco_decode_Backtrace(arr[2]),
         );
       case 1:
         return CustomEnumErrorTwinSse_Two(
-          message: dco_decode_u_32(raw[1]),
-          backtrace: dco_decode_Backtrace(raw[2]),
+          message: dco_decode_u_32(arr[1]),
+          backtrace: dco_decode_Backtrace(arr[2]),
         );
       default:
         throw Exception("unreachable");
@@ -115201,16 +115168,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   CustomEnumErrorTwinSync dco_decode_custom_enum_error_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomEnumErrorTwinSync_One(
-          message: dco_decode_String(raw[1]),
-          backtrace: dco_decode_Backtrace(raw[2]),
+          message: dco_decode_String(arr[1]),
+          backtrace: dco_decode_Backtrace(arr[2]),
         );
       case 1:
         return CustomEnumErrorTwinSync_Two(
-          message: dco_decode_u_32(raw[1]),
-          backtrace: dco_decode_Backtrace(raw[2]),
+          message: dco_decode_u_32(arr[1]),
+          backtrace: dco_decode_Backtrace(arr[2]),
         );
       default:
         throw Exception("unreachable");
@@ -115221,16 +115189,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomEnumErrorTwinSyncSse dco_decode_custom_enum_error_twin_sync_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomEnumErrorTwinSyncSse_One(
-          message: dco_decode_String(raw[1]),
-          backtrace: dco_decode_Backtrace(raw[2]),
+          message: dco_decode_String(arr[1]),
+          backtrace: dco_decode_Backtrace(arr[2]),
         );
       case 1:
         return CustomEnumErrorTwinSyncSse_Two(
-          message: dco_decode_u_32(raw[1]),
-          backtrace: dco_decode_Backtrace(raw[2]),
+          message: dco_decode_u_32(arr[1]),
+          backtrace: dco_decode_Backtrace(arr[2]),
         );
       default:
         throw Exception("unreachable");
@@ -115240,16 +115209,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   CustomErrorTwinNormal dco_decode_custom_error_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomErrorTwinNormal_Error0(
-          e: dco_decode_String(raw[1]),
-          backtrace: dco_decode_Backtrace(raw[2]),
+          e: dco_decode_String(arr[1]),
+          backtrace: dco_decode_Backtrace(arr[2]),
         );
       case 1:
         return CustomErrorTwinNormal_Error1(
-          e: dco_decode_u_32(raw[1]),
-          backtrace: dco_decode_Backtrace(raw[2]),
+          e: dco_decode_u_32(arr[1]),
+          backtrace: dco_decode_Backtrace(arr[2]),
         );
       default:
         throw Exception("unreachable");
@@ -115260,16 +115230,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomErrorTwinRustAsync dco_decode_custom_error_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomErrorTwinRustAsync_Error0(
-          e: dco_decode_String(raw[1]),
-          backtrace: dco_decode_Backtrace(raw[2]),
+          e: dco_decode_String(arr[1]),
+          backtrace: dco_decode_Backtrace(arr[2]),
         );
       case 1:
         return CustomErrorTwinRustAsync_Error1(
-          e: dco_decode_u_32(raw[1]),
-          backtrace: dco_decode_Backtrace(raw[2]),
+          e: dco_decode_u_32(arr[1]),
+          backtrace: dco_decode_Backtrace(arr[2]),
         );
       default:
         throw Exception("unreachable");
@@ -115280,16 +115251,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomErrorTwinRustAsyncSse dco_decode_custom_error_twin_rust_async_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomErrorTwinRustAsyncSse_Error0(
-          e: dco_decode_String(raw[1]),
-          backtrace: dco_decode_Backtrace(raw[2]),
+          e: dco_decode_String(arr[1]),
+          backtrace: dco_decode_Backtrace(arr[2]),
         );
       case 1:
         return CustomErrorTwinRustAsyncSse_Error1(
-          e: dco_decode_u_32(raw[1]),
-          backtrace: dco_decode_Backtrace(raw[2]),
+          e: dco_decode_u_32(arr[1]),
+          backtrace: dco_decode_Backtrace(arr[2]),
         );
       default:
         throw Exception("unreachable");
@@ -115299,16 +115271,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   CustomErrorTwinSse dco_decode_custom_error_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomErrorTwinSse_Error0(
-          e: dco_decode_String(raw[1]),
-          backtrace: dco_decode_Backtrace(raw[2]),
+          e: dco_decode_String(arr[1]),
+          backtrace: dco_decode_Backtrace(arr[2]),
         );
       case 1:
         return CustomErrorTwinSse_Error1(
-          e: dco_decode_u_32(raw[1]),
-          backtrace: dco_decode_Backtrace(raw[2]),
+          e: dco_decode_u_32(arr[1]),
+          backtrace: dco_decode_Backtrace(arr[2]),
         );
       default:
         throw Exception("unreachable");
@@ -115318,16 +115291,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   CustomErrorTwinSync dco_decode_custom_error_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomErrorTwinSync_Error0(
-          e: dco_decode_String(raw[1]),
-          backtrace: dco_decode_Backtrace(raw[2]),
+          e: dco_decode_String(arr[1]),
+          backtrace: dco_decode_Backtrace(arr[2]),
         );
       case 1:
         return CustomErrorTwinSync_Error1(
-          e: dco_decode_u_32(raw[1]),
-          backtrace: dco_decode_Backtrace(raw[2]),
+          e: dco_decode_u_32(arr[1]),
+          backtrace: dco_decode_Backtrace(arr[2]),
         );
       default:
         throw Exception("unreachable");
@@ -115337,16 +115311,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   CustomErrorTwinSyncSse dco_decode_custom_error_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomErrorTwinSyncSse_Error0(
-          e: dco_decode_String(raw[1]),
-          backtrace: dco_decode_Backtrace(raw[2]),
+          e: dco_decode_String(arr[1]),
+          backtrace: dco_decode_Backtrace(arr[2]),
         );
       case 1:
         return CustomErrorTwinSyncSse_Error1(
-          e: dco_decode_u_32(raw[1]),
-          backtrace: dco_decode_Backtrace(raw[2]),
+          e: dco_decode_u_32(arr[1]),
+          backtrace: dco_decode_Backtrace(arr[2]),
         );
       default:
         throw Exception("unreachable");
@@ -115357,14 +115332,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomNestedError1TwinNormal dco_decode_custom_nested_error_1_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomNestedError1TwinNormal_CustomNested1(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return CustomNestedError1TwinNormal_ErrorNested(
-          dco_decode_box_autoadd_custom_nested_error_2_twin_normal(raw[1]),
+          dco_decode_box_autoadd_custom_nested_error_2_twin_normal(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -115375,14 +115351,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomNestedError1TwinRustAsync
       dco_decode_custom_nested_error_1_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomNestedError1TwinRustAsync_CustomNested1(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return CustomNestedError1TwinRustAsync_ErrorNested(
-          dco_decode_box_autoadd_custom_nested_error_2_twin_rust_async(raw[1]),
+          dco_decode_box_autoadd_custom_nested_error_2_twin_rust_async(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -115393,15 +115370,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomNestedError1TwinRustAsyncSse
       dco_decode_custom_nested_error_1_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomNestedError1TwinRustAsyncSse_CustomNested1(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return CustomNestedError1TwinRustAsyncSse_ErrorNested(
           dco_decode_box_autoadd_custom_nested_error_2_twin_rust_async_sse(
-              raw[1]),
+              arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -115412,14 +115390,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomNestedError1TwinSse dco_decode_custom_nested_error_1_twin_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomNestedError1TwinSse_CustomNested1(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return CustomNestedError1TwinSse_ErrorNested(
-          dco_decode_box_autoadd_custom_nested_error_2_twin_sse(raw[1]),
+          dco_decode_box_autoadd_custom_nested_error_2_twin_sse(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -115430,14 +115409,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomNestedError1TwinSync dco_decode_custom_nested_error_1_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomNestedError1TwinSync_CustomNested1(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return CustomNestedError1TwinSync_ErrorNested(
-          dco_decode_box_autoadd_custom_nested_error_2_twin_sync(raw[1]),
+          dco_decode_box_autoadd_custom_nested_error_2_twin_sync(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -115448,14 +115428,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomNestedError1TwinSyncSse dco_decode_custom_nested_error_1_twin_sync_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomNestedError1TwinSyncSse_CustomNested1(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return CustomNestedError1TwinSyncSse_ErrorNested(
-          dco_decode_box_autoadd_custom_nested_error_2_twin_sync_sse(raw[1]),
+          dco_decode_box_autoadd_custom_nested_error_2_twin_sync_sse(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -115466,14 +115447,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomNestedError2TwinNormal dco_decode_custom_nested_error_2_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomNestedError2TwinNormal_CustomNested2(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return CustomNestedError2TwinNormal_CustomNested2Number(
-          dco_decode_u_32(raw[1]),
+          dco_decode_u_32(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -115484,14 +115466,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomNestedError2TwinRustAsync
       dco_decode_custom_nested_error_2_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomNestedError2TwinRustAsync_CustomNested2(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return CustomNestedError2TwinRustAsync_CustomNested2Number(
-          dco_decode_u_32(raw[1]),
+          dco_decode_u_32(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -115502,14 +115485,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomNestedError2TwinRustAsyncSse
       dco_decode_custom_nested_error_2_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomNestedError2TwinRustAsyncSse_CustomNested2(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return CustomNestedError2TwinRustAsyncSse_CustomNested2Number(
-          dco_decode_u_32(raw[1]),
+          dco_decode_u_32(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -115520,14 +115504,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomNestedError2TwinSse dco_decode_custom_nested_error_2_twin_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomNestedError2TwinSse_CustomNested2(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return CustomNestedError2TwinSse_CustomNested2Number(
-          dco_decode_u_32(raw[1]),
+          dco_decode_u_32(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -115538,14 +115523,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomNestedError2TwinSync dco_decode_custom_nested_error_2_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomNestedError2TwinSync_CustomNested2(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return CustomNestedError2TwinSync_CustomNested2Number(
-          dco_decode_u_32(raw[1]),
+          dco_decode_u_32(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -115556,14 +115542,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomNestedError2TwinSyncSse dco_decode_custom_nested_error_2_twin_sync_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomNestedError2TwinSyncSse_CustomNested2(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return CustomNestedError2TwinSyncSse_CustomNested2Number(
-          dco_decode_u_32(raw[1]),
+          dco_decode_u_32(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -115574,14 +115561,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomNestedErrorInnerTwinNormal
       dco_decode_custom_nested_error_inner_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomNestedErrorInnerTwinNormal_Three(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return CustomNestedErrorInnerTwinNormal_Four(
-          dco_decode_u_32(raw[1]),
+          dco_decode_u_32(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -115592,14 +115580,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomNestedErrorInnerTwinRustAsync
       dco_decode_custom_nested_error_inner_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomNestedErrorInnerTwinRustAsync_Three(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return CustomNestedErrorInnerTwinRustAsync_Four(
-          dco_decode_u_32(raw[1]),
+          dco_decode_u_32(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -115610,14 +115599,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomNestedErrorInnerTwinRustAsyncSse
       dco_decode_custom_nested_error_inner_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomNestedErrorInnerTwinRustAsyncSse_Three(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return CustomNestedErrorInnerTwinRustAsyncSse_Four(
-          dco_decode_u_32(raw[1]),
+          dco_decode_u_32(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -115628,14 +115618,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomNestedErrorInnerTwinSse dco_decode_custom_nested_error_inner_twin_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomNestedErrorInnerTwinSse_Three(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return CustomNestedErrorInnerTwinSse_Four(
-          dco_decode_u_32(raw[1]),
+          dco_decode_u_32(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -115646,14 +115637,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomNestedErrorInnerTwinSync dco_decode_custom_nested_error_inner_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomNestedErrorInnerTwinSync_Three(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return CustomNestedErrorInnerTwinSync_Four(
-          dco_decode_u_32(raw[1]),
+          dco_decode_u_32(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -115664,14 +115656,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomNestedErrorInnerTwinSyncSse
       dco_decode_custom_nested_error_inner_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomNestedErrorInnerTwinSyncSse_Three(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return CustomNestedErrorInnerTwinSyncSse_Four(
-          dco_decode_u_32(raw[1]),
+          dco_decode_u_32(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -115682,14 +115675,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomNestedErrorOuterTwinNormal
       dco_decode_custom_nested_error_outer_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomNestedErrorOuterTwinNormal_One(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return CustomNestedErrorOuterTwinNormal_Two(
-          dco_decode_box_autoadd_custom_nested_error_inner_twin_normal(raw[1]),
+          dco_decode_box_autoadd_custom_nested_error_inner_twin_normal(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -115700,15 +115694,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomNestedErrorOuterTwinRustAsync
       dco_decode_custom_nested_error_outer_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomNestedErrorOuterTwinRustAsync_One(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return CustomNestedErrorOuterTwinRustAsync_Two(
           dco_decode_box_autoadd_custom_nested_error_inner_twin_rust_async(
-              raw[1]),
+              arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -115719,15 +115714,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomNestedErrorOuterTwinRustAsyncSse
       dco_decode_custom_nested_error_outer_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomNestedErrorOuterTwinRustAsyncSse_One(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return CustomNestedErrorOuterTwinRustAsyncSse_Two(
           dco_decode_box_autoadd_custom_nested_error_inner_twin_rust_async_sse(
-              raw[1]),
+              arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -115738,14 +115734,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomNestedErrorOuterTwinSse dco_decode_custom_nested_error_outer_twin_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomNestedErrorOuterTwinSse_One(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return CustomNestedErrorOuterTwinSse_Two(
-          dco_decode_box_autoadd_custom_nested_error_inner_twin_sse(raw[1]),
+          dco_decode_box_autoadd_custom_nested_error_inner_twin_sse(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -115756,14 +115753,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomNestedErrorOuterTwinSync dco_decode_custom_nested_error_outer_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomNestedErrorOuterTwinSync_One(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return CustomNestedErrorOuterTwinSync_Two(
-          dco_decode_box_autoadd_custom_nested_error_inner_twin_sync(raw[1]),
+          dco_decode_box_autoadd_custom_nested_error_inner_twin_sync(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -115774,15 +115772,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomNestedErrorOuterTwinSyncSse
       dco_decode_custom_nested_error_outer_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomNestedErrorOuterTwinSyncSse_One(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return CustomNestedErrorOuterTwinSyncSse_Two(
           dco_decode_box_autoadd_custom_nested_error_inner_twin_sync_sse(
-              raw[1]),
+              arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -115793,7 +115792,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomStructErrorAnotherTwinNormal
       dco_decode_custom_struct_error_another_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return CustomStructErrorAnotherTwinNormal(
@@ -115805,7 +115804,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomStructErrorAnotherTwinRustAsync
       dco_decode_custom_struct_error_another_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return CustomStructErrorAnotherTwinRustAsync(
@@ -115817,7 +115816,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomStructErrorAnotherTwinRustAsyncSse
       dco_decode_custom_struct_error_another_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return CustomStructErrorAnotherTwinRustAsyncSse(
@@ -115829,7 +115828,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomStructErrorAnotherTwinSse
       dco_decode_custom_struct_error_another_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return CustomStructErrorAnotherTwinSse(
@@ -115841,7 +115840,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomStructErrorAnotherTwinSync
       dco_decode_custom_struct_error_another_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return CustomStructErrorAnotherTwinSync(
@@ -115853,7 +115852,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomStructErrorAnotherTwinSyncSse
       dco_decode_custom_struct_error_another_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return CustomStructErrorAnotherTwinSyncSse(
@@ -115865,7 +115864,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomStructErrorTwinNormal dco_decode_custom_struct_error_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return CustomStructErrorTwinNormal(
@@ -115877,7 +115876,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomStructErrorTwinRustAsync dco_decode_custom_struct_error_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return CustomStructErrorTwinRustAsync(
@@ -115889,7 +115888,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomStructErrorTwinRustAsyncSse
       dco_decode_custom_struct_error_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return CustomStructErrorTwinRustAsyncSse(
@@ -115901,7 +115900,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomStructErrorTwinSse dco_decode_custom_struct_error_twin_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return CustomStructErrorTwinSse(
@@ -115913,7 +115912,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomStructErrorTwinSync dco_decode_custom_struct_error_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return CustomStructErrorTwinSync(
@@ -115925,7 +115924,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomStructErrorTwinSyncSse dco_decode_custom_struct_error_twin_sync_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return CustomStructErrorTwinSyncSse(
@@ -115936,7 +115935,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   CustomStructTwinNormal dco_decode_custom_struct_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return CustomStructTwinNormal(
@@ -115948,7 +115947,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomStructTwinRustAsync dco_decode_custom_struct_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return CustomStructTwinRustAsync(
@@ -115960,7 +115959,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomStructTwinRustAsyncSse dco_decode_custom_struct_twin_rust_async_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return CustomStructTwinRustAsyncSse(
@@ -115971,7 +115970,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   CustomStructTwinSse dco_decode_custom_struct_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return CustomStructTwinSse(
@@ -115982,7 +115981,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   CustomStructTwinSync dco_decode_custom_struct_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return CustomStructTwinSync(
@@ -115993,7 +115992,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   CustomStructTwinSyncSse dco_decode_custom_struct_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return CustomStructTwinSyncSse(
@@ -116004,7 +116003,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   CustomizedTwinNormal dco_decode_customized_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return CustomizedTwinNormal(
@@ -116016,7 +116015,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   CustomizedTwinRustAsync dco_decode_customized_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return CustomizedTwinRustAsync(
@@ -116029,7 +116028,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomizedTwinRustAsyncSse dco_decode_customized_twin_rust_async_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return CustomizedTwinRustAsyncSse(
@@ -116041,7 +116040,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   CustomizedTwinSse dco_decode_customized_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return CustomizedTwinSse(
@@ -116053,7 +116052,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   CustomizedTwinSync dco_decode_customized_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return CustomizedTwinSync(
@@ -116065,7 +116064,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   CustomizedTwinSyncSse dco_decode_customized_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return CustomizedTwinSyncSse(
@@ -116078,7 +116077,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   DartOpaqueNestedTwinNormal dco_decode_dart_opaque_nested_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return DartOpaqueNestedTwinNormal(
@@ -116091,7 +116090,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   DartOpaqueNestedTwinRustAsync dco_decode_dart_opaque_nested_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return DartOpaqueNestedTwinRustAsync(
@@ -116104,7 +116103,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   DartOpaqueNestedTwinRustAsyncSse
       dco_decode_dart_opaque_nested_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return DartOpaqueNestedTwinRustAsyncSse(
@@ -116116,7 +116115,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   DartOpaqueNestedTwinSse dco_decode_dart_opaque_nested_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return DartOpaqueNestedTwinSse(
@@ -116129,7 +116128,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   DartOpaqueNestedTwinSync dco_decode_dart_opaque_nested_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return DartOpaqueNestedTwinSync(
@@ -116142,7 +116141,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   DartOpaqueNestedTwinSyncSse dco_decode_dart_opaque_nested_twin_sync_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return DartOpaqueNestedTwinSyncSse(
@@ -116161,7 +116160,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   DemoStructForRustCallDartTwinNormal
       dco_decode_demo_struct_for_rust_call_dart_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return DemoStructForRustCallDartTwinNormal(
@@ -116173,7 +116172,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   DemoStructForRustCallDartTwinRustAsync
       dco_decode_demo_struct_for_rust_call_dart_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return DemoStructForRustCallDartTwinRustAsync(
@@ -116186,7 +116185,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_demo_struct_for_rust_call_dart_twin_rust_async_sse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return DemoStructForRustCallDartTwinRustAsyncSse(
@@ -116198,7 +116197,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   DemoStructForRustCallDartTwinSse
       dco_decode_demo_struct_for_rust_call_dart_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return DemoStructForRustCallDartTwinSse(
@@ -116209,12 +116208,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   DistanceTwinNormal dco_decode_distance_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return DistanceTwinNormal_Unknown();
       case 1:
         return DistanceTwinNormal_Map(
-          dco_decode_f_64(raw[1]),
+          dco_decode_f_64(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -116224,12 +116224,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   DistanceTwinRustAsync dco_decode_distance_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return DistanceTwinRustAsync_Unknown();
       case 1:
         return DistanceTwinRustAsync_Map(
-          dco_decode_f_64(raw[1]),
+          dco_decode_f_64(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -116240,12 +116241,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   DistanceTwinRustAsyncSse dco_decode_distance_twin_rust_async_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return DistanceTwinRustAsyncSse_Unknown();
       case 1:
         return DistanceTwinRustAsyncSse_Map(
-          dco_decode_f_64(raw[1]),
+          dco_decode_f_64(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -116255,12 +116257,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   DistanceTwinSse dco_decode_distance_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return DistanceTwinSse_Unknown();
       case 1:
         return DistanceTwinSse_Map(
-          dco_decode_f_64(raw[1]),
+          dco_decode_f_64(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -116270,12 +116273,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   DistanceTwinSync dco_decode_distance_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return DistanceTwinSync_Unknown();
       case 1:
         return DistanceTwinSync_Map(
-          dco_decode_f_64(raw[1]),
+          dco_decode_f_64(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -116285,12 +116289,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   DistanceTwinSyncSse dco_decode_distance_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return DistanceTwinSyncSse_Unknown();
       case 1:
         return DistanceTwinSyncSse_Map(
-          dco_decode_f_64(raw[1]),
+          dco_decode_f_64(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -116300,7 +116305,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   ElementTwinNormal dco_decode_element_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return ElementTwinNormal(
@@ -116314,7 +116319,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   ElementTwinRustAsync dco_decode_element_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return ElementTwinRustAsync(
@@ -116328,7 +116333,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   ElementTwinRustAsyncSse dco_decode_element_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return ElementTwinRustAsyncSse(
@@ -116342,7 +116347,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   ElementTwinSse dco_decode_element_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return ElementTwinSse(
@@ -116356,7 +116361,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   ElementTwinSync dco_decode_element_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return ElementTwinSync(
@@ -116370,7 +116375,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   ElementTwinSyncSse dco_decode_element_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return ElementTwinSyncSse(
@@ -116384,7 +116389,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   EmptyTwinNormal dco_decode_empty_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 0)
       throw Exception('unexpected arr length: expect 0 but see ${arr.length}');
     return EmptyTwinNormal();
@@ -116393,7 +116398,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   EmptyTwinRustAsync dco_decode_empty_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 0)
       throw Exception('unexpected arr length: expect 0 but see ${arr.length}');
     return EmptyTwinRustAsync();
@@ -116402,7 +116407,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   EmptyTwinRustAsyncSse dco_decode_empty_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 0)
       throw Exception('unexpected arr length: expect 0 but see ${arr.length}');
     return EmptyTwinRustAsyncSse();
@@ -116411,7 +116416,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   EmptyTwinSse dco_decode_empty_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 0)
       throw Exception('unexpected arr length: expect 0 but see ${arr.length}');
     return EmptyTwinSse();
@@ -116420,7 +116425,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   EmptyTwinSync dco_decode_empty_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 0)
       throw Exception('unexpected arr length: expect 0 but see ${arr.length}');
     return EmptyTwinSync();
@@ -116429,7 +116434,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   EmptyTwinSyncSse dco_decode_empty_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 0)
       throw Exception('unexpected arr length: expect 0 but see ${arr.length}');
     return EmptyTwinSyncSse();
@@ -116439,14 +116444,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumDartOpaqueTwinNormal dco_decode_enum_dart_opaque_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumDartOpaqueTwinNormal_Primitive(
-          dco_decode_i_32(raw[1]),
+          dco_decode_i_32(arr[1]),
         );
       case 1:
         return EnumDartOpaqueTwinNormal_Opaque(
-          dco_decode_DartOpaque(raw[1]),
+          dco_decode_DartOpaque(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -116457,14 +116463,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumDartOpaqueTwinRustAsync dco_decode_enum_dart_opaque_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumDartOpaqueTwinRustAsync_Primitive(
-          dco_decode_i_32(raw[1]),
+          dco_decode_i_32(arr[1]),
         );
       case 1:
         return EnumDartOpaqueTwinRustAsync_Opaque(
-          dco_decode_DartOpaque(raw[1]),
+          dco_decode_DartOpaque(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -116475,14 +116482,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumDartOpaqueTwinRustAsyncSse
       dco_decode_enum_dart_opaque_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumDartOpaqueTwinRustAsyncSse_Primitive(
-          dco_decode_i_32(raw[1]),
+          dco_decode_i_32(arr[1]),
         );
       case 1:
         return EnumDartOpaqueTwinRustAsyncSse_Opaque(
-          dco_decode_DartOpaque(raw[1]),
+          dco_decode_DartOpaque(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -116492,14 +116500,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   EnumDartOpaqueTwinSse dco_decode_enum_dart_opaque_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumDartOpaqueTwinSse_Primitive(
-          dco_decode_i_32(raw[1]),
+          dco_decode_i_32(arr[1]),
         );
       case 1:
         return EnumDartOpaqueTwinSse_Opaque(
-          dco_decode_DartOpaque(raw[1]),
+          dco_decode_DartOpaque(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -116509,14 +116518,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   EnumDartOpaqueTwinSync dco_decode_enum_dart_opaque_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumDartOpaqueTwinSync_Primitive(
-          dco_decode_i_32(raw[1]),
+          dco_decode_i_32(arr[1]),
         );
       case 1:
         return EnumDartOpaqueTwinSync_Opaque(
-          dco_decode_DartOpaque(raw[1]),
+          dco_decode_DartOpaque(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -116527,14 +116537,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumDartOpaqueTwinSyncSse dco_decode_enum_dart_opaque_twin_sync_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumDartOpaqueTwinSyncSse_Primitive(
-          dco_decode_i_32(raw[1]),
+          dco_decode_i_32(arr[1]),
         );
       case 1:
         return EnumDartOpaqueTwinSyncSse_Opaque(
-          dco_decode_DartOpaque(raw[1]),
+          dco_decode_DartOpaque(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -116544,26 +116555,27 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   EnumOpaqueTwinMoi dco_decode_enum_opaque_twin_moi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumOpaqueTwinMoi_Struct(
-          dco_decode_RustOpaque_HideDataTwinMoi(raw[1]),
+          dco_decode_RustOpaque_HideDataTwinMoi(arr[1]),
         );
       case 1:
         return EnumOpaqueTwinMoi_Primitive(
-          dco_decode_RustOpaque_i16(raw[1]),
+          dco_decode_RustOpaque_i16(arr[1]),
         );
       case 2:
         return EnumOpaqueTwinMoi_TraitObj(
-          dco_decode_RustOpaque_BoxdynDartDebugTwinMoi(raw[1]),
+          dco_decode_RustOpaque_BoxdynDartDebugTwinMoi(arr[1]),
         );
       case 3:
         return EnumOpaqueTwinMoi_Mutex(
-          dco_decode_RustOpaque_MutexHideDataTwinMoi(raw[1]),
+          dco_decode_RustOpaque_MutexHideDataTwinMoi(arr[1]),
         );
       case 4:
         return EnumOpaqueTwinMoi_RwLock(
-          dco_decode_RustOpaque_RwLockHideDataTwinMoi(raw[1]),
+          dco_decode_RustOpaque_RwLockHideDataTwinMoi(arr[1]),
         );
       case 5:
         return EnumOpaqueTwinMoi_Nothing();
@@ -116576,32 +116588,33 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumOpaqueTwinMoiArray5 dco_decode_enum_opaque_twin_moi_array_5(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return EnumOpaqueTwinMoiArray5(
-        (raw as List<dynamic>).map(dco_decode_enum_opaque_twin_moi).toList());
+        dcoDecodeList(raw).map(dco_decode_enum_opaque_twin_moi).toList());
   }
 
   @protected
   EnumOpaqueTwinNormal dco_decode_enum_opaque_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumOpaqueTwinNormal_Struct(
-          dco_decode_RustOpaque_HideDataTwinNormal(raw[1]),
+          dco_decode_RustOpaque_HideDataTwinNormal(arr[1]),
         );
       case 1:
         return EnumOpaqueTwinNormal_Primitive(
-          dco_decode_RustOpaque_i32(raw[1]),
+          dco_decode_RustOpaque_i32(arr[1]),
         );
       case 2:
         return EnumOpaqueTwinNormal_TraitObj(
-          dco_decode_RustOpaque_BoxdynDartDebugTwinNormal(raw[1]),
+          dco_decode_RustOpaque_BoxdynDartDebugTwinNormal(arr[1]),
         );
       case 3:
         return EnumOpaqueTwinNormal_Mutex(
-          dco_decode_RustOpaque_MutexHideDataTwinNormal(raw[1]),
+          dco_decode_RustOpaque_MutexHideDataTwinNormal(arr[1]),
         );
       case 4:
         return EnumOpaqueTwinNormal_RwLock(
-          dco_decode_RustOpaque_RwLockHideDataTwinNormal(raw[1]),
+          dco_decode_RustOpaque_RwLockHideDataTwinNormal(arr[1]),
         );
       case 5:
         return EnumOpaqueTwinNormal_Nothing();
@@ -116614,34 +116627,34 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumOpaqueTwinNormalArray5 dco_decode_enum_opaque_twin_normal_array_5(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return EnumOpaqueTwinNormalArray5((raw as List<dynamic>)
-        .map(dco_decode_enum_opaque_twin_normal)
-        .toList());
+    return EnumOpaqueTwinNormalArray5(
+        dcoDecodeList(raw).map(dco_decode_enum_opaque_twin_normal).toList());
   }
 
   @protected
   EnumOpaqueTwinRustAsync dco_decode_enum_opaque_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumOpaqueTwinRustAsync_Struct(
-          dco_decode_RustOpaque_HideDataTwinRustAsync(raw[1]),
+          dco_decode_RustOpaque_HideDataTwinRustAsync(arr[1]),
         );
       case 1:
         return EnumOpaqueTwinRustAsync_Primitive(
-          dco_decode_RustOpaque_i32(raw[1]),
+          dco_decode_RustOpaque_i32(arr[1]),
         );
       case 2:
         return EnumOpaqueTwinRustAsync_TraitObj(
-          dco_decode_RustOpaque_BoxdynDartDebugTwinRustAsync(raw[1]),
+          dco_decode_RustOpaque_BoxdynDartDebugTwinRustAsync(arr[1]),
         );
       case 3:
         return EnumOpaqueTwinRustAsync_Mutex(
-          dco_decode_RustOpaque_MutexHideDataTwinRustAsync(raw[1]),
+          dco_decode_RustOpaque_MutexHideDataTwinRustAsync(arr[1]),
         );
       case 4:
         return EnumOpaqueTwinRustAsync_RwLock(
-          dco_decode_RustOpaque_RwLockHideDataTwinRustAsync(raw[1]),
+          dco_decode_RustOpaque_RwLockHideDataTwinRustAsync(arr[1]),
         );
       case 5:
         return EnumOpaqueTwinRustAsync_Nothing();
@@ -116654,7 +116667,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumOpaqueTwinRustAsyncArray5 dco_decode_enum_opaque_twin_rust_async_array_5(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return EnumOpaqueTwinRustAsyncArray5((raw as List<dynamic>)
+    return EnumOpaqueTwinRustAsyncArray5(dcoDecodeList(raw)
         .map(dco_decode_enum_opaque_twin_rust_async)
         .toList());
   }
@@ -116663,26 +116676,27 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumOpaqueTwinRustAsyncMoi dco_decode_enum_opaque_twin_rust_async_moi(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumOpaqueTwinRustAsyncMoi_Struct(
-          dco_decode_RustOpaque_HideDataTwinRustAsyncMoi(raw[1]),
+          dco_decode_RustOpaque_HideDataTwinRustAsyncMoi(arr[1]),
         );
       case 1:
         return EnumOpaqueTwinRustAsyncMoi_Primitive(
-          dco_decode_RustOpaque_i16(raw[1]),
+          dco_decode_RustOpaque_i16(arr[1]),
         );
       case 2:
         return EnumOpaqueTwinRustAsyncMoi_TraitObj(
-          dco_decode_RustOpaque_BoxdynDartDebugTwinRustAsyncMoi(raw[1]),
+          dco_decode_RustOpaque_BoxdynDartDebugTwinRustAsyncMoi(arr[1]),
         );
       case 3:
         return EnumOpaqueTwinRustAsyncMoi_Mutex(
-          dco_decode_RustOpaque_MutexHideDataTwinRustAsyncMoi(raw[1]),
+          dco_decode_RustOpaque_MutexHideDataTwinRustAsyncMoi(arr[1]),
         );
       case 4:
         return EnumOpaqueTwinRustAsyncMoi_RwLock(
-          dco_decode_RustOpaque_RwLockHideDataTwinRustAsyncMoi(raw[1]),
+          dco_decode_RustOpaque_RwLockHideDataTwinRustAsyncMoi(arr[1]),
         );
       case 5:
         return EnumOpaqueTwinRustAsyncMoi_Nothing();
@@ -116695,7 +116709,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumOpaqueTwinRustAsyncMoiArray5
       dco_decode_enum_opaque_twin_rust_async_moi_array_5(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return EnumOpaqueTwinRustAsyncMoiArray5((raw as List<dynamic>)
+    return EnumOpaqueTwinRustAsyncMoiArray5(dcoDecodeList(raw)
         .map(dco_decode_enum_opaque_twin_rust_async_moi)
         .toList());
   }
@@ -116704,26 +116718,27 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumOpaqueTwinRustAsyncSse dco_decode_enum_opaque_twin_rust_async_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumOpaqueTwinRustAsyncSse_Struct(
-          dco_decode_RustOpaque_HideDataTwinRustAsyncSse(raw[1]),
+          dco_decode_RustOpaque_HideDataTwinRustAsyncSse(arr[1]),
         );
       case 1:
         return EnumOpaqueTwinRustAsyncSse_Primitive(
-          dco_decode_RustOpaque_i32(raw[1]),
+          dco_decode_RustOpaque_i32(arr[1]),
         );
       case 2:
         return EnumOpaqueTwinRustAsyncSse_TraitObj(
-          dco_decode_RustOpaque_BoxdynDartDebugTwinRustAsyncSse(raw[1]),
+          dco_decode_RustOpaque_BoxdynDartDebugTwinRustAsyncSse(arr[1]),
         );
       case 3:
         return EnumOpaqueTwinRustAsyncSse_Mutex(
-          dco_decode_RustOpaque_MutexHideDataTwinRustAsyncSse(raw[1]),
+          dco_decode_RustOpaque_MutexHideDataTwinRustAsyncSse(arr[1]),
         );
       case 4:
         return EnumOpaqueTwinRustAsyncSse_RwLock(
-          dco_decode_RustOpaque_RwLockHideDataTwinRustAsyncSse(raw[1]),
+          dco_decode_RustOpaque_RwLockHideDataTwinRustAsyncSse(arr[1]),
         );
       case 5:
         return EnumOpaqueTwinRustAsyncSse_Nothing();
@@ -116736,7 +116751,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumOpaqueTwinRustAsyncSseArray5
       dco_decode_enum_opaque_twin_rust_async_sse_array_5(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return EnumOpaqueTwinRustAsyncSseArray5((raw as List<dynamic>)
+    return EnumOpaqueTwinRustAsyncSseArray5(dcoDecodeList(raw)
         .map(dco_decode_enum_opaque_twin_rust_async_sse)
         .toList());
   }
@@ -116745,26 +116760,27 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumOpaqueTwinRustAsyncSseMoi dco_decode_enum_opaque_twin_rust_async_sse_moi(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumOpaqueTwinRustAsyncSseMoi_Struct(
-          dco_decode_RustOpaque_HideDataTwinRustAsyncSseMoi(raw[1]),
+          dco_decode_RustOpaque_HideDataTwinRustAsyncSseMoi(arr[1]),
         );
       case 1:
         return EnumOpaqueTwinRustAsyncSseMoi_Primitive(
-          dco_decode_RustOpaque_i16(raw[1]),
+          dco_decode_RustOpaque_i16(arr[1]),
         );
       case 2:
         return EnumOpaqueTwinRustAsyncSseMoi_TraitObj(
-          dco_decode_RustOpaque_BoxdynDartDebugTwinRustAsyncSseMoi(raw[1]),
+          dco_decode_RustOpaque_BoxdynDartDebugTwinRustAsyncSseMoi(arr[1]),
         );
       case 3:
         return EnumOpaqueTwinRustAsyncSseMoi_Mutex(
-          dco_decode_RustOpaque_MutexHideDataTwinRustAsyncSseMoi(raw[1]),
+          dco_decode_RustOpaque_MutexHideDataTwinRustAsyncSseMoi(arr[1]),
         );
       case 4:
         return EnumOpaqueTwinRustAsyncSseMoi_RwLock(
-          dco_decode_RustOpaque_RwLockHideDataTwinRustAsyncSseMoi(raw[1]),
+          dco_decode_RustOpaque_RwLockHideDataTwinRustAsyncSseMoi(arr[1]),
         );
       case 5:
         return EnumOpaqueTwinRustAsyncSseMoi_Nothing();
@@ -116777,7 +116793,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumOpaqueTwinRustAsyncSseMoiArray5
       dco_decode_enum_opaque_twin_rust_async_sse_moi_array_5(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return EnumOpaqueTwinRustAsyncSseMoiArray5((raw as List<dynamic>)
+    return EnumOpaqueTwinRustAsyncSseMoiArray5(dcoDecodeList(raw)
         .map(dco_decode_enum_opaque_twin_rust_async_sse_moi)
         .toList());
   }
@@ -116785,26 +116801,27 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   EnumOpaqueTwinSse dco_decode_enum_opaque_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumOpaqueTwinSse_Struct(
-          dco_decode_RustOpaque_HideDataTwinSse(raw[1]),
+          dco_decode_RustOpaque_HideDataTwinSse(arr[1]),
         );
       case 1:
         return EnumOpaqueTwinSse_Primitive(
-          dco_decode_RustOpaque_i32(raw[1]),
+          dco_decode_RustOpaque_i32(arr[1]),
         );
       case 2:
         return EnumOpaqueTwinSse_TraitObj(
-          dco_decode_RustOpaque_BoxdynDartDebugTwinSse(raw[1]),
+          dco_decode_RustOpaque_BoxdynDartDebugTwinSse(arr[1]),
         );
       case 3:
         return EnumOpaqueTwinSse_Mutex(
-          dco_decode_RustOpaque_MutexHideDataTwinSse(raw[1]),
+          dco_decode_RustOpaque_MutexHideDataTwinSse(arr[1]),
         );
       case 4:
         return EnumOpaqueTwinSse_RwLock(
-          dco_decode_RustOpaque_RwLockHideDataTwinSse(raw[1]),
+          dco_decode_RustOpaque_RwLockHideDataTwinSse(arr[1]),
         );
       case 5:
         return EnumOpaqueTwinSse_Nothing();
@@ -116817,32 +116834,33 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumOpaqueTwinSseArray5 dco_decode_enum_opaque_twin_sse_array_5(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return EnumOpaqueTwinSseArray5(
-        (raw as List<dynamic>).map(dco_decode_enum_opaque_twin_sse).toList());
+        dcoDecodeList(raw).map(dco_decode_enum_opaque_twin_sse).toList());
   }
 
   @protected
   EnumOpaqueTwinSseMoi dco_decode_enum_opaque_twin_sse_moi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumOpaqueTwinSseMoi_Struct(
-          dco_decode_RustOpaque_HideDataTwinSseMoi(raw[1]),
+          dco_decode_RustOpaque_HideDataTwinSseMoi(arr[1]),
         );
       case 1:
         return EnumOpaqueTwinSseMoi_Primitive(
-          dco_decode_RustOpaque_i16(raw[1]),
+          dco_decode_RustOpaque_i16(arr[1]),
         );
       case 2:
         return EnumOpaqueTwinSseMoi_TraitObj(
-          dco_decode_RustOpaque_BoxdynDartDebugTwinSseMoi(raw[1]),
+          dco_decode_RustOpaque_BoxdynDartDebugTwinSseMoi(arr[1]),
         );
       case 3:
         return EnumOpaqueTwinSseMoi_Mutex(
-          dco_decode_RustOpaque_MutexHideDataTwinSseMoi(raw[1]),
+          dco_decode_RustOpaque_MutexHideDataTwinSseMoi(arr[1]),
         );
       case 4:
         return EnumOpaqueTwinSseMoi_RwLock(
-          dco_decode_RustOpaque_RwLockHideDataTwinSseMoi(raw[1]),
+          dco_decode_RustOpaque_RwLockHideDataTwinSseMoi(arr[1]),
         );
       case 5:
         return EnumOpaqueTwinSseMoi_Nothing();
@@ -116855,34 +116873,34 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumOpaqueTwinSseMoiArray5 dco_decode_enum_opaque_twin_sse_moi_array_5(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return EnumOpaqueTwinSseMoiArray5((raw as List<dynamic>)
-        .map(dco_decode_enum_opaque_twin_sse_moi)
-        .toList());
+    return EnumOpaqueTwinSseMoiArray5(
+        dcoDecodeList(raw).map(dco_decode_enum_opaque_twin_sse_moi).toList());
   }
 
   @protected
   EnumOpaqueTwinSync dco_decode_enum_opaque_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumOpaqueTwinSync_Struct(
-          dco_decode_RustOpaque_HideDataTwinSync(raw[1]),
+          dco_decode_RustOpaque_HideDataTwinSync(arr[1]),
         );
       case 1:
         return EnumOpaqueTwinSync_Primitive(
-          dco_decode_RustOpaque_i32(raw[1]),
+          dco_decode_RustOpaque_i32(arr[1]),
         );
       case 2:
         return EnumOpaqueTwinSync_TraitObj(
-          dco_decode_RustOpaque_BoxdynDartDebugTwinSync(raw[1]),
+          dco_decode_RustOpaque_BoxdynDartDebugTwinSync(arr[1]),
         );
       case 3:
         return EnumOpaqueTwinSync_Mutex(
-          dco_decode_RustOpaque_MutexHideDataTwinSync(raw[1]),
+          dco_decode_RustOpaque_MutexHideDataTwinSync(arr[1]),
         );
       case 4:
         return EnumOpaqueTwinSync_RwLock(
-          dco_decode_RustOpaque_RwLockHideDataTwinSync(raw[1]),
+          dco_decode_RustOpaque_RwLockHideDataTwinSync(arr[1]),
         );
       case 5:
         return EnumOpaqueTwinSync_Nothing();
@@ -116896,32 +116914,33 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return EnumOpaqueTwinSyncArray5(
-        (raw as List<dynamic>).map(dco_decode_enum_opaque_twin_sync).toList());
+        dcoDecodeList(raw).map(dco_decode_enum_opaque_twin_sync).toList());
   }
 
   @protected
   EnumOpaqueTwinSyncMoi dco_decode_enum_opaque_twin_sync_moi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumOpaqueTwinSyncMoi_Struct(
-          dco_decode_RustOpaque_HideDataTwinSyncMoi(raw[1]),
+          dco_decode_RustOpaque_HideDataTwinSyncMoi(arr[1]),
         );
       case 1:
         return EnumOpaqueTwinSyncMoi_Primitive(
-          dco_decode_RustOpaque_i16(raw[1]),
+          dco_decode_RustOpaque_i16(arr[1]),
         );
       case 2:
         return EnumOpaqueTwinSyncMoi_TraitObj(
-          dco_decode_RustOpaque_BoxdynDartDebugTwinSyncMoi(raw[1]),
+          dco_decode_RustOpaque_BoxdynDartDebugTwinSyncMoi(arr[1]),
         );
       case 3:
         return EnumOpaqueTwinSyncMoi_Mutex(
-          dco_decode_RustOpaque_MutexHideDataTwinSyncMoi(raw[1]),
+          dco_decode_RustOpaque_MutexHideDataTwinSyncMoi(arr[1]),
         );
       case 4:
         return EnumOpaqueTwinSyncMoi_RwLock(
-          dco_decode_RustOpaque_RwLockHideDataTwinSyncMoi(raw[1]),
+          dco_decode_RustOpaque_RwLockHideDataTwinSyncMoi(arr[1]),
         );
       case 5:
         return EnumOpaqueTwinSyncMoi_Nothing();
@@ -116934,34 +116953,34 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumOpaqueTwinSyncMoiArray5 dco_decode_enum_opaque_twin_sync_moi_array_5(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return EnumOpaqueTwinSyncMoiArray5((raw as List<dynamic>)
-        .map(dco_decode_enum_opaque_twin_sync_moi)
-        .toList());
+    return EnumOpaqueTwinSyncMoiArray5(
+        dcoDecodeList(raw).map(dco_decode_enum_opaque_twin_sync_moi).toList());
   }
 
   @protected
   EnumOpaqueTwinSyncSse dco_decode_enum_opaque_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumOpaqueTwinSyncSse_Struct(
-          dco_decode_RustOpaque_HideDataTwinSyncSse(raw[1]),
+          dco_decode_RustOpaque_HideDataTwinSyncSse(arr[1]),
         );
       case 1:
         return EnumOpaqueTwinSyncSse_Primitive(
-          dco_decode_RustOpaque_i32(raw[1]),
+          dco_decode_RustOpaque_i32(arr[1]),
         );
       case 2:
         return EnumOpaqueTwinSyncSse_TraitObj(
-          dco_decode_RustOpaque_BoxdynDartDebugTwinSyncSse(raw[1]),
+          dco_decode_RustOpaque_BoxdynDartDebugTwinSyncSse(arr[1]),
         );
       case 3:
         return EnumOpaqueTwinSyncSse_Mutex(
-          dco_decode_RustOpaque_MutexHideDataTwinSyncSse(raw[1]),
+          dco_decode_RustOpaque_MutexHideDataTwinSyncSse(arr[1]),
         );
       case 4:
         return EnumOpaqueTwinSyncSse_RwLock(
-          dco_decode_RustOpaque_RwLockHideDataTwinSyncSse(raw[1]),
+          dco_decode_RustOpaque_RwLockHideDataTwinSyncSse(arr[1]),
         );
       case 5:
         return EnumOpaqueTwinSyncSse_Nothing();
@@ -116974,35 +116993,35 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumOpaqueTwinSyncSseArray5 dco_decode_enum_opaque_twin_sync_sse_array_5(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return EnumOpaqueTwinSyncSseArray5((raw as List<dynamic>)
-        .map(dco_decode_enum_opaque_twin_sync_sse)
-        .toList());
+    return EnumOpaqueTwinSyncSseArray5(
+        dcoDecodeList(raw).map(dco_decode_enum_opaque_twin_sync_sse).toList());
   }
 
   @protected
   EnumOpaqueTwinSyncSseMoi dco_decode_enum_opaque_twin_sync_sse_moi(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumOpaqueTwinSyncSseMoi_Struct(
-          dco_decode_RustOpaque_HideDataTwinSyncSseMoi(raw[1]),
+          dco_decode_RustOpaque_HideDataTwinSyncSseMoi(arr[1]),
         );
       case 1:
         return EnumOpaqueTwinSyncSseMoi_Primitive(
-          dco_decode_RustOpaque_i16(raw[1]),
+          dco_decode_RustOpaque_i16(arr[1]),
         );
       case 2:
         return EnumOpaqueTwinSyncSseMoi_TraitObj(
-          dco_decode_RustOpaque_BoxdynDartDebugTwinSyncSseMoi(raw[1]),
+          dco_decode_RustOpaque_BoxdynDartDebugTwinSyncSseMoi(arr[1]),
         );
       case 3:
         return EnumOpaqueTwinSyncSseMoi_Mutex(
-          dco_decode_RustOpaque_MutexHideDataTwinSyncSseMoi(raw[1]),
+          dco_decode_RustOpaque_MutexHideDataTwinSyncSseMoi(arr[1]),
         );
       case 4:
         return EnumOpaqueTwinSyncSseMoi_RwLock(
-          dco_decode_RustOpaque_RwLockHideDataTwinSyncSseMoi(raw[1]),
+          dco_decode_RustOpaque_RwLockHideDataTwinSyncSseMoi(arr[1]),
         );
       case 5:
         return EnumOpaqueTwinSyncSseMoi_Nothing();
@@ -117015,7 +117034,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumOpaqueTwinSyncSseMoiArray5
       dco_decode_enum_opaque_twin_sync_sse_moi_array_5(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return EnumOpaqueTwinSyncSseMoiArray5((raw as List<dynamic>)
+    return EnumOpaqueTwinSyncSseMoiArray5(dcoDecodeList(raw)
         .map(dco_decode_enum_opaque_twin_sync_sse_moi)
         .toList());
   }
@@ -117023,95 +117042,97 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   EnumSimpleTwinNormal dco_decode_enum_simple_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return EnumSimpleTwinNormal.values[raw as int];
+    return EnumSimpleTwinNormal.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   EnumSimpleTwinRustAsync dco_decode_enum_simple_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return EnumSimpleTwinRustAsync.values[raw as int];
+    return EnumSimpleTwinRustAsync.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   EnumSimpleTwinRustAsyncSse dco_decode_enum_simple_twin_rust_async_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return EnumSimpleTwinRustAsyncSse.values[raw as int];
+    return EnumSimpleTwinRustAsyncSse.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   EnumSimpleTwinSse dco_decode_enum_simple_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return EnumSimpleTwinSse.values[raw as int];
+    return EnumSimpleTwinSse.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   EnumSimpleTwinSync dco_decode_enum_simple_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return EnumSimpleTwinSync.values[raw as int];
+    return EnumSimpleTwinSync.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   EnumSimpleTwinSyncSse dco_decode_enum_simple_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return EnumSimpleTwinSyncSse.values[raw as int];
+    return EnumSimpleTwinSyncSse.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   EnumWithDiscriminantTwinNormal dco_decode_enum_with_discriminant_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return EnumWithDiscriminantTwinNormal.values[raw as int];
+    return EnumWithDiscriminantTwinNormal.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   EnumWithDiscriminantTwinRustAsync
       dco_decode_enum_with_discriminant_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return EnumWithDiscriminantTwinRustAsync.values[raw as int];
+    return EnumWithDiscriminantTwinRustAsync.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   EnumWithDiscriminantTwinRustAsyncSse
       dco_decode_enum_with_discriminant_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return EnumWithDiscriminantTwinRustAsyncSse.values[raw as int];
+    return EnumWithDiscriminantTwinRustAsyncSse
+        .values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   EnumWithDiscriminantTwinSse dco_decode_enum_with_discriminant_twin_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return EnumWithDiscriminantTwinSse.values[raw as int];
+    return EnumWithDiscriminantTwinSse.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   EnumWithDiscriminantTwinSync dco_decode_enum_with_discriminant_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return EnumWithDiscriminantTwinSync.values[raw as int];
+    return EnumWithDiscriminantTwinSync.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   EnumWithDiscriminantTwinSyncSse
       dco_decode_enum_with_discriminant_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return EnumWithDiscriminantTwinSyncSse.values[raw as int];
+    return EnumWithDiscriminantTwinSyncSse.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   EnumWithGoodAndOpaqueTwinMoi dco_decode_enum_with_good_and_opaque_twin_moi(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithGoodAndOpaqueTwinMoi_Good(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return EnumWithGoodAndOpaqueTwinMoi_Opaque(
           dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinMoi(
-              raw[1]),
+              arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -117122,15 +117143,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumWithGoodAndOpaqueTwinNormal
       dco_decode_enum_with_good_and_opaque_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithGoodAndOpaqueTwinNormal_Good(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return EnumWithGoodAndOpaqueTwinNormal_Opaque(
           dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinNormal(
-              raw[1]),
+              arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -117141,15 +117163,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumWithGoodAndOpaqueTwinRustAsync
       dco_decode_enum_with_good_and_opaque_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithGoodAndOpaqueTwinRustAsync_Good(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return EnumWithGoodAndOpaqueTwinRustAsync_Opaque(
           dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinRustAsync(
-              raw[1]),
+              arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -117160,15 +117183,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumWithGoodAndOpaqueTwinRustAsyncMoi
       dco_decode_enum_with_good_and_opaque_twin_rust_async_moi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithGoodAndOpaqueTwinRustAsyncMoi_Good(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return EnumWithGoodAndOpaqueTwinRustAsyncMoi_Opaque(
           dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinRustAsyncMoi(
-              raw[1]),
+              arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -117179,15 +117203,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumWithGoodAndOpaqueTwinRustAsyncSse
       dco_decode_enum_with_good_and_opaque_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithGoodAndOpaqueTwinRustAsyncSse_Good(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return EnumWithGoodAndOpaqueTwinRustAsyncSse_Opaque(
           dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinRustAsyncSse(
-              raw[1]),
+              arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -117199,15 +117224,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_enum_with_good_and_opaque_twin_rust_async_sse_moi(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithGoodAndOpaqueTwinRustAsyncSseMoi_Good(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return EnumWithGoodAndOpaqueTwinRustAsyncSseMoi_Opaque(
           dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinRustAsyncSseMoi(
-              raw[1]),
+              arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -117218,15 +117244,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumWithGoodAndOpaqueTwinSse dco_decode_enum_with_good_and_opaque_twin_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithGoodAndOpaqueTwinSse_Good(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return EnumWithGoodAndOpaqueTwinSse_Opaque(
           dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinSse(
-              raw[1]),
+              arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -117237,15 +117264,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumWithGoodAndOpaqueTwinSseMoi
       dco_decode_enum_with_good_and_opaque_twin_sse_moi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithGoodAndOpaqueTwinSseMoi_Good(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return EnumWithGoodAndOpaqueTwinSseMoi_Opaque(
           dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinSseMoi(
-              raw[1]),
+              arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -117256,15 +117284,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumWithGoodAndOpaqueTwinSync dco_decode_enum_with_good_and_opaque_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithGoodAndOpaqueTwinSync_Good(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return EnumWithGoodAndOpaqueTwinSync_Opaque(
           dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinSync(
-              raw[1]),
+              arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -117275,15 +117304,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumWithGoodAndOpaqueTwinSyncMoi
       dco_decode_enum_with_good_and_opaque_twin_sync_moi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithGoodAndOpaqueTwinSyncMoi_Good(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return EnumWithGoodAndOpaqueTwinSyncMoi_Opaque(
           dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinSyncMoi(
-              raw[1]),
+              arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -117294,15 +117324,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumWithGoodAndOpaqueTwinSyncSse
       dco_decode_enum_with_good_and_opaque_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithGoodAndOpaqueTwinSyncSse_Good(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return EnumWithGoodAndOpaqueTwinSyncSse_Opaque(
           dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinSyncSse(
-              raw[1]),
+              arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -117313,15 +117344,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumWithGoodAndOpaqueTwinSyncSseMoi
       dco_decode_enum_with_good_and_opaque_twin_sync_sse_moi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithGoodAndOpaqueTwinSyncSseMoi_Good(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return EnumWithGoodAndOpaqueTwinSyncSseMoi_Opaque(
           dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinSyncSseMoi(
-              raw[1]),
+              arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -117332,16 +117364,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumWithItemMixedTwinNormal dco_decode_enum_with_item_mixed_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithItemMixedTwinNormal_A();
       case 1:
         return EnumWithItemMixedTwinNormal_B(
-          dco_decode_list_prim_u_8_strict(raw[1]),
+          dco_decode_list_prim_u_8_strict(arr[1]),
         );
       case 2:
         return EnumWithItemMixedTwinNormal_C(
-          cField: dco_decode_String(raw[1]),
+          cField: dco_decode_String(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -117352,16 +117385,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumWithItemMixedTwinRustAsync
       dco_decode_enum_with_item_mixed_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithItemMixedTwinRustAsync_A();
       case 1:
         return EnumWithItemMixedTwinRustAsync_B(
-          dco_decode_list_prim_u_8_strict(raw[1]),
+          dco_decode_list_prim_u_8_strict(arr[1]),
         );
       case 2:
         return EnumWithItemMixedTwinRustAsync_C(
-          cField: dco_decode_String(raw[1]),
+          cField: dco_decode_String(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -117372,16 +117406,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumWithItemMixedTwinRustAsyncSse
       dco_decode_enum_with_item_mixed_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithItemMixedTwinRustAsyncSse_A();
       case 1:
         return EnumWithItemMixedTwinRustAsyncSse_B(
-          dco_decode_list_prim_u_8_strict(raw[1]),
+          dco_decode_list_prim_u_8_strict(arr[1]),
         );
       case 2:
         return EnumWithItemMixedTwinRustAsyncSse_C(
-          cField: dco_decode_String(raw[1]),
+          cField: dco_decode_String(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -117392,16 +117427,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumWithItemMixedTwinSse dco_decode_enum_with_item_mixed_twin_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithItemMixedTwinSse_A();
       case 1:
         return EnumWithItemMixedTwinSse_B(
-          dco_decode_list_prim_u_8_strict(raw[1]),
+          dco_decode_list_prim_u_8_strict(arr[1]),
         );
       case 2:
         return EnumWithItemMixedTwinSse_C(
-          cField: dco_decode_String(raw[1]),
+          cField: dco_decode_String(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -117412,16 +117448,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumWithItemMixedTwinSync dco_decode_enum_with_item_mixed_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithItemMixedTwinSync_A();
       case 1:
         return EnumWithItemMixedTwinSync_B(
-          dco_decode_list_prim_u_8_strict(raw[1]),
+          dco_decode_list_prim_u_8_strict(arr[1]),
         );
       case 2:
         return EnumWithItemMixedTwinSync_C(
-          cField: dco_decode_String(raw[1]),
+          cField: dco_decode_String(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -117432,16 +117469,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumWithItemMixedTwinSyncSse dco_decode_enum_with_item_mixed_twin_sync_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithItemMixedTwinSyncSse_A();
       case 1:
         return EnumWithItemMixedTwinSyncSse_B(
-          dco_decode_list_prim_u_8_strict(raw[1]),
+          dco_decode_list_prim_u_8_strict(arr[1]),
         );
       case 2:
         return EnumWithItemMixedTwinSyncSse_C(
-          cField: dco_decode_String(raw[1]),
+          cField: dco_decode_String(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -117452,14 +117490,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumWithItemStructTwinNormal dco_decode_enum_with_item_struct_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithItemStructTwinNormal_A(
-          aField: dco_decode_list_prim_u_8_strict(raw[1]),
+          aField: dco_decode_list_prim_u_8_strict(arr[1]),
         );
       case 1:
         return EnumWithItemStructTwinNormal_B(
-          bField: dco_decode_list_prim_i_32_strict(raw[1]),
+          bField: dco_decode_list_prim_i_32_strict(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -117470,14 +117509,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumWithItemStructTwinRustAsync
       dco_decode_enum_with_item_struct_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithItemStructTwinRustAsync_A(
-          aField: dco_decode_list_prim_u_8_strict(raw[1]),
+          aField: dco_decode_list_prim_u_8_strict(arr[1]),
         );
       case 1:
         return EnumWithItemStructTwinRustAsync_B(
-          bField: dco_decode_list_prim_i_32_strict(raw[1]),
+          bField: dco_decode_list_prim_i_32_strict(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -117488,14 +117528,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumWithItemStructTwinRustAsyncSse
       dco_decode_enum_with_item_struct_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithItemStructTwinRustAsyncSse_A(
-          aField: dco_decode_list_prim_u_8_strict(raw[1]),
+          aField: dco_decode_list_prim_u_8_strict(arr[1]),
         );
       case 1:
         return EnumWithItemStructTwinRustAsyncSse_B(
-          bField: dco_decode_list_prim_i_32_strict(raw[1]),
+          bField: dco_decode_list_prim_i_32_strict(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -117506,14 +117547,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumWithItemStructTwinSse dco_decode_enum_with_item_struct_twin_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithItemStructTwinSse_A(
-          aField: dco_decode_list_prim_u_8_strict(raw[1]),
+          aField: dco_decode_list_prim_u_8_strict(arr[1]),
         );
       case 1:
         return EnumWithItemStructTwinSse_B(
-          bField: dco_decode_list_prim_i_32_strict(raw[1]),
+          bField: dco_decode_list_prim_i_32_strict(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -117524,14 +117566,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumWithItemStructTwinSync dco_decode_enum_with_item_struct_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithItemStructTwinSync_A(
-          aField: dco_decode_list_prim_u_8_strict(raw[1]),
+          aField: dco_decode_list_prim_u_8_strict(arr[1]),
         );
       case 1:
         return EnumWithItemStructTwinSync_B(
-          bField: dco_decode_list_prim_i_32_strict(raw[1]),
+          bField: dco_decode_list_prim_i_32_strict(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -117542,14 +117585,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumWithItemStructTwinSyncSse dco_decode_enum_with_item_struct_twin_sync_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithItemStructTwinSyncSse_A(
-          aField: dco_decode_list_prim_u_8_strict(raw[1]),
+          aField: dco_decode_list_prim_u_8_strict(arr[1]),
         );
       case 1:
         return EnumWithItemStructTwinSyncSse_B(
-          bField: dco_decode_list_prim_i_32_strict(raw[1]),
+          bField: dco_decode_list_prim_i_32_strict(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -117560,14 +117604,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumWithItemTupleTwinNormal dco_decode_enum_with_item_tuple_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithItemTupleTwinNormal_A(
-          dco_decode_list_prim_u_8_strict(raw[1]),
+          dco_decode_list_prim_u_8_strict(arr[1]),
         );
       case 1:
         return EnumWithItemTupleTwinNormal_B(
-          dco_decode_i_32(raw[1]),
+          dco_decode_i_32(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -117578,14 +117623,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumWithItemTupleTwinRustAsync
       dco_decode_enum_with_item_tuple_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithItemTupleTwinRustAsync_A(
-          dco_decode_list_prim_u_8_strict(raw[1]),
+          dco_decode_list_prim_u_8_strict(arr[1]),
         );
       case 1:
         return EnumWithItemTupleTwinRustAsync_B(
-          dco_decode_i_32(raw[1]),
+          dco_decode_i_32(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -117596,14 +117642,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumWithItemTupleTwinRustAsyncSse
       dco_decode_enum_with_item_tuple_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithItemTupleTwinRustAsyncSse_A(
-          dco_decode_list_prim_u_8_strict(raw[1]),
+          dco_decode_list_prim_u_8_strict(arr[1]),
         );
       case 1:
         return EnumWithItemTupleTwinRustAsyncSse_B(
-          dco_decode_i_32(raw[1]),
+          dco_decode_i_32(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -117614,14 +117661,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumWithItemTupleTwinSse dco_decode_enum_with_item_tuple_twin_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithItemTupleTwinSse_A(
-          dco_decode_list_prim_u_8_strict(raw[1]),
+          dco_decode_list_prim_u_8_strict(arr[1]),
         );
       case 1:
         return EnumWithItemTupleTwinSse_B(
-          dco_decode_i_32(raw[1]),
+          dco_decode_i_32(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -117632,14 +117680,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumWithItemTupleTwinSync dco_decode_enum_with_item_tuple_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithItemTupleTwinSync_A(
-          dco_decode_list_prim_u_8_strict(raw[1]),
+          dco_decode_list_prim_u_8_strict(arr[1]),
         );
       case 1:
         return EnumWithItemTupleTwinSync_B(
-          dco_decode_i_32(raw[1]),
+          dco_decode_i_32(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -117650,14 +117699,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumWithItemTupleTwinSyncSse dco_decode_enum_with_item_tuple_twin_sync_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithItemTupleTwinSyncSse_A(
-          dco_decode_list_prim_u_8_strict(raw[1]),
+          dco_decode_list_prim_u_8_strict(arr[1]),
         );
       case 1:
         return EnumWithItemTupleTwinSyncSse_B(
-          dco_decode_i_32(raw[1]),
+          dco_decode_i_32(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -117667,7 +117717,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   EventTwinNormal dco_decode_event_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return EventTwinNormal(
@@ -117679,7 +117729,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   EventTwinRustAsync dco_decode_event_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return EventTwinRustAsync(
@@ -117691,7 +117741,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   EventTwinRustAsyncSse dco_decode_event_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return EventTwinRustAsyncSse(
@@ -117703,7 +117753,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   EventTwinSse dco_decode_event_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return EventTwinSse(
@@ -117716,7 +117766,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ExoticOptionalsTwinNormal dco_decode_exotic_optionals_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 14)
       throw Exception('unexpected arr length: expect 14 but see ${arr.length}');
     return ExoticOptionalsTwinNormal(
@@ -117743,7 +117793,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ExoticOptionalsTwinRustAsync dco_decode_exotic_optionals_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 14)
       throw Exception('unexpected arr length: expect 14 but see ${arr.length}');
     return ExoticOptionalsTwinRustAsync(
@@ -117772,7 +117822,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ExoticOptionalsTwinRustAsyncSse
       dco_decode_exotic_optionals_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 14)
       throw Exception('unexpected arr length: expect 14 but see ${arr.length}');
     return ExoticOptionalsTwinRustAsyncSse(
@@ -117801,7 +117851,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   ExoticOptionalsTwinSse dco_decode_exotic_optionals_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 14)
       throw Exception('unexpected arr length: expect 14 but see ${arr.length}');
     return ExoticOptionalsTwinSse(
@@ -117827,7 +117877,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   ExoticOptionalsTwinSync dco_decode_exotic_optionals_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 14)
       throw Exception('unexpected arr length: expect 14 but see ${arr.length}');
     return ExoticOptionalsTwinSync(
@@ -117854,7 +117904,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ExoticOptionalsTwinSyncSse dco_decode_exotic_optionals_twin_sync_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 14)
       throw Exception('unexpected arr length: expect 14 but see ${arr.length}');
     return ExoticOptionalsTwinSyncSse(
@@ -117905,7 +117955,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   FeatureChronoTwinNormal dco_decode_feature_chrono_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 5)
       throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
     return FeatureChronoTwinNormal(
@@ -117921,7 +117971,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   FeatureChronoTwinRustAsync dco_decode_feature_chrono_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 5)
       throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
     return FeatureChronoTwinRustAsync(
@@ -117937,7 +117987,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   FeatureChronoTwinRustAsyncSse dco_decode_feature_chrono_twin_rust_async_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 5)
       throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
     return FeatureChronoTwinRustAsyncSse(
@@ -117952,7 +118002,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   FeatureChronoTwinSse dco_decode_feature_chrono_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 5)
       throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
     return FeatureChronoTwinSse(
@@ -117967,7 +118017,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   FeatureChronoTwinSync dco_decode_feature_chrono_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 5)
       throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
     return FeatureChronoTwinSync(
@@ -117983,7 +118033,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   FeatureChronoTwinSyncSse dco_decode_feature_chrono_twin_sync_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 5)
       throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
     return FeatureChronoTwinSyncSse(
@@ -117999,7 +118049,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   FeatureSerdeJsonTwinNormal dco_decode_feature_serde_json_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return FeatureSerdeJsonTwinNormal(
@@ -118011,7 +118061,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   FeatureSerdeJsonTwinRustAsync dco_decode_feature_serde_json_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return FeatureSerdeJsonTwinRustAsync(
@@ -118023,7 +118073,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   FeatureSerdeJsonTwinRustAsyncSse
       dco_decode_feature_serde_json_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return FeatureSerdeJsonTwinRustAsyncSse(
@@ -118034,7 +118084,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   FeatureSerdeJsonTwinSse dco_decode_feature_serde_json_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return FeatureSerdeJsonTwinSse(
@@ -118046,7 +118096,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   FeatureSerdeJsonTwinSync dco_decode_feature_serde_json_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return FeatureSerdeJsonTwinSync(
@@ -118058,7 +118108,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   FeatureSerdeJsonTwinSyncSse dco_decode_feature_serde_json_twin_sync_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return FeatureSerdeJsonTwinSyncSse(
@@ -118069,7 +118119,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   FeatureUuidTwinNormal dco_decode_feature_uuid_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return FeatureUuidTwinNormal(
@@ -118081,7 +118131,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   FeatureUuidTwinRustAsync dco_decode_feature_uuid_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return FeatureUuidTwinRustAsync(
@@ -118093,7 +118143,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   FeatureUuidTwinRustAsyncSse dco_decode_feature_uuid_twin_rust_async_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return FeatureUuidTwinRustAsyncSse(
@@ -118104,7 +118154,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   FeatureUuidTwinSse dco_decode_feature_uuid_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return FeatureUuidTwinSse(
@@ -118115,7 +118165,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   FeatureUuidTwinSync dco_decode_feature_uuid_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return FeatureUuidTwinSync(
@@ -118126,7 +118176,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   FeatureUuidTwinSyncSse dco_decode_feature_uuid_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return FeatureUuidTwinSyncSse(
@@ -118137,7 +118187,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   FeedIdTwinNormal dco_decode_feed_id_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return FeedIdTwinNormal(
@@ -118148,7 +118198,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   FeedIdTwinRustAsync dco_decode_feed_id_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return FeedIdTwinRustAsync(
@@ -118159,7 +118209,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   FeedIdTwinRustAsyncSse dco_decode_feed_id_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return FeedIdTwinRustAsyncSse(
@@ -118170,7 +118220,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   FeedIdTwinSse dco_decode_feed_id_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return FeedIdTwinSse(
@@ -118181,7 +118231,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   FeedIdTwinSync dco_decode_feed_id_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return FeedIdTwinSync(
@@ -118192,7 +118242,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   FeedIdTwinSyncSse dco_decode_feed_id_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return FeedIdTwinSyncSse(
@@ -118203,7 +118253,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   FrbLogRecord dco_decode_frb_log_record(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 6)
       throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
     return FrbLogRecord(
@@ -118220,48 +118270,48 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   GenericAliasErrorTwinNormal dco_decode_generic_alias_error_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return GenericAliasErrorTwinNormal.values[raw as int];
+    return GenericAliasErrorTwinNormal.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   GenericAliasErrorTwinRustAsync dco_decode_generic_alias_error_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return GenericAliasErrorTwinRustAsync.values[raw as int];
+    return GenericAliasErrorTwinRustAsync.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   GenericAliasErrorTwinRustAsyncSse
       dco_decode_generic_alias_error_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return GenericAliasErrorTwinRustAsyncSse.values[raw as int];
+    return GenericAliasErrorTwinRustAsyncSse.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   GenericAliasErrorTwinSse dco_decode_generic_alias_error_twin_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return GenericAliasErrorTwinSse.values[raw as int];
+    return GenericAliasErrorTwinSse.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   GenericAliasErrorTwinSync dco_decode_generic_alias_error_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return GenericAliasErrorTwinSync.values[raw as int];
+    return GenericAliasErrorTwinSync.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   GenericAliasErrorTwinSyncSse dco_decode_generic_alias_error_twin_sync_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return GenericAliasErrorTwinSyncSse.values[raw as int];
+    return GenericAliasErrorTwinSyncSse.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   HashMapValue dco_decode_hash_map_value(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return HashMapValue(
@@ -118272,13 +118322,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   int dco_decode_i_16(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dcoDecodePrimitiveInt(raw);
   }
 
   @protected
   int dco_decode_i_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dcoDecodePrimitiveInt(raw);
   }
 
   @protected
@@ -118296,7 +118346,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   int dco_decode_i_8(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dcoDecodePrimitiveInt(raw);
   }
 
   @protected
@@ -118309,7 +118359,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ItemContainerSolutionTwoTwinNormal
       dco_decode_item_container_solution_two_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return ItemContainerSolutionTwoTwinNormal(
@@ -118323,32 +118373,33 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   KitchenSinkTwinNormal dco_decode_kitchen_sink_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return KitchenSinkTwinNormal_Empty();
       case 1:
         return KitchenSinkTwinNormal_Primitives(
-          int32: dco_decode_i_32(raw[1]),
-          float64: dco_decode_f_64(raw[2]),
-          boolean: dco_decode_bool(raw[3]),
+          int32: dco_decode_i_32(arr[1]),
+          float64: dco_decode_f_64(arr[2]),
+          boolean: dco_decode_bool(arr[3]),
         );
       case 2:
         return KitchenSinkTwinNormal_Nested(
-          dco_decode_i_32(raw[1]),
-          dco_decode_box_kitchen_sink_twin_normal(raw[2]),
+          dco_decode_i_32(arr[1]),
+          dco_decode_box_kitchen_sink_twin_normal(arr[2]),
         );
       case 3:
         return KitchenSinkTwinNormal_Optional(
-          dco_decode_opt_box_autoadd_i_32(raw[1]),
-          dco_decode_opt_box_autoadd_i_32(raw[2]),
+          dco_decode_opt_box_autoadd_i_32(arr[1]),
+          dco_decode_opt_box_autoadd_i_32(arr[2]),
         );
       case 4:
         return KitchenSinkTwinNormal_Buffer(
-          dco_decode_list_prim_u_8_strict(raw[1]),
+          dco_decode_list_prim_u_8_strict(arr[1]),
         );
       case 5:
         return KitchenSinkTwinNormal_Enums(
-          dco_decode_weekdays_twin_normal(raw[1]),
+          dco_decode_weekdays_twin_normal(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -118359,32 +118410,33 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   KitchenSinkTwinRustAsync dco_decode_kitchen_sink_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return KitchenSinkTwinRustAsync_Empty();
       case 1:
         return KitchenSinkTwinRustAsync_Primitives(
-          int32: dco_decode_i_32(raw[1]),
-          float64: dco_decode_f_64(raw[2]),
-          boolean: dco_decode_bool(raw[3]),
+          int32: dco_decode_i_32(arr[1]),
+          float64: dco_decode_f_64(arr[2]),
+          boolean: dco_decode_bool(arr[3]),
         );
       case 2:
         return KitchenSinkTwinRustAsync_Nested(
-          dco_decode_i_32(raw[1]),
-          dco_decode_box_kitchen_sink_twin_rust_async(raw[2]),
+          dco_decode_i_32(arr[1]),
+          dco_decode_box_kitchen_sink_twin_rust_async(arr[2]),
         );
       case 3:
         return KitchenSinkTwinRustAsync_Optional(
-          dco_decode_opt_box_autoadd_i_32(raw[1]),
-          dco_decode_opt_box_autoadd_i_32(raw[2]),
+          dco_decode_opt_box_autoadd_i_32(arr[1]),
+          dco_decode_opt_box_autoadd_i_32(arr[2]),
         );
       case 4:
         return KitchenSinkTwinRustAsync_Buffer(
-          dco_decode_list_prim_u_8_strict(raw[1]),
+          dco_decode_list_prim_u_8_strict(arr[1]),
         );
       case 5:
         return KitchenSinkTwinRustAsync_Enums(
-          dco_decode_weekdays_twin_rust_async(raw[1]),
+          dco_decode_weekdays_twin_rust_async(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -118395,32 +118447,33 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   KitchenSinkTwinRustAsyncSse dco_decode_kitchen_sink_twin_rust_async_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return KitchenSinkTwinRustAsyncSse_Empty();
       case 1:
         return KitchenSinkTwinRustAsyncSse_Primitives(
-          int32: dco_decode_i_32(raw[1]),
-          float64: dco_decode_f_64(raw[2]),
-          boolean: dco_decode_bool(raw[3]),
+          int32: dco_decode_i_32(arr[1]),
+          float64: dco_decode_f_64(arr[2]),
+          boolean: dco_decode_bool(arr[3]),
         );
       case 2:
         return KitchenSinkTwinRustAsyncSse_Nested(
-          dco_decode_i_32(raw[1]),
-          dco_decode_box_kitchen_sink_twin_rust_async_sse(raw[2]),
+          dco_decode_i_32(arr[1]),
+          dco_decode_box_kitchen_sink_twin_rust_async_sse(arr[2]),
         );
       case 3:
         return KitchenSinkTwinRustAsyncSse_Optional(
-          dco_decode_opt_box_autoadd_i_32(raw[1]),
-          dco_decode_opt_box_autoadd_i_32(raw[2]),
+          dco_decode_opt_box_autoadd_i_32(arr[1]),
+          dco_decode_opt_box_autoadd_i_32(arr[2]),
         );
       case 4:
         return KitchenSinkTwinRustAsyncSse_Buffer(
-          dco_decode_list_prim_u_8_strict(raw[1]),
+          dco_decode_list_prim_u_8_strict(arr[1]),
         );
       case 5:
         return KitchenSinkTwinRustAsyncSse_Enums(
-          dco_decode_weekdays_twin_rust_async_sse(raw[1]),
+          dco_decode_weekdays_twin_rust_async_sse(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -118430,32 +118483,33 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   KitchenSinkTwinSse dco_decode_kitchen_sink_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return KitchenSinkTwinSse_Empty();
       case 1:
         return KitchenSinkTwinSse_Primitives(
-          int32: dco_decode_i_32(raw[1]),
-          float64: dco_decode_f_64(raw[2]),
-          boolean: dco_decode_bool(raw[3]),
+          int32: dco_decode_i_32(arr[1]),
+          float64: dco_decode_f_64(arr[2]),
+          boolean: dco_decode_bool(arr[3]),
         );
       case 2:
         return KitchenSinkTwinSse_Nested(
-          dco_decode_i_32(raw[1]),
-          dco_decode_box_kitchen_sink_twin_sse(raw[2]),
+          dco_decode_i_32(arr[1]),
+          dco_decode_box_kitchen_sink_twin_sse(arr[2]),
         );
       case 3:
         return KitchenSinkTwinSse_Optional(
-          dco_decode_opt_box_autoadd_i_32(raw[1]),
-          dco_decode_opt_box_autoadd_i_32(raw[2]),
+          dco_decode_opt_box_autoadd_i_32(arr[1]),
+          dco_decode_opt_box_autoadd_i_32(arr[2]),
         );
       case 4:
         return KitchenSinkTwinSse_Buffer(
-          dco_decode_list_prim_u_8_strict(raw[1]),
+          dco_decode_list_prim_u_8_strict(arr[1]),
         );
       case 5:
         return KitchenSinkTwinSse_Enums(
-          dco_decode_weekdays_twin_sse(raw[1]),
+          dco_decode_weekdays_twin_sse(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -118465,32 +118519,33 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   KitchenSinkTwinSync dco_decode_kitchen_sink_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return KitchenSinkTwinSync_Empty();
       case 1:
         return KitchenSinkTwinSync_Primitives(
-          int32: dco_decode_i_32(raw[1]),
-          float64: dco_decode_f_64(raw[2]),
-          boolean: dco_decode_bool(raw[3]),
+          int32: dco_decode_i_32(arr[1]),
+          float64: dco_decode_f_64(arr[2]),
+          boolean: dco_decode_bool(arr[3]),
         );
       case 2:
         return KitchenSinkTwinSync_Nested(
-          dco_decode_i_32(raw[1]),
-          dco_decode_box_kitchen_sink_twin_sync(raw[2]),
+          dco_decode_i_32(arr[1]),
+          dco_decode_box_kitchen_sink_twin_sync(arr[2]),
         );
       case 3:
         return KitchenSinkTwinSync_Optional(
-          dco_decode_opt_box_autoadd_i_32(raw[1]),
-          dco_decode_opt_box_autoadd_i_32(raw[2]),
+          dco_decode_opt_box_autoadd_i_32(arr[1]),
+          dco_decode_opt_box_autoadd_i_32(arr[2]),
         );
       case 4:
         return KitchenSinkTwinSync_Buffer(
-          dco_decode_list_prim_u_8_strict(raw[1]),
+          dco_decode_list_prim_u_8_strict(arr[1]),
         );
       case 5:
         return KitchenSinkTwinSync_Enums(
-          dco_decode_weekdays_twin_sync(raw[1]),
+          dco_decode_weekdays_twin_sync(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -118500,32 +118555,33 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   KitchenSinkTwinSyncSse dco_decode_kitchen_sink_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return KitchenSinkTwinSyncSse_Empty();
       case 1:
         return KitchenSinkTwinSyncSse_Primitives(
-          int32: dco_decode_i_32(raw[1]),
-          float64: dco_decode_f_64(raw[2]),
-          boolean: dco_decode_bool(raw[3]),
+          int32: dco_decode_i_32(arr[1]),
+          float64: dco_decode_f_64(arr[2]),
+          boolean: dco_decode_bool(arr[3]),
         );
       case 2:
         return KitchenSinkTwinSyncSse_Nested(
-          dco_decode_i_32(raw[1]),
-          dco_decode_box_kitchen_sink_twin_sync_sse(raw[2]),
+          dco_decode_i_32(arr[1]),
+          dco_decode_box_kitchen_sink_twin_sync_sse(arr[2]),
         );
       case 3:
         return KitchenSinkTwinSyncSse_Optional(
-          dco_decode_opt_box_autoadd_i_32(raw[1]),
-          dco_decode_opt_box_autoadd_i_32(raw[2]),
+          dco_decode_opt_box_autoadd_i_32(arr[1]),
+          dco_decode_opt_box_autoadd_i_32(arr[2]),
         );
       case 4:
         return KitchenSinkTwinSyncSse_Buffer(
-          dco_decode_list_prim_u_8_strict(raw[1]),
+          dco_decode_list_prim_u_8_strict(arr[1]),
         );
       case 5:
         return KitchenSinkTwinSyncSse_Enums(
-          dco_decode_weekdays_twin_sync_sse(raw[1]),
+          dco_decode_weekdays_twin_sync_sse(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -118537,7 +118593,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_list_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueItemTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(
             dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueItemTwinNormal)
         .toList();
@@ -118548,7 +118604,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_list_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinMoi(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(
             dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinMoi)
         .toList();
@@ -118559,7 +118615,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_list_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(
             dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinNormal)
         .toList();
@@ -118570,7 +118626,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_list_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinRustAsync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(
             dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinRustAsync)
         .toList();
@@ -118581,7 +118637,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_list_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinRustAsyncMoi(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(
             dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinRustAsyncMoi)
         .toList();
@@ -118592,7 +118648,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_list_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinRustAsyncSse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(
             dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinRustAsyncSse)
         .toList();
@@ -118603,7 +118659,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_list_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinRustAsyncSseMoi(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(
             dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinRustAsyncSseMoi)
         .toList();
@@ -118614,7 +118670,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_list_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinSse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(
             dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinSse)
         .toList();
@@ -118625,7 +118681,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_list_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinSseMoi(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(
             dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinSseMoi)
         .toList();
@@ -118636,7 +118692,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_list_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(
             dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinSync)
         .toList();
@@ -118647,7 +118703,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_list_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinSyncMoi(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(
             dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinSyncMoi)
         .toList();
@@ -118658,7 +118714,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_list_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinSyncSse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(
             dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinSyncSse)
         .toList();
@@ -118669,7 +118725,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_list_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinSyncSseMoi(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(
             dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinSyncSseMoi)
         .toList();
@@ -118680,7 +118736,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_list_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueItemTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(
             dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueItemTwinNormal)
         .toList();
@@ -118689,32 +118745,32 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<Duration> dco_decode_list_Chrono_Duration(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_Chrono_Duration).toList();
+    return dcoDecodeList(raw).map(dco_decode_Chrono_Duration).toList();
   }
 
   @protected
   List<DateTime> dco_decode_list_Chrono_Local(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_Chrono_Local).toList();
+    return dcoDecodeList(raw).map(dco_decode_Chrono_Local).toList();
   }
 
   @protected
   List<DateTime> dco_decode_list_Chrono_NaiveDateTime(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_Chrono_NaiveDateTime).toList();
+    return dcoDecodeList(raw).map(dco_decode_Chrono_NaiveDateTime).toList();
   }
 
   @protected
   List<Object> dco_decode_list_DartOpaque(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_DartOpaque).toList();
+    return dcoDecodeList(raw).map(dco_decode_DartOpaque).toList();
   }
 
   @protected
   List<HideDataTwinMoi> dco_decode_list_RustOpaque_HideDataTwinMoi(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_RustOpaque_HideDataTwinMoi)
         .toList();
   }
@@ -118723,7 +118779,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<HideDataTwinNormal> dco_decode_list_RustOpaque_HideDataTwinNormal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_RustOpaque_HideDataTwinNormal)
         .toList();
   }
@@ -118732,7 +118788,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<HideDataTwinRustAsync> dco_decode_list_RustOpaque_HideDataTwinRustAsync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_RustOpaque_HideDataTwinRustAsync)
         .toList();
   }
@@ -118741,7 +118797,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<HideDataTwinRustAsyncMoi>
       dco_decode_list_RustOpaque_HideDataTwinRustAsyncMoi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_RustOpaque_HideDataTwinRustAsyncMoi)
         .toList();
   }
@@ -118750,7 +118806,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<HideDataTwinRustAsyncSse>
       dco_decode_list_RustOpaque_HideDataTwinRustAsyncSse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_RustOpaque_HideDataTwinRustAsyncSse)
         .toList();
   }
@@ -118759,7 +118815,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<HideDataTwinRustAsyncSseMoi>
       dco_decode_list_RustOpaque_HideDataTwinRustAsyncSseMoi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_RustOpaque_HideDataTwinRustAsyncSseMoi)
         .toList();
   }
@@ -118768,7 +118824,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<HideDataTwinSse> dco_decode_list_RustOpaque_HideDataTwinSse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_RustOpaque_HideDataTwinSse)
         .toList();
   }
@@ -118777,7 +118833,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<HideDataTwinSseMoi> dco_decode_list_RustOpaque_HideDataTwinSseMoi(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_RustOpaque_HideDataTwinSseMoi)
         .toList();
   }
@@ -118786,7 +118842,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<HideDataTwinSync> dco_decode_list_RustOpaque_HideDataTwinSync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_RustOpaque_HideDataTwinSync)
         .toList();
   }
@@ -118795,7 +118851,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<HideDataTwinSyncMoi> dco_decode_list_RustOpaque_HideDataTwinSyncMoi(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_RustOpaque_HideDataTwinSyncMoi)
         .toList();
   }
@@ -118804,7 +118860,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<HideDataTwinSyncSse> dco_decode_list_RustOpaque_HideDataTwinSyncSse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_RustOpaque_HideDataTwinSyncSse)
         .toList();
   }
@@ -118813,7 +118869,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<HideDataTwinSyncSseMoi>
       dco_decode_list_RustOpaque_HideDataTwinSyncSseMoi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_RustOpaque_HideDataTwinSyncSseMoi)
         .toList();
   }
@@ -118821,25 +118877,25 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<Object?> dco_decode_list_SerdeJsonValue(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_SerdeJsonValue).toList();
+    return dcoDecodeList(raw).map(dco_decode_SerdeJsonValue).toList();
   }
 
   @protected
   List<RustStreamSink<int>> dco_decode_list_StreamSink_i_32_Dco(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_StreamSink_i_32_Dco).toList();
+    return dcoDecodeList(raw).map(dco_decode_StreamSink_i_32_Dco).toList();
   }
 
   @protected
   List<RustStreamSink<int>> dco_decode_list_StreamSink_i_32_Sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_StreamSink_i_32_Sse).toList();
+    return dcoDecodeList(raw).map(dco_decode_StreamSink_i_32_Sse).toList();
   }
 
   @protected
   List<String> dco_decode_list_String(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_String).toList();
+    return dcoDecodeList(raw).map(dco_decode_String).toList();
   }
 
   @protected
@@ -118858,34 +118914,32 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<ApplicationEnvVar> dco_decode_list_application_env_var(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_application_env_var).toList();
+    return dcoDecodeList(raw).map(dco_decode_application_env_var).toList();
   }
 
   @protected
   List<ApplicationMode> dco_decode_list_application_mode(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_application_mode).toList();
+    return dcoDecodeList(raw).map(dco_decode_application_mode).toList();
   }
 
   @protected
   List<ApplicationSettings> dco_decode_list_application_settings(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_application_settings).toList();
+    return dcoDecodeList(raw).map(dco_decode_application_settings).toList();
   }
 
   @protected
   List<AttributeTwinNormal> dco_decode_list_attribute_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_attribute_twin_normal)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_attribute_twin_normal).toList();
   }
 
   @protected
   List<AttributeTwinRustAsync> dco_decode_list_attribute_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_attribute_twin_rust_async)
         .toList();
   }
@@ -118894,7 +118948,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<AttributeTwinRustAsyncSse> dco_decode_list_attribute_twin_rust_async_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_attribute_twin_rust_async_sse)
         .toList();
   }
@@ -118902,29 +118956,27 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<AttributeTwinSse> dco_decode_list_attribute_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_attribute_twin_sse).toList();
+    return dcoDecodeList(raw).map(dco_decode_attribute_twin_sse).toList();
   }
 
   @protected
   List<AttributeTwinSync> dco_decode_list_attribute_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_attribute_twin_sync).toList();
+    return dcoDecodeList(raw).map(dco_decode_attribute_twin_sync).toList();
   }
 
   @protected
   List<AttributeTwinSyncSse> dco_decode_list_attribute_twin_sync_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_attribute_twin_sync_sse)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_attribute_twin_sync_sse).toList();
   }
 
   @protected
   List<BasicGeneralEnumTwinNormal>
       dco_decode_list_basic_general_enum_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_basic_general_enum_twin_normal)
         .toList();
   }
@@ -118933,7 +118985,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<BasicGeneralEnumTwinRustAsync>
       dco_decode_list_basic_general_enum_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_basic_general_enum_twin_rust_async)
         .toList();
   }
@@ -118942,7 +118994,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<BasicGeneralEnumTwinRustAsyncSse>
       dco_decode_list_basic_general_enum_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_basic_general_enum_twin_rust_async_sse)
         .toList();
   }
@@ -118951,7 +119003,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<BasicGeneralEnumTwinSse> dco_decode_list_basic_general_enum_twin_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_basic_general_enum_twin_sse)
         .toList();
   }
@@ -118960,7 +119012,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<BasicGeneralEnumTwinSync> dco_decode_list_basic_general_enum_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_basic_general_enum_twin_sync)
         .toList();
   }
@@ -118969,7 +119021,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<BasicGeneralEnumTwinSyncSse>
       dco_decode_list_basic_general_enum_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_basic_general_enum_twin_sync_sse)
         .toList();
   }
@@ -118978,7 +119030,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<BasicPrimitiveEnumTwinNormal>
       dco_decode_list_basic_primitive_enum_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_basic_primitive_enum_twin_normal)
         .toList();
   }
@@ -118987,7 +119039,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<BasicPrimitiveEnumTwinRustAsync>
       dco_decode_list_basic_primitive_enum_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_basic_primitive_enum_twin_rust_async)
         .toList();
   }
@@ -118996,7 +119048,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<BasicPrimitiveEnumTwinRustAsyncSse>
       dco_decode_list_basic_primitive_enum_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_basic_primitive_enum_twin_rust_async_sse)
         .toList();
   }
@@ -119005,7 +119057,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<BasicPrimitiveEnumTwinSse> dco_decode_list_basic_primitive_enum_twin_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_basic_primitive_enum_twin_sse)
         .toList();
   }
@@ -119014,7 +119066,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<BasicPrimitiveEnumTwinSync>
       dco_decode_list_basic_primitive_enum_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_basic_primitive_enum_twin_sync)
         .toList();
   }
@@ -119023,7 +119075,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<BasicPrimitiveEnumTwinSyncSse>
       dco_decode_list_basic_primitive_enum_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_basic_primitive_enum_twin_sync_sse)
         .toList();
   }
@@ -119032,16 +119084,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<BasicStructTwinNormal> dco_decode_list_basic_struct_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_basic_struct_twin_normal)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_basic_struct_twin_normal).toList();
   }
 
   @protected
   List<BasicStructTwinRustAsync> dco_decode_list_basic_struct_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_basic_struct_twin_rust_async)
         .toList();
   }
@@ -119050,7 +119100,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<BasicStructTwinRustAsyncSse>
       dco_decode_list_basic_struct_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_basic_struct_twin_rust_async_sse)
         .toList();
   }
@@ -119058,25 +119108,21 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<BasicStructTwinSse> dco_decode_list_basic_struct_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_basic_struct_twin_sse)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_basic_struct_twin_sse).toList();
   }
 
   @protected
   List<BasicStructTwinSync> dco_decode_list_basic_struct_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_basic_struct_twin_sync)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_basic_struct_twin_sync).toList();
   }
 
   @protected
   List<BasicStructTwinSyncSse> dco_decode_list_basic_struct_twin_sync_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_basic_struct_twin_sync_sse)
         .toList();
   }
@@ -119084,29 +119130,27 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<bool> dco_decode_list_bool(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_bool).toList();
+    return dcoDecodeList(raw).map(dco_decode_bool).toList();
   }
 
   @protected
   List<ElementTwinNormal> dco_decode_list_element_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_element_twin_normal).toList();
+    return dcoDecodeList(raw).map(dco_decode_element_twin_normal).toList();
   }
 
   @protected
   List<ElementTwinRustAsync> dco_decode_list_element_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_element_twin_rust_async)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_element_twin_rust_async).toList();
   }
 
   @protected
   List<ElementTwinRustAsyncSse> dco_decode_list_element_twin_rust_async_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_element_twin_rust_async_sse)
         .toList();
   }
@@ -119114,43 +119158,39 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<ElementTwinSse> dco_decode_list_element_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_element_twin_sse).toList();
+    return dcoDecodeList(raw).map(dco_decode_element_twin_sse).toList();
   }
 
   @protected
   List<ElementTwinSync> dco_decode_list_element_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_element_twin_sync).toList();
+    return dcoDecodeList(raw).map(dco_decode_element_twin_sync).toList();
   }
 
   @protected
   List<ElementTwinSyncSse> dco_decode_list_element_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_element_twin_sync_sse)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_element_twin_sync_sse).toList();
   }
 
   @protected
   List<EnumOpaqueTwinMoi> dco_decode_list_enum_opaque_twin_moi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_enum_opaque_twin_moi).toList();
+    return dcoDecodeList(raw).map(dco_decode_enum_opaque_twin_moi).toList();
   }
 
   @protected
   List<EnumOpaqueTwinNormal> dco_decode_list_enum_opaque_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_enum_opaque_twin_normal)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_enum_opaque_twin_normal).toList();
   }
 
   @protected
   List<EnumOpaqueTwinRustAsync> dco_decode_list_enum_opaque_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_enum_opaque_twin_rust_async)
         .toList();
   }
@@ -119159,7 +119199,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<EnumOpaqueTwinRustAsyncMoi>
       dco_decode_list_enum_opaque_twin_rust_async_moi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_enum_opaque_twin_rust_async_moi)
         .toList();
   }
@@ -119168,7 +119208,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<EnumOpaqueTwinRustAsyncSse>
       dco_decode_list_enum_opaque_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_enum_opaque_twin_rust_async_sse)
         .toList();
   }
@@ -119177,7 +119217,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<EnumOpaqueTwinRustAsyncSseMoi>
       dco_decode_list_enum_opaque_twin_rust_async_sse_moi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_enum_opaque_twin_rust_async_sse_moi)
         .toList();
   }
@@ -119185,31 +119225,27 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<EnumOpaqueTwinSse> dco_decode_list_enum_opaque_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_enum_opaque_twin_sse).toList();
+    return dcoDecodeList(raw).map(dco_decode_enum_opaque_twin_sse).toList();
   }
 
   @protected
   List<EnumOpaqueTwinSseMoi> dco_decode_list_enum_opaque_twin_sse_moi(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_enum_opaque_twin_sse_moi)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_enum_opaque_twin_sse_moi).toList();
   }
 
   @protected
   List<EnumOpaqueTwinSync> dco_decode_list_enum_opaque_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_enum_opaque_twin_sync)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_enum_opaque_twin_sync).toList();
   }
 
   @protected
   List<EnumOpaqueTwinSyncMoi> dco_decode_list_enum_opaque_twin_sync_moi(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_enum_opaque_twin_sync_moi)
         .toList();
   }
@@ -119218,7 +119254,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<EnumOpaqueTwinSyncSse> dco_decode_list_enum_opaque_twin_sync_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_enum_opaque_twin_sync_sse)
         .toList();
   }
@@ -119227,7 +119263,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<EnumOpaqueTwinSyncSseMoi> dco_decode_list_enum_opaque_twin_sync_sse_moi(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_enum_opaque_twin_sync_sse_moi)
         .toList();
   }
@@ -119235,35 +119271,33 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<Uint8List> dco_decode_list_list_prim_u_8_strict(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_list_prim_u_8_strict).toList();
+    return dcoDecodeList(raw).map(dco_decode_list_prim_u_8_strict).toList();
   }
 
   @protected
   List<MyEnum> dco_decode_list_my_enum(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_my_enum).toList();
+    return dcoDecodeList(raw).map(dco_decode_my_enum).toList();
   }
 
   @protected
   List<MySize> dco_decode_list_my_size(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_my_size).toList();
+    return dcoDecodeList(raw).map(dco_decode_my_size).toList();
   }
 
   @protected
   List<MyTreeNodeTwinNormal> dco_decode_list_my_tree_node_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_my_tree_node_twin_normal)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_my_tree_node_twin_normal).toList();
   }
 
   @protected
   List<MyTreeNodeTwinRustAsync> dco_decode_list_my_tree_node_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_my_tree_node_twin_rust_async)
         .toList();
   }
@@ -119272,7 +119306,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<MyTreeNodeTwinRustAsyncSse>
       dco_decode_list_my_tree_node_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_my_tree_node_twin_rust_async_sse)
         .toList();
   }
@@ -119280,24 +119314,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<MyTreeNodeTwinSse> dco_decode_list_my_tree_node_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_my_tree_node_twin_sse)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_my_tree_node_twin_sse).toList();
   }
 
   @protected
   List<MyTreeNodeTwinSync> dco_decode_list_my_tree_node_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_my_tree_node_twin_sync)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_my_tree_node_twin_sync).toList();
   }
 
   @protected
   List<MyTreeNodeTwinSyncSse> dco_decode_list_my_tree_node_twin_sync_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_my_tree_node_twin_sync_sse)
         .toList();
   }
@@ -119306,7 +119336,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<NestedRawStringMirrored> dco_decode_list_nested_raw_string_mirrored(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_nested_raw_string_mirrored)
         .toList();
   }
@@ -119315,7 +119345,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ListOfNestedRawStringMirrored dco_decode_list_of_nested_raw_string_mirrored(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return ListOfNestedRawStringMirrored(
@@ -119326,14 +119356,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<String?> dco_decode_list_opt_String(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_opt_String).toList();
+    return dcoDecodeList(raw).map(dco_decode_opt_String).toList();
   }
 
   @protected
   List<AttributeTwinNormal?>
       dco_decode_list_opt_box_autoadd_attribute_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_opt_box_autoadd_attribute_twin_normal)
         .toList();
   }
@@ -119342,7 +119372,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<AttributeTwinRustAsync?>
       dco_decode_list_opt_box_autoadd_attribute_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_opt_box_autoadd_attribute_twin_rust_async)
         .toList();
   }
@@ -119352,7 +119382,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_list_opt_box_autoadd_attribute_twin_rust_async_sse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_opt_box_autoadd_attribute_twin_rust_async_sse)
         .toList();
   }
@@ -119361,7 +119391,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<AttributeTwinSse?> dco_decode_list_opt_box_autoadd_attribute_twin_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_opt_box_autoadd_attribute_twin_sse)
         .toList();
   }
@@ -119370,7 +119400,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<AttributeTwinSync?> dco_decode_list_opt_box_autoadd_attribute_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_opt_box_autoadd_attribute_twin_sync)
         .toList();
   }
@@ -119379,7 +119409,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<AttributeTwinSyncSse?>
       dco_decode_list_opt_box_autoadd_attribute_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_opt_box_autoadd_attribute_twin_sync_sse)
         .toList();
   }
@@ -119387,14 +119417,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<int?> dco_decode_list_opt_box_autoadd_i_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_opt_box_autoadd_i_32).toList();
+    return dcoDecodeList(raw).map(dco_decode_opt_box_autoadd_i_32).toList();
   }
 
   @protected
   List<WeekdaysTwinNormal?>
       dco_decode_list_opt_box_autoadd_weekdays_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_opt_box_autoadd_weekdays_twin_normal)
         .toList();
   }
@@ -119403,7 +119433,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<WeekdaysTwinRustAsync?>
       dco_decode_list_opt_box_autoadd_weekdays_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_opt_box_autoadd_weekdays_twin_rust_async)
         .toList();
   }
@@ -119413,7 +119443,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_list_opt_box_autoadd_weekdays_twin_rust_async_sse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_opt_box_autoadd_weekdays_twin_rust_async_sse)
         .toList();
   }
@@ -119422,7 +119452,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<WeekdaysTwinSse?> dco_decode_list_opt_box_autoadd_weekdays_twin_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_opt_box_autoadd_weekdays_twin_sse)
         .toList();
   }
@@ -119431,7 +119461,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<WeekdaysTwinSync?> dco_decode_list_opt_box_autoadd_weekdays_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_opt_box_autoadd_weekdays_twin_sync)
         .toList();
   }
@@ -119440,7 +119470,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<WeekdaysTwinSyncSse?>
       dco_decode_list_opt_box_autoadd_weekdays_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_opt_box_autoadd_weekdays_twin_sync_sse)
         .toList();
   }
@@ -119448,7 +119478,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<Int32List?> dco_decode_list_opt_list_prim_i_32_strict(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_opt_list_prim_i_32_strict)
         .toList();
   }
@@ -119456,22 +119486,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<PointTwinNormal> dco_decode_list_point_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_point_twin_normal).toList();
+    return dcoDecodeList(raw).map(dco_decode_point_twin_normal).toList();
   }
 
   @protected
   List<PointTwinRustAsync> dco_decode_list_point_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_point_twin_rust_async)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_point_twin_rust_async).toList();
   }
 
   @protected
   List<PointTwinRustAsyncSse> dco_decode_list_point_twin_rust_async_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_point_twin_rust_async_sse)
         .toList();
   }
@@ -119479,19 +119507,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<PointTwinSse> dco_decode_list_point_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_point_twin_sse).toList();
+    return dcoDecodeList(raw).map(dco_decode_point_twin_sse).toList();
   }
 
   @protected
   List<PointTwinSync> dco_decode_list_point_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_point_twin_sync).toList();
+    return dcoDecodeList(raw).map(dco_decode_point_twin_sync).toList();
   }
 
   @protected
   List<PointTwinSyncSse> dco_decode_list_point_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_point_twin_sync_sse).toList();
+    return dcoDecodeList(raw).map(dco_decode_point_twin_sync_sse).toList();
   }
 
   @protected
@@ -119606,22 +119634,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<RawStringEnumMirrored> dco_decode_list_raw_string_enum_mirrored(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_raw_string_enum_mirrored)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_raw_string_enum_mirrored).toList();
   }
 
   @protected
   List<RawStringMirrored> dco_decode_list_raw_string_mirrored(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_raw_string_mirrored).toList();
+    return dcoDecodeList(raw).map(dco_decode_raw_string_mirrored).toList();
   }
 
   @protected
   List<(int, BasicGeneralEnumTwinNormal)>
       dco_decode_list_record_i_32_basic_general_enum_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_i_32_basic_general_enum_twin_normal)
         .toList();
   }
@@ -119631,7 +119657,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_list_record_i_32_basic_general_enum_twin_rust_async(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_i_32_basic_general_enum_twin_rust_async)
         .toList();
   }
@@ -119641,7 +119667,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_list_record_i_32_basic_general_enum_twin_rust_async_sse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_i_32_basic_general_enum_twin_rust_async_sse)
         .toList();
   }
@@ -119650,7 +119676,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<(int, BasicGeneralEnumTwinSse)>
       dco_decode_list_record_i_32_basic_general_enum_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_i_32_basic_general_enum_twin_sse)
         .toList();
   }
@@ -119659,7 +119685,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<(int, BasicGeneralEnumTwinSync)>
       dco_decode_list_record_i_32_basic_general_enum_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_i_32_basic_general_enum_twin_sync)
         .toList();
   }
@@ -119669,7 +119695,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_list_record_i_32_basic_general_enum_twin_sync_sse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_i_32_basic_general_enum_twin_sync_sse)
         .toList();
   }
@@ -119679,7 +119705,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_list_record_i_32_basic_primitive_enum_twin_normal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_i_32_basic_primitive_enum_twin_normal)
         .toList();
   }
@@ -119689,7 +119715,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_list_record_i_32_basic_primitive_enum_twin_rust_async(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_i_32_basic_primitive_enum_twin_rust_async)
         .toList();
   }
@@ -119699,7 +119725,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_list_record_i_32_basic_primitive_enum_twin_rust_async_sse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_i_32_basic_primitive_enum_twin_rust_async_sse)
         .toList();
   }
@@ -119708,7 +119734,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<(int, BasicPrimitiveEnumTwinSse)>
       dco_decode_list_record_i_32_basic_primitive_enum_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_i_32_basic_primitive_enum_twin_sse)
         .toList();
   }
@@ -119717,7 +119743,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<(int, BasicPrimitiveEnumTwinSync)>
       dco_decode_list_record_i_32_basic_primitive_enum_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_i_32_basic_primitive_enum_twin_sync)
         .toList();
   }
@@ -119727,7 +119753,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_list_record_i_32_basic_primitive_enum_twin_sync_sse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_i_32_basic_primitive_enum_twin_sync_sse)
         .toList();
   }
@@ -119736,7 +119762,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<(int, BasicStructTwinNormal)>
       dco_decode_list_record_i_32_basic_struct_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_i_32_basic_struct_twin_normal)
         .toList();
   }
@@ -119745,7 +119771,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<(int, BasicStructTwinRustAsync)>
       dco_decode_list_record_i_32_basic_struct_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_i_32_basic_struct_twin_rust_async)
         .toList();
   }
@@ -119755,7 +119781,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_list_record_i_32_basic_struct_twin_rust_async_sse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_i_32_basic_struct_twin_rust_async_sse)
         .toList();
   }
@@ -119764,7 +119790,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<(int, BasicStructTwinSse)>
       dco_decode_list_record_i_32_basic_struct_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_i_32_basic_struct_twin_sse)
         .toList();
   }
@@ -119773,7 +119799,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<(int, BasicStructTwinSync)>
       dco_decode_list_record_i_32_basic_struct_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_i_32_basic_struct_twin_sync)
         .toList();
   }
@@ -119782,7 +119808,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<(int, BasicStructTwinSyncSse)>
       dco_decode_list_record_i_32_basic_struct_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_i_32_basic_struct_twin_sync_sse)
         .toList();
   }
@@ -119790,62 +119816,62 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<(int, bool)> dco_decode_list_record_i_32_bool(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_record_i_32_bool).toList();
+    return dcoDecodeList(raw).map(dco_decode_record_i_32_bool).toList();
   }
 
   @protected
   List<(int, double)> dco_decode_list_record_i_32_f_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_record_i_32_f_32).toList();
+    return dcoDecodeList(raw).map(dco_decode_record_i_32_f_32).toList();
   }
 
   @protected
   List<(int, double)> dco_decode_list_record_i_32_f_64(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_record_i_32_f_64).toList();
+    return dcoDecodeList(raw).map(dco_decode_record_i_32_f_64).toList();
   }
 
   @protected
   List<(int, BigInt)> dco_decode_list_record_i_32_i_128(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_record_i_32_i_128).toList();
+    return dcoDecodeList(raw).map(dco_decode_record_i_32_i_128).toList();
   }
 
   @protected
   List<(int, int)> dco_decode_list_record_i_32_i_16(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_record_i_32_i_16).toList();
+    return dcoDecodeList(raw).map(dco_decode_record_i_32_i_16).toList();
   }
 
   @protected
   List<(int, int)> dco_decode_list_record_i_32_i_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_record_i_32_i_32).toList();
+    return dcoDecodeList(raw).map(dco_decode_record_i_32_i_32).toList();
   }
 
   @protected
   List<(int, PlatformInt64)> dco_decode_list_record_i_32_i_64(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_record_i_32_i_64).toList();
+    return dcoDecodeList(raw).map(dco_decode_record_i_32_i_64).toList();
   }
 
   @protected
   List<(int, int)> dco_decode_list_record_i_32_i_8(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_record_i_32_i_8).toList();
+    return dcoDecodeList(raw).map(dco_decode_record_i_32_i_8).toList();
   }
 
   @protected
   List<(int, PlatformInt64)> dco_decode_list_record_i_32_isize(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_record_i_32_isize).toList();
+    return dcoDecodeList(raw).map(dco_decode_record_i_32_isize).toList();
   }
 
   @protected
   List<(int, Uint8List)> dco_decode_list_record_i_32_list_prim_u_8_strict(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_i_32_list_prim_u_8_strict)
         .toList();
   }
@@ -119853,50 +119879,50 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<(int, String)> dco_decode_list_record_i_32_string(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_record_i_32_string).toList();
+    return dcoDecodeList(raw).map(dco_decode_record_i_32_string).toList();
   }
 
   @protected
   List<(int, BigInt)> dco_decode_list_record_i_32_u_128(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_record_i_32_u_128).toList();
+    return dcoDecodeList(raw).map(dco_decode_record_i_32_u_128).toList();
   }
 
   @protected
   List<(int, int)> dco_decode_list_record_i_32_u_16(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_record_i_32_u_16).toList();
+    return dcoDecodeList(raw).map(dco_decode_record_i_32_u_16).toList();
   }
 
   @protected
   List<(int, int)> dco_decode_list_record_i_32_u_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_record_i_32_u_32).toList();
+    return dcoDecodeList(raw).map(dco_decode_record_i_32_u_32).toList();
   }
 
   @protected
   List<(int, BigInt)> dco_decode_list_record_i_32_u_64(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_record_i_32_u_64).toList();
+    return dcoDecodeList(raw).map(dco_decode_record_i_32_u_64).toList();
   }
 
   @protected
   List<(int, int)> dco_decode_list_record_i_32_u_8(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_record_i_32_u_8).toList();
+    return dcoDecodeList(raw).map(dco_decode_record_i_32_u_8).toList();
   }
 
   @protected
   List<(int, BigInt)> dco_decode_list_record_i_32_usize(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_record_i_32_usize).toList();
+    return dcoDecodeList(raw).map(dco_decode_record_i_32_usize).toList();
   }
 
   @protected
   List<(String, EnumSimpleTwinNormal)>
       dco_decode_list_record_string_enum_simple_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_string_enum_simple_twin_normal)
         .toList();
   }
@@ -119905,7 +119931,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<(String, EnumSimpleTwinRustAsync)>
       dco_decode_list_record_string_enum_simple_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_string_enum_simple_twin_rust_async)
         .toList();
   }
@@ -119915,7 +119941,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_list_record_string_enum_simple_twin_rust_async_sse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_string_enum_simple_twin_rust_async_sse)
         .toList();
   }
@@ -119924,7 +119950,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<(String, EnumSimpleTwinSse)>
       dco_decode_list_record_string_enum_simple_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_string_enum_simple_twin_sse)
         .toList();
   }
@@ -119933,7 +119959,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<(String, EnumSimpleTwinSync)>
       dco_decode_list_record_string_enum_simple_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_string_enum_simple_twin_sync)
         .toList();
   }
@@ -119942,7 +119968,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<(String, EnumSimpleTwinSyncSse)>
       dco_decode_list_record_string_enum_simple_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_string_enum_simple_twin_sync_sse)
         .toList();
   }
@@ -119951,7 +119977,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<(String, HashMapValue)> dco_decode_list_record_string_hash_map_value(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_string_hash_map_value)
         .toList();
   }
@@ -119959,14 +119985,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<(String, int)> dco_decode_list_record_string_i_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_record_string_i_32).toList();
+    return dcoDecodeList(raw).map(dco_decode_record_string_i_32).toList();
   }
 
   @protected
   List<(String, KitchenSinkTwinNormal)>
       dco_decode_list_record_string_kitchen_sink_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_string_kitchen_sink_twin_normal)
         .toList();
   }
@@ -119975,7 +120001,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<(String, KitchenSinkTwinRustAsync)>
       dco_decode_list_record_string_kitchen_sink_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_string_kitchen_sink_twin_rust_async)
         .toList();
   }
@@ -119985,7 +120011,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_list_record_string_kitchen_sink_twin_rust_async_sse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_string_kitchen_sink_twin_rust_async_sse)
         .toList();
   }
@@ -119994,7 +120020,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<(String, KitchenSinkTwinSse)>
       dco_decode_list_record_string_kitchen_sink_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_string_kitchen_sink_twin_sse)
         .toList();
   }
@@ -120003,7 +120029,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<(String, KitchenSinkTwinSync)>
       dco_decode_list_record_string_kitchen_sink_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_string_kitchen_sink_twin_sync)
         .toList();
   }
@@ -120012,7 +120038,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<(String, KitchenSinkTwinSyncSse)>
       dco_decode_list_record_string_kitchen_sink_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_string_kitchen_sink_twin_sync_sse)
         .toList();
   }
@@ -120021,7 +120047,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<(String, Uint8List)> dco_decode_list_record_string_list_prim_u_8_strict(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_string_list_prim_u_8_strict)
         .toList();
   }
@@ -120029,16 +120055,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<(String, MySize)> dco_decode_list_record_string_my_size(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_record_string_my_size)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_record_string_my_size).toList();
   }
 
   @protected
   List<(String, Object?)> dco_decode_list_record_string_serde_json_value(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_string_serde_json_value)
         .toList();
   }
@@ -120046,14 +120070,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<(String, String)> dco_decode_list_record_string_string(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_record_string_string).toList();
+    return dcoDecodeList(raw).map(dco_decode_record_string_string).toList();
   }
 
   @protected
   List<(int, ApplicationMode)> dco_decode_list_record_u_8_application_mode(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_u_8_application_mode)
         .toList();
   }
@@ -120062,7 +120086,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<SimpleStructTwinNormal> dco_decode_list_simple_struct_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_simple_struct_twin_normal)
         .toList();
   }
@@ -120071,7 +120095,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<SimpleStructTwinRustAsync> dco_decode_list_simple_struct_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_simple_struct_twin_rust_async)
         .toList();
   }
@@ -120080,7 +120104,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<SimpleStructTwinRustAsyncSse>
       dco_decode_list_simple_struct_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_simple_struct_twin_rust_async_sse)
         .toList();
   }
@@ -120089,25 +120113,21 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<SimpleStructTwinSse> dco_decode_list_simple_struct_twin_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_simple_struct_twin_sse)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_simple_struct_twin_sse).toList();
   }
 
   @protected
   List<SimpleStructTwinSync> dco_decode_list_simple_struct_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_simple_struct_twin_sync)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_simple_struct_twin_sync).toList();
   }
 
   @protected
   List<SimpleStructTwinSyncSse> dco_decode_list_simple_struct_twin_sync_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_simple_struct_twin_sync_sse)
         .toList();
   }
@@ -120115,23 +120135,21 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<SumWithTwinNormal> dco_decode_list_sum_with_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_sum_with_twin_normal).toList();
+    return dcoDecodeList(raw).map(dco_decode_sum_with_twin_normal).toList();
   }
 
   @protected
   List<SumWithTwinRustAsync> dco_decode_list_sum_with_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_sum_with_twin_rust_async)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_sum_with_twin_rust_async).toList();
   }
 
   @protected
   List<SumWithTwinRustAsyncSse> dco_decode_list_sum_with_twin_rust_async_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_sum_with_twin_rust_async_sse)
         .toList();
   }
@@ -120139,43 +120157,39 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<SumWithTwinSse> dco_decode_list_sum_with_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_sum_with_twin_sse).toList();
+    return dcoDecodeList(raw).map(dco_decode_sum_with_twin_sse).toList();
   }
 
   @protected
   List<SumWithTwinSync> dco_decode_list_sum_with_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_sum_with_twin_sync).toList();
+    return dcoDecodeList(raw).map(dco_decode_sum_with_twin_sync).toList();
   }
 
   @protected
   List<SumWithTwinSyncSse> dco_decode_list_sum_with_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_sum_with_twin_sync_sse)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_sum_with_twin_sync_sse).toList();
   }
 
   @protected
   List<TestIdTwinNormal> dco_decode_list_test_id_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_test_id_twin_normal).toList();
+    return dcoDecodeList(raw).map(dco_decode_test_id_twin_normal).toList();
   }
 
   @protected
   List<TestIdTwinRustAsync> dco_decode_list_test_id_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_test_id_twin_rust_async)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_test_id_twin_rust_async).toList();
   }
 
   @protected
   List<TestIdTwinRustAsyncSse> dco_decode_list_test_id_twin_rust_async_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_test_id_twin_rust_async_sse)
         .toList();
   }
@@ -120183,43 +120197,39 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<TestIdTwinSse> dco_decode_list_test_id_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_test_id_twin_sse).toList();
+    return dcoDecodeList(raw).map(dco_decode_test_id_twin_sse).toList();
   }
 
   @protected
   List<TestIdTwinSync> dco_decode_list_test_id_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_test_id_twin_sync).toList();
+    return dcoDecodeList(raw).map(dco_decode_test_id_twin_sync).toList();
   }
 
   @protected
   List<TestIdTwinSyncSse> dco_decode_list_test_id_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_test_id_twin_sync_sse)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_test_id_twin_sync_sse).toList();
   }
 
   @protected
   List<WeekdaysTwinNormal> dco_decode_list_weekdays_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_weekdays_twin_normal).toList();
+    return dcoDecodeList(raw).map(dco_decode_weekdays_twin_normal).toList();
   }
 
   @protected
   List<WeekdaysTwinRustAsync> dco_decode_list_weekdays_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_weekdays_twin_rust_async)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_weekdays_twin_rust_async).toList();
   }
 
   @protected
   List<WeekdaysTwinRustAsyncSse> dco_decode_list_weekdays_twin_rust_async_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_weekdays_twin_rust_async_sse)
         .toList();
   }
@@ -120227,28 +120237,26 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<WeekdaysTwinSse> dco_decode_list_weekdays_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_weekdays_twin_sse).toList();
+    return dcoDecodeList(raw).map(dco_decode_weekdays_twin_sse).toList();
   }
 
   @protected
   List<WeekdaysTwinSync> dco_decode_list_weekdays_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_weekdays_twin_sync).toList();
+    return dcoDecodeList(raw).map(dco_decode_weekdays_twin_sync).toList();
   }
 
   @protected
   List<WeekdaysTwinSyncSse> dco_decode_list_weekdays_twin_sync_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_weekdays_twin_sync_sse)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_weekdays_twin_sync_sse).toList();
   }
 
   @protected
   Log2TwinNormal dco_decode_log_2_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return Log2TwinNormal(
@@ -120260,7 +120268,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   Log2TwinRustAsync dco_decode_log_2_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return Log2TwinRustAsync(
@@ -120272,7 +120280,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   Log2TwinRustAsyncSse dco_decode_log_2_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return Log2TwinRustAsyncSse(
@@ -120284,7 +120292,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   Log2TwinSse dco_decode_log_2_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return Log2TwinSse(
@@ -120296,7 +120304,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   Log2TwinSync dco_decode_log_2_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return Log2TwinSync(
@@ -120308,7 +120316,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   Log2TwinSyncSse dco_decode_log_2_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return Log2TwinSyncSse(
@@ -120320,7 +120328,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   LogTwinNormal dco_decode_log_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return LogTwinNormal(
@@ -120332,7 +120340,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   LogTwinRustAsync dco_decode_log_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return LogTwinRustAsync(
@@ -120344,7 +120352,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   LogTwinRustAsyncSse dco_decode_log_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return LogTwinRustAsyncSse(
@@ -120356,7 +120364,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   LogTwinSse dco_decode_log_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return LogTwinSse(
@@ -120368,7 +120376,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MacroStruct dco_decode_macro_struct(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return MacroStruct(
@@ -120379,14 +120387,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MeasureTwinNormal dco_decode_measure_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return MeasureTwinNormal_Speed(
-          dco_decode_box_speed_twin_normal(raw[1]),
+          dco_decode_box_speed_twin_normal(arr[1]),
         );
       case 1:
         return MeasureTwinNormal_Distance(
-          dco_decode_box_distance_twin_normal(raw[1]),
+          dco_decode_box_distance_twin_normal(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -120396,14 +120405,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MeasureTwinRustAsync dco_decode_measure_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return MeasureTwinRustAsync_Speed(
-          dco_decode_box_speed_twin_rust_async(raw[1]),
+          dco_decode_box_speed_twin_rust_async(arr[1]),
         );
       case 1:
         return MeasureTwinRustAsync_Distance(
-          dco_decode_box_distance_twin_rust_async(raw[1]),
+          dco_decode_box_distance_twin_rust_async(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -120413,14 +120423,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MeasureTwinRustAsyncSse dco_decode_measure_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return MeasureTwinRustAsyncSse_Speed(
-          dco_decode_box_speed_twin_rust_async_sse(raw[1]),
+          dco_decode_box_speed_twin_rust_async_sse(arr[1]),
         );
       case 1:
         return MeasureTwinRustAsyncSse_Distance(
-          dco_decode_box_distance_twin_rust_async_sse(raw[1]),
+          dco_decode_box_distance_twin_rust_async_sse(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -120430,14 +120441,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MeasureTwinSse dco_decode_measure_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return MeasureTwinSse_Speed(
-          dco_decode_box_speed_twin_sse(raw[1]),
+          dco_decode_box_speed_twin_sse(arr[1]),
         );
       case 1:
         return MeasureTwinSse_Distance(
-          dco_decode_box_distance_twin_sse(raw[1]),
+          dco_decode_box_distance_twin_sse(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -120447,14 +120459,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MeasureTwinSync dco_decode_measure_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return MeasureTwinSync_Speed(
-          dco_decode_box_speed_twin_sync(raw[1]),
+          dco_decode_box_speed_twin_sync(arr[1]),
         );
       case 1:
         return MeasureTwinSync_Distance(
-          dco_decode_box_distance_twin_sync(raw[1]),
+          dco_decode_box_distance_twin_sync(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -120464,14 +120477,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MeasureTwinSyncSse dco_decode_measure_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return MeasureTwinSyncSse_Speed(
-          dco_decode_box_speed_twin_sync_sse(raw[1]),
+          dco_decode_box_speed_twin_sync_sse(arr[1]),
         );
       case 1:
         return MeasureTwinSyncSse_Distance(
-          dco_decode_box_distance_twin_sync_sse(raw[1]),
+          dco_decode_box_distance_twin_sync_sse(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -120481,7 +120495,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MessageIdTwinNormal dco_decode_message_id_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return MessageIdTwinNormal(
@@ -120492,7 +120506,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MessageIdTwinRustAsync dco_decode_message_id_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return MessageIdTwinRustAsync(
@@ -120504,7 +120518,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   MessageIdTwinRustAsyncSse dco_decode_message_id_twin_rust_async_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return MessageIdTwinRustAsyncSse(
@@ -120515,7 +120529,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MessageIdTwinSse dco_decode_message_id_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return MessageIdTwinSse(
@@ -120526,7 +120540,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MessageIdTwinSync dco_decode_message_id_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return MessageIdTwinSync(
@@ -120537,7 +120551,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MessageIdTwinSyncSse dco_decode_message_id_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return MessageIdTwinSyncSse(
@@ -120548,7 +120562,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MirrorStructTwinNormal dco_decode_mirror_struct_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return MirrorStructTwinNormal(
@@ -120563,7 +120577,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   MirrorStructTwinRustAsync dco_decode_mirror_struct_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return MirrorStructTwinRustAsync(
@@ -120578,7 +120592,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   MirrorStructTwinRustAsyncSse dco_decode_mirror_struct_twin_rust_async_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return MirrorStructTwinRustAsyncSse(
@@ -120592,7 +120606,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MirrorStructTwinSse dco_decode_mirror_struct_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return MirrorStructTwinSse(
@@ -120606,7 +120620,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MirrorStructTwinSync dco_decode_mirror_struct_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return MirrorStructTwinSync(
@@ -120620,7 +120634,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MirrorStructTwinSyncSse dco_decode_mirror_struct_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return MirrorStructTwinSyncSse(
@@ -120635,7 +120649,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   MoreThanJustOneRawStringStructTwinNormal
       dco_decode_more_than_just_one_raw_string_struct_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return MoreThanJustOneRawStringStructTwinNormal(
@@ -120651,7 +120665,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_more_than_just_one_raw_string_struct_twin_rust_async(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return MoreThanJustOneRawStringStructTwinRustAsync(
@@ -120667,7 +120681,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_more_than_just_one_raw_string_struct_twin_rust_async_sse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return MoreThanJustOneRawStringStructTwinRustAsyncSse(
@@ -120682,7 +120696,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   MoreThanJustOneRawStringStructTwinSse
       dco_decode_more_than_just_one_raw_string_struct_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return MoreThanJustOneRawStringStructTwinSse(
@@ -120697,7 +120711,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   MoreThanJustOneRawStringStructTwinSync
       dco_decode_more_than_just_one_raw_string_struct_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return MoreThanJustOneRawStringStructTwinSync(
@@ -120713,7 +120727,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_more_than_just_one_raw_string_struct_twin_sync_sse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return MoreThanJustOneRawStringStructTwinSyncSse(
@@ -120727,7 +120741,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MyCallableTwinNormal dco_decode_my_callable_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return MyCallableTwinNormal(
@@ -120738,7 +120752,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MyCallableTwinRustAsync dco_decode_my_callable_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return MyCallableTwinRustAsync(
@@ -120750,7 +120764,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   MyCallableTwinRustAsyncSse dco_decode_my_callable_twin_rust_async_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return MyCallableTwinRustAsyncSse(
@@ -120761,7 +120775,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MyCallableTwinSse dco_decode_my_callable_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return MyCallableTwinSse(
@@ -120772,7 +120786,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MyCallableTwinSync dco_decode_my_callable_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return MyCallableTwinSync(
@@ -120783,7 +120797,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MyCallableTwinSyncSse dco_decode_my_callable_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return MyCallableTwinSyncSse(
@@ -120794,21 +120808,22 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MyEnum dco_decode_my_enum(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return MyEnum.values[raw as int];
+    return MyEnum.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   MyEnumWithJsonSerializableTwinNormal
       dco_decode_my_enum_with_json_serializable_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return MyEnumWithJsonSerializableTwinNormal_Apple(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return MyEnumWithJsonSerializableTwinNormal_Orange(
-          a: dco_decode_i_32(raw[1]),
+          a: dco_decode_i_32(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -120819,10 +120834,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   MyEnumWithoutFnWithUnignoreTwinNormal
       dco_decode_my_enum_without_fn_with_unignore_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return MyEnumWithoutFnWithUnignoreTwinNormal_One(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -120833,7 +120849,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   MyNestedStructTwinNormal dco_decode_my_nested_struct_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return MyNestedStructTwinNormal(
@@ -120846,7 +120862,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   MyNestedStructTwinRustAsync dco_decode_my_nested_struct_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return MyNestedStructTwinRustAsync(
@@ -120859,7 +120875,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   MyNestedStructTwinRustAsyncSse
       dco_decode_my_nested_struct_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return MyNestedStructTwinRustAsyncSse(
@@ -120871,7 +120887,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MyNestedStructTwinSse dco_decode_my_nested_struct_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return MyNestedStructTwinSse(
@@ -120883,7 +120899,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MyNestedStructTwinSync dco_decode_my_nested_struct_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return MyNestedStructTwinSync(
@@ -120896,7 +120912,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   MyNestedStructTwinSyncSse dco_decode_my_nested_struct_twin_sync_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return MyNestedStructTwinSyncSse(
@@ -120908,7 +120924,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MySize dco_decode_my_size(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return MySize(
@@ -120920,7 +120936,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MyStreamEntryTwinNormal dco_decode_my_stream_entry_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return MyStreamEntryTwinNormal(
@@ -120932,7 +120948,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   MyStreamEntryTwinRustAsync dco_decode_my_stream_entry_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return MyStreamEntryTwinRustAsync(
@@ -120944,7 +120960,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   MyStreamEntryTwinRustAsyncSse dco_decode_my_stream_entry_twin_rust_async_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return MyStreamEntryTwinRustAsyncSse(
@@ -120955,7 +120971,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MyStreamEntryTwinSse dco_decode_my_stream_entry_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return MyStreamEntryTwinSse(
@@ -120966,7 +120982,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MyStruct dco_decode_my_struct(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return MyStruct(
@@ -120978,7 +120994,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   MyStructContainingStreamSinkTwinNormal
       dco_decode_my_struct_containing_stream_sink_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return MyStructContainingStreamSinkTwinNormal(
@@ -120991,7 +121007,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   MyStructContainingStreamSinkTwinRustAsync
       dco_decode_my_struct_containing_stream_sink_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return MyStructContainingStreamSinkTwinRustAsync(
@@ -121005,7 +121021,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_my_struct_containing_stream_sink_twin_rust_async_sse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return MyStructContainingStreamSinkTwinRustAsyncSse(
@@ -121018,7 +121034,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   MyStructContainingStreamSinkTwinSse
       dco_decode_my_struct_containing_stream_sink_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return MyStructContainingStreamSinkTwinSse(
@@ -121031,7 +121047,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   MyStructWithJsonSerializableTwinNormal
       dco_decode_my_struct_with_json_serializable_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return MyStructWithJsonSerializableTwinNormal(
@@ -121042,7 +121058,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MyStructWithSync dco_decode_my_struct_with_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 0)
       throw Exception('unexpected arr length: expect 0 but see ${arr.length}');
     return MyStructWithSync();
@@ -121052,7 +121068,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   MyStructWithoutFnWithUnignoreTwinNormal
       dco_decode_my_struct_without_fn_with_unignore_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return MyStructWithoutFnWithUnignoreTwinNormal(
@@ -121065,7 +121081,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_my_struct_without_fn_with_unignore_with_json_serializable_twin_normal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return MyStructWithoutFnWithUnignoreWithJsonSerializableTwinNormal(
@@ -121076,7 +121092,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MyTreeNodeTwinNormal dco_decode_my_tree_node_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return MyTreeNodeTwinNormal(
@@ -121090,7 +121106,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MyTreeNodeTwinRustAsync dco_decode_my_tree_node_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return MyTreeNodeTwinRustAsync(
@@ -121105,7 +121121,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   MyTreeNodeTwinRustAsyncSse dco_decode_my_tree_node_twin_rust_async_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return MyTreeNodeTwinRustAsyncSse(
@@ -121119,7 +121135,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MyTreeNodeTwinSse dco_decode_my_tree_node_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return MyTreeNodeTwinSse(
@@ -121133,7 +121149,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MyTreeNodeTwinSync dco_decode_my_tree_node_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return MyTreeNodeTwinSync(
@@ -121147,7 +121163,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MyTreeNodeTwinSyncSse dco_decode_my_tree_node_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return MyTreeNodeTwinSyncSse(
@@ -121161,7 +121177,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   NestedRawStringMirrored dco_decode_nested_raw_string_mirrored(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return NestedRawStringMirrored(
@@ -121172,7 +121188,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   NewSimpleStruct dco_decode_new_simple_struct(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return NewSimpleStruct(
@@ -121183,7 +121199,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   NewTypeIntTwinNormal dco_decode_new_type_int_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return NewTypeIntTwinNormal(
@@ -121194,7 +121210,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   NewTypeIntTwinRustAsync dco_decode_new_type_int_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return NewTypeIntTwinRustAsync(
@@ -121206,7 +121222,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   NewTypeIntTwinRustAsyncSse dco_decode_new_type_int_twin_rust_async_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return NewTypeIntTwinRustAsyncSse(
@@ -121217,7 +121233,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   NewTypeIntTwinSse dco_decode_new_type_int_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return NewTypeIntTwinSse(
@@ -121228,7 +121244,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   NewTypeIntTwinSync dco_decode_new_type_int_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return NewTypeIntTwinSync(
@@ -121239,7 +121255,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   NewTypeIntTwinSyncSse dco_decode_new_type_int_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return NewTypeIntTwinSyncSse(
@@ -121251,7 +121267,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   NonOpaqueStructContainingIpv4Addr
       dco_decode_non_opaque_struct_containing_ipv_4_addr(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return NonOpaqueStructContainingIpv4Addr(
@@ -121264,7 +121280,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   NoteTwinNormal dco_decode_note_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return NoteTwinNormal(
@@ -121276,7 +121292,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   NoteTwinRustAsync dco_decode_note_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return NoteTwinRustAsync(
@@ -121288,7 +121304,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   NoteTwinRustAsyncSse dco_decode_note_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return NoteTwinRustAsyncSse(
@@ -121300,7 +121316,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   NoteTwinSse dco_decode_note_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return NoteTwinSse(
@@ -121312,7 +121328,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   NoteTwinSync dco_decode_note_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return NoteTwinSync(
@@ -121324,7 +121340,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   NoteTwinSyncSse dco_decode_note_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return NoteTwinSyncSse(
@@ -121336,7 +121352,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   Numbers dco_decode_numbers(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return Numbers(
@@ -121347,7 +121363,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   OldSimpleStruct dco_decode_old_simple_struct(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return OldSimpleStruct(
@@ -121358,7 +121374,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   OpaqueNestedTwinMoi dco_decode_opaque_nested_twin_moi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return OpaqueNestedTwinMoi(
@@ -121370,7 +121386,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   OpaqueNestedTwinNormal dco_decode_opaque_nested_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return OpaqueNestedTwinNormal(
@@ -121383,7 +121399,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   OpaqueNestedTwinRustAsync dco_decode_opaque_nested_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return OpaqueNestedTwinRustAsync(
@@ -121396,7 +121412,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   OpaqueNestedTwinRustAsyncMoi dco_decode_opaque_nested_twin_rust_async_moi(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return OpaqueNestedTwinRustAsyncMoi(
@@ -121409,7 +121425,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   OpaqueNestedTwinRustAsyncSse dco_decode_opaque_nested_twin_rust_async_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return OpaqueNestedTwinRustAsyncSse(
@@ -121422,7 +121438,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   OpaqueNestedTwinRustAsyncSseMoi
       dco_decode_opaque_nested_twin_rust_async_sse_moi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return OpaqueNestedTwinRustAsyncSseMoi(
@@ -121434,7 +121450,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   OpaqueNestedTwinSse dco_decode_opaque_nested_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return OpaqueNestedTwinSse(
@@ -121446,7 +121462,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   OpaqueNestedTwinSseMoi dco_decode_opaque_nested_twin_sse_moi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return OpaqueNestedTwinSseMoi(
@@ -121458,7 +121474,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   OpaqueNestedTwinSync dco_decode_opaque_nested_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return OpaqueNestedTwinSync(
@@ -121470,7 +121486,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   OpaqueNestedTwinSyncMoi dco_decode_opaque_nested_twin_sync_moi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return OpaqueNestedTwinSyncMoi(
@@ -121482,7 +121498,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   OpaqueNestedTwinSyncSse dco_decode_opaque_nested_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return OpaqueNestedTwinSyncSse(
@@ -121495,7 +121511,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   OpaqueNestedTwinSyncSseMoi dco_decode_opaque_nested_twin_sync_sse_moi(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return OpaqueNestedTwinSyncSseMoi(
@@ -122732,7 +122748,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   OptVecsTwinNormal dco_decode_opt_vecs_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return OptVecsTwinNormal(
@@ -122746,7 +122762,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   OptVecsTwinRustAsync dco_decode_opt_vecs_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return OptVecsTwinRustAsync(
@@ -122760,7 +122776,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   OptVecsTwinRustAsyncSse dco_decode_opt_vecs_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return OptVecsTwinRustAsyncSse(
@@ -122775,7 +122791,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   OptVecsTwinSse dco_decode_opt_vecs_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return OptVecsTwinSse(
@@ -122789,7 +122805,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   OptVecsTwinSync dco_decode_opt_vecs_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return OptVecsTwinSync(
@@ -122803,7 +122819,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   OptVecsTwinSyncSse dco_decode_opt_vecs_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return OptVecsTwinSyncSse(
@@ -122817,7 +122833,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PointTwinNormal dco_decode_point_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return PointTwinNormal(
@@ -122830,13 +122846,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   PointTwinNormalArray2 dco_decode_point_twin_normal_array_2(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return PointTwinNormalArray2(
-        (raw as List<dynamic>).map(dco_decode_point_twin_normal).toList());
+        dcoDecodeList(raw).map(dco_decode_point_twin_normal).toList());
   }
 
   @protected
   PointTwinRustAsync dco_decode_point_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return PointTwinRustAsync(
@@ -122850,13 +122866,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return PointTwinRustAsyncArray2(
-        (raw as List<dynamic>).map(dco_decode_point_twin_rust_async).toList());
+        dcoDecodeList(raw).map(dco_decode_point_twin_rust_async).toList());
   }
 
   @protected
   PointTwinRustAsyncSse dco_decode_point_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return PointTwinRustAsyncSse(
@@ -122869,15 +122885,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   PointTwinRustAsyncSseArray2 dco_decode_point_twin_rust_async_sse_array_2(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return PointTwinRustAsyncSseArray2((raw as List<dynamic>)
-        .map(dco_decode_point_twin_rust_async_sse)
-        .toList());
+    return PointTwinRustAsyncSseArray2(
+        dcoDecodeList(raw).map(dco_decode_point_twin_rust_async_sse).toList());
   }
 
   @protected
   PointTwinSse dco_decode_point_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return PointTwinSse(
@@ -122890,13 +122905,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   PointTwinSseArray2 dco_decode_point_twin_sse_array_2(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return PointTwinSseArray2(
-        (raw as List<dynamic>).map(dco_decode_point_twin_sse).toList());
+        dcoDecodeList(raw).map(dco_decode_point_twin_sse).toList());
   }
 
   @protected
   PointTwinSync dco_decode_point_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return PointTwinSync(
@@ -122909,13 +122924,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   PointTwinSyncArray2 dco_decode_point_twin_sync_array_2(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return PointTwinSyncArray2(
-        (raw as List<dynamic>).map(dco_decode_point_twin_sync).toList());
+        dcoDecodeList(raw).map(dco_decode_point_twin_sync).toList());
   }
 
   @protected
   PointTwinSyncSse dco_decode_point_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return PointTwinSyncSse(
@@ -122928,24 +122943,25 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   PointTwinSyncSseArray2 dco_decode_point_twin_sync_sse_array_2(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return PointTwinSyncSseArray2(
-        (raw as List<dynamic>).map(dco_decode_point_twin_sync_sse).toList());
+        dcoDecodeList(raw).map(dco_decode_point_twin_sync_sse).toList());
   }
 
   @protected
   RawStringEnumMirrored dco_decode_raw_string_enum_mirrored(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return RawStringEnumMirrored_Raw(
-          dco_decode_box_autoadd_raw_string_mirrored(raw[1]),
+          dco_decode_box_autoadd_raw_string_mirrored(arr[1]),
         );
       case 1:
         return RawStringEnumMirrored_Nested(
-          dco_decode_box_autoadd_nested_raw_string_mirrored(raw[1]),
+          dco_decode_box_autoadd_nested_raw_string_mirrored(arr[1]),
         );
       case 2:
         return RawStringEnumMirrored_ListOfNested(
-          dco_decode_box_autoadd_list_of_nested_raw_string_mirrored(raw[1]),
+          dco_decode_box_autoadd_list_of_nested_raw_string_mirrored(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -122956,14 +122972,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   RawStringItemEnumTwinNormal dco_decode_raw_string_item_enum_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return RawStringItemEnumTwinNormal_Regular(
-          regular: dco_decode_String(raw[1]),
+          regular: dco_decode_String(arr[1]),
         );
       case 1:
         return RawStringItemEnumTwinNormal_Raw(
-          type: dco_decode_String(raw[1]),
+          type: dco_decode_String(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -122974,14 +122991,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   RawStringItemEnumTwinRustAsync
       dco_decode_raw_string_item_enum_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return RawStringItemEnumTwinRustAsync_Regular(
-          regular: dco_decode_String(raw[1]),
+          regular: dco_decode_String(arr[1]),
         );
       case 1:
         return RawStringItemEnumTwinRustAsync_Raw(
-          type: dco_decode_String(raw[1]),
+          type: dco_decode_String(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -122992,14 +123010,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   RawStringItemEnumTwinRustAsyncSse
       dco_decode_raw_string_item_enum_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return RawStringItemEnumTwinRustAsyncSse_Regular(
-          regular: dco_decode_String(raw[1]),
+          regular: dco_decode_String(arr[1]),
         );
       case 1:
         return RawStringItemEnumTwinRustAsyncSse_Raw(
-          type: dco_decode_String(raw[1]),
+          type: dco_decode_String(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -123010,14 +123029,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   RawStringItemEnumTwinSse dco_decode_raw_string_item_enum_twin_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return RawStringItemEnumTwinSse_Regular(
-          regular: dco_decode_String(raw[1]),
+          regular: dco_decode_String(arr[1]),
         );
       case 1:
         return RawStringItemEnumTwinSse_Raw(
-          type: dco_decode_String(raw[1]),
+          type: dco_decode_String(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -123028,14 +123048,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   RawStringItemEnumTwinSync dco_decode_raw_string_item_enum_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return RawStringItemEnumTwinSync_Regular(
-          regular: dco_decode_String(raw[1]),
+          regular: dco_decode_String(arr[1]),
         );
       case 1:
         return RawStringItemEnumTwinSync_Raw(
-          type: dco_decode_String(raw[1]),
+          type: dco_decode_String(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -123046,14 +123067,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   RawStringItemEnumTwinSyncSse dco_decode_raw_string_item_enum_twin_sync_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return RawStringItemEnumTwinSyncSse_Regular(
-          regular: dco_decode_String(raw[1]),
+          regular: dco_decode_String(arr[1]),
         );
       case 1:
         return RawStringItemEnumTwinSyncSse_Raw(
-          type: dco_decode_String(raw[1]),
+          type: dco_decode_String(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -123064,7 +123086,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   RawStringItemStructTwinNormal dco_decode_raw_string_item_struct_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return RawStringItemStructTwinNormal(
@@ -123076,7 +123098,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   RawStringItemStructTwinRustAsync
       dco_decode_raw_string_item_struct_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return RawStringItemStructTwinRustAsync(
@@ -123088,7 +123110,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   RawStringItemStructTwinRustAsyncSse
       dco_decode_raw_string_item_struct_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return RawStringItemStructTwinRustAsyncSse(
@@ -123100,7 +123122,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   RawStringItemStructTwinSse dco_decode_raw_string_item_struct_twin_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return RawStringItemStructTwinSse(
@@ -123112,7 +123134,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   RawStringItemStructTwinSync dco_decode_raw_string_item_struct_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return RawStringItemStructTwinSync(
@@ -123124,7 +123146,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   RawStringItemStructTwinSyncSse
       dco_decode_raw_string_item_struct_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return RawStringItemStructTwinSyncSse(
@@ -123135,7 +123157,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   RawStringMirrored dco_decode_raw_string_mirrored(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return RawStringMirrored(
@@ -123149,7 +123171,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_record_application_settings_raw_string_enum_mirrored(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123166,7 +123188,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) dco_decode_record_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_opaque_one_twin_moi_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_opaque_two_twin_moi(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123185,7 +123207,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) dco_decode_record_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_opaque_one_twin_normal_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_opaque_two_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123204,7 +123226,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) dco_decode_record_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_opaque_one_twin_rust_async_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_opaque_two_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123223,7 +123245,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) dco_decode_record_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_opaque_one_twin_rust_async_moi_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_opaque_two_twin_rust_async_moi(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123242,7 +123264,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) dco_decode_record_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_opaque_one_twin_rust_async_sse_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_opaque_two_twin_rust_async_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123261,7 +123283,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) dco_decode_record_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_opaque_one_twin_rust_async_sse_moi_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_opaque_two_twin_rust_async_sse_moi(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123280,7 +123302,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) dco_decode_record_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_opaque_one_twin_sse_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_opaque_two_twin_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123299,7 +123321,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) dco_decode_record_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_opaque_one_twin_sse_moi_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_opaque_two_twin_sse_moi(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123318,7 +123340,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) dco_decode_record_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_opaque_one_twin_sync_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_opaque_two_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123337,7 +123359,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) dco_decode_record_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_opaque_one_twin_sync_moi_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_opaque_two_twin_sync_moi(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123356,7 +123378,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) dco_decode_record_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_opaque_one_twin_sync_sse_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_opaque_two_twin_sync_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123375,7 +123397,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) dco_decode_record_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_opaque_one_twin_sync_sse_moi_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_opaque_two_twin_sync_sse_moi(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123390,7 +123412,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (double, double) dco_decode_record_f_32_f_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123404,7 +123426,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (int, BasicGeneralEnumTwinNormal)
       dco_decode_record_i_32_basic_general_enum_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123418,7 +123440,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (int, BasicGeneralEnumTwinRustAsync)
       dco_decode_record_i_32_basic_general_enum_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123434,7 +123456,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     BasicGeneralEnumTwinRustAsyncSse
   ) dco_decode_record_i_32_basic_general_enum_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123448,7 +123470,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (int, BasicGeneralEnumTwinSse)
       dco_decode_record_i_32_basic_general_enum_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123462,7 +123484,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (int, BasicGeneralEnumTwinSync)
       dco_decode_record_i_32_basic_general_enum_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123476,7 +123498,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (int, BasicGeneralEnumTwinSyncSse)
       dco_decode_record_i_32_basic_general_enum_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123490,7 +123512,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (int, BasicPrimitiveEnumTwinNormal)
       dco_decode_record_i_32_basic_primitive_enum_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123504,7 +123526,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (int, BasicPrimitiveEnumTwinRustAsync)
       dco_decode_record_i_32_basic_primitive_enum_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123519,7 +123541,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_record_i_32_basic_primitive_enum_twin_rust_async_sse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123533,7 +123555,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (int, BasicPrimitiveEnumTwinSse)
       dco_decode_record_i_32_basic_primitive_enum_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123547,7 +123569,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (int, BasicPrimitiveEnumTwinSync)
       dco_decode_record_i_32_basic_primitive_enum_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123561,7 +123583,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (int, BasicPrimitiveEnumTwinSyncSse)
       dco_decode_record_i_32_basic_primitive_enum_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123575,7 +123597,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (int, BasicStructTwinNormal) dco_decode_record_i_32_basic_struct_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123589,7 +123611,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (int, BasicStructTwinRustAsync)
       dco_decode_record_i_32_basic_struct_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123603,7 +123625,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (int, BasicStructTwinRustAsyncSse)
       dco_decode_record_i_32_basic_struct_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123617,7 +123639,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (int, BasicStructTwinSse) dco_decode_record_i_32_basic_struct_twin_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123631,7 +123653,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (int, BasicStructTwinSync) dco_decode_record_i_32_basic_struct_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123645,7 +123667,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (int, BasicStructTwinSyncSse)
       dco_decode_record_i_32_basic_struct_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123658,7 +123680,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (int, bool) dco_decode_record_i_32_bool(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123671,7 +123693,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (int, double) dco_decode_record_i_32_f_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123684,7 +123706,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (int, double) dco_decode_record_i_32_f_64(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123697,7 +123719,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (int, BigInt) dco_decode_record_i_32_i_128(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123710,7 +123732,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (int, int) dco_decode_record_i_32_i_16(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123723,7 +123745,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (int, int) dco_decode_record_i_32_i_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123736,7 +123758,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (int, PlatformInt64) dco_decode_record_i_32_i_64(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123749,7 +123771,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (int, int) dco_decode_record_i_32_i_8(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123762,7 +123784,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (int, PlatformInt64) dco_decode_record_i_32_isize(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123775,7 +123797,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (int, Uint8List) dco_decode_record_i_32_list_prim_u_8_strict(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123788,7 +123810,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (int, String) dco_decode_record_i_32_string(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123801,7 +123823,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (int, BigInt) dco_decode_record_i_32_u_128(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123814,7 +123836,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (int, int) dco_decode_record_i_32_u_16(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123827,7 +123849,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (int, int) dco_decode_record_i_32_u_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123840,7 +123862,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (int, BigInt) dco_decode_record_i_32_u_64(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123853,7 +123875,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (int, int) dco_decode_record_i_32_u_8(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123866,7 +123888,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (int, BigInt) dco_decode_record_i_32_usize(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123880,7 +123902,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (String, EnumSimpleTwinNormal)
       dco_decode_record_string_enum_simple_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123894,7 +123916,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (String, EnumSimpleTwinRustAsync)
       dco_decode_record_string_enum_simple_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123908,7 +123930,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (String, EnumSimpleTwinRustAsyncSse)
       dco_decode_record_string_enum_simple_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123922,7 +123944,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (String, EnumSimpleTwinSse) dco_decode_record_string_enum_simple_twin_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123936,7 +123958,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (String, EnumSimpleTwinSync) dco_decode_record_string_enum_simple_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123950,7 +123972,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (String, EnumSimpleTwinSyncSse)
       dco_decode_record_string_enum_simple_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123963,7 +123985,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (String, HashMapValue) dco_decode_record_string_hash_map_value(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123976,7 +123998,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (String, int) dco_decode_record_string_i_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -123990,7 +124012,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (String, KitchenSinkTwinNormal)
       dco_decode_record_string_kitchen_sink_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -124004,7 +124026,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (String, KitchenSinkTwinRustAsync)
       dco_decode_record_string_kitchen_sink_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -124018,7 +124040,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (String, KitchenSinkTwinRustAsyncSse)
       dco_decode_record_string_kitchen_sink_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -124032,7 +124054,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (String, KitchenSinkTwinSse) dco_decode_record_string_kitchen_sink_twin_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -124046,7 +124068,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (String, KitchenSinkTwinSync) dco_decode_record_string_kitchen_sink_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -124060,7 +124082,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (String, KitchenSinkTwinSyncSse)
       dco_decode_record_string_kitchen_sink_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -124074,7 +124096,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (String, Uint8List) dco_decode_record_string_list_prim_u_8_strict(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -124087,7 +124109,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (String, MySize) dco_decode_record_string_my_size(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -124100,7 +124122,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (String, Object?) dco_decode_record_string_serde_json_value(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -124113,7 +124135,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (String, String) dco_decode_record_string_string(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -124126,7 +124148,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (int, ApplicationMode) dco_decode_record_u_8_application_mode(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -124139,7 +124161,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   Sequences dco_decode_sequences(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return Sequences(
@@ -124150,12 +124172,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   SimpleEnumTwinNormal dco_decode_simple_enum_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return SimpleEnumTwinNormal_First();
       case 1:
         return SimpleEnumTwinNormal_Second(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -124165,12 +124188,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   SimpleEnumTwinRustAsync dco_decode_simple_enum_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return SimpleEnumTwinRustAsync_First();
       case 1:
         return SimpleEnumTwinRustAsync_Second(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -124181,12 +124205,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   SimpleEnumTwinRustAsyncSse dco_decode_simple_enum_twin_rust_async_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return SimpleEnumTwinRustAsyncSse_First();
       case 1:
         return SimpleEnumTwinRustAsyncSse_Second(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -124196,12 +124221,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   SimpleEnumTwinSse dco_decode_simple_enum_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return SimpleEnumTwinSse_First();
       case 1:
         return SimpleEnumTwinSse_Second(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -124211,12 +124237,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   SimpleEnumTwinSync dco_decode_simple_enum_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return SimpleEnumTwinSync_First();
       case 1:
         return SimpleEnumTwinSync_Second(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -124226,12 +124253,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   SimpleEnumTwinSyncSse dco_decode_simple_enum_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return SimpleEnumTwinSyncSse_First();
       case 1:
         return SimpleEnumTwinSyncSse_Second(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -124242,49 +124270,50 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   SimplePrimitiveEnumTwinNormal dco_decode_simple_primitive_enum_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return SimplePrimitiveEnumTwinNormal.values[raw as int];
+    return SimplePrimitiveEnumTwinNormal.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   SimplePrimitiveEnumTwinRustAsync
       dco_decode_simple_primitive_enum_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return SimplePrimitiveEnumTwinRustAsync.values[raw as int];
+    return SimplePrimitiveEnumTwinRustAsync.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   SimplePrimitiveEnumTwinRustAsyncSse
       dco_decode_simple_primitive_enum_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return SimplePrimitiveEnumTwinRustAsyncSse.values[raw as int];
+    return SimplePrimitiveEnumTwinRustAsyncSse
+        .values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   SimplePrimitiveEnumTwinSse dco_decode_simple_primitive_enum_twin_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return SimplePrimitiveEnumTwinSse.values[raw as int];
+    return SimplePrimitiveEnumTwinSse.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   SimplePrimitiveEnumTwinSync dco_decode_simple_primitive_enum_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return SimplePrimitiveEnumTwinSync.values[raw as int];
+    return SimplePrimitiveEnumTwinSync.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   SimplePrimitiveEnumTwinSyncSse dco_decode_simple_primitive_enum_twin_sync_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return SimplePrimitiveEnumTwinSyncSse.values[raw as int];
+    return SimplePrimitiveEnumTwinSyncSse.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   SimpleStructForBorrowTwinNormal
       dco_decode_simple_struct_for_borrow_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return SimpleStructForBorrowTwinNormal(
@@ -124296,7 +124325,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   SimpleStructForBorrowTwinRustAsync
       dco_decode_simple_struct_for_borrow_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return SimpleStructForBorrowTwinRustAsync(
@@ -124308,7 +124337,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   SimpleStructForBorrowTwinRustAsyncSse
       dco_decode_simple_struct_for_borrow_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return SimpleStructForBorrowTwinRustAsyncSse(
@@ -124320,7 +124349,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   SimpleStructForBorrowTwinSse dco_decode_simple_struct_for_borrow_twin_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return SimpleStructForBorrowTwinSse(
@@ -124332,7 +124361,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   SimpleStructForBorrowTwinSync dco_decode_simple_struct_for_borrow_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return SimpleStructForBorrowTwinSync(
@@ -124344,7 +124373,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   SimpleStructForBorrowTwinSyncSse
       dco_decode_simple_struct_for_borrow_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return SimpleStructForBorrowTwinSyncSse(
@@ -124355,7 +124384,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   SimpleStructTwinNormal dco_decode_simple_struct_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return SimpleStructTwinNormal(
@@ -124367,7 +124396,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   SimpleStructTwinRustAsync dco_decode_simple_struct_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return SimpleStructTwinRustAsync(
@@ -124379,7 +124408,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   SimpleStructTwinRustAsyncSse dco_decode_simple_struct_twin_rust_async_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return SimpleStructTwinRustAsyncSse(
@@ -124390,7 +124419,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   SimpleStructTwinSse dco_decode_simple_struct_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return SimpleStructTwinSse(
@@ -124401,7 +124430,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   SimpleStructTwinSync dco_decode_simple_struct_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return SimpleStructTwinSync(
@@ -124412,7 +124441,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   SimpleStructTwinSyncSse dco_decode_simple_struct_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return SimpleStructTwinSyncSse(
@@ -124424,16 +124453,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   SimpleTraitForDynTwinNormalImplementor
       dco_decode_simple_trait_for_dyn_twin_normal_implementor(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return SimpleTraitForDynTwinNormalImplementor_Variant0(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStructOneWithTraitForDynTwinNormal(
-              raw[1]),
+              arr[1]),
         );
       case 1:
         return SimpleTraitForDynTwinNormalImplementor_Variant1(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStructTwoWithTraitForDynTwinNormal(
-              raw[1]),
+              arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -124444,7 +124474,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   SimpleTranslatableExternalStructWithMethod
       dco_decode_simple_translatable_external_struct_with_method(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return SimpleTranslatableExternalStructWithMethod(
@@ -124455,7 +124485,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   SomeStructTwinNormal dco_decode_some_struct_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return SomeStructTwinNormal(
@@ -124466,7 +124496,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   SomeStructTwinRustAsync dco_decode_some_struct_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return SomeStructTwinRustAsync(
@@ -124478,7 +124508,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   SomeStructTwinRustAsyncSse dco_decode_some_struct_twin_rust_async_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return SomeStructTwinRustAsyncSse(
@@ -124489,7 +124519,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   SomeStructTwinSse dco_decode_some_struct_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return SomeStructTwinSse(
@@ -124500,7 +124530,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   SomeStructTwinSync dco_decode_some_struct_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return SomeStructTwinSync(
@@ -124511,7 +124541,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   SomeStructTwinSyncSse dco_decode_some_struct_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return SomeStructTwinSyncSse(
@@ -124522,12 +124552,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   SpeedTwinNormal dco_decode_speed_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return SpeedTwinNormal_Unknown();
       case 1:
         return SpeedTwinNormal_GPS(
-          dco_decode_f_64(raw[1]),
+          dco_decode_f_64(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -124537,12 +124568,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   SpeedTwinRustAsync dco_decode_speed_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return SpeedTwinRustAsync_Unknown();
       case 1:
         return SpeedTwinRustAsync_GPS(
-          dco_decode_f_64(raw[1]),
+          dco_decode_f_64(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -124552,12 +124584,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   SpeedTwinRustAsyncSse dco_decode_speed_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return SpeedTwinRustAsyncSse_Unknown();
       case 1:
         return SpeedTwinRustAsyncSse_GPS(
-          dco_decode_f_64(raw[1]),
+          dco_decode_f_64(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -124567,12 +124600,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   SpeedTwinSse dco_decode_speed_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return SpeedTwinSse_Unknown();
       case 1:
         return SpeedTwinSse_GPS(
-          dco_decode_f_64(raw[1]),
+          dco_decode_f_64(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -124582,12 +124616,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   SpeedTwinSync dco_decode_speed_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return SpeedTwinSync_Unknown();
       case 1:
         return SpeedTwinSync_GPS(
-          dco_decode_f_64(raw[1]),
+          dco_decode_f_64(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -124597,12 +124632,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   SpeedTwinSyncSse dco_decode_speed_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return SpeedTwinSyncSse_Unknown();
       case 1:
         return SpeedTwinSyncSse_GPS(
-          dco_decode_f_64(raw[1]),
+          dco_decode_f_64(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -124612,7 +124648,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   StaticOnlyTwinNormal dco_decode_static_only_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StaticOnlyTwinNormal(
@@ -124623,7 +124659,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   StaticOnlyTwinRustAsync dco_decode_static_only_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StaticOnlyTwinRustAsync(
@@ -124635,7 +124671,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StaticOnlyTwinRustAsyncSse dco_decode_static_only_twin_rust_async_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StaticOnlyTwinRustAsyncSse(
@@ -124646,7 +124682,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   StaticOnlyTwinSse dco_decode_static_only_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StaticOnlyTwinSse(
@@ -124657,7 +124693,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   StaticOnlyTwinSync dco_decode_static_only_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StaticOnlyTwinSync(
@@ -124668,7 +124704,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   StaticOnlyTwinSyncSse dco_decode_static_only_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StaticOnlyTwinSyncSse(
@@ -124679,7 +124715,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   StructInLowerLevel dco_decode_struct_in_lower_level(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructInLowerLevel(
@@ -124690,7 +124726,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   StructInUpperLevel dco_decode_struct_in_upper_level(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructInUpperLevel(
@@ -124702,7 +124738,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithCastedPrimitiveTwinNormal
       dco_decode_struct_with_casted_primitive_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return StructWithCastedPrimitiveTwinNormal(
@@ -124717,7 +124753,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithCommentsTwinNormal dco_decode_struct_with_comments_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructWithCommentsTwinNormal(
@@ -124729,7 +124765,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithCommentsTwinRustAsync
       dco_decode_struct_with_comments_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructWithCommentsTwinRustAsync(
@@ -124741,7 +124777,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithCommentsTwinRustAsyncSse
       dco_decode_struct_with_comments_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructWithCommentsTwinRustAsyncSse(
@@ -124753,7 +124789,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithCommentsTwinSse dco_decode_struct_with_comments_twin_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructWithCommentsTwinSse(
@@ -124765,7 +124801,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithCommentsTwinSync dco_decode_struct_with_comments_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructWithCommentsTwinSync(
@@ -124777,7 +124813,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithCommentsTwinSyncSse dco_decode_struct_with_comments_twin_sync_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructWithCommentsTwinSyncSse(
@@ -124789,7 +124825,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithCustomNameMethodTwinNormal
       dco_decode_struct_with_custom_name_method_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructWithCustomNameMethodTwinNormal(
@@ -124801,7 +124837,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithDartKeywordFieldTwinNormal
       dco_decode_struct_with_dart_keyword_field_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithDartKeywordFieldTwinNormal(
@@ -124814,7 +124850,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithDartKeywordFieldTwinRustAsync
       dco_decode_struct_with_dart_keyword_field_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithDartKeywordFieldTwinRustAsync(
@@ -124828,7 +124864,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_struct_with_dart_keyword_field_twin_rust_async_sse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithDartKeywordFieldTwinRustAsyncSse(
@@ -124841,7 +124877,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithDartKeywordFieldTwinSse
       dco_decode_struct_with_dart_keyword_field_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithDartKeywordFieldTwinSse(
@@ -124854,7 +124890,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithDartKeywordFieldTwinSync
       dco_decode_struct_with_dart_keyword_field_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithDartKeywordFieldTwinSync(
@@ -124867,7 +124903,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithDartKeywordFieldTwinSyncSse
       dco_decode_struct_with_dart_keyword_field_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithDartKeywordFieldTwinSyncSse(
@@ -124880,7 +124916,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithDeepCollectionEqualityTwinNormal
       dco_decode_struct_with_deep_collection_equality_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 6)
       throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
     return StructWithDeepCollectionEqualityTwinNormal(
@@ -124898,7 +124934,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_struct_with_deep_collection_equality_twin_rust_async(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 6)
       throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
     return StructWithDeepCollectionEqualityTwinRustAsync(
@@ -124916,7 +124952,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_struct_with_deep_collection_equality_twin_rust_async_sse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 6)
       throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
     return StructWithDeepCollectionEqualityTwinRustAsyncSse(
@@ -124933,7 +124969,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithDeepCollectionEqualityTwinSse
       dco_decode_struct_with_deep_collection_equality_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 6)
       throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
     return StructWithDeepCollectionEqualityTwinSse(
@@ -124950,7 +124986,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithDeepCollectionEqualityTwinSync
       dco_decode_struct_with_deep_collection_equality_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 6)
       throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
     return StructWithDeepCollectionEqualityTwinSync(
@@ -124968,7 +125004,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_struct_with_deep_collection_equality_twin_sync_sse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 6)
       throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
     return StructWithDeepCollectionEqualityTwinSyncSse(
@@ -124985,7 +125021,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithEnumTwinNormal dco_decode_struct_with_enum_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithEnumTwinNormal(
@@ -124998,7 +125034,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithEnumTwinRustAsync dco_decode_struct_with_enum_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithEnumTwinRustAsync(
@@ -125011,7 +125047,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithEnumTwinRustAsyncSse
       dco_decode_struct_with_enum_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithEnumTwinRustAsyncSse(
@@ -125023,7 +125059,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   StructWithEnumTwinSse dco_decode_struct_with_enum_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithEnumTwinSse(
@@ -125035,7 +125071,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   StructWithEnumTwinSync dco_decode_struct_with_enum_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithEnumTwinSync(
@@ -125048,7 +125084,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithEnumTwinSyncSse dco_decode_struct_with_enum_twin_sync_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithEnumTwinSyncSse(
@@ -125061,7 +125097,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithExplicitAutoOpaqueFieldTwinMoi
       dco_decode_struct_with_explicit_auto_opaque_field_twin_moi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithExplicitAutoOpaqueFieldTwinMoi(
@@ -125077,7 +125113,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_struct_with_explicit_auto_opaque_field_twin_normal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithExplicitAutoOpaqueFieldTwinNormal(
@@ -125093,7 +125129,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_struct_with_explicit_auto_opaque_field_twin_rust_async(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithExplicitAutoOpaqueFieldTwinRustAsync(
@@ -125109,7 +125145,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_struct_with_explicit_auto_opaque_field_twin_rust_async_moi(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithExplicitAutoOpaqueFieldTwinRustAsyncMoi(
@@ -125125,7 +125161,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_struct_with_explicit_auto_opaque_field_twin_rust_async_sse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithExplicitAutoOpaqueFieldTwinRustAsyncSse(
@@ -125141,7 +125177,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_struct_with_explicit_auto_opaque_field_twin_rust_async_sse_moi(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithExplicitAutoOpaqueFieldTwinRustAsyncSseMoi(
@@ -125156,7 +125192,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithExplicitAutoOpaqueFieldTwinSse
       dco_decode_struct_with_explicit_auto_opaque_field_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithExplicitAutoOpaqueFieldTwinSse(
@@ -125172,7 +125208,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_struct_with_explicit_auto_opaque_field_twin_sse_moi(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithExplicitAutoOpaqueFieldTwinSseMoi(
@@ -125187,7 +125223,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithExplicitAutoOpaqueFieldTwinSync
       dco_decode_struct_with_explicit_auto_opaque_field_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithExplicitAutoOpaqueFieldTwinSync(
@@ -125203,7 +125239,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_struct_with_explicit_auto_opaque_field_twin_sync_moi(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithExplicitAutoOpaqueFieldTwinSyncMoi(
@@ -125219,7 +125255,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_struct_with_explicit_auto_opaque_field_twin_sync_sse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithExplicitAutoOpaqueFieldTwinSyncSse(
@@ -125235,7 +125271,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_struct_with_explicit_auto_opaque_field_twin_sync_sse_moi(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithExplicitAutoOpaqueFieldTwinSyncSseMoi(
@@ -125250,7 +125286,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithFieldRenameTwinNormal
       dco_decode_struct_with_field_rename_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructWithFieldRenameTwinNormal(
@@ -125262,7 +125298,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithFieldRenameTwinRustAsync
       dco_decode_struct_with_field_rename_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructWithFieldRenameTwinRustAsync(
@@ -125274,7 +125310,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithFieldRenameTwinRustAsyncSse
       dco_decode_struct_with_field_rename_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructWithFieldRenameTwinRustAsyncSse(
@@ -125286,7 +125322,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithFieldRenameTwinSse dco_decode_struct_with_field_rename_twin_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructWithFieldRenameTwinSse(
@@ -125298,7 +125334,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithFieldRenameTwinSync dco_decode_struct_with_field_rename_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructWithFieldRenameTwinSync(
@@ -125310,7 +125346,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithFieldRenameTwinSyncSse
       dco_decode_struct_with_field_rename_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructWithFieldRenameTwinSyncSse(
@@ -125322,7 +125358,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithGoodAndOpaqueFieldTwinMoi
       dco_decode_struct_with_good_and_opaque_field_twin_moi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return StructWithGoodAndOpaqueFieldTwinMoi(
@@ -125340,7 +125376,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithGoodAndOpaqueFieldTwinNormal
       dco_decode_struct_with_good_and_opaque_field_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return StructWithGoodAndOpaqueFieldTwinNormal(
@@ -125359,7 +125395,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_struct_with_good_and_opaque_field_twin_rust_async(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return StructWithGoodAndOpaqueFieldTwinRustAsync(
@@ -125378,7 +125414,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_struct_with_good_and_opaque_field_twin_rust_async_moi(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return StructWithGoodAndOpaqueFieldTwinRustAsyncMoi(
@@ -125397,7 +125433,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_struct_with_good_and_opaque_field_twin_rust_async_sse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return StructWithGoodAndOpaqueFieldTwinRustAsyncSse(
@@ -125416,7 +125452,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_struct_with_good_and_opaque_field_twin_rust_async_sse_moi(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return StructWithGoodAndOpaqueFieldTwinRustAsyncSseMoi(
@@ -125434,7 +125470,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithGoodAndOpaqueFieldTwinSse
       dco_decode_struct_with_good_and_opaque_field_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return StructWithGoodAndOpaqueFieldTwinSse(
@@ -125452,7 +125488,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithGoodAndOpaqueFieldTwinSseMoi
       dco_decode_struct_with_good_and_opaque_field_twin_sse_moi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return StructWithGoodAndOpaqueFieldTwinSseMoi(
@@ -125470,7 +125506,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithGoodAndOpaqueFieldTwinSync
       dco_decode_struct_with_good_and_opaque_field_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return StructWithGoodAndOpaqueFieldTwinSync(
@@ -125488,7 +125524,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithGoodAndOpaqueFieldTwinSyncMoi
       dco_decode_struct_with_good_and_opaque_field_twin_sync_moi(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return StructWithGoodAndOpaqueFieldTwinSyncMoi(
@@ -125506,7 +125542,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithGoodAndOpaqueFieldTwinSyncSse
       dco_decode_struct_with_good_and_opaque_field_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return StructWithGoodAndOpaqueFieldTwinSyncSse(
@@ -125525,7 +125561,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_struct_with_good_and_opaque_field_twin_sync_sse_moi(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return StructWithGoodAndOpaqueFieldTwinSyncSseMoi(
@@ -125542,7 +125578,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   StructWithHashMap dco_decode_struct_with_hash_map(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructWithHashMap(
@@ -125554,7 +125590,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithImplBlockInAnotherFile
       dco_decode_struct_with_impl_block_in_another_file(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 0)
       throw Exception('unexpected arr length: expect 0 but see ${arr.length}');
     return StructWithImplBlockInAnotherFile();
@@ -125565,7 +125601,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_struct_with_impl_block_in_another_file_dependency(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 0)
       throw Exception('unexpected arr length: expect 0 but see ${arr.length}');
     return StructWithImplBlockInAnotherFileDependency();
@@ -125575,7 +125611,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithOneFieldTwinNormal dco_decode_struct_with_one_field_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructWithOneFieldTwinNormal(
@@ -125587,7 +125623,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithOneFieldTwinRustAsync
       dco_decode_struct_with_one_field_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructWithOneFieldTwinRustAsync(
@@ -125599,7 +125635,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithOneFieldTwinRustAsyncSse
       dco_decode_struct_with_one_field_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructWithOneFieldTwinRustAsyncSse(
@@ -125611,7 +125647,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithOneFieldTwinSse dco_decode_struct_with_one_field_twin_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructWithOneFieldTwinSse(
@@ -125623,7 +125659,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithOneFieldTwinSync dco_decode_struct_with_one_field_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructWithOneFieldTwinSync(
@@ -125635,7 +125671,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithOneFieldTwinSyncSse dco_decode_struct_with_one_field_twin_sync_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructWithOneFieldTwinSyncSse(
@@ -125646,7 +125682,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   StructWithRawNameField dco_decode_struct_with_raw_name_field(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructWithRawNameField(
@@ -125659,7 +125695,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_struct_with_rust_auto_opaque_field_with_many_derive(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructWithRustAutoOpaqueFieldWithManyDerive(
@@ -125673,7 +125709,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithRustAutoOpaqueWithNonCloneData
       dco_decode_struct_with_rust_auto_opaque_with_non_clone_data(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructWithRustAutoOpaqueWithNonCloneData(
@@ -125688,7 +125724,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_struct_with_shallow_collection_equality_twin_normal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 6)
       throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
     return StructWithShallowCollectionEqualityTwinNormal(
@@ -125706,7 +125742,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_struct_with_shallow_collection_equality_twin_rust_async(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 6)
       throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
     return StructWithShallowCollectionEqualityTwinRustAsync(
@@ -125724,7 +125760,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_struct_with_shallow_collection_equality_twin_rust_async_sse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 6)
       throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
     return StructWithShallowCollectionEqualityTwinRustAsyncSse(
@@ -125741,7 +125777,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithShallowCollectionEqualityTwinSse
       dco_decode_struct_with_shallow_collection_equality_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 6)
       throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
     return StructWithShallowCollectionEqualityTwinSse(
@@ -125759,7 +125795,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_struct_with_shallow_collection_equality_twin_sync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 6)
       throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
     return StructWithShallowCollectionEqualityTwinSync(
@@ -125777,7 +125813,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_struct_with_shallow_collection_equality_twin_sync_sse(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 6)
       throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
     return StructWithShallowCollectionEqualityTwinSyncSse(
@@ -125794,7 +125830,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithTwoFieldTwinNormal dco_decode_struct_with_two_field_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithTwoFieldTwinNormal(
@@ -125807,7 +125843,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithTwoFieldTwinRustAsync
       dco_decode_struct_with_two_field_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithTwoFieldTwinRustAsync(
@@ -125820,7 +125856,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithTwoFieldTwinRustAsyncSse
       dco_decode_struct_with_two_field_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithTwoFieldTwinRustAsyncSse(
@@ -125833,7 +125869,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithTwoFieldTwinSse dco_decode_struct_with_two_field_twin_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithTwoFieldTwinSse(
@@ -125846,7 +125882,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithTwoFieldTwinSync dco_decode_struct_with_two_field_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithTwoFieldTwinSync(
@@ -125859,7 +125895,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithTwoFieldTwinSyncSse dco_decode_struct_with_two_field_twin_sync_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithTwoFieldTwinSyncSse(
@@ -125872,7 +125908,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithZeroFieldTwinNormal dco_decode_struct_with_zero_field_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 0)
       throw Exception('unexpected arr length: expect 0 but see ${arr.length}');
     return StructWithZeroFieldTwinNormal();
@@ -125882,7 +125918,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithZeroFieldTwinRustAsync
       dco_decode_struct_with_zero_field_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 0)
       throw Exception('unexpected arr length: expect 0 but see ${arr.length}');
     return StructWithZeroFieldTwinRustAsync();
@@ -125892,7 +125928,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithZeroFieldTwinRustAsyncSse
       dco_decode_struct_with_zero_field_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 0)
       throw Exception('unexpected arr length: expect 0 but see ${arr.length}');
     return StructWithZeroFieldTwinRustAsyncSse();
@@ -125902,7 +125938,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithZeroFieldTwinSse dco_decode_struct_with_zero_field_twin_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 0)
       throw Exception('unexpected arr length: expect 0 but see ${arr.length}');
     return StructWithZeroFieldTwinSse();
@@ -125912,7 +125948,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithZeroFieldTwinSync dco_decode_struct_with_zero_field_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 0)
       throw Exception('unexpected arr length: expect 0 but see ${arr.length}');
     return StructWithZeroFieldTwinSync();
@@ -125922,7 +125958,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithZeroFieldTwinSyncSse
       dco_decode_struct_with_zero_field_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 0)
       throw Exception('unexpected arr length: expect 0 but see ${arr.length}');
     return StructWithZeroFieldTwinSyncSse();
@@ -125931,7 +125967,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   SumWithTwinNormal dco_decode_sum_with_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return SumWithTwinNormal(
@@ -125943,13 +125979,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   SumWithTwinNormalArray3 dco_decode_sum_with_twin_normal_array_3(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return SumWithTwinNormalArray3(
-        (raw as List<dynamic>).map(dco_decode_sum_with_twin_normal).toList());
+        dcoDecodeList(raw).map(dco_decode_sum_with_twin_normal).toList());
   }
 
   @protected
   SumWithTwinRustAsync dco_decode_sum_with_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return SumWithTwinRustAsync(
@@ -125961,15 +125997,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   SumWithTwinRustAsyncArray3 dco_decode_sum_with_twin_rust_async_array_3(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return SumWithTwinRustAsyncArray3((raw as List<dynamic>)
-        .map(dco_decode_sum_with_twin_rust_async)
-        .toList());
+    return SumWithTwinRustAsyncArray3(
+        dcoDecodeList(raw).map(dco_decode_sum_with_twin_rust_async).toList());
   }
 
   @protected
   SumWithTwinRustAsyncSse dco_decode_sum_with_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return SumWithTwinRustAsyncSse(
@@ -125981,7 +126016,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   SumWithTwinRustAsyncSseArray3 dco_decode_sum_with_twin_rust_async_sse_array_3(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return SumWithTwinRustAsyncSseArray3((raw as List<dynamic>)
+    return SumWithTwinRustAsyncSseArray3(dcoDecodeList(raw)
         .map(dco_decode_sum_with_twin_rust_async_sse)
         .toList());
   }
@@ -125989,7 +126024,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   SumWithTwinSse dco_decode_sum_with_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return SumWithTwinSse(
@@ -126001,13 +126036,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   SumWithTwinSseArray3 dco_decode_sum_with_twin_sse_array_3(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return SumWithTwinSseArray3(
-        (raw as List<dynamic>).map(dco_decode_sum_with_twin_sse).toList());
+        dcoDecodeList(raw).map(dco_decode_sum_with_twin_sse).toList());
   }
 
   @protected
   SumWithTwinSync dco_decode_sum_with_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return SumWithTwinSync(
@@ -126019,13 +126054,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   SumWithTwinSyncArray3 dco_decode_sum_with_twin_sync_array_3(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return SumWithTwinSyncArray3(
-        (raw as List<dynamic>).map(dco_decode_sum_with_twin_sync).toList());
+        dcoDecodeList(raw).map(dco_decode_sum_with_twin_sync).toList());
   }
 
   @protected
   SumWithTwinSyncSse dco_decode_sum_with_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return SumWithTwinSyncSse(
@@ -126038,13 +126073,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return SumWithTwinSyncSseArray3(
-        (raw as List<dynamic>).map(dco_decode_sum_with_twin_sync_sse).toList());
+        dcoDecodeList(raw).map(dco_decode_sum_with_twin_sync_sse).toList());
   }
 
   @protected
   TestChronoTwinNormal dco_decode_test_chrono_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return TestChronoTwinNormal(
@@ -126058,7 +126093,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   TestChronoTwinRustAsync dco_decode_test_chrono_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return TestChronoTwinRustAsync(
@@ -126073,7 +126108,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TestChronoTwinRustAsyncSse dco_decode_test_chrono_twin_rust_async_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return TestChronoTwinRustAsyncSse(
@@ -126087,7 +126122,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   TestChronoTwinSse dco_decode_test_chrono_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return TestChronoTwinSse(
@@ -126101,7 +126136,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   TestChronoTwinSync dco_decode_test_chrono_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return TestChronoTwinSync(
@@ -126115,7 +126150,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   TestChronoTwinSyncSse dco_decode_test_chrono_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return TestChronoTwinSyncSse(
@@ -126129,7 +126164,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   TestIdTwinNormal dco_decode_test_id_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return TestIdTwinNormal(
@@ -126141,20 +126176,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TestIdTwinNormalArray2 dco_decode_test_id_twin_normal_array_2(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return TestIdTwinNormalArray2(
-        (raw as List<dynamic>).map(dco_decode_test_id_twin_normal).toList());
+        dcoDecodeList(raw).map(dco_decode_test_id_twin_normal).toList());
   }
 
   @protected
   TestIdTwinNormalArray4 dco_decode_test_id_twin_normal_array_4(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return TestIdTwinNormalArray4(
-        (raw as List<dynamic>).map(dco_decode_test_id_twin_normal).toList());
+        dcoDecodeList(raw).map(dco_decode_test_id_twin_normal).toList());
   }
 
   @protected
   TestIdTwinRustAsync dco_decode_test_id_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return TestIdTwinRustAsync(
@@ -126166,24 +126201,22 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TestIdTwinRustAsyncArray2 dco_decode_test_id_twin_rust_async_array_2(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return TestIdTwinRustAsyncArray2((raw as List<dynamic>)
-        .map(dco_decode_test_id_twin_rust_async)
-        .toList());
+    return TestIdTwinRustAsyncArray2(
+        dcoDecodeList(raw).map(dco_decode_test_id_twin_rust_async).toList());
   }
 
   @protected
   TestIdTwinRustAsyncArray4 dco_decode_test_id_twin_rust_async_array_4(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return TestIdTwinRustAsyncArray4((raw as List<dynamic>)
-        .map(dco_decode_test_id_twin_rust_async)
-        .toList());
+    return TestIdTwinRustAsyncArray4(
+        dcoDecodeList(raw).map(dco_decode_test_id_twin_rust_async).toList());
   }
 
   @protected
   TestIdTwinRustAsyncSse dco_decode_test_id_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return TestIdTwinRustAsyncSse(
@@ -126195,7 +126228,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TestIdTwinRustAsyncSseArray2 dco_decode_test_id_twin_rust_async_sse_array_2(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return TestIdTwinRustAsyncSseArray2((raw as List<dynamic>)
+    return TestIdTwinRustAsyncSseArray2(dcoDecodeList(raw)
         .map(dco_decode_test_id_twin_rust_async_sse)
         .toList());
   }
@@ -126204,7 +126237,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TestIdTwinRustAsyncSseArray4 dco_decode_test_id_twin_rust_async_sse_array_4(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return TestIdTwinRustAsyncSseArray4((raw as List<dynamic>)
+    return TestIdTwinRustAsyncSseArray4(dcoDecodeList(raw)
         .map(dco_decode_test_id_twin_rust_async_sse)
         .toList());
   }
@@ -126212,7 +126245,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   TestIdTwinSse dco_decode_test_id_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return TestIdTwinSse(
@@ -126224,20 +126257,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TestIdTwinSseArray2 dco_decode_test_id_twin_sse_array_2(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return TestIdTwinSseArray2(
-        (raw as List<dynamic>).map(dco_decode_test_id_twin_sse).toList());
+        dcoDecodeList(raw).map(dco_decode_test_id_twin_sse).toList());
   }
 
   @protected
   TestIdTwinSseArray4 dco_decode_test_id_twin_sse_array_4(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return TestIdTwinSseArray4(
-        (raw as List<dynamic>).map(dco_decode_test_id_twin_sse).toList());
+        dcoDecodeList(raw).map(dco_decode_test_id_twin_sse).toList());
   }
 
   @protected
   TestIdTwinSync dco_decode_test_id_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return TestIdTwinSync(
@@ -126249,20 +126282,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TestIdTwinSyncArray2 dco_decode_test_id_twin_sync_array_2(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return TestIdTwinSyncArray2(
-        (raw as List<dynamic>).map(dco_decode_test_id_twin_sync).toList());
+        dcoDecodeList(raw).map(dco_decode_test_id_twin_sync).toList());
   }
 
   @protected
   TestIdTwinSyncArray4 dco_decode_test_id_twin_sync_array_4(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return TestIdTwinSyncArray4(
-        (raw as List<dynamic>).map(dco_decode_test_id_twin_sync).toList());
+        dcoDecodeList(raw).map(dco_decode_test_id_twin_sync).toList());
   }
 
   @protected
   TestIdTwinSyncSse dco_decode_test_id_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return TestIdTwinSyncSse(
@@ -126275,7 +126308,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return TestIdTwinSyncSseArray2(
-        (raw as List<dynamic>).map(dco_decode_test_id_twin_sync_sse).toList());
+        dcoDecodeList(raw).map(dco_decode_test_id_twin_sync_sse).toList());
   }
 
   @protected
@@ -126283,13 +126316,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return TestIdTwinSyncSseArray4(
-        (raw as List<dynamic>).map(dco_decode_test_id_twin_sync_sse).toList());
+        dcoDecodeList(raw).map(dco_decode_test_id_twin_sync_sse).toList());
   }
 
   @protected
   TestModelTwinNormal dco_decode_test_model_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return TestModelTwinNormal(
@@ -126303,7 +126336,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   TestModelTwinRustAsync dco_decode_test_model_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return TestModelTwinRustAsync(
@@ -126318,7 +126351,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TestModelTwinRustAsyncSse dco_decode_test_model_twin_rust_async_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return TestModelTwinRustAsyncSse(
@@ -126332,7 +126365,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   TestModelTwinSse dco_decode_test_model_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return TestModelTwinSse(
@@ -126346,7 +126379,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   TestModelTwinSync dco_decode_test_model_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return TestModelTwinSync(
@@ -126360,7 +126393,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   TestModelTwinSyncSse dco_decode_test_model_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return TestModelTwinSyncSse(
@@ -126375,7 +126408,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TranslatableStructWithDartCodeTwinNormal
       dco_decode_translatable_struct_with_dart_code_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return TranslatableStructWithDartCodeTwinNormal(
@@ -126387,7 +126420,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TupleStructWithOneFieldTwinNormal
       dco_decode_tuple_struct_with_one_field_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return TupleStructWithOneFieldTwinNormal(
@@ -126399,7 +126432,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TupleStructWithOneFieldTwinRustAsync
       dco_decode_tuple_struct_with_one_field_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return TupleStructWithOneFieldTwinRustAsync(
@@ -126411,7 +126444,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TupleStructWithOneFieldTwinRustAsyncSse
       dco_decode_tuple_struct_with_one_field_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return TupleStructWithOneFieldTwinRustAsyncSse(
@@ -126423,7 +126456,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TupleStructWithOneFieldTwinSse
       dco_decode_tuple_struct_with_one_field_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return TupleStructWithOneFieldTwinSse(
@@ -126435,7 +126468,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TupleStructWithOneFieldTwinSync
       dco_decode_tuple_struct_with_one_field_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return TupleStructWithOneFieldTwinSync(
@@ -126447,7 +126480,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TupleStructWithOneFieldTwinSyncSse
       dco_decode_tuple_struct_with_one_field_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return TupleStructWithOneFieldTwinSyncSse(
@@ -126459,7 +126492,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TupleStructWithTwoFieldTwinNormal
       dco_decode_tuple_struct_with_two_field_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return TupleStructWithTwoFieldTwinNormal(
@@ -126472,7 +126505,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TupleStructWithTwoFieldTwinRustAsync
       dco_decode_tuple_struct_with_two_field_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return TupleStructWithTwoFieldTwinRustAsync(
@@ -126485,7 +126518,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TupleStructWithTwoFieldTwinRustAsyncSse
       dco_decode_tuple_struct_with_two_field_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return TupleStructWithTwoFieldTwinRustAsyncSse(
@@ -126498,7 +126531,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TupleStructWithTwoFieldTwinSse
       dco_decode_tuple_struct_with_two_field_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return TupleStructWithTwoFieldTwinSse(
@@ -126511,7 +126544,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TupleStructWithTwoFieldTwinSync
       dco_decode_tuple_struct_with_two_field_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return TupleStructWithTwoFieldTwinSync(
@@ -126524,7 +126557,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TupleStructWithTwoFieldTwinSyncSse
       dco_decode_tuple_struct_with_two_field_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return TupleStructWithTwoFieldTwinSyncSse(
@@ -126536,13 +126569,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   int dco_decode_u_16(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dcoDecodePrimitiveInt(raw);
   }
 
   @protected
   int dco_decode_u_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dcoDecodePrimitiveInt(raw);
   }
 
   @protected
@@ -126554,7 +126587,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   int dco_decode_u_8(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dcoDecodePrimitiveInt(raw);
   }
 
   @protected
@@ -126602,7 +126635,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   UserIdTwinNormal dco_decode_user_id_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return UserIdTwinNormal(
@@ -126613,7 +126646,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   UserIdTwinRustAsync dco_decode_user_id_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return UserIdTwinRustAsync(
@@ -126624,7 +126657,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   UserIdTwinRustAsyncSse dco_decode_user_id_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return UserIdTwinRustAsyncSse(
@@ -126635,7 +126668,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   UserIdTwinSse dco_decode_user_id_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return UserIdTwinSse(
@@ -126646,7 +126679,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   UserIdTwinSync dco_decode_user_id_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return UserIdTwinSync(
@@ -126657,7 +126690,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   UserIdTwinSyncSse dco_decode_user_id_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return UserIdTwinSyncSse(
@@ -126675,7 +126708,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   VecOfPrimitivePackTwinNormal dco_decode_vec_of_primitive_pack_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 11)
       throw Exception('unexpected arr length: expect 11 but see ${arr.length}');
     return VecOfPrimitivePackTwinNormal(
@@ -126697,7 +126730,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   VecOfPrimitivePackTwinRustAsync
       dco_decode_vec_of_primitive_pack_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 11)
       throw Exception('unexpected arr length: expect 11 but see ${arr.length}');
     return VecOfPrimitivePackTwinRustAsync(
@@ -126719,7 +126752,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   VecOfPrimitivePackTwinRustAsyncSse
       dco_decode_vec_of_primitive_pack_twin_rust_async_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 11)
       throw Exception('unexpected arr length: expect 11 but see ${arr.length}');
     return VecOfPrimitivePackTwinRustAsyncSse(
@@ -126741,7 +126774,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   VecOfPrimitivePackTwinSse dco_decode_vec_of_primitive_pack_twin_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 11)
       throw Exception('unexpected arr length: expect 11 but see ${arr.length}');
     return VecOfPrimitivePackTwinSse(
@@ -126763,7 +126796,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   VecOfPrimitivePackTwinSync dco_decode_vec_of_primitive_pack_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 11)
       throw Exception('unexpected arr length: expect 11 but see ${arr.length}');
     return VecOfPrimitivePackTwinSync(
@@ -126785,7 +126818,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   VecOfPrimitivePackTwinSyncSse dco_decode_vec_of_primitive_pack_twin_sync_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 11)
       throw Exception('unexpected arr length: expect 11 but see ${arr.length}');
     return VecOfPrimitivePackTwinSyncSse(
@@ -126806,38 +126839,38 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   WeekdaysTwinNormal dco_decode_weekdays_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return WeekdaysTwinNormal.values[raw as int];
+    return WeekdaysTwinNormal.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   WeekdaysTwinRustAsync dco_decode_weekdays_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return WeekdaysTwinRustAsync.values[raw as int];
+    return WeekdaysTwinRustAsync.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   WeekdaysTwinRustAsyncSse dco_decode_weekdays_twin_rust_async_sse(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return WeekdaysTwinRustAsyncSse.values[raw as int];
+    return WeekdaysTwinRustAsyncSse.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   WeekdaysTwinSse dco_decode_weekdays_twin_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return WeekdaysTwinSse.values[raw as int];
+    return WeekdaysTwinSse.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   WeekdaysTwinSync dco_decode_weekdays_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return WeekdaysTwinSync.values[raw as int];
+    return WeekdaysTwinSync.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   WeekdaysTwinSyncSse dco_decode_weekdays_twin_sync_sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return WeekdaysTwinSyncSse.values[raw as int];
+    return WeekdaysTwinSyncSse.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected

--- a/frb_example/pure_dart/lib/src/rust/frb_generated.web.dart
+++ b/frb_example/pure_dart/lib/src/rust/frb_generated.web.dart
@@ -26529,7 +26529,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   JSAny cst_encode_list_prim_i_64_strict(Int64List raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
-    return raw.inner.jsify()!;
+    return cstEncodeInt64List(raw.inner);
   }
 
   @protected
@@ -26571,7 +26571,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   JSAny cst_encode_list_prim_u_64_strict(Uint64List raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
-    return raw.inner.jsify()!;
+    return cstEncodeUint64List(raw.inner);
   }
 
   @protected

--- a/frb_example/pure_dart_pde/lib/src/rust/frb_generated.dart
+++ b/frb_example/pure_dart_pde/lib/src/rust/frb_generated.dart
@@ -44462,7 +44462,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             argNames: ["id"],
           );
 
-  Future<void> Function(int, dynamic)
+  Future<void> Function(dynamic, dynamic)
       encode_DartFn_Inputs_CustomSerializer_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerIpv4Addr_Output_CustomSerializer_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerIpv4Addr_AnyhowException(
           FutureOr<InternetAddress> Function(InternetAddress) raw) {
     return (callId, rawArg0) async {
@@ -44491,14 +44491,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       final output = serializer.intoRaw();
 
       generalizedFrbRustBinding.dartFnDeliverOutput(
-          callId: callId,
+          callId: dcoDecodePrimitiveInt(callId),
           ptr: output.ptr,
           rustVecLen: output.rustVecLen,
           dataLen: output.dataLen);
     };
   }
 
-  Future<void> Function(int, dynamic)
+  Future<void> Function(dynamic, dynamic)
       encode_DartFn_Inputs_DartOpaque_Output_unit_AnyhowException(
           FutureOr<void> Function(Object) raw) {
     return (callId, rawArg0) async {
@@ -44524,14 +44524,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       final output = serializer.intoRaw();
 
       generalizedFrbRustBinding.dartFnDeliverOutput(
-          callId: callId,
+          callId: dcoDecodePrimitiveInt(callId),
           ptr: output.ptr,
           rustVecLen: output.rustVecLen,
           dataLen: output.dataLen);
     };
   }
 
-  Future<void> Function(int, dynamic)
+  Future<void> Function(dynamic, dynamic)
       encode_DartFn_Inputs_String_Output_String_AnyhowException(
           FutureOr<String> Function(String) raw) {
     return (callId, rawArg0) async {
@@ -44557,14 +44557,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       final output = serializer.intoRaw();
 
       generalizedFrbRustBinding.dartFnDeliverOutput(
-          callId: callId,
+          callId: dcoDecodePrimitiveInt(callId),
           ptr: output.ptr,
           rustVecLen: output.rustVecLen,
           dataLen: output.dataLen);
     };
   }
 
-  Future<void> Function(int, dynamic)
+  Future<void> Function(dynamic, dynamic)
       encode_DartFn_Inputs_String_Output_unit_AnyhowException(
           FutureOr<void> Function(String) raw) {
     return (callId, rawArg0) async {
@@ -44590,14 +44590,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       final output = serializer.intoRaw();
 
       generalizedFrbRustBinding.dartFnDeliverOutput(
-          callId: callId,
+          callId: dcoDecodePrimitiveInt(callId),
           ptr: output.ptr,
           rustVecLen: output.rustVecLen,
           dataLen: output.dataLen);
     };
   }
 
-  Future<void> Function(int, dynamic, dynamic)
+  Future<void> Function(dynamic, dynamic, dynamic)
       encode_DartFn_Inputs_String_demo_struct_for_rust_call_dart_twin_normal_Output_unit_AnyhowException(
           FutureOr<void> Function(String, DemoStructForRustCallDartTwinNormal)
               raw) {
@@ -44626,14 +44626,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       final output = serializer.intoRaw();
 
       generalizedFrbRustBinding.dartFnDeliverOutput(
-          callId: callId,
+          callId: dcoDecodePrimitiveInt(callId),
           ptr: output.ptr,
           rustVecLen: output.rustVecLen,
           dataLen: output.dataLen);
     };
   }
 
-  Future<void> Function(int, dynamic, dynamic)
+  Future<void> Function(dynamic, dynamic, dynamic)
       encode_DartFn_Inputs_String_demo_struct_for_rust_call_dart_twin_rust_async_Output_unit_AnyhowException(
           FutureOr<void> Function(
                   String, DemoStructForRustCallDartTwinRustAsync)
@@ -44663,7 +44663,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       final output = serializer.intoRaw();
 
       generalizedFrbRustBinding.dartFnDeliverOutput(
-          callId: callId,
+          callId: dcoDecodePrimitiveInt(callId),
           ptr: output.ptr,
           rustVecLen: output.rustVecLen,
           dataLen: output.dataLen);
@@ -44671,7 +44671,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   Future<void> Function(
-    int,
+    dynamic,
   ) encode_DartFn_Inputs__Output_DartOpaque_AnyhowException(
       FutureOr<Object> Function() raw) {
     return (
@@ -44697,7 +44697,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       final output = serializer.intoRaw();
 
       generalizedFrbRustBinding.dartFnDeliverOutput(
-          callId: callId,
+          callId: dcoDecodePrimitiveInt(callId),
           ptr: output.ptr,
           rustVecLen: output.rustVecLen,
           dataLen: output.dataLen);
@@ -44705,7 +44705,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   Future<void> Function(
-    int,
+    dynamic,
   ) encode_DartFn_Inputs__Output_String_AnyhowException(
       FutureOr<String> Function() raw) {
     return (
@@ -44731,7 +44731,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       final output = serializer.intoRaw();
 
       generalizedFrbRustBinding.dartFnDeliverOutput(
-          callId: callId,
+          callId: dcoDecodePrimitiveInt(callId),
           ptr: output.ptr,
           rustVecLen: output.rustVecLen,
           dataLen: output.dataLen);
@@ -44739,7 +44739,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   Future<void> Function(
-    int,
+    dynamic,
   ) encode_DartFn_Inputs__Output_unit_AnyhowException(
       FutureOr<void> Function() raw) {
     return (
@@ -44765,14 +44765,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       final output = serializer.intoRaw();
 
       generalizedFrbRustBinding.dartFnDeliverOutput(
-          callId: callId,
+          callId: dcoDecodePrimitiveInt(callId),
           ptr: output.ptr,
           rustVecLen: output.rustVecLen,
           dataLen: output.dataLen);
     };
   }
 
-  Future<void> Function(int, dynamic)
+  Future<void> Function(dynamic, dynamic)
       encode_DartFn_Inputs_demo_struct_for_rust_call_dart_twin_normal_Output_demo_struct_for_rust_call_dart_twin_normal_AnyhowException(
           FutureOr<DemoStructForRustCallDartTwinNormal> Function(
                   DemoStructForRustCallDartTwinNormal)
@@ -44802,14 +44802,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       final output = serializer.intoRaw();
 
       generalizedFrbRustBinding.dartFnDeliverOutput(
-          callId: callId,
+          callId: dcoDecodePrimitiveInt(callId),
           ptr: output.ptr,
           rustVecLen: output.rustVecLen,
           dataLen: output.dataLen);
     };
   }
 
-  Future<void> Function(int, dynamic)
+  Future<void> Function(dynamic, dynamic)
       encode_DartFn_Inputs_demo_struct_for_rust_call_dart_twin_rust_async_Output_demo_struct_for_rust_call_dart_twin_rust_async_AnyhowException(
           FutureOr<DemoStructForRustCallDartTwinRustAsync> Function(
                   DemoStructForRustCallDartTwinRustAsync)
@@ -44839,7 +44839,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       final output = serializer.intoRaw();
 
       generalizedFrbRustBinding.dartFnDeliverOutput(
-          callId: callId,
+          callId: dcoDecodePrimitiveInt(callId),
           ptr: output.ptr,
           rustVecLen: output.rustVecLen,
           dataLen: output.dataLen);
@@ -45583,7 +45583,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   AnyhowException dco_decode_AnyhowException(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AnyhowException(raw as String);
+    return AnyhowException(dcoDecodeString(raw));
   }
 
   @protected
@@ -45735,8 +45735,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBoxdynAnySendSyncstatic(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BoxAnyMyDartTypeRenameImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return BoxAnyMyDartTypeRenameImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -45744,7 +45743,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBoxdynFnStringStringSendSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BoxFnStringStringImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BoxFnStringStringImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -45752,7 +45751,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBoxdynMyTraitTwinNormalSendSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BoxMyTraitTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BoxMyTraitTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -45760,8 +45759,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBoxdynMyTraitTwinRustAsyncSendSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BoxMyTraitTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return BoxMyTraitTwinRustAsyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -45769,7 +45767,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBoxdynMyTraitTwinSyncSendSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BoxMyTraitTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BoxMyTraitTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -45778,7 +45776,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return ConstructorOpaqueStructTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -45787,7 +45785,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return ConstructorOpaqueSyncStructTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -45795,8 +45793,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCustomHasherTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return CustomHasherTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return CustomHasherTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -45805,7 +45802,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return CustomHasherTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -45813,7 +45810,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCustomHasherTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return CustomHasherTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return CustomHasherTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -45822,7 +45819,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return DeliberateFailSanityCheckTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -45830,7 +45827,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDroppableTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DroppableTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return DroppableTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -45838,8 +45835,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDroppableTwinRustAsync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DroppableTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return DroppableTwinRustAsyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -45847,7 +45843,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDroppableTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DroppableTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return DroppableTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -45856,7 +45852,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return EnumWithGoodAndOpaqueWithoutOptionTwinNormalImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -45865,7 +45861,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return EnumWithGoodAndOpaqueWithoutOptionTwinRustAsyncImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -45874,7 +45870,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return EnumWithGoodAndOpaqueWithoutOptionTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -45883,7 +45879,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return ItemContainerSolutionOneTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -45891,8 +45887,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLtOwnedStructTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return LtOwnedStructTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return LtOwnedStructTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -45900,7 +45895,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLtOwnedStructTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return LtOwnedStructTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return LtOwnedStructTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -45908,7 +45903,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLtSubStructTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return LtSubStructTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return LtSubStructTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -45916,7 +45911,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLtSubStructTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return LtSubStructTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return LtSubStructTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -45924,8 +45919,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMyAudioParamTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return MyAudioParamTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return MyAudioParamTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -45934,7 +45928,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MyImplTraitWithSelfTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -45943,7 +45937,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MyImplTraitWithSelfTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -45951,7 +45945,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMyNodeTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return MyNodeTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return MyNodeTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -45960,7 +45954,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MyStructWithTryFromTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -45969,7 +45963,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -45978,7 +45972,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -45987,7 +45981,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -45996,7 +45990,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46005,7 +45999,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46013,8 +46007,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return NonCloneSimpleTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return NonCloneSimpleTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46022,7 +46015,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueItemTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueItemTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueItemTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46030,7 +46023,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueOneTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueOneTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueOneTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46038,8 +46031,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueOneTwinRustAsync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueOneTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return OpaqueOneTwinRustAsyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46047,7 +46039,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueOneTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueOneTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueOneTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46056,7 +46048,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return OpaqueStructWithDartCodeTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46064,7 +46056,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueTwoTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueTwoTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueTwoTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46072,8 +46064,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueTwoTwinRustAsync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueTwoTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return OpaqueTwoTwinRustAsyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46081,7 +46072,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueTwoTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueTwoTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueTwoTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46090,7 +46081,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return RustOpaqueWebLockingDataTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46098,7 +46089,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerSimpleLogger(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return SimpleLoggerImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return SimpleLoggerImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46107,7 +46098,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return SimpleOpaqueExternalStructWithMethodImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46116,7 +46107,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StaticGetterOnlyTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46125,7 +46116,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StaticGetterOnlyTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46134,7 +46125,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StaticGetterOnlyTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46143,7 +46134,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructInMiscNoTwinExampleAImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46152,7 +46143,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructInMiscNoTwinExampleBImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46161,7 +46152,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructOneWithTraitForDynTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46170,7 +46161,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructOneWithTraitTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46179,7 +46170,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructOneWithTraitTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46188,7 +46179,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructTwoWithTraitForDynTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46197,7 +46188,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructTwoWithTraitTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46206,7 +46197,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructTwoWithTraitTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46215,7 +46206,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinNormalImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46224,7 +46215,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinRustAsyncImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46233,7 +46224,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinSyncImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46242,7 +46233,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithImplBlockInMultiFileImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46251,7 +46242,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithRustAutoOpaqueFieldWithManyDeriveInnerImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46260,7 +46251,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithSimpleSetterTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46268,7 +46259,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerTypeForIgnore(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return TypeForIgnoreImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return TypeForIgnoreImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46276,7 +46267,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerTypeForIgnoreAll(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return TypeForIgnoreAllImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return TypeForIgnoreAllImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46285,7 +46276,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return ConstructorOpaqueStructTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46294,7 +46285,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return ConstructorOpaqueSyncStructTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46303,7 +46294,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return DeliberateFailSanityCheckTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46311,7 +46302,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDroppableTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DroppableTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return DroppableTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46319,8 +46310,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDroppableTwinRustAsync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DroppableTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return DroppableTwinRustAsyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46328,7 +46318,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDroppableTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DroppableTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return DroppableTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46337,7 +46327,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return ItemContainerSolutionOneTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46345,7 +46335,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLtSubStructTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return LtSubStructTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return LtSubStructTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46353,7 +46343,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLtSubStructTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return LtSubStructTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return LtSubStructTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46362,7 +46352,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46371,7 +46361,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46379,8 +46369,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return NonCloneSimpleTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return NonCloneSimpleTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46389,7 +46378,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return RustOpaqueWebLockingDataTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46398,7 +46387,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructOneWithTraitForDynTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46407,7 +46396,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructOneWithTraitTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46416,7 +46405,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructOneWithTraitTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46425,7 +46414,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructTwoWithTraitForDynTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46434,7 +46423,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructTwoWithTraitTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46443,7 +46432,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructTwoWithTraitTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46452,7 +46441,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinNormalImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46461,7 +46450,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinRustAsyncImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46470,7 +46459,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinSyncImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46479,7 +46468,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithSimpleSetterTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46487,7 +46476,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerTypeForIgnoreAll(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return TypeForIgnoreAllImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return TypeForIgnoreAllImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46496,7 +46485,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return ConstructorOpaqueStructTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46505,7 +46494,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return ConstructorOpaqueSyncStructTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46514,7 +46503,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return DeliberateFailSanityCheckTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46522,7 +46511,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDroppableTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DroppableTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return DroppableTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46530,8 +46519,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDroppableTwinRustAsync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DroppableTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return DroppableTwinRustAsyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46539,7 +46527,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDroppableTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DroppableTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return DroppableTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46548,7 +46536,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return ItemContainerSolutionOneTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46556,8 +46544,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLtOwnedStructTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return LtOwnedStructTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return LtOwnedStructTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46565,7 +46552,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLtOwnedStructTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return LtOwnedStructTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return LtOwnedStructTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46573,7 +46560,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLtSubStructTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return LtSubStructTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return LtSubStructTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46581,7 +46568,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLtSubStructTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return LtSubStructTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return LtSubStructTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46589,8 +46576,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMyAudioParamTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return MyAudioParamTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return MyAudioParamTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46599,7 +46585,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MyImplTraitWithSelfTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46608,7 +46594,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MyImplTraitWithSelfTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46616,7 +46602,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMyNodeTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return MyNodeTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return MyNodeTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46625,7 +46611,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MyStructWithTryFromTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46634,7 +46620,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46643,7 +46629,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46652,7 +46638,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46661,7 +46647,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46670,7 +46656,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46678,8 +46664,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return NonCloneSimpleTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return NonCloneSimpleTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46688,7 +46673,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return OpaqueStructWithDartCodeTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46697,7 +46682,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return RustOpaqueWebLockingDataTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46705,7 +46690,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerSimpleLogger(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return SimpleLoggerImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return SimpleLoggerImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46714,7 +46699,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return SimpleOpaqueExternalStructWithMethodImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46723,7 +46708,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructInMiscNoTwinExampleAImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46732,7 +46717,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructInMiscNoTwinExampleBImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46741,7 +46726,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructOneWithTraitForDynTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46750,7 +46735,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructOneWithTraitTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46759,7 +46744,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructOneWithTraitTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46768,7 +46753,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructTwoWithTraitForDynTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46777,7 +46762,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructTwoWithTraitTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46786,7 +46771,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructTwoWithTraitTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46795,7 +46780,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinNormalImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46804,7 +46789,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinRustAsyncImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46813,7 +46798,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinSyncImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46822,7 +46807,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithImplBlockInMultiFileImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46831,7 +46816,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithSimpleSetterTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -46839,7 +46824,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerTypeForIgnore(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return TypeForIgnoreImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return TypeForIgnoreImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -46847,13 +46832,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerTypeForIgnoreAll(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return TypeForIgnoreAllImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return TypeForIgnoreAllImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
   String dco_decode_Backtrace(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as String;
+    return dcoDecodeString(raw);
   }
 
   @protected
@@ -46887,7 +46872,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   String dco_decode_Char(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return String.fromCharCode(raw);
+    return String.fromCharCode(dcoDecodePrimitiveInt(raw));
   }
 
   @protected
@@ -47030,8 +47015,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   ObjectArray1 dco_decode_DartOpaque_array_1(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return ObjectArray1(
-        (raw as List<dynamic>).map(dco_decode_DartOpaque).toList());
+    return ObjectArray1(dcoDecodeList(raw).map(dco_decode_DartOpaque).toList());
   }
 
   @protected
@@ -47044,7 +47028,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BigInt dco_decode_I128(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BigInt.parse(raw as String);
+    return BigInt.parse(dcoDecodeString(raw));
   }
 
   @protected
@@ -47515,8 +47499,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   BoxDartDebugTwinNormal dco_decode_RustOpaque_BoxdynDartDebugTwinNormal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BoxDartDebugTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return BoxDartDebugTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -47524,14 +47507,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return BoxDartDebugTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
   BoxDartDebugTwinSync dco_decode_RustOpaque_BoxdynDartDebugTwinSync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BoxDartDebugTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BoxDartDebugTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -47539,7 +47522,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return FrbOpaqueReturnTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -47547,15 +47530,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_FrbOpaqueReturnTwinRustAsync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return FrbOpaqueReturnTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
   FrbOpaqueReturnTwinSync dco_decode_RustOpaque_FrbOpaqueReturnTwinSync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return FrbOpaqueReturnTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return FrbOpaqueReturnTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -47563,7 +47545,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_FrbOpaqueSyncReturnTwinNormal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return FrbOpaqueSyncReturnTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -47571,20 +47553,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return HideDataAnotherTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
   HideDataTwinNormal dco_decode_RustOpaque_HideDataTwinNormal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return HideDataTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return HideDataTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
   HideDataTwinNormalArray2 dco_decode_RustOpaque_HideDataTwinNormal_array_2(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return HideDataTwinNormalArray2((raw as List<dynamic>)
+    return HideDataTwinNormalArray2(dcoDecodeList(raw)
         .map(dco_decode_RustOpaque_HideDataTwinNormal)
         .toList());
   }
@@ -47593,14 +47575,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   HideDataTwinRustAsync dco_decode_RustOpaque_HideDataTwinRustAsync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return HideDataTwinRustAsyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return HideDataTwinRustAsyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
   HideDataTwinRustAsyncArray2
       dco_decode_RustOpaque_HideDataTwinRustAsync_array_2(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return HideDataTwinRustAsyncArray2((raw as List<dynamic>)
+    return HideDataTwinRustAsyncArray2(dcoDecodeList(raw)
         .map(dco_decode_RustOpaque_HideDataTwinRustAsync)
         .toList());
   }
@@ -47608,14 +47590,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   HideDataTwinSync dco_decode_RustOpaque_HideDataTwinSync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return HideDataTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return HideDataTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
   HideDataTwinSyncArray2 dco_decode_RustOpaque_HideDataTwinSync_array_2(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return HideDataTwinSyncArray2((raw as List<dynamic>)
+    return HideDataTwinSyncArray2(dcoDecodeList(raw)
         .map(dco_decode_RustOpaque_HideDataTwinSync)
         .toList());
   }
@@ -47624,8 +47606,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   MutexHideDataTwinNormal dco_decode_RustOpaque_MutexHideDataTwinNormal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return MutexHideDataTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return MutexHideDataTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -47633,22 +47614,21 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MutexHideDataTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
   MutexHideDataTwinSync dco_decode_RustOpaque_MutexHideDataTwinSync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return MutexHideDataTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return MutexHideDataTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
   NonCloneDataTwinNormal dco_decode_RustOpaque_NonCloneDataTwinNormal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return NonCloneDataTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return NonCloneDataTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -47656,13 +47636,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneDataTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
   NonCloneDataTwinSync dco_decode_RustOpaque_NonCloneDataTwinSync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return NonCloneDataTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return NonCloneDataTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -47670,7 +47650,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return RwLockHideDataTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -47678,15 +47658,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return RwLockHideDataTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
   RwLockHideDataTwinSync dco_decode_RustOpaque_RwLockHideDataTwinSync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return RwLockHideDataTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return RwLockHideDataTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -47694,8 +47673,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBoxdynAnySendSyncstatic(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BoxAnyMyDartTypeRenameImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return BoxAnyMyDartTypeRenameImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -47703,7 +47681,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBoxdynFnStringStringSendSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BoxFnStringStringImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BoxFnStringStringImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -47711,7 +47689,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBoxdynMyTraitTwinNormalSendSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BoxMyTraitTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BoxMyTraitTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -47719,8 +47697,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBoxdynMyTraitTwinRustAsyncSendSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BoxMyTraitTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return BoxMyTraitTwinRustAsyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -47728,7 +47705,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBoxdynMyTraitTwinSyncSendSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BoxMyTraitTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BoxMyTraitTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -47737,7 +47714,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return ConstructorOpaqueStructTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -47746,7 +47723,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return ConstructorOpaqueSyncStructTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -47754,8 +47731,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCustomHasherTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return CustomHasherTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return CustomHasherTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -47764,7 +47740,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return CustomHasherTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -47772,7 +47748,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCustomHasherTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return CustomHasherTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return CustomHasherTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -47781,7 +47757,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return DeliberateFailSanityCheckTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -47789,7 +47765,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDroppableTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DroppableTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return DroppableTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -47797,8 +47773,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDroppableTwinRustAsync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DroppableTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return DroppableTwinRustAsyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -47806,7 +47781,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDroppableTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DroppableTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return DroppableTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -47815,7 +47790,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return EnumWithGoodAndOpaqueWithoutOptionTwinNormalImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -47824,7 +47799,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return EnumWithGoodAndOpaqueWithoutOptionTwinRustAsyncImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -47833,7 +47808,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return EnumWithGoodAndOpaqueWithoutOptionTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -47842,7 +47817,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return ItemContainerSolutionOneTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -47851,7 +47826,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return LtNestedTypeWithLifetimeTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -47860,7 +47835,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return LtNestedTypeWithLifetimeTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -47869,7 +47844,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return LtTypeWithLifetimeTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -47878,7 +47853,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return LtTypeWithLifetimeTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -47887,7 +47862,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return LtTypeWithMultiDepTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -47896,7 +47871,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return LtTypeWithMultiDepTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -47904,8 +47879,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLtOwnedStructTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return LtOwnedStructTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return LtOwnedStructTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -47913,7 +47887,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLtOwnedStructTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return LtOwnedStructTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return LtOwnedStructTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -47921,7 +47895,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLtSubStructTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return LtSubStructTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return LtSubStructTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -47929,7 +47903,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLtSubStructTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return LtSubStructTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return LtSubStructTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -47937,8 +47911,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMyAudioParamTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return MyAudioParamTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return MyAudioParamTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -47947,7 +47920,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MyImplTraitWithSelfTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -47956,7 +47929,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MyImplTraitWithSelfTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -47964,7 +47937,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMyNodeTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return MyNodeTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return MyNodeTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -47973,7 +47946,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MyStructWithTryFromTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -47981,7 +47954,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneDataRaw(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return NonCloneDataRawImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return NonCloneDataRawImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -47990,7 +47963,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -47999,7 +47972,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -48008,7 +47981,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleEnumTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -48017,7 +47990,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -48026,7 +47999,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return NonCloneSimpleTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -48034,8 +48007,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return NonCloneSimpleTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return NonCloneSimpleTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -48043,7 +48015,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueItemTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueItemTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueItemTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -48051,7 +48023,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueOneTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueOneTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueOneTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -48059,8 +48031,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueOneTwinRustAsync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueOneTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return OpaqueOneTwinRustAsyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -48068,7 +48039,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueOneTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueOneTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueOneTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -48077,7 +48048,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return OpaqueStructWithDartCodeTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -48085,7 +48056,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueTwoTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueTwoTwinNormalImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueTwoTwinNormalImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -48093,8 +48064,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueTwoTwinRustAsync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueTwoTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+    return OpaqueTwoTwinRustAsyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -48102,7 +48072,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueTwoTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return OpaqueTwoTwinSyncImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return OpaqueTwoTwinSyncImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -48111,7 +48081,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return RustAutoOpaqueWebLockingDataTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -48120,7 +48090,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return RustOpaqueWebLockingDataTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -48128,7 +48098,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerSimpleLogger(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return SimpleLoggerImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return SimpleLoggerImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -48137,7 +48107,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return SimpleOpaqueExternalStructWithMethodImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -48146,7 +48116,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StaticGetterOnlyTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -48155,7 +48125,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StaticGetterOnlyTwinRustAsyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -48164,7 +48134,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StaticGetterOnlyTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -48173,7 +48143,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructInMiscNoTwinExampleAImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -48182,7 +48152,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructInMiscNoTwinExampleBImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -48191,7 +48161,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructOneWithTraitForDynTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -48200,7 +48170,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructOneWithTraitTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -48209,7 +48179,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructOneWithTraitTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -48218,7 +48188,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructTwoWithTraitForDynTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -48227,7 +48197,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructTwoWithTraitTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -48236,7 +48206,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructTwoWithTraitTwinSyncImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -48245,7 +48215,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinNormalImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -48254,7 +48224,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinRustAsyncImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -48263,7 +48233,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithGoodAndOpaqueFieldWithoutOptionTwinSyncImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -48272,7 +48242,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithImplBlockInMultiFileImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -48281,7 +48251,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithRustAutoOpaqueFieldWithManyDeriveInnerImpl
-        .frbInternalDcoDecode(raw as List<dynamic>);
+        .frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -48290,7 +48260,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return StructWithSimpleSetterTwinNormalImpl.frbInternalDcoDecode(
-        raw as List<dynamic>);
+        dcoDecodeList(raw));
   }
 
   @protected
@@ -48298,7 +48268,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerTypeForIgnore(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return TypeForIgnoreImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return TypeForIgnoreImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -48306,19 +48276,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerTypeForIgnoreAll(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return TypeForIgnoreAllImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return TypeForIgnoreAllImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
   I32 dco_decode_RustOpaque_i32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return I32Impl.frbInternalDcoDecode(raw as List<dynamic>);
+    return I32Impl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
   Object? dco_decode_SerdeJsonValue(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return jsonDecode(raw as String);
+    return jsonDecode(dcoDecodeString(raw));
   }
 
   @protected
@@ -48569,7 +48539,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   String dco_decode_String(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as String;
+    return dcoDecodeString(raw);
   }
 
   @protected
@@ -48632,7 +48602,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BigInt dco_decode_U128(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BigInt.parse(raw as String);
+    return BigInt.parse(dcoDecodeString(raw));
   }
 
   @protected
@@ -48644,7 +48614,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   ATwinNormal dco_decode_a_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return ATwinNormal(
@@ -48655,7 +48625,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   ATwinRustAsync dco_decode_a_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return ATwinRustAsync(
@@ -48666,7 +48636,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   ATwinSync dco_decode_a_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return ATwinSync(
@@ -48677,22 +48647,23 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   AbcTwinNormal dco_decode_abc_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return AbcTwinNormal_A(
-          dco_decode_box_autoadd_a_twin_normal(raw[1]),
+          dco_decode_box_autoadd_a_twin_normal(arr[1]),
         );
       case 1:
         return AbcTwinNormal_B(
-          dco_decode_box_autoadd_b_twin_normal(raw[1]),
+          dco_decode_box_autoadd_b_twin_normal(arr[1]),
         );
       case 2:
         return AbcTwinNormal_C(
-          dco_decode_box_autoadd_c_twin_normal(raw[1]),
+          dco_decode_box_autoadd_c_twin_normal(arr[1]),
         );
       case 3:
         return AbcTwinNormal_JustInt(
-          dco_decode_i_32(raw[1]),
+          dco_decode_i_32(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -48702,22 +48673,23 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   AbcTwinRustAsync dco_decode_abc_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return AbcTwinRustAsync_A(
-          dco_decode_box_autoadd_a_twin_rust_async(raw[1]),
+          dco_decode_box_autoadd_a_twin_rust_async(arr[1]),
         );
       case 1:
         return AbcTwinRustAsync_B(
-          dco_decode_box_autoadd_b_twin_rust_async(raw[1]),
+          dco_decode_box_autoadd_b_twin_rust_async(arr[1]),
         );
       case 2:
         return AbcTwinRustAsync_C(
-          dco_decode_box_autoadd_c_twin_rust_async(raw[1]),
+          dco_decode_box_autoadd_c_twin_rust_async(arr[1]),
         );
       case 3:
         return AbcTwinRustAsync_JustInt(
-          dco_decode_i_32(raw[1]),
+          dco_decode_i_32(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -48727,22 +48699,23 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   AbcTwinSync dco_decode_abc_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return AbcTwinSync_A(
-          dco_decode_box_autoadd_a_twin_sync(raw[1]),
+          dco_decode_box_autoadd_a_twin_sync(arr[1]),
         );
       case 1:
         return AbcTwinSync_B(
-          dco_decode_box_autoadd_b_twin_sync(raw[1]),
+          dco_decode_box_autoadd_b_twin_sync(arr[1]),
         );
       case 2:
         return AbcTwinSync_C(
-          dco_decode_box_autoadd_c_twin_sync(raw[1]),
+          dco_decode_box_autoadd_c_twin_sync(arr[1]),
         );
       case 3:
         return AbcTwinSync_JustInt(
-          dco_decode_i_32(raw[1]),
+          dco_decode_i_32(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -48753,7 +48726,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   AnotherMacroStructTwinNormal dco_decode_another_macro_struct_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return AnotherMacroStructTwinNormal(
@@ -48765,7 +48738,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   AnotherTwinNormal dco_decode_another_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return AnotherTwinNormal(
@@ -48776,7 +48749,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   AnotherTwinRustAsync dco_decode_another_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return AnotherTwinRustAsync(
@@ -48787,7 +48760,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   AnotherTwinSync dco_decode_another_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return AnotherTwinSync(
@@ -48798,7 +48771,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   ApplicationEnv dco_decode_application_env(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return ApplicationEnv(
@@ -48809,7 +48782,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   ApplicationEnvVar dco_decode_application_env_var(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return ApplicationEnvVar(
@@ -48821,15 +48794,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   ApplicationMessage dco_decode_application_message(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return ApplicationMessage_DisplayMessage(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return ApplicationMessage_RenderPixel(
-          x: dco_decode_i_32(raw[1]),
-          y: dco_decode_i_32(raw[2]),
+          x: dco_decode_i_32(arr[1]),
+          y: dco_decode_i_32(arr[2]),
         );
       case 2:
         return ApplicationMessage_Exit();
@@ -48841,20 +48815,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   ApplicationMode dco_decode_application_mode(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return ApplicationMode.values[raw as int];
+    return ApplicationMode.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   ApplicationModeArray2 dco_decode_application_mode_array_2(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return ApplicationModeArray2(
-        (raw as List<dynamic>).map(dco_decode_application_mode).toList());
+        dcoDecodeList(raw).map(dco_decode_application_mode).toList());
   }
 
   @protected
   ApplicationSettings dco_decode_application_settings(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 5)
       throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
     return ApplicationSettings(
@@ -48869,7 +48843,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   AttributeTwinNormal dco_decode_attribute_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return AttributeTwinNormal(
@@ -48881,7 +48855,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   AttributeTwinRustAsync dco_decode_attribute_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return AttributeTwinRustAsync(
@@ -48893,7 +48867,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   AttributeTwinSync dco_decode_attribute_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return AttributeTwinSync(
@@ -48907,16 +48881,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_auto_ref_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_my_audio_param_twin_normal_proxy_enum(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMyAudioParamTwinNormalProxyEnum_Variant0(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMyNodeTwinNormal(
-              raw[1]),
+              arr[1]),
         );
       case 1:
         return Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMyAudioParamTwinNormalProxyEnum_Variant1(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMyNodeTwinNormal(
-              raw[1]),
+              arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -48926,7 +48901,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BTwinNormal dco_decode_b_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return BTwinNormal(
@@ -48937,7 +48912,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BTwinRustAsync dco_decode_b_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return BTwinRustAsync(
@@ -48948,7 +48923,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BTwinSync dco_decode_b_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return BTwinSync(
@@ -48960,10 +48935,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   BasicGeneralEnumTwinNormal dco_decode_basic_general_enum_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return BasicGeneralEnumTwinNormal_Apple(
-          field: dco_decode_String(raw[1]),
+          field: dco_decode_String(arr[1]),
         );
       case 1:
         return BasicGeneralEnumTwinNormal_Orange();
@@ -48976,10 +48952,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   BasicGeneralEnumTwinRustAsync dco_decode_basic_general_enum_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return BasicGeneralEnumTwinRustAsync_Apple(
-          field: dco_decode_String(raw[1]),
+          field: dco_decode_String(arr[1]),
         );
       case 1:
         return BasicGeneralEnumTwinRustAsync_Orange();
@@ -48992,10 +48969,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   BasicGeneralEnumTwinSync dco_decode_basic_general_enum_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return BasicGeneralEnumTwinSync_Apple(
-          field: dco_decode_String(raw[1]),
+          field: dco_decode_String(arr[1]),
         );
       case 1:
         return BasicGeneralEnumTwinSync_Orange();
@@ -49008,27 +48986,27 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   BasicPrimitiveEnumTwinNormal dco_decode_basic_primitive_enum_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BasicPrimitiveEnumTwinNormal.values[raw as int];
+    return BasicPrimitiveEnumTwinNormal.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   BasicPrimitiveEnumTwinRustAsync
       dco_decode_basic_primitive_enum_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BasicPrimitiveEnumTwinRustAsync.values[raw as int];
+    return BasicPrimitiveEnumTwinRustAsync.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   BasicPrimitiveEnumTwinSync dco_decode_basic_primitive_enum_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BasicPrimitiveEnumTwinSync.values[raw as int];
+    return BasicPrimitiveEnumTwinSync.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   BasicStructTwinNormal dco_decode_basic_struct_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return BasicStructTwinNormal(
@@ -49041,7 +49019,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   BasicStructTwinRustAsync dco_decode_basic_struct_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return BasicStructTwinRustAsync(
@@ -49053,7 +49031,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BasicStructTwinSync dco_decode_basic_struct_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return BasicStructTwinSync(
@@ -49066,7 +49044,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   BenchmarkBinaryTreeTwinNormal dco_decode_benchmark_binary_tree_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return BenchmarkBinaryTreeTwinNormal(
@@ -49080,7 +49058,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   BenchmarkBinaryTreeTwinRustAsync
       dco_decode_benchmark_binary_tree_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return BenchmarkBinaryTreeTwinRustAsync(
@@ -49094,7 +49072,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   BenchmarkBinaryTreeTwinSync dco_decode_benchmark_binary_tree_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return BenchmarkBinaryTreeTwinSync(
@@ -49107,7 +49085,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BenchmarkBlobTwinNormal dco_decode_benchmark_blob_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return BenchmarkBlobTwinNormal(
@@ -49121,7 +49099,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   BenchmarkBlobTwinRustAsync dco_decode_benchmark_blob_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return BenchmarkBlobTwinRustAsync(
@@ -49134,7 +49112,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BenchmarkBlobTwinSync dco_decode_benchmark_blob_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return BenchmarkBlobTwinSync(
@@ -49147,7 +49125,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BigBuffersTwinNormal dco_decode_big_buffers_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return BigBuffersTwinNormal(
@@ -49159,7 +49137,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BigBuffersTwinRustAsync dco_decode_big_buffers_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return BigBuffersTwinRustAsync(
@@ -49171,7 +49149,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BigBuffersTwinSync dco_decode_big_buffers_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return BigBuffersTwinSync(
@@ -49183,7 +49161,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BlobTwinNormal dco_decode_blob_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return BlobTwinNormal(
@@ -49194,7 +49172,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BlobTwinRustAsync dco_decode_blob_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return BlobTwinRustAsync(
@@ -49205,7 +49183,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   BlobTwinSync dco_decode_blob_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return BlobTwinSync(
@@ -50008,13 +49986,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   int dco_decode_box_autoadd_i_16(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dco_decode_i_16(raw);
   }
 
   @protected
   int dco_decode_box_autoadd_i_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dco_decode_i_32(raw);
   }
 
   @protected
@@ -50026,7 +50004,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   int dco_decode_box_autoadd_i_8(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dco_decode_i_8(raw);
   }
 
   @protected
@@ -50846,13 +50824,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   int dco_decode_box_autoadd_u_16(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dco_decode_u_16(raw);
   }
 
   @protected
   int dco_decode_box_autoadd_u_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dco_decode_u_32(raw);
   }
 
   @protected
@@ -50864,7 +50842,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   int dco_decode_box_autoadd_u_8(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dco_decode_u_8(raw);
   }
 
   @protected
@@ -51022,7 +51000,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   int dco_decode_box_i_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dco_decode_i_32(raw);
   }
 
   @protected
@@ -51034,7 +51012,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   int dco_decode_box_i_8(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dco_decode_i_8(raw);
   }
 
   @protected
@@ -51083,7 +51061,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   int dco_decode_box_u_8(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dco_decode_u_8(raw);
   }
 
   @protected
@@ -51119,7 +51097,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   CTwinNormal dco_decode_c_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return CTwinNormal(
@@ -51130,7 +51108,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   CTwinRustAsync dco_decode_c_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return CTwinRustAsync(
@@ -51141,7 +51119,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   CTwinSync dco_decode_c_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return CTwinSync(
@@ -51153,7 +51131,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ConcatenateWithTwinNormal dco_decode_concatenate_with_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return ConcatenateWithTwinNormal(
@@ -51165,7 +51143,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ConcatenateWithTwinRustAsync dco_decode_concatenate_with_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return ConcatenateWithTwinRustAsync(
@@ -51176,7 +51154,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   ConcatenateWithTwinSync dco_decode_concatenate_with_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return ConcatenateWithTwinSync(
@@ -51188,7 +51166,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ConstructorTranslatableStructTwinNormal
       dco_decode_constructor_translatable_struct_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return ConstructorTranslatableStructTwinNormal(
@@ -51200,7 +51178,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ConstructorTranslatableSyncStructTwinNormal
       dco_decode_constructor_translatable_sync_struct_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return ConstructorTranslatableSyncStructTwinNormal.raw(
@@ -51212,7 +51190,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ContainsMirroredSubStructTwinNormal
       dco_decode_contains_mirrored_sub_struct_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return ContainsMirroredSubStructTwinNormal(
@@ -51225,7 +51203,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ContainsMirroredSubStructTwinRustAsync
       dco_decode_contains_mirrored_sub_struct_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return ContainsMirroredSubStructTwinRustAsync(
@@ -51238,7 +51216,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ContainsMirroredSubStructTwinSync
       dco_decode_contains_mirrored_sub_struct_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return ContainsMirroredSubStructTwinSync(
@@ -51251,16 +51229,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomEnumErrorTwinNormal dco_decode_custom_enum_error_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomEnumErrorTwinNormal_One(
-          message: dco_decode_String(raw[1]),
-          backtrace: dco_decode_Backtrace(raw[2]),
+          message: dco_decode_String(arr[1]),
+          backtrace: dco_decode_Backtrace(arr[2]),
         );
       case 1:
         return CustomEnumErrorTwinNormal_Two(
-          message: dco_decode_u_32(raw[1]),
-          backtrace: dco_decode_Backtrace(raw[2]),
+          message: dco_decode_u_32(arr[1]),
+          backtrace: dco_decode_Backtrace(arr[2]),
         );
       default:
         throw Exception("unreachable");
@@ -51271,16 +51250,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomEnumErrorTwinRustAsync dco_decode_custom_enum_error_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomEnumErrorTwinRustAsync_One(
-          message: dco_decode_String(raw[1]),
-          backtrace: dco_decode_Backtrace(raw[2]),
+          message: dco_decode_String(arr[1]),
+          backtrace: dco_decode_Backtrace(arr[2]),
         );
       case 1:
         return CustomEnumErrorTwinRustAsync_Two(
-          message: dco_decode_u_32(raw[1]),
-          backtrace: dco_decode_Backtrace(raw[2]),
+          message: dco_decode_u_32(arr[1]),
+          backtrace: dco_decode_Backtrace(arr[2]),
         );
       default:
         throw Exception("unreachable");
@@ -51290,16 +51270,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   CustomEnumErrorTwinSync dco_decode_custom_enum_error_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomEnumErrorTwinSync_One(
-          message: dco_decode_String(raw[1]),
-          backtrace: dco_decode_Backtrace(raw[2]),
+          message: dco_decode_String(arr[1]),
+          backtrace: dco_decode_Backtrace(arr[2]),
         );
       case 1:
         return CustomEnumErrorTwinSync_Two(
-          message: dco_decode_u_32(raw[1]),
-          backtrace: dco_decode_Backtrace(raw[2]),
+          message: dco_decode_u_32(arr[1]),
+          backtrace: dco_decode_Backtrace(arr[2]),
         );
       default:
         throw Exception("unreachable");
@@ -51309,16 +51290,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   CustomErrorTwinNormal dco_decode_custom_error_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomErrorTwinNormal_Error0(
-          e: dco_decode_String(raw[1]),
-          backtrace: dco_decode_Backtrace(raw[2]),
+          e: dco_decode_String(arr[1]),
+          backtrace: dco_decode_Backtrace(arr[2]),
         );
       case 1:
         return CustomErrorTwinNormal_Error1(
-          e: dco_decode_u_32(raw[1]),
-          backtrace: dco_decode_Backtrace(raw[2]),
+          e: dco_decode_u_32(arr[1]),
+          backtrace: dco_decode_Backtrace(arr[2]),
         );
       default:
         throw Exception("unreachable");
@@ -51329,16 +51311,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomErrorTwinRustAsync dco_decode_custom_error_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomErrorTwinRustAsync_Error0(
-          e: dco_decode_String(raw[1]),
-          backtrace: dco_decode_Backtrace(raw[2]),
+          e: dco_decode_String(arr[1]),
+          backtrace: dco_decode_Backtrace(arr[2]),
         );
       case 1:
         return CustomErrorTwinRustAsync_Error1(
-          e: dco_decode_u_32(raw[1]),
-          backtrace: dco_decode_Backtrace(raw[2]),
+          e: dco_decode_u_32(arr[1]),
+          backtrace: dco_decode_Backtrace(arr[2]),
         );
       default:
         throw Exception("unreachable");
@@ -51348,16 +51331,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   CustomErrorTwinSync dco_decode_custom_error_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomErrorTwinSync_Error0(
-          e: dco_decode_String(raw[1]),
-          backtrace: dco_decode_Backtrace(raw[2]),
+          e: dco_decode_String(arr[1]),
+          backtrace: dco_decode_Backtrace(arr[2]),
         );
       case 1:
         return CustomErrorTwinSync_Error1(
-          e: dco_decode_u_32(raw[1]),
-          backtrace: dco_decode_Backtrace(raw[2]),
+          e: dco_decode_u_32(arr[1]),
+          backtrace: dco_decode_Backtrace(arr[2]),
         );
       default:
         throw Exception("unreachable");
@@ -51368,14 +51352,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomNestedError1TwinNormal dco_decode_custom_nested_error_1_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomNestedError1TwinNormal_CustomNested1(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return CustomNestedError1TwinNormal_ErrorNested(
-          dco_decode_box_autoadd_custom_nested_error_2_twin_normal(raw[1]),
+          dco_decode_box_autoadd_custom_nested_error_2_twin_normal(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -51386,14 +51371,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomNestedError1TwinRustAsync
       dco_decode_custom_nested_error_1_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomNestedError1TwinRustAsync_CustomNested1(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return CustomNestedError1TwinRustAsync_ErrorNested(
-          dco_decode_box_autoadd_custom_nested_error_2_twin_rust_async(raw[1]),
+          dco_decode_box_autoadd_custom_nested_error_2_twin_rust_async(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -51404,14 +51390,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomNestedError1TwinSync dco_decode_custom_nested_error_1_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomNestedError1TwinSync_CustomNested1(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return CustomNestedError1TwinSync_ErrorNested(
-          dco_decode_box_autoadd_custom_nested_error_2_twin_sync(raw[1]),
+          dco_decode_box_autoadd_custom_nested_error_2_twin_sync(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -51422,14 +51409,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomNestedError2TwinNormal dco_decode_custom_nested_error_2_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomNestedError2TwinNormal_CustomNested2(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return CustomNestedError2TwinNormal_CustomNested2Number(
-          dco_decode_u_32(raw[1]),
+          dco_decode_u_32(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -51440,14 +51428,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomNestedError2TwinRustAsync
       dco_decode_custom_nested_error_2_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomNestedError2TwinRustAsync_CustomNested2(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return CustomNestedError2TwinRustAsync_CustomNested2Number(
-          dco_decode_u_32(raw[1]),
+          dco_decode_u_32(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -51458,14 +51447,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomNestedError2TwinSync dco_decode_custom_nested_error_2_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomNestedError2TwinSync_CustomNested2(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return CustomNestedError2TwinSync_CustomNested2Number(
-          dco_decode_u_32(raw[1]),
+          dco_decode_u_32(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -51476,14 +51466,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomNestedErrorInnerTwinNormal
       dco_decode_custom_nested_error_inner_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomNestedErrorInnerTwinNormal_Three(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return CustomNestedErrorInnerTwinNormal_Four(
-          dco_decode_u_32(raw[1]),
+          dco_decode_u_32(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -51494,14 +51485,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomNestedErrorInnerTwinRustAsync
       dco_decode_custom_nested_error_inner_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomNestedErrorInnerTwinRustAsync_Three(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return CustomNestedErrorInnerTwinRustAsync_Four(
-          dco_decode_u_32(raw[1]),
+          dco_decode_u_32(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -51512,14 +51504,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomNestedErrorInnerTwinSync dco_decode_custom_nested_error_inner_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomNestedErrorInnerTwinSync_Three(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return CustomNestedErrorInnerTwinSync_Four(
-          dco_decode_u_32(raw[1]),
+          dco_decode_u_32(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -51530,14 +51523,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomNestedErrorOuterTwinNormal
       dco_decode_custom_nested_error_outer_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomNestedErrorOuterTwinNormal_One(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return CustomNestedErrorOuterTwinNormal_Two(
-          dco_decode_box_autoadd_custom_nested_error_inner_twin_normal(raw[1]),
+          dco_decode_box_autoadd_custom_nested_error_inner_twin_normal(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -51548,15 +51542,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomNestedErrorOuterTwinRustAsync
       dco_decode_custom_nested_error_outer_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomNestedErrorOuterTwinRustAsync_One(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return CustomNestedErrorOuterTwinRustAsync_Two(
           dco_decode_box_autoadd_custom_nested_error_inner_twin_rust_async(
-              raw[1]),
+              arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -51567,14 +51562,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomNestedErrorOuterTwinSync dco_decode_custom_nested_error_outer_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return CustomNestedErrorOuterTwinSync_One(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return CustomNestedErrorOuterTwinSync_Two(
-          dco_decode_box_autoadd_custom_nested_error_inner_twin_sync(raw[1]),
+          dco_decode_box_autoadd_custom_nested_error_inner_twin_sync(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -51585,7 +51581,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomStructErrorAnotherTwinNormal
       dco_decode_custom_struct_error_another_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return CustomStructErrorAnotherTwinNormal(
@@ -51597,7 +51593,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomStructErrorAnotherTwinRustAsync
       dco_decode_custom_struct_error_another_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return CustomStructErrorAnotherTwinRustAsync(
@@ -51609,7 +51605,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomStructErrorAnotherTwinSync
       dco_decode_custom_struct_error_another_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return CustomStructErrorAnotherTwinSync(
@@ -51621,7 +51617,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomStructErrorTwinNormal dco_decode_custom_struct_error_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return CustomStructErrorTwinNormal(
@@ -51633,7 +51629,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomStructErrorTwinRustAsync dco_decode_custom_struct_error_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return CustomStructErrorTwinRustAsync(
@@ -51645,7 +51641,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomStructErrorTwinSync dco_decode_custom_struct_error_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return CustomStructErrorTwinSync(
@@ -51656,7 +51652,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   CustomStructTwinNormal dco_decode_custom_struct_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return CustomStructTwinNormal(
@@ -51668,7 +51664,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   CustomStructTwinRustAsync dco_decode_custom_struct_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return CustomStructTwinRustAsync(
@@ -51679,7 +51675,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   CustomStructTwinSync dco_decode_custom_struct_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return CustomStructTwinSync(
@@ -51690,7 +51686,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   CustomizedTwinNormal dco_decode_customized_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return CustomizedTwinNormal(
@@ -51702,7 +51698,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   CustomizedTwinRustAsync dco_decode_customized_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return CustomizedTwinRustAsync(
@@ -51714,7 +51710,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   CustomizedTwinSync dco_decode_customized_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return CustomizedTwinSync(
@@ -51727,7 +51723,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   DartOpaqueNestedTwinNormal dco_decode_dart_opaque_nested_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return DartOpaqueNestedTwinNormal(
@@ -51740,7 +51736,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   DartOpaqueNestedTwinRustAsync dco_decode_dart_opaque_nested_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return DartOpaqueNestedTwinRustAsync(
@@ -51753,7 +51749,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   DartOpaqueNestedTwinSync dco_decode_dart_opaque_nested_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return DartOpaqueNestedTwinSync(
@@ -51766,7 +51762,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   DemoStructForRustCallDartTwinNormal
       dco_decode_demo_struct_for_rust_call_dart_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return DemoStructForRustCallDartTwinNormal(
@@ -51778,7 +51774,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   DemoStructForRustCallDartTwinRustAsync
       dco_decode_demo_struct_for_rust_call_dart_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return DemoStructForRustCallDartTwinRustAsync(
@@ -51789,12 +51785,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   DistanceTwinNormal dco_decode_distance_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return DistanceTwinNormal_Unknown();
       case 1:
         return DistanceTwinNormal_Map(
-          dco_decode_f_64(raw[1]),
+          dco_decode_f_64(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -51804,12 +51801,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   DistanceTwinRustAsync dco_decode_distance_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return DistanceTwinRustAsync_Unknown();
       case 1:
         return DistanceTwinRustAsync_Map(
-          dco_decode_f_64(raw[1]),
+          dco_decode_f_64(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -51819,12 +51817,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   DistanceTwinSync dco_decode_distance_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return DistanceTwinSync_Unknown();
       case 1:
         return DistanceTwinSync_Map(
-          dco_decode_f_64(raw[1]),
+          dco_decode_f_64(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -51834,7 +51833,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   ElementTwinNormal dco_decode_element_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return ElementTwinNormal(
@@ -51848,7 +51847,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   ElementTwinRustAsync dco_decode_element_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return ElementTwinRustAsync(
@@ -51862,7 +51861,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   ElementTwinSync dco_decode_element_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return ElementTwinSync(
@@ -51876,7 +51875,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   EmptyTwinNormal dco_decode_empty_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 0)
       throw Exception('unexpected arr length: expect 0 but see ${arr.length}');
     return EmptyTwinNormal();
@@ -51885,7 +51884,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   EmptyTwinRustAsync dco_decode_empty_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 0)
       throw Exception('unexpected arr length: expect 0 but see ${arr.length}');
     return EmptyTwinRustAsync();
@@ -51894,7 +51893,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   EmptyTwinSync dco_decode_empty_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 0)
       throw Exception('unexpected arr length: expect 0 but see ${arr.length}');
     return EmptyTwinSync();
@@ -51904,14 +51903,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumDartOpaqueTwinNormal dco_decode_enum_dart_opaque_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumDartOpaqueTwinNormal_Primitive(
-          dco_decode_i_32(raw[1]),
+          dco_decode_i_32(arr[1]),
         );
       case 1:
         return EnumDartOpaqueTwinNormal_Opaque(
-          dco_decode_DartOpaque(raw[1]),
+          dco_decode_DartOpaque(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -51922,14 +51922,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumDartOpaqueTwinRustAsync dco_decode_enum_dart_opaque_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumDartOpaqueTwinRustAsync_Primitive(
-          dco_decode_i_32(raw[1]),
+          dco_decode_i_32(arr[1]),
         );
       case 1:
         return EnumDartOpaqueTwinRustAsync_Opaque(
-          dco_decode_DartOpaque(raw[1]),
+          dco_decode_DartOpaque(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -51939,14 +51940,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   EnumDartOpaqueTwinSync dco_decode_enum_dart_opaque_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumDartOpaqueTwinSync_Primitive(
-          dco_decode_i_32(raw[1]),
+          dco_decode_i_32(arr[1]),
         );
       case 1:
         return EnumDartOpaqueTwinSync_Opaque(
-          dco_decode_DartOpaque(raw[1]),
+          dco_decode_DartOpaque(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -51956,26 +51958,27 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   EnumOpaqueTwinNormal dco_decode_enum_opaque_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumOpaqueTwinNormal_Struct(
-          dco_decode_RustOpaque_HideDataTwinNormal(raw[1]),
+          dco_decode_RustOpaque_HideDataTwinNormal(arr[1]),
         );
       case 1:
         return EnumOpaqueTwinNormal_Primitive(
-          dco_decode_RustOpaque_i32(raw[1]),
+          dco_decode_RustOpaque_i32(arr[1]),
         );
       case 2:
         return EnumOpaqueTwinNormal_TraitObj(
-          dco_decode_RustOpaque_BoxdynDartDebugTwinNormal(raw[1]),
+          dco_decode_RustOpaque_BoxdynDartDebugTwinNormal(arr[1]),
         );
       case 3:
         return EnumOpaqueTwinNormal_Mutex(
-          dco_decode_RustOpaque_MutexHideDataTwinNormal(raw[1]),
+          dco_decode_RustOpaque_MutexHideDataTwinNormal(arr[1]),
         );
       case 4:
         return EnumOpaqueTwinNormal_RwLock(
-          dco_decode_RustOpaque_RwLockHideDataTwinNormal(raw[1]),
+          dco_decode_RustOpaque_RwLockHideDataTwinNormal(arr[1]),
         );
       case 5:
         return EnumOpaqueTwinNormal_Nothing();
@@ -51988,34 +51991,34 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumOpaqueTwinNormalArray5 dco_decode_enum_opaque_twin_normal_array_5(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return EnumOpaqueTwinNormalArray5((raw as List<dynamic>)
-        .map(dco_decode_enum_opaque_twin_normal)
-        .toList());
+    return EnumOpaqueTwinNormalArray5(
+        dcoDecodeList(raw).map(dco_decode_enum_opaque_twin_normal).toList());
   }
 
   @protected
   EnumOpaqueTwinRustAsync dco_decode_enum_opaque_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumOpaqueTwinRustAsync_Struct(
-          dco_decode_RustOpaque_HideDataTwinRustAsync(raw[1]),
+          dco_decode_RustOpaque_HideDataTwinRustAsync(arr[1]),
         );
       case 1:
         return EnumOpaqueTwinRustAsync_Primitive(
-          dco_decode_RustOpaque_i32(raw[1]),
+          dco_decode_RustOpaque_i32(arr[1]),
         );
       case 2:
         return EnumOpaqueTwinRustAsync_TraitObj(
-          dco_decode_RustOpaque_BoxdynDartDebugTwinRustAsync(raw[1]),
+          dco_decode_RustOpaque_BoxdynDartDebugTwinRustAsync(arr[1]),
         );
       case 3:
         return EnumOpaqueTwinRustAsync_Mutex(
-          dco_decode_RustOpaque_MutexHideDataTwinRustAsync(raw[1]),
+          dco_decode_RustOpaque_MutexHideDataTwinRustAsync(arr[1]),
         );
       case 4:
         return EnumOpaqueTwinRustAsync_RwLock(
-          dco_decode_RustOpaque_RwLockHideDataTwinRustAsync(raw[1]),
+          dco_decode_RustOpaque_RwLockHideDataTwinRustAsync(arr[1]),
         );
       case 5:
         return EnumOpaqueTwinRustAsync_Nothing();
@@ -52028,7 +52031,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumOpaqueTwinRustAsyncArray5 dco_decode_enum_opaque_twin_rust_async_array_5(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return EnumOpaqueTwinRustAsyncArray5((raw as List<dynamic>)
+    return EnumOpaqueTwinRustAsyncArray5(dcoDecodeList(raw)
         .map(dco_decode_enum_opaque_twin_rust_async)
         .toList());
   }
@@ -52036,26 +52039,27 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   EnumOpaqueTwinSync dco_decode_enum_opaque_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumOpaqueTwinSync_Struct(
-          dco_decode_RustOpaque_HideDataTwinSync(raw[1]),
+          dco_decode_RustOpaque_HideDataTwinSync(arr[1]),
         );
       case 1:
         return EnumOpaqueTwinSync_Primitive(
-          dco_decode_RustOpaque_i32(raw[1]),
+          dco_decode_RustOpaque_i32(arr[1]),
         );
       case 2:
         return EnumOpaqueTwinSync_TraitObj(
-          dco_decode_RustOpaque_BoxdynDartDebugTwinSync(raw[1]),
+          dco_decode_RustOpaque_BoxdynDartDebugTwinSync(arr[1]),
         );
       case 3:
         return EnumOpaqueTwinSync_Mutex(
-          dco_decode_RustOpaque_MutexHideDataTwinSync(raw[1]),
+          dco_decode_RustOpaque_MutexHideDataTwinSync(arr[1]),
         );
       case 4:
         return EnumOpaqueTwinSync_RwLock(
-          dco_decode_RustOpaque_RwLockHideDataTwinSync(raw[1]),
+          dco_decode_RustOpaque_RwLockHideDataTwinSync(arr[1]),
         );
       case 5:
         return EnumOpaqueTwinSync_Nothing();
@@ -52069,61 +52073,62 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return EnumOpaqueTwinSyncArray5(
-        (raw as List<dynamic>).map(dco_decode_enum_opaque_twin_sync).toList());
+        dcoDecodeList(raw).map(dco_decode_enum_opaque_twin_sync).toList());
   }
 
   @protected
   EnumSimpleTwinNormal dco_decode_enum_simple_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return EnumSimpleTwinNormal.values[raw as int];
+    return EnumSimpleTwinNormal.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   EnumSimpleTwinRustAsync dco_decode_enum_simple_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return EnumSimpleTwinRustAsync.values[raw as int];
+    return EnumSimpleTwinRustAsync.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   EnumSimpleTwinSync dco_decode_enum_simple_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return EnumSimpleTwinSync.values[raw as int];
+    return EnumSimpleTwinSync.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   EnumWithDiscriminantTwinNormal dco_decode_enum_with_discriminant_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return EnumWithDiscriminantTwinNormal.values[raw as int];
+    return EnumWithDiscriminantTwinNormal.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   EnumWithDiscriminantTwinRustAsync
       dco_decode_enum_with_discriminant_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return EnumWithDiscriminantTwinRustAsync.values[raw as int];
+    return EnumWithDiscriminantTwinRustAsync.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   EnumWithDiscriminantTwinSync dco_decode_enum_with_discriminant_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return EnumWithDiscriminantTwinSync.values[raw as int];
+    return EnumWithDiscriminantTwinSync.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   EnumWithGoodAndOpaqueTwinNormal
       dco_decode_enum_with_good_and_opaque_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithGoodAndOpaqueTwinNormal_Good(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return EnumWithGoodAndOpaqueTwinNormal_Opaque(
           dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinNormal(
-              raw[1]),
+              arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -52134,15 +52139,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumWithGoodAndOpaqueTwinRustAsync
       dco_decode_enum_with_good_and_opaque_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithGoodAndOpaqueTwinRustAsync_Good(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return EnumWithGoodAndOpaqueTwinRustAsync_Opaque(
           dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinRustAsync(
-              raw[1]),
+              arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -52153,15 +52159,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumWithGoodAndOpaqueTwinSync dco_decode_enum_with_good_and_opaque_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithGoodAndOpaqueTwinSync_Good(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return EnumWithGoodAndOpaqueTwinSync_Opaque(
           dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinSync(
-              raw[1]),
+              arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -52172,16 +52179,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumWithItemMixedTwinNormal dco_decode_enum_with_item_mixed_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithItemMixedTwinNormal_A();
       case 1:
         return EnumWithItemMixedTwinNormal_B(
-          dco_decode_list_prim_u_8_strict(raw[1]),
+          dco_decode_list_prim_u_8_strict(arr[1]),
         );
       case 2:
         return EnumWithItemMixedTwinNormal_C(
-          cField: dco_decode_String(raw[1]),
+          cField: dco_decode_String(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -52192,16 +52200,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumWithItemMixedTwinRustAsync
       dco_decode_enum_with_item_mixed_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithItemMixedTwinRustAsync_A();
       case 1:
         return EnumWithItemMixedTwinRustAsync_B(
-          dco_decode_list_prim_u_8_strict(raw[1]),
+          dco_decode_list_prim_u_8_strict(arr[1]),
         );
       case 2:
         return EnumWithItemMixedTwinRustAsync_C(
-          cField: dco_decode_String(raw[1]),
+          cField: dco_decode_String(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -52212,16 +52221,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumWithItemMixedTwinSync dco_decode_enum_with_item_mixed_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithItemMixedTwinSync_A();
       case 1:
         return EnumWithItemMixedTwinSync_B(
-          dco_decode_list_prim_u_8_strict(raw[1]),
+          dco_decode_list_prim_u_8_strict(arr[1]),
         );
       case 2:
         return EnumWithItemMixedTwinSync_C(
-          cField: dco_decode_String(raw[1]),
+          cField: dco_decode_String(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -52232,14 +52242,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumWithItemStructTwinNormal dco_decode_enum_with_item_struct_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithItemStructTwinNormal_A(
-          aField: dco_decode_list_prim_u_8_strict(raw[1]),
+          aField: dco_decode_list_prim_u_8_strict(arr[1]),
         );
       case 1:
         return EnumWithItemStructTwinNormal_B(
-          bField: dco_decode_list_prim_i_32_strict(raw[1]),
+          bField: dco_decode_list_prim_i_32_strict(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -52250,14 +52261,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumWithItemStructTwinRustAsync
       dco_decode_enum_with_item_struct_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithItemStructTwinRustAsync_A(
-          aField: dco_decode_list_prim_u_8_strict(raw[1]),
+          aField: dco_decode_list_prim_u_8_strict(arr[1]),
         );
       case 1:
         return EnumWithItemStructTwinRustAsync_B(
-          bField: dco_decode_list_prim_i_32_strict(raw[1]),
+          bField: dco_decode_list_prim_i_32_strict(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -52268,14 +52280,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumWithItemStructTwinSync dco_decode_enum_with_item_struct_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithItemStructTwinSync_A(
-          aField: dco_decode_list_prim_u_8_strict(raw[1]),
+          aField: dco_decode_list_prim_u_8_strict(arr[1]),
         );
       case 1:
         return EnumWithItemStructTwinSync_B(
-          bField: dco_decode_list_prim_i_32_strict(raw[1]),
+          bField: dco_decode_list_prim_i_32_strict(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -52286,14 +52299,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumWithItemTupleTwinNormal dco_decode_enum_with_item_tuple_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithItemTupleTwinNormal_A(
-          dco_decode_list_prim_u_8_strict(raw[1]),
+          dco_decode_list_prim_u_8_strict(arr[1]),
         );
       case 1:
         return EnumWithItemTupleTwinNormal_B(
-          dco_decode_i_32(raw[1]),
+          dco_decode_i_32(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -52304,14 +52318,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumWithItemTupleTwinRustAsync
       dco_decode_enum_with_item_tuple_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithItemTupleTwinRustAsync_A(
-          dco_decode_list_prim_u_8_strict(raw[1]),
+          dco_decode_list_prim_u_8_strict(arr[1]),
         );
       case 1:
         return EnumWithItemTupleTwinRustAsync_B(
-          dco_decode_i_32(raw[1]),
+          dco_decode_i_32(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -52322,14 +52337,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   EnumWithItemTupleTwinSync dco_decode_enum_with_item_tuple_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return EnumWithItemTupleTwinSync_A(
-          dco_decode_list_prim_u_8_strict(raw[1]),
+          dco_decode_list_prim_u_8_strict(arr[1]),
         );
       case 1:
         return EnumWithItemTupleTwinSync_B(
-          dco_decode_i_32(raw[1]),
+          dco_decode_i_32(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -52339,7 +52355,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   EventTwinNormal dco_decode_event_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return EventTwinNormal(
@@ -52351,7 +52367,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   EventTwinRustAsync dco_decode_event_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return EventTwinRustAsync(
@@ -52364,7 +52380,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ExoticOptionalsTwinNormal dco_decode_exotic_optionals_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 14)
       throw Exception('unexpected arr length: expect 14 but see ${arr.length}');
     return ExoticOptionalsTwinNormal(
@@ -52391,7 +52407,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ExoticOptionalsTwinRustAsync dco_decode_exotic_optionals_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 14)
       throw Exception('unexpected arr length: expect 14 but see ${arr.length}');
     return ExoticOptionalsTwinRustAsync(
@@ -52419,7 +52435,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   ExoticOptionalsTwinSync dco_decode_exotic_optionals_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 14)
       throw Exception('unexpected arr length: expect 14 but see ${arr.length}');
     return ExoticOptionalsTwinSync(
@@ -52469,7 +52485,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   FeatureChronoTwinNormal dco_decode_feature_chrono_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 5)
       throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
     return FeatureChronoTwinNormal(
@@ -52485,7 +52501,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   FeatureChronoTwinRustAsync dco_decode_feature_chrono_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 5)
       throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
     return FeatureChronoTwinRustAsync(
@@ -52500,7 +52516,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   FeatureChronoTwinSync dco_decode_feature_chrono_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 5)
       throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
     return FeatureChronoTwinSync(
@@ -52516,7 +52532,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   FeatureSerdeJsonTwinNormal dco_decode_feature_serde_json_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return FeatureSerdeJsonTwinNormal(
@@ -52528,7 +52544,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   FeatureSerdeJsonTwinRustAsync dco_decode_feature_serde_json_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return FeatureSerdeJsonTwinRustAsync(
@@ -52540,7 +52556,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   FeatureSerdeJsonTwinSync dco_decode_feature_serde_json_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return FeatureSerdeJsonTwinSync(
@@ -52551,7 +52567,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   FeatureUuidTwinNormal dco_decode_feature_uuid_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return FeatureUuidTwinNormal(
@@ -52563,7 +52579,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   FeatureUuidTwinRustAsync dco_decode_feature_uuid_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return FeatureUuidTwinRustAsync(
@@ -52574,7 +52590,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   FeatureUuidTwinSync dco_decode_feature_uuid_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return FeatureUuidTwinSync(
@@ -52585,7 +52601,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   FeedIdTwinNormal dco_decode_feed_id_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return FeedIdTwinNormal(
@@ -52596,7 +52612,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   FeedIdTwinRustAsync dco_decode_feed_id_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return FeedIdTwinRustAsync(
@@ -52607,7 +52623,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   FeedIdTwinSync dco_decode_feed_id_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return FeedIdTwinSync(
@@ -52618,7 +52634,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   FrbLogRecord dco_decode_frb_log_record(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 6)
       throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
     return FrbLogRecord(
@@ -52635,27 +52651,27 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   GenericAliasErrorTwinNormal dco_decode_generic_alias_error_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return GenericAliasErrorTwinNormal.values[raw as int];
+    return GenericAliasErrorTwinNormal.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   GenericAliasErrorTwinRustAsync dco_decode_generic_alias_error_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return GenericAliasErrorTwinRustAsync.values[raw as int];
+    return GenericAliasErrorTwinRustAsync.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   GenericAliasErrorTwinSync dco_decode_generic_alias_error_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return GenericAliasErrorTwinSync.values[raw as int];
+    return GenericAliasErrorTwinSync.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   HashMapValue dco_decode_hash_map_value(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return HashMapValue(
@@ -52666,13 +52682,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   int dco_decode_i_16(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dcoDecodePrimitiveInt(raw);
   }
 
   @protected
   int dco_decode_i_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dcoDecodePrimitiveInt(raw);
   }
 
   @protected
@@ -52690,7 +52706,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   int dco_decode_i_8(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dcoDecodePrimitiveInt(raw);
   }
 
   @protected
@@ -52703,7 +52719,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ItemContainerSolutionTwoTwinNormal
       dco_decode_item_container_solution_two_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return ItemContainerSolutionTwoTwinNormal(
@@ -52717,32 +52733,33 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   KitchenSinkTwinNormal dco_decode_kitchen_sink_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return KitchenSinkTwinNormal_Empty();
       case 1:
         return KitchenSinkTwinNormal_Primitives(
-          int32: dco_decode_i_32(raw[1]),
-          float64: dco_decode_f_64(raw[2]),
-          boolean: dco_decode_bool(raw[3]),
+          int32: dco_decode_i_32(arr[1]),
+          float64: dco_decode_f_64(arr[2]),
+          boolean: dco_decode_bool(arr[3]),
         );
       case 2:
         return KitchenSinkTwinNormal_Nested(
-          dco_decode_i_32(raw[1]),
-          dco_decode_box_kitchen_sink_twin_normal(raw[2]),
+          dco_decode_i_32(arr[1]),
+          dco_decode_box_kitchen_sink_twin_normal(arr[2]),
         );
       case 3:
         return KitchenSinkTwinNormal_Optional(
-          dco_decode_opt_box_autoadd_i_32(raw[1]),
-          dco_decode_opt_box_autoadd_i_32(raw[2]),
+          dco_decode_opt_box_autoadd_i_32(arr[1]),
+          dco_decode_opt_box_autoadd_i_32(arr[2]),
         );
       case 4:
         return KitchenSinkTwinNormal_Buffer(
-          dco_decode_list_prim_u_8_strict(raw[1]),
+          dco_decode_list_prim_u_8_strict(arr[1]),
         );
       case 5:
         return KitchenSinkTwinNormal_Enums(
-          dco_decode_weekdays_twin_normal(raw[1]),
+          dco_decode_weekdays_twin_normal(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -52753,32 +52770,33 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   KitchenSinkTwinRustAsync dco_decode_kitchen_sink_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return KitchenSinkTwinRustAsync_Empty();
       case 1:
         return KitchenSinkTwinRustAsync_Primitives(
-          int32: dco_decode_i_32(raw[1]),
-          float64: dco_decode_f_64(raw[2]),
-          boolean: dco_decode_bool(raw[3]),
+          int32: dco_decode_i_32(arr[1]),
+          float64: dco_decode_f_64(arr[2]),
+          boolean: dco_decode_bool(arr[3]),
         );
       case 2:
         return KitchenSinkTwinRustAsync_Nested(
-          dco_decode_i_32(raw[1]),
-          dco_decode_box_kitchen_sink_twin_rust_async(raw[2]),
+          dco_decode_i_32(arr[1]),
+          dco_decode_box_kitchen_sink_twin_rust_async(arr[2]),
         );
       case 3:
         return KitchenSinkTwinRustAsync_Optional(
-          dco_decode_opt_box_autoadd_i_32(raw[1]),
-          dco_decode_opt_box_autoadd_i_32(raw[2]),
+          dco_decode_opt_box_autoadd_i_32(arr[1]),
+          dco_decode_opt_box_autoadd_i_32(arr[2]),
         );
       case 4:
         return KitchenSinkTwinRustAsync_Buffer(
-          dco_decode_list_prim_u_8_strict(raw[1]),
+          dco_decode_list_prim_u_8_strict(arr[1]),
         );
       case 5:
         return KitchenSinkTwinRustAsync_Enums(
-          dco_decode_weekdays_twin_rust_async(raw[1]),
+          dco_decode_weekdays_twin_rust_async(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -52788,32 +52806,33 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   KitchenSinkTwinSync dco_decode_kitchen_sink_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return KitchenSinkTwinSync_Empty();
       case 1:
         return KitchenSinkTwinSync_Primitives(
-          int32: dco_decode_i_32(raw[1]),
-          float64: dco_decode_f_64(raw[2]),
-          boolean: dco_decode_bool(raw[3]),
+          int32: dco_decode_i_32(arr[1]),
+          float64: dco_decode_f_64(arr[2]),
+          boolean: dco_decode_bool(arr[3]),
         );
       case 2:
         return KitchenSinkTwinSync_Nested(
-          dco_decode_i_32(raw[1]),
-          dco_decode_box_kitchen_sink_twin_sync(raw[2]),
+          dco_decode_i_32(arr[1]),
+          dco_decode_box_kitchen_sink_twin_sync(arr[2]),
         );
       case 3:
         return KitchenSinkTwinSync_Optional(
-          dco_decode_opt_box_autoadd_i_32(raw[1]),
-          dco_decode_opt_box_autoadd_i_32(raw[2]),
+          dco_decode_opt_box_autoadd_i_32(arr[1]),
+          dco_decode_opt_box_autoadd_i_32(arr[2]),
         );
       case 4:
         return KitchenSinkTwinSync_Buffer(
-          dco_decode_list_prim_u_8_strict(raw[1]),
+          dco_decode_list_prim_u_8_strict(arr[1]),
         );
       case 5:
         return KitchenSinkTwinSync_Enums(
-          dco_decode_weekdays_twin_sync(raw[1]),
+          dco_decode_weekdays_twin_sync(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -52825,7 +52844,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_list_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueItemTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(
             dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueItemTwinNormal)
         .toList();
@@ -52836,7 +52855,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_list_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(
             dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinNormal)
         .toList();
@@ -52847,7 +52866,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_list_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinRustAsync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(
             dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinRustAsync)
         .toList();
@@ -52858,7 +52877,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_list_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinSync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(
             dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNonCloneSimpleTwinSync)
         .toList();
@@ -52869,7 +52888,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_list_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueItemTwinNormal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(
             dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOpaqueItemTwinNormal)
         .toList();
@@ -52878,32 +52897,32 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<Duration> dco_decode_list_Chrono_Duration(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_Chrono_Duration).toList();
+    return dcoDecodeList(raw).map(dco_decode_Chrono_Duration).toList();
   }
 
   @protected
   List<DateTime> dco_decode_list_Chrono_Local(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_Chrono_Local).toList();
+    return dcoDecodeList(raw).map(dco_decode_Chrono_Local).toList();
   }
 
   @protected
   List<DateTime> dco_decode_list_Chrono_NaiveDateTime(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_Chrono_NaiveDateTime).toList();
+    return dcoDecodeList(raw).map(dco_decode_Chrono_NaiveDateTime).toList();
   }
 
   @protected
   List<Object> dco_decode_list_DartOpaque(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_DartOpaque).toList();
+    return dcoDecodeList(raw).map(dco_decode_DartOpaque).toList();
   }
 
   @protected
   List<HideDataTwinNormal> dco_decode_list_RustOpaque_HideDataTwinNormal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_RustOpaque_HideDataTwinNormal)
         .toList();
   }
@@ -52912,7 +52931,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<HideDataTwinRustAsync> dco_decode_list_RustOpaque_HideDataTwinRustAsync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_RustOpaque_HideDataTwinRustAsync)
         .toList();
   }
@@ -52921,7 +52940,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<HideDataTwinSync> dco_decode_list_RustOpaque_HideDataTwinSync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_RustOpaque_HideDataTwinSync)
         .toList();
   }
@@ -52929,19 +52948,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<Object?> dco_decode_list_SerdeJsonValue(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_SerdeJsonValue).toList();
+    return dcoDecodeList(raw).map(dco_decode_SerdeJsonValue).toList();
   }
 
   @protected
   List<RustStreamSink<int>> dco_decode_list_StreamSink_i_32_Sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_StreamSink_i_32_Sse).toList();
+    return dcoDecodeList(raw).map(dco_decode_StreamSink_i_32_Sse).toList();
   }
 
   @protected
   List<String> dco_decode_list_String(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_String).toList();
+    return dcoDecodeList(raw).map(dco_decode_String).toList();
   }
 
   @protected
@@ -52960,34 +52979,32 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<ApplicationEnvVar> dco_decode_list_application_env_var(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_application_env_var).toList();
+    return dcoDecodeList(raw).map(dco_decode_application_env_var).toList();
   }
 
   @protected
   List<ApplicationMode> dco_decode_list_application_mode(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_application_mode).toList();
+    return dcoDecodeList(raw).map(dco_decode_application_mode).toList();
   }
 
   @protected
   List<ApplicationSettings> dco_decode_list_application_settings(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_application_settings).toList();
+    return dcoDecodeList(raw).map(dco_decode_application_settings).toList();
   }
 
   @protected
   List<AttributeTwinNormal> dco_decode_list_attribute_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_attribute_twin_normal)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_attribute_twin_normal).toList();
   }
 
   @protected
   List<AttributeTwinRustAsync> dco_decode_list_attribute_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_attribute_twin_rust_async)
         .toList();
   }
@@ -52995,14 +53012,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<AttributeTwinSync> dco_decode_list_attribute_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_attribute_twin_sync).toList();
+    return dcoDecodeList(raw).map(dco_decode_attribute_twin_sync).toList();
   }
 
   @protected
   List<BasicGeneralEnumTwinNormal>
       dco_decode_list_basic_general_enum_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_basic_general_enum_twin_normal)
         .toList();
   }
@@ -53011,7 +53028,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<BasicGeneralEnumTwinRustAsync>
       dco_decode_list_basic_general_enum_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_basic_general_enum_twin_rust_async)
         .toList();
   }
@@ -53020,7 +53037,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<BasicGeneralEnumTwinSync> dco_decode_list_basic_general_enum_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_basic_general_enum_twin_sync)
         .toList();
   }
@@ -53029,7 +53046,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<BasicPrimitiveEnumTwinNormal>
       dco_decode_list_basic_primitive_enum_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_basic_primitive_enum_twin_normal)
         .toList();
   }
@@ -53038,7 +53055,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<BasicPrimitiveEnumTwinRustAsync>
       dco_decode_list_basic_primitive_enum_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_basic_primitive_enum_twin_rust_async)
         .toList();
   }
@@ -53047,7 +53064,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<BasicPrimitiveEnumTwinSync>
       dco_decode_list_basic_primitive_enum_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_basic_primitive_enum_twin_sync)
         .toList();
   }
@@ -53056,16 +53073,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<BasicStructTwinNormal> dco_decode_list_basic_struct_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_basic_struct_twin_normal)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_basic_struct_twin_normal).toList();
   }
 
   @protected
   List<BasicStructTwinRustAsync> dco_decode_list_basic_struct_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_basic_struct_twin_rust_async)
         .toList();
   }
@@ -53074,52 +53089,46 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<BasicStructTwinSync> dco_decode_list_basic_struct_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_basic_struct_twin_sync)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_basic_struct_twin_sync).toList();
   }
 
   @protected
   List<bool> dco_decode_list_bool(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_bool).toList();
+    return dcoDecodeList(raw).map(dco_decode_bool).toList();
   }
 
   @protected
   List<ElementTwinNormal> dco_decode_list_element_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_element_twin_normal).toList();
+    return dcoDecodeList(raw).map(dco_decode_element_twin_normal).toList();
   }
 
   @protected
   List<ElementTwinRustAsync> dco_decode_list_element_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_element_twin_rust_async)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_element_twin_rust_async).toList();
   }
 
   @protected
   List<ElementTwinSync> dco_decode_list_element_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_element_twin_sync).toList();
+    return dcoDecodeList(raw).map(dco_decode_element_twin_sync).toList();
   }
 
   @protected
   List<EnumOpaqueTwinNormal> dco_decode_list_enum_opaque_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_enum_opaque_twin_normal)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_enum_opaque_twin_normal).toList();
   }
 
   @protected
   List<EnumOpaqueTwinRustAsync> dco_decode_list_enum_opaque_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_enum_opaque_twin_rust_async)
         .toList();
   }
@@ -53127,43 +53136,39 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<EnumOpaqueTwinSync> dco_decode_list_enum_opaque_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_enum_opaque_twin_sync)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_enum_opaque_twin_sync).toList();
   }
 
   @protected
   List<Uint8List> dco_decode_list_list_prim_u_8_strict(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_list_prim_u_8_strict).toList();
+    return dcoDecodeList(raw).map(dco_decode_list_prim_u_8_strict).toList();
   }
 
   @protected
   List<MyEnum> dco_decode_list_my_enum(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_my_enum).toList();
+    return dcoDecodeList(raw).map(dco_decode_my_enum).toList();
   }
 
   @protected
   List<MySize> dco_decode_list_my_size(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_my_size).toList();
+    return dcoDecodeList(raw).map(dco_decode_my_size).toList();
   }
 
   @protected
   List<MyTreeNodeTwinNormal> dco_decode_list_my_tree_node_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_my_tree_node_twin_normal)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_my_tree_node_twin_normal).toList();
   }
 
   @protected
   List<MyTreeNodeTwinRustAsync> dco_decode_list_my_tree_node_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_my_tree_node_twin_rust_async)
         .toList();
   }
@@ -53171,16 +53176,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<MyTreeNodeTwinSync> dco_decode_list_my_tree_node_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_my_tree_node_twin_sync)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_my_tree_node_twin_sync).toList();
   }
 
   @protected
   List<NestedRawStringMirrored> dco_decode_list_nested_raw_string_mirrored(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_nested_raw_string_mirrored)
         .toList();
   }
@@ -53189,7 +53192,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ListOfNestedRawStringMirrored dco_decode_list_of_nested_raw_string_mirrored(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return ListOfNestedRawStringMirrored(
@@ -53200,14 +53203,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<String?> dco_decode_list_opt_String(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_opt_String).toList();
+    return dcoDecodeList(raw).map(dco_decode_opt_String).toList();
   }
 
   @protected
   List<AttributeTwinNormal?>
       dco_decode_list_opt_box_autoadd_attribute_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_opt_box_autoadd_attribute_twin_normal)
         .toList();
   }
@@ -53216,7 +53219,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<AttributeTwinRustAsync?>
       dco_decode_list_opt_box_autoadd_attribute_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_opt_box_autoadd_attribute_twin_rust_async)
         .toList();
   }
@@ -53225,7 +53228,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<AttributeTwinSync?> dco_decode_list_opt_box_autoadd_attribute_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_opt_box_autoadd_attribute_twin_sync)
         .toList();
   }
@@ -53233,14 +53236,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<int?> dco_decode_list_opt_box_autoadd_i_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_opt_box_autoadd_i_32).toList();
+    return dcoDecodeList(raw).map(dco_decode_opt_box_autoadd_i_32).toList();
   }
 
   @protected
   List<WeekdaysTwinNormal?>
       dco_decode_list_opt_box_autoadd_weekdays_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_opt_box_autoadd_weekdays_twin_normal)
         .toList();
   }
@@ -53249,7 +53252,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<WeekdaysTwinRustAsync?>
       dco_decode_list_opt_box_autoadd_weekdays_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_opt_box_autoadd_weekdays_twin_rust_async)
         .toList();
   }
@@ -53258,7 +53261,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<WeekdaysTwinSync?> dco_decode_list_opt_box_autoadd_weekdays_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_opt_box_autoadd_weekdays_twin_sync)
         .toList();
   }
@@ -53266,7 +53269,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<Int32List?> dco_decode_list_opt_list_prim_i_32_strict(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_opt_list_prim_i_32_strict)
         .toList();
   }
@@ -53274,21 +53277,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<PointTwinNormal> dco_decode_list_point_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_point_twin_normal).toList();
+    return dcoDecodeList(raw).map(dco_decode_point_twin_normal).toList();
   }
 
   @protected
   List<PointTwinRustAsync> dco_decode_list_point_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_point_twin_rust_async)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_point_twin_rust_async).toList();
   }
 
   @protected
   List<PointTwinSync> dco_decode_list_point_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_point_twin_sync).toList();
+    return dcoDecodeList(raw).map(dco_decode_point_twin_sync).toList();
   }
 
   @protected
@@ -53403,22 +53404,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<RawStringEnumMirrored> dco_decode_list_raw_string_enum_mirrored(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_raw_string_enum_mirrored)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_raw_string_enum_mirrored).toList();
   }
 
   @protected
   List<RawStringMirrored> dco_decode_list_raw_string_mirrored(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_raw_string_mirrored).toList();
+    return dcoDecodeList(raw).map(dco_decode_raw_string_mirrored).toList();
   }
 
   @protected
   List<(int, BasicGeneralEnumTwinNormal)>
       dco_decode_list_record_i_32_basic_general_enum_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_i_32_basic_general_enum_twin_normal)
         .toList();
   }
@@ -53428,7 +53427,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_list_record_i_32_basic_general_enum_twin_rust_async(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_i_32_basic_general_enum_twin_rust_async)
         .toList();
   }
@@ -53437,7 +53436,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<(int, BasicGeneralEnumTwinSync)>
       dco_decode_list_record_i_32_basic_general_enum_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_i_32_basic_general_enum_twin_sync)
         .toList();
   }
@@ -53447,7 +53446,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_list_record_i_32_basic_primitive_enum_twin_normal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_i_32_basic_primitive_enum_twin_normal)
         .toList();
   }
@@ -53457,7 +53456,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_list_record_i_32_basic_primitive_enum_twin_rust_async(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_i_32_basic_primitive_enum_twin_rust_async)
         .toList();
   }
@@ -53466,7 +53465,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<(int, BasicPrimitiveEnumTwinSync)>
       dco_decode_list_record_i_32_basic_primitive_enum_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_i_32_basic_primitive_enum_twin_sync)
         .toList();
   }
@@ -53475,7 +53474,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<(int, BasicStructTwinNormal)>
       dco_decode_list_record_i_32_basic_struct_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_i_32_basic_struct_twin_normal)
         .toList();
   }
@@ -53484,7 +53483,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<(int, BasicStructTwinRustAsync)>
       dco_decode_list_record_i_32_basic_struct_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_i_32_basic_struct_twin_rust_async)
         .toList();
   }
@@ -53493,7 +53492,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<(int, BasicStructTwinSync)>
       dco_decode_list_record_i_32_basic_struct_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_i_32_basic_struct_twin_sync)
         .toList();
   }
@@ -53501,62 +53500,62 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<(int, bool)> dco_decode_list_record_i_32_bool(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_record_i_32_bool).toList();
+    return dcoDecodeList(raw).map(dco_decode_record_i_32_bool).toList();
   }
 
   @protected
   List<(int, double)> dco_decode_list_record_i_32_f_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_record_i_32_f_32).toList();
+    return dcoDecodeList(raw).map(dco_decode_record_i_32_f_32).toList();
   }
 
   @protected
   List<(int, double)> dco_decode_list_record_i_32_f_64(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_record_i_32_f_64).toList();
+    return dcoDecodeList(raw).map(dco_decode_record_i_32_f_64).toList();
   }
 
   @protected
   List<(int, BigInt)> dco_decode_list_record_i_32_i_128(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_record_i_32_i_128).toList();
+    return dcoDecodeList(raw).map(dco_decode_record_i_32_i_128).toList();
   }
 
   @protected
   List<(int, int)> dco_decode_list_record_i_32_i_16(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_record_i_32_i_16).toList();
+    return dcoDecodeList(raw).map(dco_decode_record_i_32_i_16).toList();
   }
 
   @protected
   List<(int, int)> dco_decode_list_record_i_32_i_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_record_i_32_i_32).toList();
+    return dcoDecodeList(raw).map(dco_decode_record_i_32_i_32).toList();
   }
 
   @protected
   List<(int, PlatformInt64)> dco_decode_list_record_i_32_i_64(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_record_i_32_i_64).toList();
+    return dcoDecodeList(raw).map(dco_decode_record_i_32_i_64).toList();
   }
 
   @protected
   List<(int, int)> dco_decode_list_record_i_32_i_8(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_record_i_32_i_8).toList();
+    return dcoDecodeList(raw).map(dco_decode_record_i_32_i_8).toList();
   }
 
   @protected
   List<(int, PlatformInt64)> dco_decode_list_record_i_32_isize(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_record_i_32_isize).toList();
+    return dcoDecodeList(raw).map(dco_decode_record_i_32_isize).toList();
   }
 
   @protected
   List<(int, Uint8List)> dco_decode_list_record_i_32_list_prim_u_8_strict(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_i_32_list_prim_u_8_strict)
         .toList();
   }
@@ -53564,50 +53563,50 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<(int, String)> dco_decode_list_record_i_32_string(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_record_i_32_string).toList();
+    return dcoDecodeList(raw).map(dco_decode_record_i_32_string).toList();
   }
 
   @protected
   List<(int, BigInt)> dco_decode_list_record_i_32_u_128(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_record_i_32_u_128).toList();
+    return dcoDecodeList(raw).map(dco_decode_record_i_32_u_128).toList();
   }
 
   @protected
   List<(int, int)> dco_decode_list_record_i_32_u_16(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_record_i_32_u_16).toList();
+    return dcoDecodeList(raw).map(dco_decode_record_i_32_u_16).toList();
   }
 
   @protected
   List<(int, int)> dco_decode_list_record_i_32_u_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_record_i_32_u_32).toList();
+    return dcoDecodeList(raw).map(dco_decode_record_i_32_u_32).toList();
   }
 
   @protected
   List<(int, BigInt)> dco_decode_list_record_i_32_u_64(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_record_i_32_u_64).toList();
+    return dcoDecodeList(raw).map(dco_decode_record_i_32_u_64).toList();
   }
 
   @protected
   List<(int, int)> dco_decode_list_record_i_32_u_8(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_record_i_32_u_8).toList();
+    return dcoDecodeList(raw).map(dco_decode_record_i_32_u_8).toList();
   }
 
   @protected
   List<(int, BigInt)> dco_decode_list_record_i_32_usize(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_record_i_32_usize).toList();
+    return dcoDecodeList(raw).map(dco_decode_record_i_32_usize).toList();
   }
 
   @protected
   List<(String, EnumSimpleTwinNormal)>
       dco_decode_list_record_string_enum_simple_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_string_enum_simple_twin_normal)
         .toList();
   }
@@ -53616,7 +53615,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<(String, EnumSimpleTwinRustAsync)>
       dco_decode_list_record_string_enum_simple_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_string_enum_simple_twin_rust_async)
         .toList();
   }
@@ -53625,7 +53624,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<(String, EnumSimpleTwinSync)>
       dco_decode_list_record_string_enum_simple_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_string_enum_simple_twin_sync)
         .toList();
   }
@@ -53634,7 +53633,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<(String, HashMapValue)> dco_decode_list_record_string_hash_map_value(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_string_hash_map_value)
         .toList();
   }
@@ -53642,14 +53641,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<(String, int)> dco_decode_list_record_string_i_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_record_string_i_32).toList();
+    return dcoDecodeList(raw).map(dco_decode_record_string_i_32).toList();
   }
 
   @protected
   List<(String, KitchenSinkTwinNormal)>
       dco_decode_list_record_string_kitchen_sink_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_string_kitchen_sink_twin_normal)
         .toList();
   }
@@ -53658,7 +53657,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<(String, KitchenSinkTwinRustAsync)>
       dco_decode_list_record_string_kitchen_sink_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_string_kitchen_sink_twin_rust_async)
         .toList();
   }
@@ -53667,7 +53666,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<(String, KitchenSinkTwinSync)>
       dco_decode_list_record_string_kitchen_sink_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_string_kitchen_sink_twin_sync)
         .toList();
   }
@@ -53676,7 +53675,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<(String, Uint8List)> dco_decode_list_record_string_list_prim_u_8_strict(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_string_list_prim_u_8_strict)
         .toList();
   }
@@ -53684,16 +53683,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<(String, MySize)> dco_decode_list_record_string_my_size(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_record_string_my_size)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_record_string_my_size).toList();
   }
 
   @protected
   List<(String, Object?)> dco_decode_list_record_string_serde_json_value(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_string_serde_json_value)
         .toList();
   }
@@ -53701,14 +53698,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<(String, String)> dco_decode_list_record_string_string(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_record_string_string).toList();
+    return dcoDecodeList(raw).map(dco_decode_record_string_string).toList();
   }
 
   @protected
   List<(int, ApplicationMode)> dco_decode_list_record_u_8_application_mode(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_record_u_8_application_mode)
         .toList();
   }
@@ -53717,7 +53714,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<SimpleStructTwinNormal> dco_decode_list_simple_struct_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_simple_struct_twin_normal)
         .toList();
   }
@@ -53726,7 +53723,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<SimpleStructTwinRustAsync> dco_decode_list_simple_struct_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
+    return dcoDecodeList(raw)
         .map(dco_decode_simple_struct_twin_rust_async)
         .toList();
   }
@@ -53735,78 +53732,70 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<SimpleStructTwinSync> dco_decode_list_simple_struct_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_simple_struct_twin_sync)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_simple_struct_twin_sync).toList();
   }
 
   @protected
   List<SumWithTwinNormal> dco_decode_list_sum_with_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_sum_with_twin_normal).toList();
+    return dcoDecodeList(raw).map(dco_decode_sum_with_twin_normal).toList();
   }
 
   @protected
   List<SumWithTwinRustAsync> dco_decode_list_sum_with_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_sum_with_twin_rust_async)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_sum_with_twin_rust_async).toList();
   }
 
   @protected
   List<SumWithTwinSync> dco_decode_list_sum_with_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_sum_with_twin_sync).toList();
+    return dcoDecodeList(raw).map(dco_decode_sum_with_twin_sync).toList();
   }
 
   @protected
   List<TestIdTwinNormal> dco_decode_list_test_id_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_test_id_twin_normal).toList();
+    return dcoDecodeList(raw).map(dco_decode_test_id_twin_normal).toList();
   }
 
   @protected
   List<TestIdTwinRustAsync> dco_decode_list_test_id_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_test_id_twin_rust_async)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_test_id_twin_rust_async).toList();
   }
 
   @protected
   List<TestIdTwinSync> dco_decode_list_test_id_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_test_id_twin_sync).toList();
+    return dcoDecodeList(raw).map(dco_decode_test_id_twin_sync).toList();
   }
 
   @protected
   List<WeekdaysTwinNormal> dco_decode_list_weekdays_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_weekdays_twin_normal).toList();
+    return dcoDecodeList(raw).map(dco_decode_weekdays_twin_normal).toList();
   }
 
   @protected
   List<WeekdaysTwinRustAsync> dco_decode_list_weekdays_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>)
-        .map(dco_decode_weekdays_twin_rust_async)
-        .toList();
+    return dcoDecodeList(raw).map(dco_decode_weekdays_twin_rust_async).toList();
   }
 
   @protected
   List<WeekdaysTwinSync> dco_decode_list_weekdays_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_weekdays_twin_sync).toList();
+    return dcoDecodeList(raw).map(dco_decode_weekdays_twin_sync).toList();
   }
 
   @protected
   Log2TwinNormal dco_decode_log_2_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return Log2TwinNormal(
@@ -53818,7 +53807,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   Log2TwinRustAsync dco_decode_log_2_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return Log2TwinRustAsync(
@@ -53830,7 +53819,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   Log2TwinSync dco_decode_log_2_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return Log2TwinSync(
@@ -53842,7 +53831,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   LogTwinNormal dco_decode_log_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return LogTwinNormal(
@@ -53854,7 +53843,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   LogTwinRustAsync dco_decode_log_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return LogTwinRustAsync(
@@ -53866,7 +53855,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MacroStruct dco_decode_macro_struct(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return MacroStruct(
@@ -53877,14 +53866,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MeasureTwinNormal dco_decode_measure_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return MeasureTwinNormal_Speed(
-          dco_decode_box_speed_twin_normal(raw[1]),
+          dco_decode_box_speed_twin_normal(arr[1]),
         );
       case 1:
         return MeasureTwinNormal_Distance(
-          dco_decode_box_distance_twin_normal(raw[1]),
+          dco_decode_box_distance_twin_normal(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -53894,14 +53884,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MeasureTwinRustAsync dco_decode_measure_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return MeasureTwinRustAsync_Speed(
-          dco_decode_box_speed_twin_rust_async(raw[1]),
+          dco_decode_box_speed_twin_rust_async(arr[1]),
         );
       case 1:
         return MeasureTwinRustAsync_Distance(
-          dco_decode_box_distance_twin_rust_async(raw[1]),
+          dco_decode_box_distance_twin_rust_async(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -53911,14 +53902,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MeasureTwinSync dco_decode_measure_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return MeasureTwinSync_Speed(
-          dco_decode_box_speed_twin_sync(raw[1]),
+          dco_decode_box_speed_twin_sync(arr[1]),
         );
       case 1:
         return MeasureTwinSync_Distance(
-          dco_decode_box_distance_twin_sync(raw[1]),
+          dco_decode_box_distance_twin_sync(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -53928,7 +53920,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MessageIdTwinNormal dco_decode_message_id_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return MessageIdTwinNormal(
@@ -53939,7 +53931,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MessageIdTwinRustAsync dco_decode_message_id_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return MessageIdTwinRustAsync(
@@ -53950,7 +53942,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MessageIdTwinSync dco_decode_message_id_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return MessageIdTwinSync(
@@ -53961,7 +53953,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MirrorStructTwinNormal dco_decode_mirror_struct_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return MirrorStructTwinNormal(
@@ -53976,7 +53968,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   MirrorStructTwinRustAsync dco_decode_mirror_struct_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return MirrorStructTwinRustAsync(
@@ -53990,7 +53982,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MirrorStructTwinSync dco_decode_mirror_struct_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return MirrorStructTwinSync(
@@ -54005,7 +53997,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   MoreThanJustOneRawStringStructTwinNormal
       dco_decode_more_than_just_one_raw_string_struct_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return MoreThanJustOneRawStringStructTwinNormal(
@@ -54021,7 +54013,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_more_than_just_one_raw_string_struct_twin_rust_async(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return MoreThanJustOneRawStringStructTwinRustAsync(
@@ -54036,7 +54028,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   MoreThanJustOneRawStringStructTwinSync
       dco_decode_more_than_just_one_raw_string_struct_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return MoreThanJustOneRawStringStructTwinSync(
@@ -54050,7 +54042,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MyCallableTwinNormal dco_decode_my_callable_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return MyCallableTwinNormal(
@@ -54061,7 +54053,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MyCallableTwinRustAsync dco_decode_my_callable_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return MyCallableTwinRustAsync(
@@ -54072,7 +54064,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MyCallableTwinSync dco_decode_my_callable_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return MyCallableTwinSync(
@@ -54083,21 +54075,22 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MyEnum dco_decode_my_enum(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return MyEnum.values[raw as int];
+    return MyEnum.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   MyEnumWithJsonSerializableTwinNormal
       dco_decode_my_enum_with_json_serializable_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return MyEnumWithJsonSerializableTwinNormal_Apple(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       case 1:
         return MyEnumWithJsonSerializableTwinNormal_Orange(
-          a: dco_decode_i_32(raw[1]),
+          a: dco_decode_i_32(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -54108,10 +54101,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   MyEnumWithoutFnWithUnignoreTwinNormal
       dco_decode_my_enum_without_fn_with_unignore_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return MyEnumWithoutFnWithUnignoreTwinNormal_One(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -54122,7 +54116,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   MyNestedStructTwinNormal dco_decode_my_nested_struct_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return MyNestedStructTwinNormal(
@@ -54135,7 +54129,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   MyNestedStructTwinRustAsync dco_decode_my_nested_struct_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return MyNestedStructTwinRustAsync(
@@ -54147,7 +54141,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MyNestedStructTwinSync dco_decode_my_nested_struct_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return MyNestedStructTwinSync(
@@ -54159,7 +54153,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MySize dco_decode_my_size(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return MySize(
@@ -54171,7 +54165,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MyStreamEntryTwinNormal dco_decode_my_stream_entry_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return MyStreamEntryTwinNormal(
@@ -54183,7 +54177,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   MyStreamEntryTwinRustAsync dco_decode_my_stream_entry_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return MyStreamEntryTwinRustAsync(
@@ -54194,7 +54188,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MyStruct dco_decode_my_struct(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return MyStruct(
@@ -54206,7 +54200,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   MyStructContainingStreamSinkTwinNormal
       dco_decode_my_struct_containing_stream_sink_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return MyStructContainingStreamSinkTwinNormal(
@@ -54219,7 +54213,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   MyStructContainingStreamSinkTwinRustAsync
       dco_decode_my_struct_containing_stream_sink_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return MyStructContainingStreamSinkTwinRustAsync(
@@ -54232,7 +54226,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   MyStructWithJsonSerializableTwinNormal
       dco_decode_my_struct_with_json_serializable_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return MyStructWithJsonSerializableTwinNormal(
@@ -54243,7 +54237,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MyStructWithSync dco_decode_my_struct_with_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 0)
       throw Exception('unexpected arr length: expect 0 but see ${arr.length}');
     return MyStructWithSync();
@@ -54253,7 +54247,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   MyStructWithoutFnWithUnignoreTwinNormal
       dco_decode_my_struct_without_fn_with_unignore_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return MyStructWithoutFnWithUnignoreTwinNormal(
@@ -54266,7 +54260,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_my_struct_without_fn_with_unignore_with_json_serializable_twin_normal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return MyStructWithoutFnWithUnignoreWithJsonSerializableTwinNormal(
@@ -54277,7 +54271,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MyTreeNodeTwinNormal dco_decode_my_tree_node_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return MyTreeNodeTwinNormal(
@@ -54291,7 +54285,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MyTreeNodeTwinRustAsync dco_decode_my_tree_node_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return MyTreeNodeTwinRustAsync(
@@ -54305,7 +54299,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   MyTreeNodeTwinSync dco_decode_my_tree_node_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return MyTreeNodeTwinSync(
@@ -54319,7 +54313,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   NestedRawStringMirrored dco_decode_nested_raw_string_mirrored(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return NestedRawStringMirrored(
@@ -54330,7 +54324,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   NewSimpleStruct dco_decode_new_simple_struct(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return NewSimpleStruct(
@@ -54341,7 +54335,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   NewTypeIntTwinNormal dco_decode_new_type_int_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return NewTypeIntTwinNormal(
@@ -54352,7 +54346,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   NewTypeIntTwinRustAsync dco_decode_new_type_int_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return NewTypeIntTwinRustAsync(
@@ -54363,7 +54357,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   NewTypeIntTwinSync dco_decode_new_type_int_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return NewTypeIntTwinSync(
@@ -54375,7 +54369,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   NonOpaqueStructContainingIpv4Addr
       dco_decode_non_opaque_struct_containing_ipv_4_addr(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return NonOpaqueStructContainingIpv4Addr(
@@ -54388,7 +54382,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   NoteTwinNormal dco_decode_note_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return NoteTwinNormal(
@@ -54400,7 +54394,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   NoteTwinRustAsync dco_decode_note_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return NoteTwinRustAsync(
@@ -54412,7 +54406,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   NoteTwinSync dco_decode_note_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return NoteTwinSync(
@@ -54424,7 +54418,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   Numbers dco_decode_numbers(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return Numbers(
@@ -54435,7 +54429,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   OldSimpleStruct dco_decode_old_simple_struct(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return OldSimpleStruct(
@@ -54446,7 +54440,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   OpaqueNestedTwinNormal dco_decode_opaque_nested_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return OpaqueNestedTwinNormal(
@@ -54459,7 +54453,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   OpaqueNestedTwinRustAsync dco_decode_opaque_nested_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return OpaqueNestedTwinRustAsync(
@@ -54471,7 +54465,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   OpaqueNestedTwinSync dco_decode_opaque_nested_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return OpaqueNestedTwinSync(
@@ -55134,7 +55128,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   OptVecsTwinNormal dco_decode_opt_vecs_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return OptVecsTwinNormal(
@@ -55148,7 +55142,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   OptVecsTwinRustAsync dco_decode_opt_vecs_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return OptVecsTwinRustAsync(
@@ -55162,7 +55156,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   OptVecsTwinSync dco_decode_opt_vecs_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return OptVecsTwinSync(
@@ -55176,7 +55170,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PointTwinNormal dco_decode_point_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return PointTwinNormal(
@@ -55189,13 +55183,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   PointTwinNormalArray2 dco_decode_point_twin_normal_array_2(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return PointTwinNormalArray2(
-        (raw as List<dynamic>).map(dco_decode_point_twin_normal).toList());
+        dcoDecodeList(raw).map(dco_decode_point_twin_normal).toList());
   }
 
   @protected
   PointTwinRustAsync dco_decode_point_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return PointTwinRustAsync(
@@ -55209,13 +55203,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return PointTwinRustAsyncArray2(
-        (raw as List<dynamic>).map(dco_decode_point_twin_rust_async).toList());
+        dcoDecodeList(raw).map(dco_decode_point_twin_rust_async).toList());
   }
 
   @protected
   PointTwinSync dco_decode_point_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return PointTwinSync(
@@ -55228,24 +55222,25 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   PointTwinSyncArray2 dco_decode_point_twin_sync_array_2(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return PointTwinSyncArray2(
-        (raw as List<dynamic>).map(dco_decode_point_twin_sync).toList());
+        dcoDecodeList(raw).map(dco_decode_point_twin_sync).toList());
   }
 
   @protected
   RawStringEnumMirrored dco_decode_raw_string_enum_mirrored(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return RawStringEnumMirrored_Raw(
-          dco_decode_box_autoadd_raw_string_mirrored(raw[1]),
+          dco_decode_box_autoadd_raw_string_mirrored(arr[1]),
         );
       case 1:
         return RawStringEnumMirrored_Nested(
-          dco_decode_box_autoadd_nested_raw_string_mirrored(raw[1]),
+          dco_decode_box_autoadd_nested_raw_string_mirrored(arr[1]),
         );
       case 2:
         return RawStringEnumMirrored_ListOfNested(
-          dco_decode_box_autoadd_list_of_nested_raw_string_mirrored(raw[1]),
+          dco_decode_box_autoadd_list_of_nested_raw_string_mirrored(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -55256,14 +55251,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   RawStringItemEnumTwinNormal dco_decode_raw_string_item_enum_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return RawStringItemEnumTwinNormal_Regular(
-          regular: dco_decode_String(raw[1]),
+          regular: dco_decode_String(arr[1]),
         );
       case 1:
         return RawStringItemEnumTwinNormal_Raw(
-          type: dco_decode_String(raw[1]),
+          type: dco_decode_String(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -55274,14 +55270,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   RawStringItemEnumTwinRustAsync
       dco_decode_raw_string_item_enum_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return RawStringItemEnumTwinRustAsync_Regular(
-          regular: dco_decode_String(raw[1]),
+          regular: dco_decode_String(arr[1]),
         );
       case 1:
         return RawStringItemEnumTwinRustAsync_Raw(
-          type: dco_decode_String(raw[1]),
+          type: dco_decode_String(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -55292,14 +55289,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   RawStringItemEnumTwinSync dco_decode_raw_string_item_enum_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return RawStringItemEnumTwinSync_Regular(
-          regular: dco_decode_String(raw[1]),
+          regular: dco_decode_String(arr[1]),
         );
       case 1:
         return RawStringItemEnumTwinSync_Raw(
-          type: dco_decode_String(raw[1]),
+          type: dco_decode_String(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -55310,7 +55308,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   RawStringItemStructTwinNormal dco_decode_raw_string_item_struct_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return RawStringItemStructTwinNormal(
@@ -55322,7 +55320,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   RawStringItemStructTwinRustAsync
       dco_decode_raw_string_item_struct_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return RawStringItemStructTwinRustAsync(
@@ -55334,7 +55332,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   RawStringItemStructTwinSync dco_decode_raw_string_item_struct_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return RawStringItemStructTwinSync(
@@ -55345,7 +55343,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   RawStringMirrored dco_decode_raw_string_mirrored(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return RawStringMirrored(
@@ -55359,7 +55357,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_record_application_settings_raw_string_enum_mirrored(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55376,7 +55374,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) dco_decode_record_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_opaque_one_twin_normal_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_opaque_two_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55395,7 +55393,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) dco_decode_record_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_opaque_one_twin_rust_async_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_opaque_two_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55414,7 +55412,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) dco_decode_record_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_opaque_one_twin_sync_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_opaque_two_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55429,7 +55427,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (double, double) dco_decode_record_f_32_f_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55443,7 +55441,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (int, BasicGeneralEnumTwinNormal)
       dco_decode_record_i_32_basic_general_enum_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55457,7 +55455,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (int, BasicGeneralEnumTwinRustAsync)
       dco_decode_record_i_32_basic_general_enum_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55471,7 +55469,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (int, BasicGeneralEnumTwinSync)
       dco_decode_record_i_32_basic_general_enum_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55485,7 +55483,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (int, BasicPrimitiveEnumTwinNormal)
       dco_decode_record_i_32_basic_primitive_enum_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55499,7 +55497,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (int, BasicPrimitiveEnumTwinRustAsync)
       dco_decode_record_i_32_basic_primitive_enum_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55513,7 +55511,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (int, BasicPrimitiveEnumTwinSync)
       dco_decode_record_i_32_basic_primitive_enum_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55527,7 +55525,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (int, BasicStructTwinNormal) dco_decode_record_i_32_basic_struct_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55541,7 +55539,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (int, BasicStructTwinRustAsync)
       dco_decode_record_i_32_basic_struct_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55555,7 +55553,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (int, BasicStructTwinSync) dco_decode_record_i_32_basic_struct_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55568,7 +55566,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (int, bool) dco_decode_record_i_32_bool(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55581,7 +55579,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (int, double) dco_decode_record_i_32_f_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55594,7 +55592,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (int, double) dco_decode_record_i_32_f_64(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55607,7 +55605,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (int, BigInt) dco_decode_record_i_32_i_128(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55620,7 +55618,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (int, int) dco_decode_record_i_32_i_16(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55633,7 +55631,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (int, int) dco_decode_record_i_32_i_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55646,7 +55644,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (int, PlatformInt64) dco_decode_record_i_32_i_64(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55659,7 +55657,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (int, int) dco_decode_record_i_32_i_8(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55672,7 +55670,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (int, PlatformInt64) dco_decode_record_i_32_isize(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55685,7 +55683,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (int, Uint8List) dco_decode_record_i_32_list_prim_u_8_strict(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55698,7 +55696,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (int, String) dco_decode_record_i_32_string(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55711,7 +55709,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (int, BigInt) dco_decode_record_i_32_u_128(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55724,7 +55722,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (int, int) dco_decode_record_i_32_u_16(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55737,7 +55735,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (int, int) dco_decode_record_i_32_u_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55750,7 +55748,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (int, BigInt) dco_decode_record_i_32_u_64(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55763,7 +55761,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (int, int) dco_decode_record_i_32_u_8(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55776,7 +55774,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (int, BigInt) dco_decode_record_i_32_usize(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55790,7 +55788,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (String, EnumSimpleTwinNormal)
       dco_decode_record_string_enum_simple_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55804,7 +55802,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (String, EnumSimpleTwinRustAsync)
       dco_decode_record_string_enum_simple_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55818,7 +55816,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (String, EnumSimpleTwinSync) dco_decode_record_string_enum_simple_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55831,7 +55829,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (String, HashMapValue) dco_decode_record_string_hash_map_value(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55844,7 +55842,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (String, int) dco_decode_record_string_i_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55858,7 +55856,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (String, KitchenSinkTwinNormal)
       dco_decode_record_string_kitchen_sink_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55872,7 +55870,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (String, KitchenSinkTwinRustAsync)
       dco_decode_record_string_kitchen_sink_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55886,7 +55884,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (String, KitchenSinkTwinSync) dco_decode_record_string_kitchen_sink_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55900,7 +55898,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   (String, Uint8List) dco_decode_record_string_list_prim_u_8_strict(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55913,7 +55911,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (String, MySize) dco_decode_record_string_my_size(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55926,7 +55924,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (String, Object?) dco_decode_record_string_serde_json_value(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55939,7 +55937,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (String, String) dco_decode_record_string_string(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55952,7 +55950,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   (int, ApplicationMode) dco_decode_record_u_8_application_mode(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2) {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
@@ -55965,7 +55963,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   Sequences dco_decode_sequences(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return Sequences(
@@ -55976,12 +55974,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   SimpleEnumTwinNormal dco_decode_simple_enum_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return SimpleEnumTwinNormal_First();
       case 1:
         return SimpleEnumTwinNormal_Second(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -55991,12 +55990,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   SimpleEnumTwinRustAsync dco_decode_simple_enum_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return SimpleEnumTwinRustAsync_First();
       case 1:
         return SimpleEnumTwinRustAsync_Second(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -56006,12 +56006,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   SimpleEnumTwinSync dco_decode_simple_enum_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return SimpleEnumTwinSync_First();
       case 1:
         return SimpleEnumTwinSync_Second(
-          dco_decode_String(raw[1]),
+          dco_decode_String(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -56022,28 +56023,28 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   SimplePrimitiveEnumTwinNormal dco_decode_simple_primitive_enum_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return SimplePrimitiveEnumTwinNormal.values[raw as int];
+    return SimplePrimitiveEnumTwinNormal.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   SimplePrimitiveEnumTwinRustAsync
       dco_decode_simple_primitive_enum_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return SimplePrimitiveEnumTwinRustAsync.values[raw as int];
+    return SimplePrimitiveEnumTwinRustAsync.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   SimplePrimitiveEnumTwinSync dco_decode_simple_primitive_enum_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return SimplePrimitiveEnumTwinSync.values[raw as int];
+    return SimplePrimitiveEnumTwinSync.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   SimpleStructForBorrowTwinNormal
       dco_decode_simple_struct_for_borrow_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return SimpleStructForBorrowTwinNormal(
@@ -56055,7 +56056,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   SimpleStructForBorrowTwinRustAsync
       dco_decode_simple_struct_for_borrow_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return SimpleStructForBorrowTwinRustAsync(
@@ -56067,7 +56068,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   SimpleStructForBorrowTwinSync dco_decode_simple_struct_for_borrow_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return SimpleStructForBorrowTwinSync(
@@ -56078,7 +56079,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   SimpleStructTwinNormal dco_decode_simple_struct_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return SimpleStructTwinNormal(
@@ -56090,7 +56091,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   SimpleStructTwinRustAsync dco_decode_simple_struct_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return SimpleStructTwinRustAsync(
@@ -56101,7 +56102,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   SimpleStructTwinSync dco_decode_simple_struct_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return SimpleStructTwinSync(
@@ -56113,16 +56114,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   SimpleTraitForDynTwinNormalImplementor
       dco_decode_simple_trait_for_dyn_twin_normal_implementor(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return SimpleTraitForDynTwinNormalImplementor_Variant0(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStructOneWithTraitForDynTwinNormal(
-              raw[1]),
+              arr[1]),
         );
       case 1:
         return SimpleTraitForDynTwinNormalImplementor_Variant1(
           dco_decode_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStructTwoWithTraitForDynTwinNormal(
-              raw[1]),
+              arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -56133,7 +56135,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   SimpleTranslatableExternalStructWithMethod
       dco_decode_simple_translatable_external_struct_with_method(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return SimpleTranslatableExternalStructWithMethod(
@@ -56144,7 +56146,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   SomeStructTwinNormal dco_decode_some_struct_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return SomeStructTwinNormal(
@@ -56155,7 +56157,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   SomeStructTwinRustAsync dco_decode_some_struct_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return SomeStructTwinRustAsync(
@@ -56166,7 +56168,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   SomeStructTwinSync dco_decode_some_struct_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return SomeStructTwinSync(
@@ -56177,12 +56179,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   SpeedTwinNormal dco_decode_speed_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return SpeedTwinNormal_Unknown();
       case 1:
         return SpeedTwinNormal_GPS(
-          dco_decode_f_64(raw[1]),
+          dco_decode_f_64(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -56192,12 +56195,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   SpeedTwinRustAsync dco_decode_speed_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return SpeedTwinRustAsync_Unknown();
       case 1:
         return SpeedTwinRustAsync_GPS(
-          dco_decode_f_64(raw[1]),
+          dco_decode_f_64(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -56207,12 +56211,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   SpeedTwinSync dco_decode_speed_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
+    final arr = dcoDecodeList(raw);
+    switch (dcoDecodePrimitiveInt(arr[0])) {
       case 0:
         return SpeedTwinSync_Unknown();
       case 1:
         return SpeedTwinSync_GPS(
-          dco_decode_f_64(raw[1]),
+          dco_decode_f_64(arr[1]),
         );
       default:
         throw Exception("unreachable");
@@ -56222,7 +56227,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   StaticOnlyTwinNormal dco_decode_static_only_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StaticOnlyTwinNormal(
@@ -56233,7 +56238,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   StaticOnlyTwinRustAsync dco_decode_static_only_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StaticOnlyTwinRustAsync(
@@ -56244,7 +56249,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   StaticOnlyTwinSync dco_decode_static_only_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StaticOnlyTwinSync(
@@ -56255,7 +56260,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   StructInLowerLevel dco_decode_struct_in_lower_level(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructInLowerLevel(
@@ -56266,7 +56271,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   StructInUpperLevel dco_decode_struct_in_upper_level(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructInUpperLevel(
@@ -56278,7 +56283,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithCastedPrimitiveTwinNormal
       dco_decode_struct_with_casted_primitive_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return StructWithCastedPrimitiveTwinNormal(
@@ -56293,7 +56298,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithCommentsTwinNormal dco_decode_struct_with_comments_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructWithCommentsTwinNormal(
@@ -56305,7 +56310,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithCommentsTwinRustAsync
       dco_decode_struct_with_comments_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructWithCommentsTwinRustAsync(
@@ -56317,7 +56322,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithCommentsTwinSync dco_decode_struct_with_comments_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructWithCommentsTwinSync(
@@ -56329,7 +56334,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithCustomNameMethodTwinNormal
       dco_decode_struct_with_custom_name_method_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructWithCustomNameMethodTwinNormal(
@@ -56341,7 +56346,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithDartKeywordFieldTwinNormal
       dco_decode_struct_with_dart_keyword_field_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithDartKeywordFieldTwinNormal(
@@ -56354,7 +56359,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithDartKeywordFieldTwinRustAsync
       dco_decode_struct_with_dart_keyword_field_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithDartKeywordFieldTwinRustAsync(
@@ -56367,7 +56372,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithDartKeywordFieldTwinSync
       dco_decode_struct_with_dart_keyword_field_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithDartKeywordFieldTwinSync(
@@ -56380,7 +56385,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithDeepCollectionEqualityTwinNormal
       dco_decode_struct_with_deep_collection_equality_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 6)
       throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
     return StructWithDeepCollectionEqualityTwinNormal(
@@ -56398,7 +56403,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_struct_with_deep_collection_equality_twin_rust_async(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 6)
       throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
     return StructWithDeepCollectionEqualityTwinRustAsync(
@@ -56415,7 +56420,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithDeepCollectionEqualityTwinSync
       dco_decode_struct_with_deep_collection_equality_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 6)
       throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
     return StructWithDeepCollectionEqualityTwinSync(
@@ -56432,7 +56437,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithEnumTwinNormal dco_decode_struct_with_enum_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithEnumTwinNormal(
@@ -56445,7 +56450,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithEnumTwinRustAsync dco_decode_struct_with_enum_twin_rust_async(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithEnumTwinRustAsync(
@@ -56457,7 +56462,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   StructWithEnumTwinSync dco_decode_struct_with_enum_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithEnumTwinSync(
@@ -56471,7 +56476,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_struct_with_explicit_auto_opaque_field_twin_normal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithExplicitAutoOpaqueFieldTwinNormal(
@@ -56487,7 +56492,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_struct_with_explicit_auto_opaque_field_twin_rust_async(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithExplicitAutoOpaqueFieldTwinRustAsync(
@@ -56502,7 +56507,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithExplicitAutoOpaqueFieldTwinSync
       dco_decode_struct_with_explicit_auto_opaque_field_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithExplicitAutoOpaqueFieldTwinSync(
@@ -56517,7 +56522,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithFieldRenameTwinNormal
       dco_decode_struct_with_field_rename_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructWithFieldRenameTwinNormal(
@@ -56529,7 +56534,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithFieldRenameTwinRustAsync
       dco_decode_struct_with_field_rename_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructWithFieldRenameTwinRustAsync(
@@ -56541,7 +56546,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithFieldRenameTwinSync dco_decode_struct_with_field_rename_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructWithFieldRenameTwinSync(
@@ -56553,7 +56558,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithGoodAndOpaqueFieldTwinNormal
       dco_decode_struct_with_good_and_opaque_field_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return StructWithGoodAndOpaqueFieldTwinNormal(
@@ -56572,7 +56577,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_struct_with_good_and_opaque_field_twin_rust_async(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return StructWithGoodAndOpaqueFieldTwinRustAsync(
@@ -56590,7 +56595,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithGoodAndOpaqueFieldTwinSync
       dco_decode_struct_with_good_and_opaque_field_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return StructWithGoodAndOpaqueFieldTwinSync(
@@ -56607,7 +56612,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   StructWithHashMap dco_decode_struct_with_hash_map(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructWithHashMap(
@@ -56619,7 +56624,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithImplBlockInAnotherFile
       dco_decode_struct_with_impl_block_in_another_file(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 0)
       throw Exception('unexpected arr length: expect 0 but see ${arr.length}');
     return StructWithImplBlockInAnotherFile();
@@ -56630,7 +56635,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_struct_with_impl_block_in_another_file_dependency(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 0)
       throw Exception('unexpected arr length: expect 0 but see ${arr.length}');
     return StructWithImplBlockInAnotherFileDependency();
@@ -56640,7 +56645,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithOneFieldTwinNormal dco_decode_struct_with_one_field_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructWithOneFieldTwinNormal(
@@ -56652,7 +56657,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithOneFieldTwinRustAsync
       dco_decode_struct_with_one_field_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructWithOneFieldTwinRustAsync(
@@ -56664,7 +56669,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithOneFieldTwinSync dco_decode_struct_with_one_field_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructWithOneFieldTwinSync(
@@ -56675,7 +56680,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   StructWithRawNameField dco_decode_struct_with_raw_name_field(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructWithRawNameField(
@@ -56688,7 +56693,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_struct_with_rust_auto_opaque_field_with_many_derive(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructWithRustAutoOpaqueFieldWithManyDerive(
@@ -56702,7 +56707,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithRustAutoOpaqueWithNonCloneData
       dco_decode_struct_with_rust_auto_opaque_with_non_clone_data(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return StructWithRustAutoOpaqueWithNonCloneData(
@@ -56717,7 +56722,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_struct_with_shallow_collection_equality_twin_normal(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 6)
       throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
     return StructWithShallowCollectionEqualityTwinNormal(
@@ -56735,7 +56740,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_struct_with_shallow_collection_equality_twin_rust_async(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 6)
       throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
     return StructWithShallowCollectionEqualityTwinRustAsync(
@@ -56753,7 +56758,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_struct_with_shallow_collection_equality_twin_sync(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 6)
       throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
     return StructWithShallowCollectionEqualityTwinSync(
@@ -56770,7 +56775,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithTwoFieldTwinNormal dco_decode_struct_with_two_field_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithTwoFieldTwinNormal(
@@ -56783,7 +56788,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithTwoFieldTwinRustAsync
       dco_decode_struct_with_two_field_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithTwoFieldTwinRustAsync(
@@ -56796,7 +56801,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithTwoFieldTwinSync dco_decode_struct_with_two_field_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return StructWithTwoFieldTwinSync(
@@ -56809,7 +56814,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithZeroFieldTwinNormal dco_decode_struct_with_zero_field_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 0)
       throw Exception('unexpected arr length: expect 0 but see ${arr.length}');
     return StructWithZeroFieldTwinNormal();
@@ -56819,7 +56824,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithZeroFieldTwinRustAsync
       dco_decode_struct_with_zero_field_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 0)
       throw Exception('unexpected arr length: expect 0 but see ${arr.length}');
     return StructWithZeroFieldTwinRustAsync();
@@ -56829,7 +56834,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StructWithZeroFieldTwinSync dco_decode_struct_with_zero_field_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 0)
       throw Exception('unexpected arr length: expect 0 but see ${arr.length}');
     return StructWithZeroFieldTwinSync();
@@ -56838,7 +56843,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   SumWithTwinNormal dco_decode_sum_with_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return SumWithTwinNormal(
@@ -56850,13 +56855,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   SumWithTwinNormalArray3 dco_decode_sum_with_twin_normal_array_3(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return SumWithTwinNormalArray3(
-        (raw as List<dynamic>).map(dco_decode_sum_with_twin_normal).toList());
+        dcoDecodeList(raw).map(dco_decode_sum_with_twin_normal).toList());
   }
 
   @protected
   SumWithTwinRustAsync dco_decode_sum_with_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return SumWithTwinRustAsync(
@@ -56868,15 +56873,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   SumWithTwinRustAsyncArray3 dco_decode_sum_with_twin_rust_async_array_3(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return SumWithTwinRustAsyncArray3((raw as List<dynamic>)
-        .map(dco_decode_sum_with_twin_rust_async)
-        .toList());
+    return SumWithTwinRustAsyncArray3(
+        dcoDecodeList(raw).map(dco_decode_sum_with_twin_rust_async).toList());
   }
 
   @protected
   SumWithTwinSync dco_decode_sum_with_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return SumWithTwinSync(
@@ -56888,13 +56892,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   SumWithTwinSyncArray3 dco_decode_sum_with_twin_sync_array_3(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return SumWithTwinSyncArray3(
-        (raw as List<dynamic>).map(dco_decode_sum_with_twin_sync).toList());
+        dcoDecodeList(raw).map(dco_decode_sum_with_twin_sync).toList());
   }
 
   @protected
   TestChronoTwinNormal dco_decode_test_chrono_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return TestChronoTwinNormal(
@@ -56908,7 +56912,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   TestChronoTwinRustAsync dco_decode_test_chrono_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return TestChronoTwinRustAsync(
@@ -56922,7 +56926,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   TestChronoTwinSync dco_decode_test_chrono_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return TestChronoTwinSync(
@@ -56936,7 +56940,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   TestIdTwinNormal dco_decode_test_id_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return TestIdTwinNormal(
@@ -56948,20 +56952,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TestIdTwinNormalArray2 dco_decode_test_id_twin_normal_array_2(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return TestIdTwinNormalArray2(
-        (raw as List<dynamic>).map(dco_decode_test_id_twin_normal).toList());
+        dcoDecodeList(raw).map(dco_decode_test_id_twin_normal).toList());
   }
 
   @protected
   TestIdTwinNormalArray4 dco_decode_test_id_twin_normal_array_4(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return TestIdTwinNormalArray4(
-        (raw as List<dynamic>).map(dco_decode_test_id_twin_normal).toList());
+        dcoDecodeList(raw).map(dco_decode_test_id_twin_normal).toList());
   }
 
   @protected
   TestIdTwinRustAsync dco_decode_test_id_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return TestIdTwinRustAsync(
@@ -56973,24 +56977,22 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TestIdTwinRustAsyncArray2 dco_decode_test_id_twin_rust_async_array_2(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return TestIdTwinRustAsyncArray2((raw as List<dynamic>)
-        .map(dco_decode_test_id_twin_rust_async)
-        .toList());
+    return TestIdTwinRustAsyncArray2(
+        dcoDecodeList(raw).map(dco_decode_test_id_twin_rust_async).toList());
   }
 
   @protected
   TestIdTwinRustAsyncArray4 dco_decode_test_id_twin_rust_async_array_4(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return TestIdTwinRustAsyncArray4((raw as List<dynamic>)
-        .map(dco_decode_test_id_twin_rust_async)
-        .toList());
+    return TestIdTwinRustAsyncArray4(
+        dcoDecodeList(raw).map(dco_decode_test_id_twin_rust_async).toList());
   }
 
   @protected
   TestIdTwinSync dco_decode_test_id_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return TestIdTwinSync(
@@ -57002,20 +57004,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TestIdTwinSyncArray2 dco_decode_test_id_twin_sync_array_2(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return TestIdTwinSyncArray2(
-        (raw as List<dynamic>).map(dco_decode_test_id_twin_sync).toList());
+        dcoDecodeList(raw).map(dco_decode_test_id_twin_sync).toList());
   }
 
   @protected
   TestIdTwinSyncArray4 dco_decode_test_id_twin_sync_array_4(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return TestIdTwinSyncArray4(
-        (raw as List<dynamic>).map(dco_decode_test_id_twin_sync).toList());
+        dcoDecodeList(raw).map(dco_decode_test_id_twin_sync).toList());
   }
 
   @protected
   TestModelTwinNormal dco_decode_test_model_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return TestModelTwinNormal(
@@ -57029,7 +57031,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   TestModelTwinRustAsync dco_decode_test_model_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return TestModelTwinRustAsync(
@@ -57043,7 +57045,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   TestModelTwinSync dco_decode_test_model_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 4)
       throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return TestModelTwinSync(
@@ -57058,7 +57060,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TranslatableStructWithDartCodeTwinNormal
       dco_decode_translatable_struct_with_dart_code_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return TranslatableStructWithDartCodeTwinNormal(
@@ -57070,7 +57072,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TupleStructWithOneFieldTwinNormal
       dco_decode_tuple_struct_with_one_field_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return TupleStructWithOneFieldTwinNormal(
@@ -57082,7 +57084,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TupleStructWithOneFieldTwinRustAsync
       dco_decode_tuple_struct_with_one_field_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return TupleStructWithOneFieldTwinRustAsync(
@@ -57094,7 +57096,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TupleStructWithOneFieldTwinSync
       dco_decode_tuple_struct_with_one_field_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return TupleStructWithOneFieldTwinSync(
@@ -57106,7 +57108,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TupleStructWithTwoFieldTwinNormal
       dco_decode_tuple_struct_with_two_field_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return TupleStructWithTwoFieldTwinNormal(
@@ -57119,7 +57121,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TupleStructWithTwoFieldTwinRustAsync
       dco_decode_tuple_struct_with_two_field_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return TupleStructWithTwoFieldTwinRustAsync(
@@ -57132,7 +57134,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TupleStructWithTwoFieldTwinSync
       dco_decode_tuple_struct_with_two_field_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return TupleStructWithTwoFieldTwinSync(
@@ -57144,13 +57146,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   int dco_decode_u_16(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dcoDecodePrimitiveInt(raw);
   }
 
   @protected
   int dco_decode_u_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dcoDecodePrimitiveInt(raw);
   }
 
   @protected
@@ -57162,7 +57164,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   int dco_decode_u_8(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dcoDecodePrimitiveInt(raw);
   }
 
   @protected
@@ -57210,7 +57212,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   UserIdTwinNormal dco_decode_user_id_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return UserIdTwinNormal(
@@ -57221,7 +57223,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   UserIdTwinRustAsync dco_decode_user_id_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return UserIdTwinRustAsync(
@@ -57232,7 +57234,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   UserIdTwinSync dco_decode_user_id_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return UserIdTwinSync(
@@ -57250,7 +57252,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   VecOfPrimitivePackTwinNormal dco_decode_vec_of_primitive_pack_twin_normal(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 11)
       throw Exception('unexpected arr length: expect 11 but see ${arr.length}');
     return VecOfPrimitivePackTwinNormal(
@@ -57272,7 +57274,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   VecOfPrimitivePackTwinRustAsync
       dco_decode_vec_of_primitive_pack_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 11)
       throw Exception('unexpected arr length: expect 11 but see ${arr.length}');
     return VecOfPrimitivePackTwinRustAsync(
@@ -57294,7 +57296,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   VecOfPrimitivePackTwinSync dco_decode_vec_of_primitive_pack_twin_sync(
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 11)
       throw Exception('unexpected arr length: expect 11 but see ${arr.length}');
     return VecOfPrimitivePackTwinSync(
@@ -57315,19 +57317,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   WeekdaysTwinNormal dco_decode_weekdays_twin_normal(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return WeekdaysTwinNormal.values[raw as int];
+    return WeekdaysTwinNormal.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   WeekdaysTwinRustAsync dco_decode_weekdays_twin_rust_async(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return WeekdaysTwinRustAsync.values[raw as int];
+    return WeekdaysTwinRustAsync.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   WeekdaysTwinSync dco_decode_weekdays_twin_sync(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return WeekdaysTwinSync.values[raw as int];
+    return WeekdaysTwinSync.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected

--- a/frb_example/rust_ui_counter/ui/lib/src/rust/frb_generated.dart
+++ b/frb_example/rust_ui_counter/ui/lib/src/rust/frb_generated.dart
@@ -328,7 +328,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   AnyhowException dco_decode_AnyhowException(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AnyhowException(raw as String);
+    return AnyhowException(dcoDecodeString(raw));
   }
 
   @protected
@@ -336,7 +336,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBaseRustState(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BaseRustStateImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BaseRustStateImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -344,7 +344,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRustState(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return RustStateImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return RustStateImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -352,7 +352,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBaseRustState(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BaseRustStateImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BaseRustStateImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -360,7 +360,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRustState(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return RustStateImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return RustStateImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -368,7 +368,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRustState(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return RustStateImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return RustStateImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -376,7 +376,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBaseRustState(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BaseRustStateImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BaseRustStateImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -384,7 +384,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRustState(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return RustStateImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return RustStateImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -396,13 +396,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   String dco_decode_String(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as String;
+    return dcoDecodeString(raw);
   }
 
   @protected
   int dco_decode_i_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dcoDecodePrimitiveInt(raw);
   }
 
   @protected
@@ -414,7 +414,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   int dco_decode_u_8(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dcoDecodePrimitiveInt(raw);
   }
 
   @protected

--- a/frb_example/rust_ui_todo_list/ui/lib/src/rust/frb_generated.dart
+++ b/frb_example/rust_ui_todo_list/ui/lib/src/rust/frb_generated.dart
@@ -466,7 +466,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   AnyhowException dco_decode_AnyhowException(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return AnyhowException(raw as String);
+    return AnyhowException(dcoDecodeString(raw));
   }
 
   @protected
@@ -474,7 +474,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBaseRustState(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BaseRustStateImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BaseRustStateImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -482,7 +482,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRustState(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return RustStateImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return RustStateImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -490,7 +490,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBaseRustState(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BaseRustStateImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BaseRustStateImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -498,7 +498,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRustState(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return RustStateImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return RustStateImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -506,7 +506,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRustState(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return RustStateImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return RustStateImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -514,7 +514,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBaseRustState(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return BaseRustStateImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return BaseRustStateImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -522,7 +522,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRustState(
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return RustStateImpl.frbInternalDcoDecode(raw as List<dynamic>);
+    return RustStateImpl.frbInternalDcoDecode(dcoDecodeList(raw));
   }
 
   @protected
@@ -534,7 +534,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   String dco_decode_String(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as String;
+    return dcoDecodeString(raw);
   }
 
   @protected
@@ -546,19 +546,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   Filter dco_decode_filter(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return Filter.values[raw as int];
+    return Filter.values[dcoDecodePrimitiveInt(raw)];
   }
 
   @protected
   int dco_decode_i_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dcoDecodePrimitiveInt(raw);
   }
 
   @protected
   Item dco_decode_item(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
+    final arr = dcoDecodeList(raw);
     if (arr.length != 3)
       throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return Item(
@@ -571,7 +571,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   List<Item> dco_decode_list_item(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_item).toList();
+    return dcoDecodeList(raw).map(dco_decode_item).toList();
   }
 
   @protected
@@ -583,7 +583,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   int dco_decode_u_8(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as int;
+    return dcoDecodePrimitiveInt(raw);
   }
 
   @protected


### PR DESCRIPTION
## Summary

- Normalize DCO integers, strings, lists, records, structures, and envelopes across dart2js and dart2wasm.
- Keep generator changes, runtime helpers, focused protocol tests, and generated fixtures together.

## Validation

- Not rerun during the history-only PR split.