### PR TITLE
Isolate wasm-pack from cargo llvm-cov

### DIFF
--- a/frb_dart/lib/src/cli/build_web/executor.dart
+++ b/frb_dart/lib/src/cli/build_web/executor.dart
@@ -19,6 +19,13 @@ const _cargoLlvmCovEnvKeys = [
   'CARGO_LLVM_COV_BUILD_DIR',
 ];
 
+@visibleForTesting
+List<String> computeWasmPackRemovedParentEnvKeys(
+  Map<String, String> parentEnvironment,
+) => parentEnvironment['CARGO_LLVM_COV'] == '1'
+    ? _cargoLlvmCovEnvKeys
+    : const [];
+
 /// Command runner used by build-web, injectable by tests.
 @visibleForTesting
 typedef BuildWebCommandRunner =
@@ -254,9 +261,9 @@ Future<void> _executeWasmPack(
       'RUSTFLAGS': rustflagsResolution.rustflags,
       if (stdout.supportsAnsiEscapes) 'CARGO_TERM_COLOR': 'always',
     },
-    removedParentEnvKeys: Platform.environment['CARGO_LLVM_COV'] == '1'
-        ? _cargoLlvmCovEnvKeys
-        : const [],
+    removedParentEnvKeys: computeWasmPackRemovedParentEnvKeys(
+      Platform.environment,
+    ),
   );
 }
 

--- a/frb_dart/lib/src/cli/run_command.dart
+++ b/frb_dart/lib/src/cli/run_command.dart
@@ -31,11 +31,27 @@ Future<RunCommandOutput> runCommand(
   bool silent = false,
   bool? checkExitCode,
   bool printCommandInStderr = false,
+  List<String> removedParentEnvKeys = const [],
   Duration? timeout,
 }) async {
+  final removedKeysSet = removedParentEnvKeys
+      .map((key) => key.toUpperCase())
+      .toSet();
+  final processEnvironment = removedParentEnvKeys.isEmpty
+      ? env
+      : {
+          for (final entry in Platform.environment.entries)
+            if (!removedKeysSet.contains(entry.key.toUpperCase()))
+              entry.key: entry.value,
+          ...?env,
+        };
+  final displayEnvironment = removedParentEnvKeys.isEmpty
+      ? env
+      : {...?env, 'removedParentEnvKeys': removedParentEnvKeys.join(',')};
+
   // ignore: avoid_print
   (printCommandInStderr ? stderr : stdout).writeAndFlush(
-    '\x1B[1m> $command ${arguments.join(' ')}\x1B[0m (pwd: $pwd, env: $env)\n',
+    '\x1B[1m> $command ${arguments.join(' ')}\x1B[0m (pwd: $pwd, env: $displayEnvironment)\n',
   );
 
   final process = await Process.start(
@@ -43,8 +59,8 @@ Future<RunCommandOutput> runCommand(
     arguments,
     runInShell: shell,
     workingDirectory: pwd,
-    environment: env,
-    includeParentEnvironment: true,
+    environment: processEnvironment,
+    includeParentEnvironment: removedParentEnvKeys.isEmpty,
   );
 
   final stdoutText = <String>[];

--- a/frb_dart/test/build_web_executor_test.dart
+++ b/frb_dart/test/build_web_executor_test.dart
@@ -7,6 +7,28 @@ import 'package:flutter_rust_bridge/src/cli/run_command.dart';
 import 'package:test/test.dart';
 
 void main() {
+  test('wasm-pack retains unrelated wrappers without cargo llvm-cov', () {
+    expect(
+      computeWasmPackRemovedParentEnvKeys(const {
+        'RUSTC_WRAPPER': 'sccache',
+      }),
+      isEmpty,
+    );
+  });
+
+  test('wasm-pack removes cargo llvm-cov environment', () {
+    final removedKeys = computeWasmPackRemovedParentEnvKeys(const {
+      'CARGO_LLVM_COV': '1',
+      'LLVM_PROFILE_FILE': 'coverage-%p.profraw',
+      'RUSTC_WRAPPER': 'cargo-llvm-cov',
+    });
+
+    expect(
+      removedKeys,
+      containsAll(['CARGO_LLVM_COV', 'LLVM_PROFILE_FILE', 'RUSTC_WRAPPER']),
+    );
+  });
+
   test('default path returns full threaded wasm rustflags', () {
     final resolution = computeWasmPackRustflagsResolution(argsOverride: null);
 
@@ -173,7 +195,10 @@ void main() {
         wasmPack.env,
         containsPair('RUSTFLAGS', buildWebDefaultWasmPackRustflags),
       );
-      expect(wasmPack.removedParentEnvKeys, contains('LLVM_PROFILE_FILE'));
+      expect(
+        wasmPack.removedParentEnvKeys,
+        computeWasmPackRemovedParentEnvKeys(Platform.environment),
+      );
 
       final dartCompiles = calls
           .where((call) => call.command == 'dart')

--- a/frb_dart/test/run_command_test.dart
+++ b/frb_dart/test/run_command_test.dart
@@ -16,6 +16,38 @@ void main() {
   });
 
   test(
+    'runCommand can remove selected parent environment keys',
+    skip: !(Platform.isLinux || Platform.isMacOS),
+    () async {
+      final output = await runCommand(
+        '/usr/bin/env',
+        [],
+        shell: false,
+        silent: true,
+        removedParentEnvKeys: const ['PATH'],
+      );
+
+      expect(output.stdout.split('\n'), isNot(contains(startsWith('PATH='))));
+    },
+  );
+
+  test(
+    'runCommand removes selected parent environment keys case-insensitively',
+    skip: !(Platform.isLinux || Platform.isMacOS),
+    () async {
+      final output = await runCommand(
+        '/usr/bin/env',
+        [],
+        shell: false,
+        silent: true,
+        removedParentEnvKeys: const ['path'],
+      );
+
+      expect(output.stdout.split('\n'), isNot(contains(startsWith('PATH='))));
+    },
+  );
+
+  test(
     'runCommand kills the process tree when timeout expires',
     skip: !(Platform.isLinux || Platform.isMacOS),
     () async {


### PR DESCRIPTION
## Summary

- Remove cargo-llvm-cov wrapper variables before invoking wasm-pack.
- Preserve ordinary compiler wrappers such as sccache outside cargo-llvm-cov runs.

## Validation

- Not rerun during the history-only PR split.