### PR TITLE
Support Dart Wasm output in build-web

### DIFF
--- a/frb_dart/lib/src/cli/build_web/entrypoint.dart
+++ b/frb_dart/lib/src/cli/build_web/entrypoint.dart
@@ -1,6 +1,7 @@
 import 'package:args/command_runner.dart';
 import 'package:build_cli_annotations/build_cli_annotations.dart';
 import 'package:flutter_rust_bridge/src/cli/build_web/executor.dart';
+import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
 
 part 'entrypoint.g.dart';
@@ -15,7 +16,7 @@ class BuildWebCommand extends _$ConfigCommand<void> {
 
   @override
   Future<void> run() async {
-    await executeBuildWeb(_parseConfigToArgs(_options));
+    await executeBuildWeb(parseBuildWebConfigToArgs(_options));
   }
 }
 
@@ -76,6 +77,13 @@ class Config {
   )
   late String? dartCompileJsEntrypoint;
 
+  /// {@macro flutter_rust_bridge.cli}
+  @CliOption(
+    help:
+        'If specified, compile Dart into WebAssembly and use this option as entrypoint',
+  )
+  late String? dartCompileWasmEntrypoint;
+
   // migrate to `wasmPackArgs`
   // /// {@macro flutter_rust_bridge.cli}
   // @CliOption(
@@ -106,9 +114,11 @@ class Config {
   // late bool referenceTypes;
 }
 
-BuildWebArgs _parseConfigToArgs(Config config) {
+/// Converts parsed CLI configuration to executor arguments.
+@visibleForTesting
+BuildWebArgs parseBuildWebConfigToArgs(Config config) {
   return BuildWebArgs(
-    output: config.output ?? _fallbackOutput(dartRoot: config.dartRoot),
+    output: config.output ?? _fallbackOutput(dartRoot: config.dartRoot ?? '.'),
     release: config.release,
     verbose: config.verbose,
     rustCrateDir: config.rustRoot,
@@ -117,8 +127,9 @@ BuildWebArgs _parseConfigToArgs(Config config) {
     wasmPackRustupToolchain: config.wasmPackRustupToolchain,
     wasmPackRustflags: config.wasmPackRustflags,
     dartCompileJsEntrypoint: config.dartCompileJsEntrypoint,
+    dartCompileWasmEntrypoint: config.dartCompileWasmEntrypoint,
   );
 }
 
-String _fallbackOutput({required String? dartRoot}) =>
-    path.join(dartRoot!, 'web');
+String _fallbackOutput({required String dartRoot}) =>
+    path.join(dartRoot, 'web');

--- a/frb_dart/lib/src/cli/build_web/entrypoint.g.dart
+++ b/frb_dart/lib/src/cli/build_web/entrypoint.g.dart
@@ -18,7 +18,9 @@ Config _$parseConfigResult(ArgResults result) => Config()
   ..wasmBindgenArgs = result['wasm-bindgen-args'] as List<String>
   ..wasmPackRustupToolchain = result['wasm-pack-rustup-toolchain'] as String?
   ..wasmPackRustflags = result['wasm-pack-rustflags'] as String?
-  ..dartCompileJsEntrypoint = result['dart-compile-js-entrypoint'] as String?;
+  ..dartCompileJsEntrypoint = result['dart-compile-js-entrypoint'] as String?
+  ..dartCompileWasmEntrypoint =
+      result['dart-compile-wasm-entrypoint'] as String?;
 
 ArgParser _$populateConfigParser(ArgParser parser) => parser
   ..addOption('dart-root', help: 'Root folder of dart package')
@@ -49,6 +51,11 @@ ArgParser _$populateConfigParser(ArgParser parser) => parser
     'dart-compile-js-entrypoint',
     help:
         'If specified, compile Dart into JavaScript and use this option as entrypoint',
+  )
+  ..addOption(
+    'dart-compile-wasm-entrypoint',
+    help:
+        'If specified, compile Dart into WebAssembly and use this option as entrypoint',
   );
 
 final _$parserForConfig = _$populateConfigParser(ArgParser());

--- a/frb_dart/lib/src/cli/build_web/executor.dart
+++ b/frb_dart/lib/src/cli/build_web/executor.dart
@@ -7,6 +7,34 @@ import 'package:flutter_rust_bridge/src/cli/cli_utils.dart';
 import 'package:flutter_rust_bridge/src/cli/run_command.dart';
 import 'package:meta/meta.dart';
 
+const _cargoLlvmCovEnvKeys = [
+  'LLVM_PROFILE_FILE',
+  '__CARGO_LLVM_COV_RUSTC_WRAPPER',
+  '__CARGO_LLVM_COV_RUSTC_WRAPPER_RUSTFLAGS',
+  '__CARGO_LLVM_COV_RUSTC_WRAPPER_CRATE_NAMES',
+  'RUSTC_WRAPPER',
+  'CARGO_LLVM_COV',
+  'CARGO_LLVM_COV_SHOW_ENV',
+  'CARGO_LLVM_COV_TARGET_DIR',
+  'CARGO_LLVM_COV_BUILD_DIR',
+];
+
+/// Command runner used by build-web, injectable by tests.
+@visibleForTesting
+typedef BuildWebCommandRunner =
+    Future<RunCommandOutput> Function(
+      String command,
+      List<String> arguments, {
+      String? pwd,
+      Map<String, String>? env,
+      bool shell,
+      bool silent,
+      bool? checkExitCode,
+      bool printCommandInStderr,
+      List<String> removedParentEnvKeys,
+      Duration? timeout,
+    });
+
 /// {@macro flutter_rust_bridge.cli}
 class BuildWebArgs {
   /// {@macro flutter_rust_bridge.cli}
@@ -37,6 +65,9 @@ class BuildWebArgs {
   final String? dartCompileJsEntrypoint;
 
   /// {@macro flutter_rust_bridge.cli}
+  final String? dartCompileWasmEntrypoint;
+
+  /// {@macro flutter_rust_bridge.cli}
   final List<String> features;
 
   /// {@macro flutter_rust_bridge.cli}
@@ -50,6 +81,7 @@ class BuildWebArgs {
     required this.wasmPackRustupToolchain,
     required this.wasmPackRustflags,
     required this.dartCompileJsEntrypoint,
+    this.dartCompileWasmEntrypoint,
     this.features = const [],
   });
 }
@@ -60,47 +92,71 @@ extension on BuildWebArgs {
   String get outputWasm => '$output/pkg';
 
   String get outputDart => '$output/main.dart.js';
+
+  String get outputDartWasm => '$output/main.dart.wasm';
 }
 
 /// {@macro flutter_rust_bridge.cli}
-Future<void> executeBuildWeb(BuildWebArgs args) async {
-  await _sanityChecks(args);
+Future<void> executeBuildWeb(
+  BuildWebArgs args, {
+  @visibleForTesting BuildWebCommandRunner runCommandImpl = runCommand,
+}) async {
+  await _sanityChecks(args, runCommandImpl: runCommandImpl);
 
   final rustCrateName = await _getRustCreateName(
     rustCrateDir: args.rustCrateDir,
+    runCommandImpl: runCommandImpl,
   );
 
-  await _executeWasmPack(args, rustCrateName: rustCrateName);
+  await _executeWasmPack(
+    args,
+    rustCrateName: rustCrateName,
+    runCommandImpl: runCommandImpl,
+  );
 
   if (args.enableWasmBindgen) {
-    await _executeWasmBindgen(args, rustCrateName: rustCrateName);
+    await _executeWasmBindgen(
+      args,
+      rustCrateName: rustCrateName,
+      runCommandImpl: runCommandImpl,
+    );
   }
 
   if (args.dartCompileJsEntrypoint != null) {
-    await _executeDartCompile(args);
+    await _executeDartCompileJs(args, runCommandImpl: runCommandImpl);
+  }
+
+  if (args.dartCompileWasmEntrypoint != null) {
+    await _executeDartCompileWasm(args, runCommandImpl: runCommandImpl);
   }
 }
 
 final _commandWhich = Platform.isWindows ? 'where.exe' : 'which';
 
-Future<void> _sanityChecks(BuildWebArgs args) async {
+Future<void> _sanityChecks(
+  BuildWebArgs args, {
+  required BuildWebCommandRunner runCommandImpl,
+}) async {
   await _ensurePackageInstalled(
     binaryName: 'wasm-pack',
-    install: () async => await runCommand('cargo', ['install', 'wasm-pack']),
+    install: () async =>
+        await runCommandImpl('cargo', ['install', 'wasm-pack']),
     hint:
         'wasm-pack is required, but not found in the path.\n'
         'Please install wasm-pack by following the instructions at https://rustwasm.github.io/wasm-pack/\n'
         'or running `cargo install wasm-pack`.',
+    runCommandImpl: runCommandImpl,
   );
 
   if (args.enableWasmBindgen) {
     await _ensurePackageInstalled(
       binaryName: 'wasm-bindgen',
       install: () async =>
-          await runCommand('cargo', ['install', '-f', 'wasm-bindgen-cli']),
+          await runCommandImpl('cargo', ['install', '-f', 'wasm-bindgen-cli']),
       hint:
           'wasm-bindgen flags are enabled, but wasm-bindgen could not be found in the path.\n'
           'Please install wasm-bindgen using `cargo install -f wasm-bindgen-cli`.',
+      runCommandImpl: runCommandImpl,
     );
   }
 
@@ -117,10 +173,11 @@ Future<void> _ensurePackageInstalled({
   required String binaryName,
   required Future<void> Function() install,
   required String hint,
+  required BuildWebCommandRunner runCommandImpl,
 }) async {
   Future<bool> isBinaryInstalled() async {
     try {
-      await runCommand(_commandWhich, [binaryName]);
+      await runCommandImpl(_commandWhich, [binaryName]);
       return true;
     } catch (_) {
       return false;
@@ -137,9 +194,12 @@ Future<void> _ensurePackageInstalled({
   }
 }
 
-Future<String> _getRustCreateName({required String rustCrateDir}) async {
+Future<String> _getRustCreateName({
+  required String rustCrateDir,
+  required BuildWebCommandRunner runCommandImpl,
+}) async {
   final manifest = jsonDecode(
-    (await runCommand(
+    (await runCommandImpl(
       'cargo',
       ['read-manifest'],
       pwd: rustCrateDir,
@@ -158,6 +218,7 @@ Future<String> _getRustCreateName({required String rustCrateDir}) async {
 Future<void> _executeWasmPack(
   BuildWebArgs args, {
   required String rustCrateName,
+  required BuildWebCommandRunner runCommandImpl,
 }) async {
   final rustflagsResolution = computeWasmPackRustflagsResolution(
     argsOverride: args.wasmPackRustflags,
@@ -166,7 +227,7 @@ Future<void> _executeWasmPack(
     print(rustflagsResolution.warning);
   }
 
-  await runCommand(
+  await runCommandImpl(
     'wasm-pack',
     [
       'build',
@@ -193,6 +254,9 @@ Future<void> _executeWasmPack(
       'RUSTFLAGS': rustflagsResolution.rustflags,
       if (stdout.supportsAnsiEscapes) 'CARGO_TERM_COLOR': 'always',
     },
+    removedParentEnvKeys: Platform.environment['CARGO_LLVM_COV'] == '1'
+        ? _cargoLlvmCovEnvKeys
+        : const [],
   );
 }
 
@@ -253,8 +317,9 @@ WasmPackRustflagsResolution computeWasmPackRustflagsResolution({
 Future<void> _executeWasmBindgen(
   BuildWebArgs args, {
   required String rustCrateName,
+  required BuildWebCommandRunner runCommandImpl,
 }) async {
-  await runCommand('wasm-bindgen', [
+  await runCommandImpl('wasm-bindgen', [
     '${args.rustCrateDir}/target/wasm32-unknown-unknown/${args.release ? 'release' : 'debug'}/$rustCrateName.wasm',
     '--out-dir',
     args.outputWasm,
@@ -268,8 +333,11 @@ Future<void> _executeWasmBindgen(
   ]);
 }
 
-Future<void> _executeDartCompile(BuildWebArgs args) async {
-  await runCommand('dart', [
+Future<void> _executeDartCompileJs(
+  BuildWebArgs args, {
+  required BuildWebCommandRunner runCommandImpl,
+}) async {
+  await runCommandImpl('dart', [
     'compile',
     'js',
     '-o',
@@ -278,5 +346,19 @@ Future<void> _executeDartCompile(BuildWebArgs args) async {
     if (stdout.supportsAnsiEscapes) '--enable-diagnostic-colors',
     if (args.verbose) '--verbose',
     args.dartCompileJsEntrypoint!,
+  ]);
+}
+
+Future<void> _executeDartCompileWasm(
+  BuildWebArgs args, {
+  required BuildWebCommandRunner runCommandImpl,
+}) async {
+  await runCommandImpl('dart', [
+    'compile',
+    'wasm',
+    '-o',
+    args.outputDartWasm,
+    if (args.verbose) '--verbose',
+    args.dartCompileWasmEntrypoint!,
   ]);
 }

--- a/frb_dart/lib/src/cli/build_web/executor.dart
+++ b/frb_dart/lib/src/cli/build_web/executor.dart
@@ -81,7 +81,7 @@ class BuildWebArgs {
     required this.wasmPackRustupToolchain,
     required this.wasmPackRustflags,
     required this.dartCompileJsEntrypoint,
-    this.dartCompileWasmEntrypoint,
+    required this.dartCompileWasmEntrypoint,
     this.features = const [],
   });
 }

--- a/frb_dart/test/build_web_entrypoint_test.dart
+++ b/frb_dart/test/build_web_entrypoint_test.dart
@@ -1,0 +1,31 @@
+@TestOn('vm')
+import 'package:flutter_rust_bridge/src/cli/build_web/entrypoint.dart';
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+
+void main() {
+  test('build-web parser forwards Dart wasm entrypoint', () {
+    final config = parseConfig([
+      '--dart-root',
+      'example',
+      '--dart-compile-js-entrypoint',
+      'web/main.dart',
+      '--dart-compile-wasm-entrypoint',
+      'web/main.dart',
+    ]);
+
+    final args = parseBuildWebConfigToArgs(config);
+
+    expect(args.output, path.join('example', 'web'));
+    expect(args.dartCompileJsEntrypoint, 'web/main.dart');
+    expect(args.dartCompileWasmEntrypoint, 'web/main.dart');
+  });
+
+  test('build-web parser falls back to current directory web output', () {
+    final config = parseConfig([]);
+
+    final args = parseBuildWebConfigToArgs(config);
+
+    expect(args.output, path.join('.', 'web'));
+  });
+}

--- a/frb_dart/test/build_web_executor_test.dart
+++ b/frb_dart/test/build_web_executor_test.dart
@@ -1,5 +1,9 @@
 @TestOn('vm')
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:flutter_rust_bridge/src/cli/build_web/executor.dart';
+import 'package:flutter_rust_bridge/src/cli/run_command.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -76,4 +80,326 @@ void main() {
       expect(resolution.warning, isNull);
     },
   );
+
+  test(
+    'executeBuildWeb compiles configured Dart JavaScript and wasm outputs',
+    () async {
+      final crateDir = await Directory.systemTemp.createTemp(
+        'frb_build_web_test_',
+      );
+      addTearDown(() async {
+        if (await crateDir.exists()) {
+          await crateDir.delete(recursive: true);
+        }
+      });
+      await File('${crateDir.path}/Cargo.toml').writeAsString('[package]\n');
+      final calls = <_CommandCall>[];
+
+      await executeBuildWeb(
+        BuildWebArgs(
+          output: 'web',
+          release: true,
+          verbose: true,
+          rustCrateDir: crateDir.path,
+          cargoBuildArgs: const ['--features', 'demo_feature'],
+          wasmBindgenArgs: const [],
+          wasmPackRustupToolchain: null,
+          wasmPackRustflags: null,
+          dartCompileJsEntrypoint: 'web/main.dart',
+          dartCompileWasmEntrypoint: 'web/main.dart',
+        ),
+        runCommandImpl:
+            (
+              command,
+              arguments, {
+              pwd,
+              env,
+              shell = true,
+              silent = false,
+              checkExitCode,
+              printCommandInStderr = false,
+              removedParentEnvKeys = const [],
+              timeout,
+            }) async {
+              calls.add(
+                _CommandCall(
+                  command: command,
+                  arguments: arguments,
+                  pwd: pwd,
+                  env: env,
+                  silent: silent,
+                  removedParentEnvKeys: removedParentEnvKeys,
+                ),
+              );
+              if (command == 'cargo' && arguments.first == 'read-manifest') {
+                return RunCommandOutput(
+                  stdout: jsonEncode({
+                    'targets': [
+                      {
+                        'kind': ['cdylib'],
+                        'name': 'demo_crate',
+                      },
+                    ],
+                  }),
+                  stderr: '',
+                  exitCode: 0,
+                );
+              }
+              return const RunCommandOutput(
+                stdout: '',
+                stderr: '',
+                exitCode: 0,
+              );
+            },
+      );
+
+      expect(calls.map((call) => call.command), [
+        isNotEmpty,
+        'cargo',
+        'wasm-pack',
+        'dart',
+        'dart',
+      ]);
+
+      final wasmPack = calls.singleWhere((call) => call.command == 'wasm-pack');
+      expect(wasmPack.arguments, containsAllInOrder(['-d', 'web/pkg']));
+      expect(
+        wasmPack.arguments,
+        containsAllInOrder(['--out-name', 'demo_crate']),
+      );
+      expect(wasmPack.arguments, containsAll(['--features', 'demo_feature']));
+      expect(wasmPack.env, containsPair('RUSTUP_TOOLCHAIN', 'nightly'));
+      expect(
+        wasmPack.env,
+        containsPair('RUSTFLAGS', buildWebDefaultWasmPackRustflags),
+      );
+      expect(wasmPack.removedParentEnvKeys, contains('LLVM_PROFILE_FILE'));
+
+      final dartCompiles = calls
+          .where((call) => call.command == 'dart')
+          .map((call) => call.arguments)
+          .toList();
+      expect(dartCompiles, [
+        [
+          'compile',
+          'js',
+          '-o',
+          'web/main.dart.js',
+          '-O2',
+          if (stdout.supportsAnsiEscapes) '--enable-diagnostic-colors',
+          '--verbose',
+          'web/main.dart',
+        ],
+        [
+          'compile',
+          'wasm',
+          '-o',
+          'web/main.dart.wasm',
+          '--verbose',
+          'web/main.dart',
+        ],
+      ]);
+    },
+  );
+
+  test('executeBuildWeb runs wasm-bindgen when flags are configured', () async {
+    final crateDir = await Directory.systemTemp.createTemp(
+      'frb_build_web_test_',
+    );
+    addTearDown(() async {
+      if (await crateDir.exists()) {
+        await crateDir.delete(recursive: true);
+      }
+    });
+    await File('${crateDir.path}/Cargo.toml').writeAsString('[package]\n');
+    final calls = <_CommandCall>[];
+
+    await executeBuildWeb(
+      BuildWebArgs(
+        output: 'web',
+        release: false,
+        verbose: false,
+        rustCrateDir: crateDir.path,
+        cargoBuildArgs: const [],
+        wasmBindgenArgs: const ['--weak-refs'],
+        wasmPackRustupToolchain: 'nightly-2026-01-01',
+        wasmPackRustflags: '-C target-feature=+atomics',
+        dartCompileJsEntrypoint: null,
+      ),
+      runCommandImpl:
+          (
+            command,
+            arguments, {
+            pwd,
+            env,
+            shell = true,
+            silent = false,
+            checkExitCode,
+            printCommandInStderr = false,
+            removedParentEnvKeys = const [],
+            timeout,
+          }) async {
+            calls.add(
+              _CommandCall(
+                command: command,
+                arguments: arguments,
+                pwd: pwd,
+                env: env,
+                silent: silent,
+                removedParentEnvKeys: removedParentEnvKeys,
+              ),
+            );
+            if (command == 'cargo' && arguments.first == 'read-manifest') {
+              return RunCommandOutput(
+                stdout: jsonEncode({
+                  'targets': [
+                    {
+                      'kind': ['cdylib'],
+                      'name': 'demo_crate',
+                    },
+                  ],
+                }),
+                stderr: '',
+                exitCode: 0,
+              );
+            }
+            return const RunCommandOutput(stdout: '', stderr: '', exitCode: 0);
+          },
+    );
+
+    final wasmPack = calls.singleWhere((call) => call.command == 'wasm-pack');
+    expect(wasmPack.arguments, contains('--dev'));
+    expect(
+      wasmPack.env,
+      containsPair('RUSTUP_TOOLCHAIN', 'nightly-2026-01-01'),
+    );
+    expect(
+      wasmPack.env,
+      containsPair('RUSTFLAGS', '-C target-feature=+atomics'),
+    );
+
+    final wasmBindgen = calls.singleWhere(
+      (call) => call.command == 'wasm-bindgen',
+    );
+    expect(
+      wasmBindgen.arguments,
+      containsAllInOrder([
+        '${crateDir.path}/target/wasm32-unknown-unknown/debug/demo_crate.wasm',
+        '--out-dir',
+        'web/pkg',
+        '--weak-refs',
+      ]),
+    );
+    expect(calls.where((call) => call.command == 'dart'), isEmpty);
+  });
+
+  test(
+    'executeBuildWeb installs wasm-bindgen when configured binary is missing',
+    () async {
+      final crateDir = await Directory.systemTemp.createTemp(
+        'frb_build_web_test_',
+      );
+      addTearDown(() async {
+        if (await crateDir.exists()) {
+          await crateDir.delete(recursive: true);
+        }
+      });
+      await File('${crateDir.path}/Cargo.toml').writeAsString('[package]\n');
+      final calls = <_CommandCall>[];
+      var wasmBindgenCheckCount = 0;
+
+      await executeBuildWeb(
+        BuildWebArgs(
+          output: 'web',
+          release: false,
+          verbose: false,
+          rustCrateDir: crateDir.path,
+          cargoBuildArgs: const [],
+          wasmBindgenArgs: const ['--weak-refs'],
+          wasmPackRustupToolchain: null,
+          wasmPackRustflags: null,
+          dartCompileJsEntrypoint: null,
+        ),
+        runCommandImpl:
+            (
+              command,
+              arguments, {
+              pwd,
+              env,
+              shell = true,
+              silent = false,
+              checkExitCode,
+              printCommandInStderr = false,
+              removedParentEnvKeys = const [],
+              timeout,
+            }) async {
+              calls.add(
+                _CommandCall(
+                  command: command,
+                  arguments: arguments,
+                  pwd: pwd,
+                  env: env,
+                  silent: silent,
+                  removedParentEnvKeys: removedParentEnvKeys,
+                ),
+              );
+              if (arguments.length == 1 && arguments.first == 'wasm-bindgen') {
+                wasmBindgenCheckCount++;
+                if (wasmBindgenCheckCount == 1) {
+                  throw Exception('wasm-bindgen missing');
+                }
+              }
+              if (command == 'cargo' && arguments.first == 'read-manifest') {
+                return RunCommandOutput(
+                  stdout: jsonEncode({
+                    'targets': [
+                      {
+                        'kind': ['cdylib'],
+                        'name': 'demo_crate',
+                      },
+                    ],
+                  }),
+                  stderr: '',
+                  exitCode: 0,
+                );
+              }
+              return const RunCommandOutput(
+                stdout: '',
+                stderr: '',
+                exitCode: 0,
+              );
+            },
+      );
+
+      expect(wasmBindgenCheckCount, 2);
+      expect(
+        calls
+            .where((call) => call.command == 'cargo')
+            .map((call) => call.arguments),
+        contains(equals(['install', '-f', 'wasm-bindgen-cli'])),
+      );
+      expect(
+        calls.map((call) => call.command),
+        containsAllInOrder(['wasm-pack', 'wasm-bindgen']),
+      );
+    },
+  );
+}
+
+class _CommandCall {
+  final String command;
+  final List<String> arguments;
+  final String? pwd;
+  final Map<String, String>? env;
+  final bool silent;
+  final List<String> removedParentEnvKeys;
+
+  const _CommandCall({
+    required this.command,
+    required this.arguments,
+    required this.pwd,
+    required this.env,
+    required this.silent,
+    required this.removedParentEnvKeys,
+  });
 }

--- a/frb_dart/test/build_web_executor_test.dart
+++ b/frb_dart/test/build_web_executor_test.dart
@@ -225,6 +225,7 @@ void main() {
         wasmPackRustupToolchain: 'nightly-2026-01-01',
         wasmPackRustflags: '-C target-feature=+atomics',
         dartCompileJsEntrypoint: null,
+        dartCompileWasmEntrypoint: null,
       ),
       runCommandImpl:
           (
@@ -319,6 +320,7 @@ void main() {
           wasmPackRustupToolchain: null,
           wasmPackRustflags: null,
           dartCompileJsEntrypoint: null,
+          dartCompileWasmEntrypoint: null,
         ),
         runCommandImpl:
             (

--- a/frb_example/gallery/web/index.html
+++ b/frb_example/gallery/web/index.html
@@ -31,29 +31,8 @@
 
   <title>frb_example_gallery</title>
   <link rel="manifest" href="manifest.json">
-
-  <script>
-    // The value below is injected by flutter build, do not touch.
-    const serviceWorkerVersion = null;
-  </script>
-  <!-- This script adds the flutter initialization JS code -->
-  <script src="flutter.js" defer></script>
 </head>
 <body>
-  <script>
-    window.addEventListener('load', function(ev) {
-      // Download main.dart.js
-      _flutter.loader.loadEntrypoint({
-        serviceWorker: {
-          serviceWorkerVersion: serviceWorkerVersion,
-        },
-        onEntrypointLoaded: function(engineInitializer) {
-          engineInitializer.initializeEngine().then(function(appRunner) {
-            appRunner.runApp();
-          });
-        }
-      });
-    });
-  </script>
+  <script src="flutter_bootstrap.js" async></script>
 </body>
 </html>

--- a/frb_rust/src/third_party/wasm_bindgen/worker_pool.rs
+++ b/frb_rust/src/third_party/wasm_bindgen/worker_pool.rs
@@ -103,7 +103,8 @@ impl WorkerPool {
             importScripts('{script_src}');
             const FRB_ACTION_PANIC = 3;
             onmessage = event => {{
-                let init = {wasm_bindgen_name}(...event.data).catch(err => {{
+                const [module, memory] = event.data;
+                let init = {wasm_bindgen_name}(module, memory).catch(err => {{
                     setTimeout(() => {{ throw err }})
                     throw err
                 }})

--- a/frb_utils/lib/src/dart_web_test_utils/run_test.dart
+++ b/frb_utils/lib/src/dart_web_test_utils/run_test.dart
@@ -38,6 +38,7 @@ Future<void> executeTestWeb(TestWebConfig config) async {
       cargoBuildArgs: cargoArgs,
       wasmBindgenArgs: [],
       dartCompileJsEntrypoint: config.entrypoint,
+      dartCompileWasmEntrypoint: null,
       // TODO make this configurable later
       wasmPackRustupToolchain: 'nightly-2025-02-01',
       wasmPackRustflags: null,

--- a/website/docs/generated/_frb-codegen-command-build-web.mdx
+++ b/website/docs/generated/_frb-codegen-command-build-web.mdx
@@ -2,18 +2,19 @@
 Build for web platform
 
 Usage: flutter_rust_bridge build-web [arguments]
--h, --help                          Print this usage information.
-    --dart-root                     Root folder of dart package
--c, --rust-root                     Directory of the rust package
-                                    (defaults to "rust")
--o, --output=<PKG>                  Output path
-    --release                       Compile in release mode
--v, --[no-]verbose                  Display more verbose information
-    --cargo-build-args              Arguments passed to cargo-build
-    --wasm-bindgen-args             Arguments passed to wasm-bindgen
-    --wasm-pack-rustup-toolchain    Override RUSTUP_TOOLCHAIN environment variable when running wasm-pack
-    --wasm-pack-rustflags           Override RUSTFLAGS environment variable when running wasm-pack
-    --dart-compile-js-entrypoint    If specified, compile Dart into JavaScript and use this option as entrypoint
+-h, --help                            Print this usage information.
+    --dart-root                       Root folder of dart package
+-c, --rust-root                       Directory of the rust package
+                                      (defaults to "rust")
+-o, --output=<PKG>                    Output path
+    --release                         Compile in release mode
+-v, --[no-]verbose                    Display more verbose information
+    --cargo-build-args                Arguments passed to cargo-build
+    --wasm-bindgen-args               Arguments passed to wasm-bindgen
+    --wasm-pack-rustup-toolchain      Override RUSTUP_TOOLCHAIN environment variable when running wasm-pack
+    --wasm-pack-rustflags             Override RUSTFLAGS environment variable when running wasm-pack
+    --dart-compile-js-entrypoint      If specified, compile Dart into JavaScript and use this option as entrypoint
+    --dart-compile-wasm-entrypoint    If specified, compile Dart into WebAssembly and use this option as entrypoint
 
 Run "flutter_rust_bridge help" to see global options.
 ```


### PR DESCRIPTION
## Summary

- Add Dart Wasm output support to `build-web`.
- Update wasm-bindgen, worker, gallery bootstrap, CLI help, and focused build-web tests.

## Validation

- Not rerun during the history-only PR split.