### PR TITLE
Check post-merge Wasm CI failures

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -844,6 +844,10 @@ jobs:
           architecture: x64
       - run: cargo install cargo-llvm-cov --version 0.6.24 --locked
 
+      - name: Allow Chrome sandbox user namespaces
+        if: runner.os == 'Linux' && matrix.package == 'frb_utils'
+        run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+
       # execute
       - run: ./frb_internal test-dart-native --package ${{ matrix.package }} --coverage
 


### PR DESCRIPTION
The new browser regression test makes `Test :: Dart :: Native (ubuntu-24.04, frb_utils)` fail before reaching its assertion: Chrome reports `No usable sandbox!`.

- **Why it worked before:** [0ae747faeb](https://github.com/fzyzcjy/flutter_rust_bridge/commit/0ae747faebe21f1098a276b0d488d2859f61c37d) added `reports failure when the wasm module loader is missing`, which launches Puppeteer from the native Dart suite. The earlier tests in this file only checked environment selection and generated HTML; they did not launch Chrome.
- **Why this fix:** Ubuntu 24.04's AppArmor user-namespace restriction prevents this Chrome launch. The existing Dart and Flutter web jobs already clear this restriction; the native job did not. Apply the same runner setup only to Linux `frb_utils`. This allows Chrome's sandbox to start without changing the test or adding `--no-sandbox`.
- **Evidence:** [The rerun](https://github.com/fzyzcjy/flutter_rust_bridge/actions/runs/33961434598/job/101393206206) still failed with 7 tests passed and this browser test failing at startup. The Docker-only sandbox flags do not apply on the hosted Ubuntu runner.
- **Validation:** [Focused fix run](https://github.com/fzyzcjy/flutter_rust_bridge/actions/runs/34000178504), filter `test_dart_native[image=ubuntu-24.04,package=frb_utils]`; result pending. This temporary PR also tracks [the pre-merge failure reruns](https://github.com/fzyzcjy/flutter_rust_bridge/actions/runs/34000084569). Partial CI is not full-CI readiness evidence.
