### PR TITLE
Support dart2wasm in web test harnesses

### DIFF
--- a/frb_dart/lib/src/consts.dart
+++ b/frb_dart/lib/src/consts.dart
@@ -1,3 +1,2 @@
-/// borrowed from flutter foundation [kIsWeb](https://api.flutter.dev/flutter/foundation/kIsWeb-constant.html),
-/// but allows for using it in a Dart context alike
-const bool kIsWeb = identical(0, 0.0);
+/// Whether the current Dart compilation target is Web.
+const bool kIsWeb = bool.fromEnvironment('dart.library.js_interop');

--- a/frb_dart/test/consts_web_test.dart
+++ b/frb_dart/test/consts_web_test.dart
@@ -1,9 +1,9 @@
-@TestOn('vm')
+@TestOn('browser')
 import 'package:flutter_rust_bridge/src/consts.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('kIsWeb is false on the VM', () {
-    expect(kIsWeb, isFalse);
+  test('kIsWeb is true in browser runtimes', () {
+    expect(kIsWeb, isTrue);
   });
 }

--- a/frb_dart/test/read_buffer_test.dart
+++ b/frb_dart/test/read_buffer_test.dart
@@ -1,6 +1,5 @@
 import 'dart:typed_data';
 
-import 'package:flutter_rust_bridge/src/consts.dart';
 import 'package:flutter_rust_bridge/src/third_party/flutter_foundation_serialization/read_buffer.dart';
 import 'package:test/test.dart';
 
@@ -32,16 +31,7 @@ void main() {
   test('ReadBuffer keeps its position when a read exceeds remaining bytes', () {
     final buffer = ReadBuffer(ByteData.sublistView(Uint8List.fromList([7])));
 
-    expect(
-      buffer.getUint16,
-      throwsA(
-        predicate<Object>(
-          (error) => kIsWeb
-              ? error is ArgumentError && error is! RangeError
-              : error is RangeError,
-        ),
-      ),
-    );
+    expect(buffer.getUint16, throwsA(isA<ArgumentError>()));
     expect(buffer.getUint8(), 7);
     expect(buffer.hasRemaining, isFalse);
   });

--- a/frb_example/pure_dart/test/test_utils.dart
+++ b/frb_example/pure_dart/test/test_utils.dart
@@ -70,9 +70,11 @@ void debugPrint(String message) {
 
 Uint8List createLargeList({required int mb}) => Uint8List(1000000 * mb);
 
-/// borrowed from flutter foundation [kIsWeb](https://api.flutter.dev/flutter/foundation/kIsWeb-constant.html),
-/// but allows for using it in a Dart context alike
-const bool kIsWeb = identical(0, 0.0);
+/// Whether the current Dart compilation target is Web.
+const bool kIsWeb = bool.fromEnvironment('dart.library.js_interop');
+
+/// Whether these tests were compiled by `dart compile wasm`.
+const bool kIsDartWasm = kIsWeb && !identical(0, 0.0);
 
 String? skipWeb([String reason = 'unspecified']) =>
     kIsWeb ? 'Skipped on web (reason: $reason)' : null;
@@ -118,7 +120,11 @@ Future<void> expectRustPanicRaw(
   String mode,
   Matcher matcher,
 ) async {
-  if (kIsWeb && mode.contains('RustAsync')) {
+  if (kIsDartWasm) {
+    markTestSkipped(
+      'Skipped because Rust panics abort the WebAssembly module when tests run with dart2wasm.',
+    );
+  } else if (kIsWeb && mode.contains('RustAsync')) {
     print('expectRustPanicRaw check it should have no response');
     // expect it timeouts (hangs), instead of throws
     var bodyCompleted = false;

--- a/frb_example/pure_dart_pde/test/test_utils.dart
+++ b/frb_example/pure_dart_pde/test/test_utils.dart
@@ -72,9 +72,11 @@ void debugPrint(String message) {
 
 Uint8List createLargeList({required int mb}) => Uint8List(1000000 * mb);
 
-/// borrowed from flutter foundation [kIsWeb](https://api.flutter.dev/flutter/foundation/kIsWeb-constant.html),
-/// but allows for using it in a Dart context alike
-const bool kIsWeb = identical(0, 0.0);
+/// Whether the current Dart compilation target is Web.
+const bool kIsWeb = bool.fromEnvironment('dart.library.js_interop');
+
+/// Whether these tests were compiled by `dart compile wasm`.
+const bool kIsDartWasm = kIsWeb && !identical(0, 0.0);
 
 String? skipWeb([String reason = 'unspecified']) =>
     kIsWeb ? 'Skipped on web (reason: $reason)' : null;
@@ -120,7 +122,11 @@ Future<void> expectRustPanicRaw(
   String mode,
   Matcher matcher,
 ) async {
-  if (kIsWeb && mode.contains('RustAsync')) {
+  if (kIsDartWasm) {
+    markTestSkipped(
+      'Skipped because Rust panics abort the WebAssembly module when tests run with dart2wasm.',
+    );
+  } else if (kIsWeb && mode.contains('RustAsync')) {
     print('expectRustPanicRaw check it should have no response');
     // expect it timeouts (hangs), instead of throws
     var bodyCompleted = false;

--- a/frb_utils/lib/src/commands/test_web_command.dart
+++ b/frb_utils/lib/src/commands/test_web_command.dart
@@ -27,4 +27,7 @@ class TestWebConfig {
 
   @CliOption(help: 'Rust feature flags to set during build')
   late List<String> rustFeatures;
+
+  @CliOption(help: 'Compile the Dart test entrypoint with dart2wasm')
+  late bool wasm;
 }

--- a/frb_utils/lib/src/commands/test_web_command.g.dart
+++ b/frb_utils/lib/src/commands/test_web_command.g.dart
@@ -9,7 +9,8 @@ part of 'test_web_command.dart';
 TestWebConfig _$parseTestWebConfigResult(ArgResults result) => TestWebConfig()
   ..entrypoint = result['entrypoint'] as String
   ..headless = result['headless'] as bool
-  ..rustFeatures = result['rust-features'] as List<String>;
+  ..rustFeatures = result['rust-features'] as List<String>
+  ..wasm = result['wasm'] as bool;
 
 ArgParser _$populateTestWebConfigParser(ArgParser parser) => parser
   ..addOption(
@@ -24,6 +25,10 @@ ArgParser _$populateTestWebConfigParser(ArgParser parser) => parser
   ..addMultiOption(
     'rust-features',
     help: 'Rust feature flags to set during build',
+  )
+  ..addFlag(
+    'wasm',
+    help: 'Compile the Dart test entrypoint with dart2wasm',
   );
 
 final _$parserForTestWebConfig = _$populateTestWebConfigParser(ArgParser());

--- a/frb_utils/lib/src/dart_web_test_utils/dart_web_test_entrypoint.dart
+++ b/frb_utils/lib/src/dart_web_test_utils/dart_web_test_entrypoint.dart
@@ -1,17 +1,17 @@
 // ignore_for_file: implementation_imports, avoid_print, deprecated_member_use, deprecated_member_use_from_same_package
 
 import 'dart:async';
-import 'dart:convert';
-import 'dart:html';
+import 'dart:js_interop';
 
-import 'package:flutter_rust_bridge_utils/src/dart_web_test_utils/run_test.dart';
-import 'package:js/js.dart';
 import 'package:test_core/src/direct_run.dart';
 import 'package:test_core/src/runner/reporter/expanded.dart';
 import 'package:test_core/src/util/print_sink.dart';
 
 @JS('close')
 external void _jsClose();
+
+@JS('sendTestResult')
+external JSPromise<JSAny?> _jsSendTestResult(JSBoolean result);
 
 Future<void> dartWebTestEntrypoint(FutureOr<void> Function() testMain) async {
   final result = await directRunTests(
@@ -34,11 +34,6 @@ Future<void> dartWebTestEntrypoint(FutureOr<void> Function() testMain) async {
 }
 
 Future<void> _sendResult({required bool result}) async {
-  final url = Uri.base.replace(scheme: 'ws').toString();
-  print('sendResult result=$result to url=$url');
-
-  final socket = WebSocket(url);
-  await socket.onOpen.first;
-
-  socket.send(jsonEncode({kTestResultKey: result}));
+  print('sendResult result=$result');
+  await _jsSendTestResult(result.toJS).toDart;
 }

--- a/frb_utils/lib/src/dart_web_test_utils/run_test.dart
+++ b/frb_utils/lib/src/dart_web_test_utils/run_test.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: avoid_print, implementation_imports
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -37,8 +38,8 @@ Future<void> executeTestWeb(TestWebConfig config) async {
       rustCrateDir: '$dartRoot/rust',
       cargoBuildArgs: cargoArgs,
       wasmBindgenArgs: [],
-      dartCompileJsEntrypoint: config.entrypoint,
-      dartCompileWasmEntrypoint: null,
+      dartCompileJsEntrypoint: config.wasm ? null : config.entrypoint,
+      dartCompileWasmEntrypoint: config.wasm ? config.entrypoint : null,
       // TODO make this configurable later
       wasmPackRustupToolchain: 'nightly-2025-02-01',
       wasmPackRustflags: null,
@@ -61,12 +62,17 @@ Future<void> executeTestWeb(TestWebConfig config) async {
           await browser?.close();
         },
       ),
-      _createIndexFileHandler(),
+      _createIndexFileHandler(wasm: config.wasm),
     ],
   );
 
   print('executeTestWeb: launchBrowser');
   browser = await _launchBrowser(baseAddr: baseAddr, headless: config.headless);
+  Timer(const Duration(minutes: 10), () async {
+    print('executeTestWeb: timed out waiting for the test result');
+    await browser?.close();
+    exit(1);
+  });
 }
 
 Handler _createWebSocketHandler({
@@ -91,10 +97,12 @@ Handler _createWebSocketHandler({
 
 const _kTestEntrypointHttpName = 'test_entrypoint.html';
 
-Handler _createIndexFileHandler() => (request) {
+Handler _createIndexFileHandler({required bool wasm}) => (request) {
       if (request.url.path == _kTestEntrypointHttpName) {
         return Response.ok(
-          kTestEntrypointHtmlContent,
+          testEntrypointHtmlContent(
+            wasm ? kWasmEntrypointScript : kJsEntrypointScript,
+          ),
           headers: {HttpHeaders.contentTypeHeader: 'text/html'},
         );
       }

--- a/frb_utils/lib/src/dart_web_test_utils/static_content.dart
+++ b/frb_utils/lib/src/dart_web_test_utils/static_content.dart
@@ -47,7 +47,8 @@ const _kTestEntrypointHtmlContentTemplate = r'''
     </style>
   </body>
   <script>
-    const log = console.log;
+    const nativeLog = console.log.bind(console);
+    const nativeError = console.error.bind(console);
     const output = document.getElementById("output");
     const linkRegex = /(http:\/\/.*\.(js|wasm))/g;
     const colorize = (value) => {
@@ -74,7 +75,7 @@ const _kTestEntrypointHtmlContentTemplate = r'''
     const channel = new WebSocket(href);
     globalThis.sendTestResult = (result) =>
       new Promise((resolve, reject) => {
-        console.log(`sendResult result=${result} to url=${href}`);
+        nativeLog(`sendResult result=${result} to url=${href}`);
         const resultChannel = new WebSocket(href);
         resultChannel.onopen = () => {
           resultChannel.send(JSON.stringify({ __result__: result }));
@@ -85,17 +86,20 @@ const _kTestEntrypointHtmlContentTemplate = r'''
     console.log = (...args) => {
       for (const a of args) {
         output.appendChild(colorize(a));
-        channel.send(JSON.stringify(a));
+        if (channel.readyState === WebSocket.OPEN) {
+          channel.send(JSON.stringify(a));
+        }
       }
-      log(...args);
+      nativeLog(...args);
     };
-    const error = console.error;
     console.error = (...args) => {
       for (const a of args) {
         output.append(decorateError(a));
-        channel.send(JSON.stringify(a));
+        if (channel.readyState === WebSocket.OPEN) {
+          channel.send(JSON.stringify(a));
+        }
       }
-      error(...args);
+      nativeError(...args);
     };
   </script>
   @@ENTRYPOINT_SCRIPT@@
@@ -115,7 +119,7 @@ const kWasmEntrypointScript = r'''
       const instance = await app.instantiate({});
       instance.invokeMain();
     } catch (error) {
-      console.error(error);
+      nativeError(error);
       await globalThis.sendTestResult(false);
     }
   </script>

--- a/frb_utils/lib/src/dart_web_test_utils/static_content.dart
+++ b/frb_utils/lib/src/dart_web_test_utils/static_content.dart
@@ -1,4 +1,10 @@
-const kTestEntrypointHtmlContent = r'''
+String testEntrypointHtmlContent(String entrypointScript) =>
+    _kTestEntrypointHtmlContentTemplate.replaceFirst(
+      '@@ENTRYPOINT_SCRIPT@@',
+      entrypointScript,
+    );
+
+const _kTestEntrypointHtmlContentTemplate = r'''
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -66,6 +72,16 @@ const kTestEntrypointHtmlContent = r'''
     };
     const href = window.location.href.replace("http", "ws");
     const channel = new WebSocket(href);
+    globalThis.sendTestResult = (result) =>
+      new Promise((resolve, reject) => {
+        console.log(`sendResult result=${result} to url=${href}`);
+        const resultChannel = new WebSocket(href);
+        resultChannel.onopen = () => {
+          resultChannel.send(JSON.stringify({ __result__: result }));
+          resolve(null);
+        };
+        resultChannel.onerror = reject;
+      });
     console.log = (...args) => {
       for (const a of args) {
         output.appendChild(colorize(a));
@@ -82,6 +98,25 @@ const kTestEntrypointHtmlContent = r'''
       error(...args);
     };
   </script>
-  <script src="main.dart.js" async></script>
+  @@ENTRYPOINT_SCRIPT@@
 </html>
+''';
+
+const kJsEntrypointScript = r'''
+  <script src="main.dart.js" async></script>
+''';
+
+const kWasmEntrypointScript = r'''
+  <script type="module">
+    try {
+      const { compile } = await import("./main.dart.mjs");
+      const response = await fetch("./main.dart.wasm");
+      const app = await compile(await response.arrayBuffer());
+      const instance = await app.instantiate({});
+      instance.invokeMain();
+    } catch (error) {
+      console.error(error);
+      await globalThis.sendTestResult(false);
+    }
+  </script>
 ''';

--- a/frb_utils/test/src/dart_web_test_utils/run_test_test.dart
+++ b/frb_utils/test/src/dart_web_test_utils/run_test_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_rust_bridge_utils/src/dart_web_test_utils/run_test.dart';
+import 'package:flutter_rust_bridge_utils/src/dart_web_test_utils/static_content.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -44,6 +45,28 @@ void main() {
         }, isInContainer: true),
         '/tmp/chrome-bin',
       );
+    });
+  });
+
+  group('testEntrypointHtmlContent', () {
+    test('uses JavaScript entrypoint for dart2js runs', () {
+      final html = testEntrypointHtmlContent(kJsEntrypointScript);
+
+      expect(html, contains('sendTestResult'));
+      expect(html, contains('main.dart.js'));
+      expect(html, isNot(contains('main.dart.mjs')));
+    });
+
+    test('uses module loader for dart2wasm runs', () {
+      final html = testEntrypointHtmlContent(kWasmEntrypointScript);
+
+      expect(html, contains('sendTestResult'));
+      expect(html, contains('type="module"'));
+      expect(html, contains('main.dart.mjs'));
+      expect(html, contains('main.dart.wasm'));
+      expect(html, contains('catch (error)'));
+      expect(html, contains('sendTestResult(false)'));
+      expect(html, isNot(contains('main.dart.js')));
     });
   });
 }

--- a/frb_utils/test/src/dart_web_test_utils/run_test_test.dart
+++ b/frb_utils/test/src/dart_web_test_utils/run_test_test.dart
@@ -1,5 +1,13 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:flutter_rust_bridge_utils/src/dart_web_test_utils/run_test.dart';
 import 'package:flutter_rust_bridge_utils/src/dart_web_test_utils/static_content.dart';
+import 'package:puppeteer/puppeteer.dart' hide Response;
+import 'package:shelf/shelf.dart';
+import 'package:shelf/shelf_io.dart' as shelf_io;
+import 'package:shelf_web_socket/shelf_web_socket.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -67,6 +75,62 @@ void main() {
       expect(html, contains('catch (error)'));
       expect(html, contains('sendTestResult(false)'));
       expect(html, isNot(contains('main.dart.js')));
+    });
+
+    test('reports failure when the wasm module loader is missing', () async {
+      final result = Completer<bool>();
+      final handler = Cascade()
+          .add(
+            webSocketHandler((channel) {
+              channel.stream.listen((message) {
+                final decoded = jsonDecode(message as String);
+                if (decoded is Map && decoded.containsKey(kTestResultKey)) {
+                  result.complete(decoded[kTestResultKey] as bool);
+                }
+              });
+            }),
+          )
+          .add((request) {
+            if (request.url.path == 'test_entrypoint.html') {
+              return Response.ok(
+                testEntrypointHtmlContent(kWasmEntrypointScript),
+                headers: {HttpHeaders.contentTypeHeader: 'text/html'},
+              );
+            }
+            return Response.notFound(null);
+          })
+          .handler;
+      final server = await shelf_io.serve(
+        handler,
+        InternetAddress.loopbackIPv4,
+        0,
+      );
+      Browser? browser;
+
+      try {
+        browser = await puppeteer.launch(
+          executablePath: browserExecutablePathFromEnvironment(
+            Platform.environment,
+            isInContainer: File('/.dockerenv').existsSync(),
+          ),
+          headless: true,
+          args: File('/.dockerenv').existsSync()
+              ? ['--no-sandbox', '--disable-setuid-sandbox']
+              : [],
+        );
+        final page = await browser.newPage();
+        await page.goto(
+          'http://${server.address.address}:${server.port}/test_entrypoint.html',
+        );
+
+        expect(
+          await result.future.timeout(const Duration(seconds: 10)),
+          isFalse,
+        );
+      } finally {
+        await browser?.close();
+        await server.close(force: true);
+      }
     });
   });
 }

--- a/tools/frb_internal/lib/src/makefile_dart/test.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/test.dart
@@ -13,6 +13,7 @@ import 'package:flutter_rust_bridge_internal/src/makefile_dart/release.dart';
 import 'package:flutter_rust_bridge_internal/src/misc/dart_sanitizer_tester.dart'
     as dart_sanitizer_tester;
 import 'package:flutter_rust_bridge_internal/src/utils/codecov_transformer.dart';
+import 'package:flutter_rust_bridge_internal/src/utils/execute_process.dart';
 import 'package:flutter_rust_bridge_internal/src/utils/makefile_dart_infra.dart';
 import 'package:meta/meta.dart';
 import 'package:retry/retry.dart';
@@ -51,8 +52,8 @@ List<Command<void>> createCommands() {
     SimpleConfigCommand(
       'test-dart-web',
       testDartWeb,
-      _$populateTestDartConfigParser,
-      _$parseTestDartConfigResult,
+      _$populateTestDartWebConfigParser,
+      _$parseTestDartWebConfigResult,
     ),
     SimpleConfigCommand(
       'test-dart-valgrind',
@@ -130,6 +131,15 @@ class TestDartConfig {
 }
 
 @CliOptions()
+class TestDartWebConfig {
+  @CliOption(convert: convertConfigPackage)
+  final String package;
+  final bool wasm;
+
+  const TestDartWebConfig({required this.package, required this.wasm});
+}
+
+@CliOptions()
 class TestDartNativeConfig {
   @CliOption(convert: convertConfigPackage)
   final String package;
@@ -174,8 +184,13 @@ class TestFlutterWebConfig {
   @CliOption(convert: convertConfigPackage)
   final String package;
   final bool coverage;
+  final bool wasm;
 
-  const TestFlutterWebConfig({required this.package, required this.coverage});
+  const TestFlutterWebConfig({
+    required this.package,
+    required this.coverage,
+    required this.wasm,
+  });
 }
 
 @CliOptions()
@@ -538,24 +553,36 @@ String getCoverageDir(String lang) {
   return ans;
 }
 
-Future<void> testDartWeb(TestDartConfig config) async {
+Future<void> testDartWeb(TestDartWebConfig config) async {
   await runPubGetIfNotRunYet(config.package);
 
   final package = config.package;
   if (package == 'frb_dart') {
     await exec(
-      'dart test -p chrome',
+      'dart test -p chrome ${config.wasm ? "--compiler dart2wasm" : ""}',
       relativePwd: package,
-      // extraEnv: kEnvEnableRustBacktrace,
+      extraEnv: await _dartTestChromeExtraEnv(),
     );
   } else {
     final features = getRustFeaturesOfPackage(config.package);
     await exec(
-      'dart run flutter_rust_bridge_utils test-web --entrypoint ../$package/test/dart_web_test_entrypoint.dart ${features != null ? "--rust-features $features" : ""}',
+      'dart run flutter_rust_bridge_utils test-web --entrypoint ../$package/test/dart_web_test_entrypoint.dart ${features != null ? "--rust-features $features" : ""} ${config.wasm ? "--wasm" : ""}',
       relativePwd: 'frb_utils',
       // extraEnv: kEnvEnableRustBacktrace,
     );
   }
+}
+
+Future<Map<String, String>?> _dartTestChromeExtraEnv() async {
+  final customChromeExecutable = Platform.environment['CHROME_EXECUTABLE'];
+  if (customChromeExecutable != null && customChromeExecutable.isNotEmpty) {
+    return null;
+  }
+
+  final wrapperPath = await _dockerChromeWrapperPath();
+  if (wrapperPath == null) return null;
+
+  return {'CHROME_EXECUTABLE': wrapperPath};
 }
 
 /// ref https://github.com/dart-lang/sdk/blob/master/runtime/tools/valgrind.py
@@ -689,11 +716,15 @@ Future<void> flutterIntegrationTestRaw({
 Future<void> testFlutterWeb(TestFlutterWebConfig config) async {
   await _runFlutterDoctor();
   await runPubGetIfNotRunYet(config.package);
-  await _installDartCoverage();
+  if (config.coverage) {
+    await _installDartCoverage();
+  }
 
   final buildWebPackage = resolveBuildWebPackage(config.package);
   await executeFrbCodegen(
-    'build-web --dart-coverage',
+    'build-web '
+    '${config.coverage ? "--dart-coverage" : ""} '
+    '--wasm-pack-rustup-toolchain $kPinnedRustfmtNightly',
     relativePwd: buildWebPackage,
     coverage: config.coverage,
     coverageName: 'TestFlutterWeb',
@@ -704,6 +735,8 @@ Future<void> testFlutterWeb(TestFlutterWebConfig config) async {
     '--driver=test_driver/integration_test.dart '
     '--target=integration_test/simple_test.dart '
     '-d web-server '
+    '${await _flutterWebChromeBinaryArg()}'
+    '${config.wasm ? '--wasm ' : ''}'
     '--verbose',
     relativePwd: config.package,
   );
@@ -758,5 +791,34 @@ Future<void> _runFlutterDoctor() async {
 
   await exec('flutter doctor -v');
 }
+
+Future<String> _flutterWebChromeBinaryArg() async {
+  final chromeBinary = Platform.environment['CHROME_EXECUTABLE'];
+  if (chromeBinary != null && chromeBinary.isNotEmpty) {
+    return '--chrome-binary=${_shellEscapeArgument(chromeBinary)} ';
+  }
+
+  final wrapperPath = await _dockerChromeWrapperPath();
+  return wrapperPath == null ? '' : '--chrome-binary=$wrapperPath ';
+}
+
+Future<String?> _dockerChromeWrapperPath() async {
+  if (!File('/.dockerenv').existsSync()) return null;
+
+  final wrapper = File('${Directory.systemTemp.path}/frb-test-chrome.sh');
+  if (!wrapper.existsSync()) {
+    wrapper.writeAsStringSync('''
+#!/bin/sh
+exec /usr/bin/google-chrome --no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage "\$@"
+''');
+    await exec('chmod 755 ${wrapper.path}');
+  }
+
+  return wrapper.path;
+}
+
+String _shellEscapeArgument(String value) => Platform.isWindows
+    ? "'${value.replaceAll("'", "''")}'"
+    : "'${value.replaceAll("'", r"'\''")}'";
 
 const kEnvEnableRustBacktrace = {'RUST_BACKTRACE': 'full'};

--- a/tools/frb_internal/lib/src/makefile_dart/test.g.dart
+++ b/tools/frb_internal/lib/src/makefile_dart/test.g.dart
@@ -110,6 +110,25 @@ TestDartConfig parseTestDartConfig(List<String> args) {
   return _$parseTestDartConfigResult(result);
 }
 
+TestDartWebConfig _$parseTestDartWebConfigResult(ArgResults result) =>
+    TestDartWebConfig(
+      package: convertConfigPackage(result['package'] as String),
+      wasm: result['wasm'] as bool,
+    );
+
+ArgParser _$populateTestDartWebConfigParser(ArgParser parser) => parser
+  ..addOption('package')
+  ..addFlag('wasm');
+
+final _$parserForTestDartWebConfig = _$populateTestDartWebConfigParser(
+  ArgParser(),
+);
+
+TestDartWebConfig parseTestDartWebConfig(List<String> args) {
+  final result = _$parserForTestDartWebConfig.parse(args);
+  return _$parseTestDartWebConfigResult(result);
+}
+
 TestDartNativeConfig _$parseTestDartNativeConfigResult(ArgResults result) =>
     TestDartNativeConfig(
       package: convertConfigPackage(result['package'] as String),
@@ -186,11 +205,13 @@ TestFlutterWebConfig _$parseTestFlutterWebConfigResult(ArgResults result) =>
     TestFlutterWebConfig(
       package: convertConfigPackage(result['package'] as String),
       coverage: result['coverage'] as bool,
+      wasm: result['wasm'] as bool,
     );
 
 ArgParser _$populateTestFlutterWebConfigParser(ArgParser parser) => parser
   ..addOption('package')
-  ..addFlag('coverage');
+  ..addFlag('coverage')
+  ..addFlag('wasm');
 
 final _$parserForTestFlutterWebConfig = _$populateTestFlutterWebConfigParser(
   ArgParser(),

--- a/tools/frb_internal/test/makefile_dart_test.dart
+++ b/tools/frb_internal/test/makefile_dart_test.dart
@@ -10,7 +10,8 @@ import 'package:flutter_rust_bridge_internal/src/makefile_dart/lint.dart';
 import 'package:flutter_rust_bridge_internal/src/makefile_dart/post_release.dart';
 import 'package:flutter_rust_bridge_internal/src/makefile_dart/quickstart_smoke.dart';
 import 'package:flutter_rust_bridge_internal/src/makefile_dart/release.dart';
-import 'package:flutter_rust_bridge_internal/src/makefile_dart/released_version.dart';
+import 'package:flutter_rust_bridge_internal/src/makefile_dart/released_version.dart'
+    as released_version;
 import 'package:flutter_rust_bridge_internal/src/makefile_dart/test.dart';
 import 'package:test/test.dart';
 
@@ -634,7 +635,7 @@ dev_dependencies:
   group('release version check', () {
     test('parses crates.io package metadata', () {
       expect(
-        parseCratesIoReleasedVersion({
+        released_version.parseCratesIoReleasedVersion({
           'crate': {'max_version': '2.12.0'},
         }),
         '2.12.0',
@@ -643,7 +644,7 @@ dev_dependencies:
 
     test('parses pub.dev package metadata', () {
       expect(
-        parsePubDevReleasedVersion({
+        released_version.parsePubDevReleasedVersion({
           'latest': {'version': '2.12.0'},
         }),
         '2.12.0',
@@ -652,7 +653,7 @@ dev_dependencies:
 
     test('finds pub.dev prerelease target version outside latest', () {
       expect(
-        parsePubDevReleasedVersion({
+        released_version.parsePubDevReleasedVersion({
           'latest': {'version': '2.12.0'},
           'versions': [
             {'version': '2.12.0'},
@@ -664,14 +665,14 @@ dev_dependencies:
     });
 
     test('summarizes whether every package is published', () {
-      final output = buildReleasePackageStatusOutput([
-        const ReleasePackageStatus(
+      final output = released_version.buildReleasePackageStatusOutput([
+        const released_version.ReleasePackageStatus(
           registry: 'crates.io',
           name: 'flutter_rust_bridge',
           manifestVersion: '2.12.0',
           releasedVersion: '2.12.0',
         ),
-        const ReleasePackageStatus(
+        const released_version.ReleasePackageStatus(
           registry: 'pub.dev',
           name: 'flutter_rust_bridge',
           manifestVersion: '2.12.0',
@@ -699,7 +700,7 @@ dev_dependencies:
     });
 
     test('uses explicit target version for every published package', () async {
-      final statuses = await fetchReleasePackageStatuses(
+      final statuses = await released_version.fetchReleasePackageStatuses(
         targetVersion: '9.9.9',
         fetcher: (uri) async {
           if (uri.host == 'crates.io') {
@@ -733,7 +734,7 @@ dev_dependencies:
     test(
       'reports hooks as unreleased when its target version is absent',
       () async {
-        final statuses = await fetchReleasePackageStatuses(
+        final statuses = await released_version.fetchReleasePackageStatuses(
           targetVersion: '9.9.9',
           fetcher: (uri) async {
             if (uri.host == 'crates.io') {
@@ -752,7 +753,9 @@ dev_dependencies:
           },
         );
 
-        final output = buildReleasePackageStatusOutput(statuses);
+        final output = released_version.buildReleasePackageStatusOutput(
+          statuses,
+        );
         final hooksStatus = statuses.singleWhere(
           (status) => status.name == 'flutter_rust_bridge_hooks',
         );
@@ -765,7 +768,7 @@ dev_dependencies:
     test(
       'reports hooks as unreleased when only another version exists',
       () async {
-        final statuses = await fetchReleasePackageStatuses(
+        final statuses = await released_version.fetchReleasePackageStatuses(
           targetVersion: '9.9.9',
           fetcher: (uri) async {
             if (uri.host == 'crates.io') {
@@ -785,7 +788,9 @@ dev_dependencies:
           },
         );
 
-        final output = buildReleasePackageStatusOutput(statuses);
+        final output = released_version.buildReleasePackageStatusOutput(
+          statuses,
+        );
         final hooksStatus = statuses.singleWhere(
           (status) => status.name == 'flutter_rust_bridge_hooks',
         );
@@ -798,9 +803,8 @@ dev_dependencies:
     test(
       'uses each local Dart manifest version as its pub.dev target',
       () async {
-        final rustVersion = getWorkspaceRustVersion();
-
-        final statuses = await fetchReleasePackageStatuses(
+        final rustVersion = released_version.getWorkspaceRustVersion();
+        final statuses = await released_version.fetchReleasePackageStatuses(
           dartPackageManifestFetcher: (package) => switch (package) {
             'frb_dart' =>
               '''

--- a/tools/manual_tests/frb-local-docker-dev-env.md
+++ b/tools/manual_tests/frb-local-docker-dev-env.md
@@ -66,7 +66,7 @@ rustup component list --toolchain "${nightly_toolchain}" --installed | grep llvm
 
 ## Test Data
 
-- Input files, API examples, account fixtures, or generated assets: checked-in packages `frb_rust`, `frb_dart`, and `frb_example/pure_dart`.
+- Input files, API examples, account fixtures, or generated assets: checked-in packages `frb_rust`, `frb_dart`, `frb_example/pure_dart`, and `frb_example/flutter_via_create`.
 - Reset procedure before each run: return to a clean checkout or record intentional local changes in the execution record.
 
 ## Steps
@@ -90,43 +90,72 @@ rustup component list --toolchain "${nightly_toolchain}" --installed | grep llvm
    '
    ```
 
-2. Run a focused Rust package test in Docker.
+1. Run a focused Rust package test in Docker.
 
    ```bash
    .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- ./frb_internal test-rust-package --package frb_rust
    ```
 
-3. Run a focused Dart native test in Docker.
+1. Run a focused Dart native test in Docker.
 
    ```bash
    .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- ./frb_internal test-dart-native --package frb_dart
    ```
 
-4. Run a focused Dart web test in Docker.
+1. Run a focused Dart web JavaScript test in Docker.
 
    ```bash
    .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- ./frb_internal test-dart-web --package frb_example/pure_dart
    ```
 
-5. Run a focused Flutter web coverage test in Docker.
+1. Run the Dart web dart2wasm browser test command in Docker.
+
+   ```bash
+   .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- ./frb_internal test-dart-web --package frb_dart --wasm
+   ```
+
+1. Start the headless WebDriver service used by Flutter web drive commands.
+
+   ```bash
+   .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- bash -lc '
+   set -euo pipefail
+   export DISPLAY=:99
+   if ! curl -fsS http://127.0.0.1:4444/status >/tmp/frb-local-webdriver-status.log 2>&1; then
+     chromedriver --port=4444 --verbose >/tmp/frb-local-chromedriver.log 2>&1 &
+   fi
+   if ! xdpyinfo -display :99 >/tmp/frb-local-xdpyinfo.log 2>&1; then
+     Xvfb -ac :99 -screen 0 1280x1024x24 >/tmp/frb-local-xvfb.log 2>&1 &
+   fi
+   sleep 15
+   curl -fsS http://127.0.0.1:4444/status
+   '
+   ```
+
+1. Run the Flutter web JavaScript coverage command in Docker.
 
    ```bash
    .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- ./frb_internal test-flutter-web --package frb_example/flutter_via_create --coverage
    ```
 
-6. Run a focused Linux Flutter native integration test in Docker through a headless display.
+1. Run the Flutter web dart2wasm coverage command in Docker.
+
+   ```bash
+   .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- ./frb_internal test-flutter-web --package frb_example/flutter_via_create --coverage --wasm
+   ```
+
+1. Run a focused Linux Flutter native integration test in Docker through a headless display.
 
    ```bash
    .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- xvfb-run -a ./frb_internal test-flutter-native --package frb_example/flutter_via_create --flutter-test-args '--device-id linux'
    ```
 
-7. Smoke-test the Linux Flutter release build command in Docker.
+1. Smoke-test the Linux Flutter release build command in Docker.
 
    ```bash
    .claude/skills/frb-dev-env/frb_dev_env.py docker exec -- ./frb_internal build-flutter --target linux
    ```
 
-8. Confirm the checkout did not gain unexpected generated or cache files.
+1. Confirm the checkout did not gain unexpected generated or cache files.
 
    ```bash
    git status --short
@@ -140,7 +169,9 @@ The Docker environment coverage test passes when every command exits successfull
 ./frb_internal test-rust-package --package frb_rust
 ./frb_internal test-dart-native --package frb_dart
 ./frb_internal test-dart-web --package frb_example/pure_dart
+./frb_internal test-dart-web --package frb_dart --wasm
 ./frb_internal test-flutter-web --package frb_example/flutter_via_create --coverage
+./frb_internal test-flutter-web --package frb_example/flutter_via_create --coverage --wasm
 xvfb-run -a ./frb_internal test-flutter-native --package frb_example/flutter_via_create --flutter-test-args '--device-id linux'
 ./frb_internal build-flutter --target linux
 ```
@@ -153,6 +184,7 @@ The test fails if any of the following happens:
 - Any required tool version command fails inside the container.
 - The Rust, Dart native, Dart web, Flutter web, or Linux Flutter native test command exits non-zero because Docker, browser startup, Linux desktop startup, package setup, toolchain availability, or local environment plumbing failed.
 - The Dart or Flutter web test requires a visible GUI session instead of running in a headless browser.
+- The dart2wasm web commands fail before launching Chrome or before reaching the actual test body. A deterministic test assertion failure or timeout after Chrome starts is product/test behavior to investigate separately, not a Docker environment failure; record the exact failing test and command.
 - The Flutter web drive command fails with `Unable to start a WebDriver session` because no compatible `chromedriver` is available.
 - The Linux Flutter native test cannot find the `linux` device, cannot start under `xvfb-run`, or exits non-zero unexpectedly.
 - The Linux Flutter build command exits non-zero unexpectedly or does not produce release artifacts under `target/build_flutter_output`.
@@ -172,7 +204,9 @@ The test is blocked, not failed, if the Docker image cannot be pulled because of
 
 - If submodules are uninitialized, rerun `git submodule update --init --recursive` and record the output.
 - If the container is missing or stopped, rerun `.claude/skills/frb-dev-env/frb_dev_env.py docker create` and record the helper output.
-- If Chrome, Chromium, or ChromeDriver cannot start, record the command, version, container architecture, and whether the web test log mentions sandbox flags.
+- If Chrome, Chromium, or ChromeDriver cannot start, record the command, version, container architecture, and whether the web test log mentions sandbox flags. For `dart test -p chrome`, verify that `CHROME_EXECUTABLE` points to the Docker no-sandbox wrapper when running inside the FRB Docker container.
+- If `flutter drive` reaches `dart2wasm` successfully and then fails to start a WebDriver session, record the container architecture, whether `chromedriver --version` succeeds, and whether the run is using `web-server` or `chrome`.
+- If Flutter web coverage fails only on the dart2wasm command, record whether the failure happened during FRB codegen, `flutter drive --wasm`, coverage formatting, or artifact generation.
 - If the Flutter web coverage step fails with a missing `Cargo.lock` under the nightly standard library source, verify the container is using the current Docker image and that the image has `rust-src` installed for the pinned nightly toolchain.
 - If the Flutter web coverage step fails with `can't find crate for profiler_builtins`, verify the container is using the current Docker image and that the image has `llvm-tools-preview` installed for the pinned nightly toolchain.
 - If the Linux Flutter native test cannot start, record `flutter devices`, `xvfb-run --help`, and whether the log mentions GTK, display, OpenGL, or missing Linux desktop dependencies.


### PR DESCRIPTION
## Summary

- Add dart2wasm support to Dart and Flutter Web test harnesses.
- Add Wasm loading, failure propagation, Docker Chrome handling, and compiler-independent completion logic.

## Validation

- Not rerun during the history-only PR split.