### PR TITLE
Normalize web callback and opaque interop

### DIFF
--- a/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/misc/ty/dart_fn.rs
+++ b/frb_codegen/src/library/codegen/generator/wire/dart/spec_generator/misc/ty/dart_fn.rs
@@ -45,7 +45,7 @@ impl WireDartGeneratorMiscTrait for DartFnWireDartGenerator<'_> {
 
         let api_impl_body = format!(
             r#"
-            Future<void> Function(int, {repeated_dynamics})
+            Future<void> Function(dynamic, {repeated_dynamics})
                 encode_{mir_safe_ident}({dart_api_type} raw) {{
               return (callId, {raw_parameter_names}) async {{
                 {decode_block}
@@ -70,7 +70,7 @@ impl WireDartGeneratorMiscTrait for DartFnWireDartGenerator<'_> {
                 final output = serializer.intoRaw();
 
                 generalizedFrbRustBinding.dartFnDeliverOutput(
-                  callId: callId, ptr: output.ptr, rustVecLen: output.rustVecLen, dataLen: output.dataLen);
+                  callId: dcoDecodePrimitiveInt(callId), ptr: output.ptr, rustVecLen: output.rustVecLen, dataLen: output.dataLen);
               }};
             }}
             "#,
@@ -119,6 +119,7 @@ mod tests {
         let output = generator.generate_extra_functions().unwrap();
         let body = &output.common.api_impl_class_body;
         assert!(body.contains(&format!("encode_{mir_safe_ident}")));
+        assert!(body.contains("Future<void> Function(dynamic, dynamic)"));
         assert!(body.contains("final arg0 = dco_decode_i_32(rawArg0);"));
         assert!(body.contains("try {"));
         assert!(body.contains("} catch (e, s) {"));
@@ -133,5 +134,6 @@ mod tests {
             DartFnOutputAction::Error as i32
         )));
         assert!(body.contains("generalizedFrbRustBinding.dartFnDeliverOutput("));
+        assert!(body.contains("callId: dcoDecodePrimitiveInt(callId)"));
     }
 }

--- a/frb_dart/lib/src/dart_opaque/_common.dart
+++ b/frb_dart/lib/src/dart_opaque/_common.dart
@@ -8,6 +8,8 @@ Object decodeDartOpaqueCommon(
 ) {
   if (raw is BigInt) {
     raw = raw.toInt();
+  } else if (raw is double && raw.isFinite && raw == raw.truncateToDouble()) {
+    raw = raw.toInt();
   }
   return generalizedFrbRustBinding.dartOpaqueRust2DartDecode(raw);
 }

--- a/frb_dart/lib/src/generalized_frb_rust_binding/_web.dart
+++ b/frb_dart/lib/src/generalized_frb_rust_binding/_web.dart
@@ -79,13 +79,13 @@ class GeneralizedFrbRustBinding {
     Object object,
     NativePortType dartHandlerPort,
   ) => _wasmBindgen.frb_dart_opaque_dart2rust_encode(
-    object.jsify()!,
+    object.toExternalReference,
     dartHandlerPort,
   );
 
   /// {@macro flutter_rust_bridge.only_for_generated_code}
   Object dartOpaqueRust2DartDecode(int ptr) =>
-      _wasmBindgen.frb_dart_opaque_rust2dart_decode(ptr).dartify()!;
+      _wasmBindgen.frb_dart_opaque_rust2dart_decode(ptr).toDartObject!;
 
   /// {@macro flutter_rust_bridge.only_for_generated_code}
   void dartOpaqueDropThreadBoxPersistentHandle(int ptr) =>
@@ -141,13 +141,15 @@ extension type _JSWasmBindgen(JSObject _) implements JSObject {
   /// {@macro flutter_rust_bridge.only_for_generated_code}
   @JS("frb_dart_opaque_dart2rust_encode")
   external int frb_dart_opaque_dart2rust_encode(
-    JSAny object,
+    ExternalDartReference<Object?> object,
     NativePortType dartHandlerPort,
   );
 
   /// {@macro flutter_rust_bridge.only_for_generated_code}
   @JS("frb_dart_opaque_rust2dart_decode")
-  external JSAny frb_dart_opaque_rust2dart_decode(int ptr);
+  external ExternalDartReference<Object?> frb_dart_opaque_rust2dart_decode(
+    int ptr,
+  );
 
   /// {@macro flutter_rust_bridge.only_for_generated_code}
   @JS("frb_dart_opaque_drop_thread_box_persistent_handle")

--- a/frb_dart/lib/src/generalized_isolate/_web.dart
+++ b/frb_dart/lib/src/generalized_isolate/_web.dart
@@ -6,6 +6,8 @@ import 'dart:async';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated_web.dart';
 import 'package:web/web.dart' as web;
 
+dynamic _extractData(web.MessageEvent event) => event.data.dartify();
+
 /// {@macro flutter_rust_bridge.internal}
 String serializeNativePort(NativePortType port) {
   if (port.isA<web.BroadcastChannel>()) {
@@ -52,8 +54,6 @@ class ReceivePort extends Stream<dynamic> {
     return subscription;
   }
 
-  static dynamic _extractData(web.MessageEvent event) => event.data;
-
   /// {@macro flutter_rust_bridge.same_as_native}
   SendPort get sendPort => _rawReceivePort.sendPort;
 
@@ -73,7 +73,7 @@ class RawReceivePort {
 
   /// {@macro flutter_rust_bridge.same_as_native}
   set handler(Function(dynamic) handler) {
-    _webReceivePort._onMessage.listen((event) => handler(event.data));
+    _webReceivePort._onMessage.listen((event) => handler(_extractData(event)));
     _webReceivePort._start();
   }
 

--- a/frb_dart/lib/src/main_components/port_manager.dart
+++ b/frb_dart/lib/src/main_components/port_manager.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_rust_bridge/src/generalized_frb_rust_binding/generalized_frb_rust_binding.dart';
 import 'package:flutter_rust_bridge/src/main_components/handler.dart';
+import 'package:flutter_rust_bridge/src/manual_impl/manual_impl.dart';
 import 'package:flutter_rust_bridge/src/platform_types/platform_types.dart';
 import 'package:flutter_rust_bridge/src/utils/base_lazy_port_manager.dart';
 
@@ -37,11 +38,11 @@ class DartHandlerPortManager extends BaseLazyPortManager {
 
   @override
   void onData(covariant List<dynamic> message) {
-    switch (message[0]) {
+    switch (dcoDecodePrimitiveInt(message[0])) {
       case _DartHandlerPortAction.dartOpaqueDrop:
         assert(message.length == 2);
         _generalizedFrbRustBinding.dartOpaqueDropThreadBoxPersistentHandle(
-          message[1],
+          dcoDecodePrimitiveInt(message[1]),
         );
       case _DartHandlerPortAction.dartFnInvoke:
         _handler.dartFnInvoke(message.sublist(1), _generalizedFrbRustBinding);

--- a/frb_dart/lib/src/misc/rust_opaque.dart
+++ b/frb_dart/lib/src/misc/rust_opaque.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_rust_bridge/src/rust_arc/_common.dart';
+import 'package:flutter_rust_bridge/src/manual_impl/manual_impl.dart';
 import 'package:meta/meta.dart';
 
 /// {@macro flutter_rust_bridge.only_for_generated_code}
@@ -27,8 +28,8 @@ abstract class RustOpaque implements RustOpaqueInterface {
     List<dynamic> wire,
     RustArcStaticData staticData,
   ) : this._fromRaw(
-        ptr: wire[0],
-        externalSizeOnNative: wire[1],
+        ptr: dcoDecodePrimitiveInt(wire[0]),
+        externalSizeOnNative: dcoDecodePrimitiveInt(wire[1]),
         staticData: staticData,
       );
 


### PR DESCRIPTION
## Summary

- Normalize Dart callback IDs, opaque references, and Web message data across compiler representations.
- Build on the DCO normalization layer below this PR.

## Validation

- Not rerun during the history-only PR split.