### PR TITLE
Wait for Web receivers before starting Rust

### DIFF
--- a/frb_dart/lib/src/generalized_isolate/_io.dart
+++ b/frb_dart/lib/src/generalized_isolate/_io.dart
@@ -1,9 +1,11 @@
 import 'dart:isolate';
 import 'package:flutter_rust_bridge/src/platform_types/platform_types.dart';
+import 'package:meta/meta.dart';
 
 export 'dart:ffi' show NativePort;
 export 'dart:isolate';
 
+@internal
 Future<void> initializeBroadcastChannel() async {}
 
 /// {@macro flutter_rust_bridge.internal}

--- a/frb_dart/lib/src/generalized_isolate/_io.dart
+++ b/frb_dart/lib/src/generalized_isolate/_io.dart
@@ -4,6 +4,8 @@ import 'package:flutter_rust_bridge/src/platform_types/platform_types.dart';
 export 'dart:ffi' show NativePort;
 export 'dart:isolate';
 
+Future<void> initializeBroadcastChannel() async {}
+
 /// {@macro flutter_rust_bridge.internal}
 ReceivePort broadcastPort(String channelName) => ReceivePort(channelName);
 

--- a/frb_dart/lib/src/generalized_isolate/_web.dart
+++ b/frb_dart/lib/src/generalized_isolate/_web.dart
@@ -6,6 +6,7 @@ import 'dart:js_interop_unsafe';
 import 'dart:math';
 
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated_web.dart';
+import 'package:meta/meta.dart';
 import 'package:web/web.dart' as web;
 
 dynamic _extractData(JSAny? data) => data.dartify();
@@ -36,6 +37,7 @@ web.BroadcastChannel _createBroadcastChannel() {
   return web.BroadcastChannel('__frb_broadcast_$nonce');
 }
 
+@internal
 Future<void> initializeBroadcastChannel() =>
     _broadcastChannelReady ??= _initializeBroadcastChannel().onError((
       Object error,

--- a/frb_dart/lib/src/generalized_isolate/_web.dart
+++ b/frb_dart/lib/src/generalized_isolate/_web.dart
@@ -2,20 +2,77 @@
 library html_isolate;
 
 import 'dart:async';
+import 'dart:js_interop_unsafe';
+import 'dart:math';
 
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated_web.dart';
 import 'package:web/web.dart' as web;
 
-dynamic _extractData(web.MessageEvent event) => event.data.dartify();
+dynamic _extractData(JSAny? data) => data.dartify();
 
 /// {@macro flutter_rust_bridge.internal}
 String serializeNativePort(NativePortType port) {
+  final name = port.getProperty<JSString?>('__frb_port_name'.toJS);
+  if (name != null) {
+    return name.toDart;
+  }
   if (port.isA<web.BroadcastChannel>()) {
     return (port as web.BroadcastChannel).name;
   }
   throw UnimplementedError(
     "serializeNativePort see unknown port=$port (type=${port.runtimeType})",
   );
+}
+
+final _namedPorts = <String, web.MessagePort>{};
+
+// Indeed a BroadcastChannel, not a Broadcast "Port"
+final _broadcastChannel = _createBroadcastChannel();
+Future<void>? _broadcastChannelReady;
+
+web.BroadcastChannel _createBroadcastChannel() {
+  final random = Random.secure();
+  final nonce = List.generate(4, (_) => random.nextInt(1 << 32)).join('_');
+  return web.BroadcastChannel('__frb_broadcast_$nonce');
+}
+
+Future<void> initializeBroadcastChannel() =>
+    _broadcastChannelReady ??= _initializeBroadcastChannel().onError((
+      Object error,
+      StackTrace stackTrace,
+    ) {
+      _broadcastChannelReady = null;
+      Error.throwWithStackTrace(error, stackTrace);
+    });
+
+Future<void> _initializeBroadcastChannel() async {
+  final ready = Completer<void>();
+  _broadcastChannel.onmessage = ((web.MessageEvent event) {
+    final data = event.data;
+    if (data == '__frb_ready'.toJS) {
+      if (!ready.isCompleted) ready.complete();
+      return;
+    }
+    if (!data.isA<JSArray<JSAny?>>()) return;
+    final message = data as JSArray<JSAny?>;
+    if (message.length != 2 || !message[0].isA<JSString>()) return;
+    final port = _namedPorts[(message[0] as JSString).toDart];
+    port?.postMessage(message[1]);
+  }).toJS;
+  // Note: It is *wrong* to reuse the same HTML BroadcastChannel object,
+  // because HTML BroadcastChannel spec says that, the event will not be fired
+  // at the object which sends it. Therefore, we need two different objects.
+  final sender = web.BroadcastChannel(_broadcastChannel.name);
+  final timer = Timer.periodic(const Duration(milliseconds: 10), (_) {
+    sender.postMessage('__frb_ready'.toJS);
+  });
+  try {
+    sender.postMessage('__frb_ready'.toJS);
+    await ready.future.timeout(const Duration(seconds: 10));
+  } finally {
+    timer.cancel();
+    sender.close();
+  }
 }
 
 /// {@macro flutter_rust_bridge.internal}
@@ -42,7 +99,7 @@ class ReceivePort extends Stream<dynamic> {
     void Function()? onDone,
     bool? cancelOnError,
   }) {
-    final subscription = _rawReceivePort._webReceivePort._onMessage
+    final subscription = _rawReceivePort._webReceivePort._messages
         .map(_extractData)
         .listen(
           onData,
@@ -73,7 +130,7 @@ class RawReceivePort {
 
   /// {@macro flutter_rust_bridge.same_as_native}
   set handler(Function(dynamic) handler) {
-    _webReceivePort._onMessage.listen((event) => handler(_extractData(event)));
+    _webReceivePort._messages.map(_extractData).listen(handler);
     _webReceivePort._start();
   }
 
@@ -116,22 +173,30 @@ class _WebMessageChannel implements _WebChannel {
 }
 
 class _WebBroadcastChannel implements _WebChannel {
-  final web.BroadcastChannel _sendChannel;
-  final web.BroadcastChannel _receiveChannel;
+  final _channel = web.MessageChannel();
+  final String _name;
 
-  _WebBroadcastChannel(String channelName)
-    // Note: It is *wrong* to reuse the same HTML BroadcastChannel object,
-    // because HTML BroadcastChannel spec says that, the event will not be fired
-    // at the object which sends it. Therefore, we need two different objects.
-    : _sendChannel = web.BroadcastChannel(channelName),
-      _receiveChannel = web.BroadcastChannel(channelName);
-
-  @override
-  SendPort get _sendPort => SendPort._(_sendChannel);
+  _WebBroadcastChannel(this._name) {
+    _channel.port2.setProperty(
+      '__frb_port_name'.toJS,
+      '${_broadcastChannel.name}/$_name'.toJS,
+    );
+    _namedPorts[_name] = _channel.port2;
+  }
 
   @override
-  _WebPortLike get _receivePort =>
-      _WebPortLike._broadcastChannel(_receiveChannel);
+  SendPort get _sendPort => SendPort._(_channel.port2);
+
+  @override
+  _WebPortLike get _receivePort => _WebBroadcastPort(this);
+
+  void _close() {
+    if (_namedPorts[_name] == _channel.port2) {
+      _namedPorts.remove(_name);
+    }
+    _channel.port1.close();
+    _channel.port2.close();
+  }
 }
 
 /// {@macro flutter_rust_bridge.same_as_native}
@@ -139,9 +204,6 @@ abstract class _WebPortLike {
   const _WebPortLike._();
 
   factory _WebPortLike._messagePort(web.MessagePort port) = _WebMessagePort;
-
-  factory _WebPortLike._broadcastChannel(web.BroadcastChannel channel) =
-      _WebBroadcastPort;
 
   void _start();
 
@@ -152,6 +214,8 @@ abstract class _WebPortLike {
 
   Stream<web.MessageEvent> get _onMessage =>
       _kMessageEvent.forTarget(_nativePort);
+
+  Stream<JSAny?> get _messages => _onMessage.map((event) => event.data);
   static const _kMessageEvent = web.EventStreamProvider<web.MessageEvent>(
     'message',
   );
@@ -170,16 +234,61 @@ class _WebMessagePort extends _WebPortLike {
   void _close() => _nativePort.close();
 }
 
-// Indeed a BroadcastChannel, not a Broadcast "Port"
 class _WebBroadcastPort extends _WebPortLike {
-  @override
-  final web.BroadcastChannel _nativePort;
-
-  _WebBroadcastPort(this._nativePort) : super._();
+  final _WebBroadcastChannel _channel;
 
   @override
-  void _start() {}
+  web.MessagePort get _nativePort => _channel._channel.port1;
+
+  _WebBroadcastPort(this._channel) : super._();
 
   @override
-  void _close() => _nativePort.close();
+  Stream<JSAny?> get _messages {
+    if (!_channel._name.startsWith('__frb_streamsink_')) {
+      return super._messages;
+    }
+    var nextSequence = 0;
+    final pending = <int, JSArray<JSAny?>>{};
+    return super._messages.expand((message) sync* {
+      if (message != null && message.isA<JSArray>()) {
+        final frame = message as JSArray<JSAny?>;
+        if (frame.toDart.isNotEmpty && frame[0].isA<JSString>()) {
+          final tag = (frame[0] as JSString).toDart;
+          if (tag == '__frb_stream_failed') {
+            if (frame.length != 1) {
+              throw StateError('Invalid Web stream failure frame');
+            }
+            throw StateError('Web stream transport failed');
+          }
+          if (tag == '__frb_stream') {
+            if ((frame.length != 2 && frame.length != 3) ||
+                !frame[1].isA<JSNumber>()) {
+              throw StateError('Invalid Web stream frame');
+            }
+            final sequence = (frame[1] as JSNumber).toDartDouble;
+            if (!sequence.isFinite ||
+                sequence != sequence.truncateToDouble() ||
+                sequence < nextSequence ||
+                sequence > 9007199254740991 ||
+                pending.containsKey(sequence.toInt())) {
+              throw StateError('Invalid Web stream sequence');
+            }
+            pending[sequence.toInt()] = frame;
+            while (pending.containsKey(nextSequence)) {
+              final ready = pending.remove(nextSequence++)!;
+              if (ready.length == 3) yield ready[2];
+            }
+            return;
+          }
+        }
+      }
+      yield message;
+    });
+  }
+
+  @override
+  void _start() => _nativePort.start();
+
+  @override
+  void _close() => _channel._close();
 }

--- a/frb_dart/lib/src/generalized_isolate/_web.dart
+++ b/frb_dart/lib/src/generalized_isolate/_web.dart
@@ -32,7 +32,7 @@ Future<void>? _broadcastChannelReady;
 
 web.BroadcastChannel _createBroadcastChannel() {
   final random = Random.secure();
-  final nonce = List.generate(4, (_) => random.nextInt(1 << 32)).join('_');
+  final nonce = List.generate(4, (_) => random.nextInt(0x100000000)).join('_');
   return web.BroadcastChannel('__frb_broadcast_$nonce');
 }
 

--- a/frb_dart/lib/src/generalized_isolate/_web.dart
+++ b/frb_dart/lib/src/generalized_isolate/_web.dart
@@ -6,7 +6,6 @@ import 'dart:js_interop_unsafe';
 import 'dart:math';
 
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated_web.dart';
-import 'package:meta/meta.dart';
 import 'package:web/web.dart' as web;
 
 dynamic _extractData(JSAny? data) => data.dartify();

--- a/frb_dart/lib/src/main_components/entrypoint.dart
+++ b/frb_dart/lib/src/main_components/entrypoint.dart
@@ -1,4 +1,6 @@
 import 'package:flutter_rust_bridge/src/generalized_frb_rust_binding/generalized_frb_rust_binding.dart';
+import 'package:flutter_rust_bridge/src/generalized_isolate/generalized_isolate.dart'
+    show initializeBroadcastChannel;
 import 'package:flutter_rust_bridge/src/loader/_common.dart';
 import 'package:flutter_rust_bridge/src/loader/loader.dart';
 import 'package:flutter_rust_bridge/src/logging/frb_logging.dart';
@@ -51,6 +53,8 @@ abstract class BaseEntrypoint<
     }
 
     _sanityCheckCodegenVersion(forceSameCodegenVersion);
+
+    await initializeBroadcastChannel();
 
     externalLibrary ??= await _loadDefaultExternalLibrary();
     handler ??= BaseHandler();

--- a/frb_dart/lib/src/main_components/entrypoint.dart
+++ b/frb_dart/lib/src/main_components/entrypoint.dart
@@ -48,13 +48,11 @@ abstract class BaseEntrypoint<
     ExternalLibrary? externalLibrary,
     bool forceSameCodegenVersion = true,
   }) async {
-    await initializeBroadcastChannel();
-
-    if (__state != null) {
-      throw StateError('Should not initialize flutter_rust_bridge twice');
-    }
-
+    _ensureUninitialized();
     _sanityCheckCodegenVersion(forceSameCodegenVersion);
+
+    await initializeBroadcastChannel();
+    _ensureUninitialized();
 
     externalLibrary ??= await _loadDefaultExternalLibrary();
     handler ??= BaseHandler();
@@ -82,9 +80,7 @@ abstract class BaseEntrypoint<
   /// {@macro flutter_rust_bridge.only_for_generated_code}
   @protected
   void initMockImpl({required A api}) {
-    if (__state != null) {
-      throw StateError('Should not initialize flutter_rust_bridge twice');
-    }
+    _ensureUninitialized();
 
     __state = _FakeEntrypointState(api: api);
   }
@@ -107,6 +103,12 @@ abstract class BaseEntrypoint<
       'WARN: resetState() (should only be used in internal tests, never be used by normal users)',
     );
     __state = null;
+  }
+
+  void _ensureUninitialized() {
+    if (__state != null) {
+      throw StateError('Should not initialize flutter_rust_bridge twice');
+    }
   }
 
   void _sanityCheckCodegenVersion(bool forceSameCodegenVersion) {

--- a/frb_dart/lib/src/main_components/entrypoint.dart
+++ b/frb_dart/lib/src/main_components/entrypoint.dart
@@ -48,13 +48,13 @@ abstract class BaseEntrypoint<
     ExternalLibrary? externalLibrary,
     bool forceSameCodegenVersion = true,
   }) async {
+    await initializeBroadcastChannel();
+
     if (__state != null) {
       throw StateError('Should not initialize flutter_rust_bridge twice');
     }
 
     _sanityCheckCodegenVersion(forceSameCodegenVersion);
-
-    await initializeBroadcastChannel();
 
     externalLibrary ??= await _loadDefaultExternalLibrary();
     handler ??= BaseHandler();

--- a/frb_dart/test/entrypoint_test.dart
+++ b/frb_dart/test/entrypoint_test.dart
@@ -1,10 +1,32 @@
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated_common.dart';
 import 'package:flutter_rust_bridge/src/consts.dart' show kIsWeb;
+import 'package:flutter_rust_bridge/src/misc/version.dart';
 import 'package:flutter_rust_bridge/src/cli/build_web/entrypoint.dart'
     as build_web;
 import 'package:test/test.dart';
 
 void main() {
+  test('initialization rejects state installed during readiness', () async {
+    final entrypoint = _FakeBaseEntrypointWithCodegenVersion(
+      kFlutterRustBridgeRuntimeVersion,
+    );
+    final pending = entrypoint._initialize();
+    final api = _FakeApi();
+    entrypoint._mock(api);
+
+    await expectLater(
+      pending,
+      throwsA(
+        isA<StateError>().having(
+          (error) => error.message,
+          'message',
+          'Should not initialize flutter_rust_bridge twice',
+        ),
+      ),
+    );
+    expect(entrypoint.api, same(api));
+  });
+
   test('Should be ready when initMock is called', () async {
     final entrypoint = _FakeBaseEntrypoint();
 
@@ -128,6 +150,10 @@ void main() {
 
 class _FakeBaseEntrypointWithCodegenVersion extends _FakeBaseEntrypoint {
   _FakeBaseEntrypointWithCodegenVersion(this.codegenVersion);
+
+  Future<void> _initialize() => initImpl(api: _FakeApi());
+
+  void _mock(BaseApi api) => initMockImpl(api: api);
 
   @override
   final String codegenVersion;

--- a/frb_dart/test/generalized_isolate_web_initialization_test.dart
+++ b/frb_dart/test/generalized_isolate_web_initialization_test.dart
@@ -1,0 +1,38 @@
+@TestOn('browser')
+import 'dart:js_interop';
+
+import 'package:flutter_rust_bridge/src/generalized_isolate/_web.dart';
+import 'package:test/test.dart';
+
+@JS('BroadcastChannel.prototype.postMessage')
+external JSFunction get _postMessage;
+
+@JS('BroadcastChannel.prototype.postMessage')
+external set _postMessage(JSFunction value);
+
+@JS('crypto.randomUUID')
+external JSFunction? get _randomUUID;
+
+@JS('crypto.randomUUID')
+external set _randomUUID(JSFunction? value);
+
+void main() {
+  test('failed initialization retries without randomUUID', () async {
+    final original = _postMessage;
+    final originalRandomUUID = _randomUUID;
+    try {
+      _randomUUID = null;
+      _postMessage = _failPostMessage.toJS;
+      await expectLater(initializeBroadcastChannel(), throwsA(anything));
+      _postMessage = original;
+      await initializeBroadcastChannel();
+    } finally {
+      _postMessage = original;
+      _randomUUID = originalRandomUUID;
+    }
+  });
+}
+
+void _failPostMessage(JSAny? value) {
+  throw StateError('injected initialization failure');
+}

--- a/frb_dart/test/generalized_isolate_web_test.dart
+++ b/frb_dart/test/generalized_isolate_web_test.dart
@@ -1,0 +1,98 @@
+@TestOn('browser')
+library;
+
+import 'dart:js_interop';
+
+import 'package:flutter_rust_bridge/src/generalized_isolate/_web.dart';
+import 'package:test/test.dart';
+import 'package:web/web.dart' as web;
+
+void main() {
+  test(
+    'lazy broadcast ports preserve reserved-looking user payloads',
+    () async {
+      final port = broadcastPort('__frb_lazy_port_protocol_test');
+      final sender = port.sendPort.nativePort as web.MessagePort;
+      addTearDown(port.close);
+      addTearDown(() => sender.close());
+      final received = port.take(2).toList();
+
+      sender.postMessage(['__frb_stream', 0, 'user data'].jsify());
+      sender.postMessage(['__frb_stream_failed'].jsify());
+
+      final values = await received;
+      expect(values, everyElement(isA<List<Object?>>()));
+      expect(values, [
+        ['__frb_stream', 0, 'user data'],
+        ['__frb_stream_failed'],
+      ]);
+    },
+  );
+
+  test(
+    'broadcast stream values precede an early close in sequence order',
+    () async {
+      final port = broadcastPort('__frb_streamsink_ordered');
+      final sender = port.sendPort.nativePort as web.MessagePort;
+      addTearDown(port.close);
+      addTearDown(() => sender.close());
+      final received = port.take(3).toList();
+
+      sender.postMessage(['__frb_stream', 2, 'closed'].jsify());
+      sender.postMessage(['__frb_stream', 1, 'second'].jsify());
+      sender.postMessage(['__frb_stream', 0, 'first'].jsify());
+
+      final values = await received;
+      expect(values, everyElement(isA<String>()));
+      expect(values, ['first', 'second', 'closed']);
+    },
+  );
+
+  test('rejected broadcast payload reservations do not block close', () async {
+    final port = broadcastPort('__frb_streamsink_rejected');
+    final sender = port.sendPort.nativePort as web.MessagePort;
+    addTearDown(port.close);
+    addTearDown(() => sender.close());
+    final received = port.take(2).toList();
+
+    sender.postMessage(['__frb_stream', 2, 'closed'].jsify());
+    sender.postMessage(['__frb_stream', 1, 'value'].jsify());
+    sender.postMessage(['__frb_stream', 0].jsify());
+
+    final values = await received;
+    expect(values, everyElement(isA<String>()));
+    expect(values, ['value', 'closed']);
+  });
+
+  test(
+    'broadcast transport failure errors instead of closing across a gap',
+    () async {
+      final port = broadcastPort('__frb_streamsink_failed');
+      final sender = port.sendPort.nativePort as web.MessagePort;
+      addTearDown(port.close);
+      addTearDown(() => sender.close());
+      final received = port.first;
+
+      sender.postMessage(['__frb_stream_failed'].jsify());
+
+      await expectLater(received, throwsStateError);
+    },
+  );
+
+  test(
+    'ordinary message ports preserve reserved-looking user payloads',
+    () async {
+      final port = ReceivePort();
+      final sender = port.sendPort.nativePort as web.MessagePort;
+      addTearDown(port.close);
+      addTearDown(() => sender.close());
+      final received = port.first;
+
+      sender.postMessage(['__frb_stream', 0, 'user data'].jsify());
+
+      final value = await received;
+      expect(value, isA<List<Object?>>());
+      expect(value, ['__frb_stream', 0, 'user data']);
+    },
+  );
+}

--- a/frb_example/pure_dart/test/api/method_test.dart
+++ b/frb_example/pure_dart/test/api/method_test.dart
@@ -93,6 +93,25 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(stream.toList(), completion([0, 1, 2, 3, 4]));
   });
 
+  test('fresh worker streams preserve every value TwinNormal', () async {
+    for (var batch = 0; batch < 250; batch++) {
+      final streams = List.generate(
+        8,
+        (_) => ConcatenateWithTwinNormal
+                .handleSomeStaticStreamSinkSingleArgTwinNormal()
+            .toList(),
+      );
+      final results = await Future.wait(streams);
+      for (var index = 0; index < results.length; index++) {
+        expect(
+          results[index],
+          [0, 1, 2, 3, 4],
+          reason: 'batch $batch stream $index',
+        );
+      }
+    }
+  });
+
   test('getter', () async {
     final concatenateWith = ConcatenateWithTwinNormal(a: "apple");
     expect(await concatenateWith.simpleGetterTwinNormal, equals("apple"));

--- a/frb_example/pure_dart/test/api/pseudo_manual/method_twin_rust_async_sse_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/method_twin_rust_async_sse_test.dart
@@ -105,6 +105,25 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(stream.toList(), completion([0, 1, 2, 3, 4]));
   });
 
+  test('fresh worker streams preserve every value TwinRustAsyncSse', () async {
+    for (var batch = 0; batch < 250; batch++) {
+      final streams = List.generate(
+        8,
+        (_) => ConcatenateWithTwinRustAsyncSse
+                .handleSomeStaticStreamSinkSingleArgTwinRustAsyncSse()
+            .toList(),
+      );
+      final results = await Future.wait(streams);
+      for (var index = 0; index < results.length; index++) {
+        expect(
+          results[index],
+          [0, 1, 2, 3, 4],
+          reason: 'batch $batch stream $index',
+        );
+      }
+    }
+  });
+
   test('getter', () async {
     final concatenateWith = ConcatenateWithTwinRustAsyncSse(a: "apple");
     expect(await concatenateWith.simpleGetterTwinRustAsyncSse, equals("apple"));

--- a/frb_example/pure_dart/test/api/pseudo_manual/method_twin_rust_async_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/method_twin_rust_async_test.dart
@@ -100,6 +100,25 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(stream.toList(), completion([0, 1, 2, 3, 4]));
   });
 
+  test('fresh worker streams preserve every value TwinRustAsync', () async {
+    for (var batch = 0; batch < 250; batch++) {
+      final streams = List.generate(
+        8,
+        (_) => ConcatenateWithTwinRustAsync
+                .handleSomeStaticStreamSinkSingleArgTwinRustAsync()
+            .toList(),
+      );
+      final results = await Future.wait(streams);
+      for (var index = 0; index < results.length; index++) {
+        expect(
+          results[index],
+          [0, 1, 2, 3, 4],
+          reason: 'batch $batch stream $index',
+        );
+      }
+    }
+  });
+
   test('getter', () async {
     final concatenateWith = ConcatenateWithTwinRustAsync(a: "apple");
     expect(await concatenateWith.simpleGetterTwinRustAsync, equals("apple"));

--- a/frb_example/pure_dart/test/api/pseudo_manual/method_twin_sse_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/method_twin_sse_test.dart
@@ -96,6 +96,25 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(stream.toList(), completion([0, 1, 2, 3, 4]));
   });
 
+  test('fresh worker streams preserve every value TwinSse', () async {
+    for (var batch = 0; batch < 250; batch++) {
+      final streams = List.generate(
+        8,
+        (_) =>
+            ConcatenateWithTwinSse.handleSomeStaticStreamSinkSingleArgTwinSse()
+                .toList(),
+      );
+      final results = await Future.wait(streams);
+      for (var index = 0; index < results.length; index++) {
+        expect(
+          results[index],
+          [0, 1, 2, 3, 4],
+          reason: 'batch $batch stream $index',
+        );
+      }
+    }
+  });
+
   test('getter', () async {
     final concatenateWith = ConcatenateWithTwinSse(a: "apple");
     expect(await concatenateWith.simpleGetterTwinSse, equals("apple"));

--- a/frb_example/pure_dart/test/api/pseudo_manual/method_twin_sync_sse_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/method_twin_sync_sse_test.dart
@@ -99,6 +99,25 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(stream.toList(), completion([0, 1, 2, 3, 4]));
   });
 
+  test('fresh worker streams preserve every value TwinSyncSse', () async {
+    for (var batch = 0; batch < 250; batch++) {
+      final streams = List.generate(
+        8,
+        (_) => ConcatenateWithTwinSyncSse
+                .handleSomeStaticStreamSinkSingleArgTwinSyncSse()
+            .toList(),
+      );
+      final results = await Future.wait(streams);
+      for (var index = 0; index < results.length; index++) {
+        expect(
+          results[index],
+          [0, 1, 2, 3, 4],
+          reason: 'batch $batch stream $index',
+        );
+      }
+    }
+  });
+
   test('getter', () async {
     final concatenateWith = ConcatenateWithTwinSyncSse(a: "apple");
     expect(await concatenateWith.simpleGetterTwinSyncSse, equals("apple"));

--- a/frb_example/pure_dart/test/api/pseudo_manual/method_twin_sync_test.dart
+++ b/frb_example/pure_dart/test/api/pseudo_manual/method_twin_sync_test.dart
@@ -96,6 +96,25 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(stream.toList(), completion([0, 1, 2, 3, 4]));
   });
 
+  test('fresh worker streams preserve every value TwinSync', () async {
+    for (var batch = 0; batch < 250; batch++) {
+      final streams = List.generate(
+        8,
+        (_) => ConcatenateWithTwinSync
+                .handleSomeStaticStreamSinkSingleArgTwinSync()
+            .toList(),
+      );
+      final results = await Future.wait(streams);
+      for (var index = 0; index < results.length; index++) {
+        expect(
+          results[index],
+          [0, 1, 2, 3, 4],
+          reason: 'batch $batch stream $index',
+        );
+      }
+    }
+  });
+
   test('getter', () async {
     final concatenateWith = ConcatenateWithTwinSync(a: "apple");
     expect(await concatenateWith.simpleGetterTwinSync, equals("apple"));

--- a/frb_example/pure_dart_pde/test/api/method_test.dart
+++ b/frb_example/pure_dart_pde/test/api/method_test.dart
@@ -95,6 +95,25 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(stream.toList(), completion([0, 1, 2, 3, 4]));
   });
 
+  test('fresh worker streams preserve every value TwinNormal', () async {
+    for (var batch = 0; batch < 250; batch++) {
+      final streams = List.generate(
+        8,
+        (_) => ConcatenateWithTwinNormal
+                .handleSomeStaticStreamSinkSingleArgTwinNormal()
+            .toList(),
+      );
+      final results = await Future.wait(streams);
+      for (var index = 0; index < results.length; index++) {
+        expect(
+          results[index],
+          [0, 1, 2, 3, 4],
+          reason: 'batch $batch stream $index',
+        );
+      }
+    }
+  });
+
   test('getter', () async {
     final concatenateWith = ConcatenateWithTwinNormal(a: "apple");
     expect(await concatenateWith.simpleGetterTwinNormal, equals("apple"));

--- a/frb_example/pure_dart_pde/test/api/pseudo_manual/method_twin_rust_async_test.dart
+++ b/frb_example/pure_dart_pde/test/api/pseudo_manual/method_twin_rust_async_test.dart
@@ -102,6 +102,25 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(stream.toList(), completion([0, 1, 2, 3, 4]));
   });
 
+  test('fresh worker streams preserve every value TwinRustAsync', () async {
+    for (var batch = 0; batch < 250; batch++) {
+      final streams = List.generate(
+        8,
+        (_) => ConcatenateWithTwinRustAsync
+                .handleSomeStaticStreamSinkSingleArgTwinRustAsync()
+            .toList(),
+      );
+      final results = await Future.wait(streams);
+      for (var index = 0; index < results.length; index++) {
+        expect(
+          results[index],
+          [0, 1, 2, 3, 4],
+          reason: 'batch $batch stream $index',
+        );
+      }
+    }
+  });
+
   test('getter', () async {
     final concatenateWith = ConcatenateWithTwinRustAsync(a: "apple");
     expect(await concatenateWith.simpleGetterTwinRustAsync, equals("apple"));

--- a/frb_example/pure_dart_pde/test/api/pseudo_manual/method_twin_sync_test.dart
+++ b/frb_example/pure_dart_pde/test/api/pseudo_manual/method_twin_sync_test.dart
@@ -98,6 +98,25 @@ Future<void> main({bool skipRustLibInit = false}) async {
     expect(stream.toList(), completion([0, 1, 2, 3, 4]));
   });
 
+  test('fresh worker streams preserve every value TwinSync', () async {
+    for (var batch = 0; batch < 250; batch++) {
+      final streams = List.generate(
+        8,
+        (_) => ConcatenateWithTwinSync
+                .handleSomeStaticStreamSinkSingleArgTwinSync()
+            .toList(),
+      );
+      final results = await Future.wait(streams);
+      for (var index = 0; index < results.length; index++) {
+        expect(
+          results[index],
+          [0, 1, 2, 3, 4],
+          reason: 'batch $batch stream $index',
+        );
+      }
+    }
+  });
+
   test('getter', () async {
     final concatenateWith = ConcatenateWithTwinSync(a: "apple");
     expect(await concatenateWith.simpleGetterTwinSync, equals("apple"));

--- a/frb_rust/src/generalized_isolate/web/port_like.rs
+++ b/frb_rust/src/generalized_isolate/web/port_like.rs
@@ -1,8 +1,18 @@
+use js_sys::{Array, Object, Reflect};
+use std::cell::RefCell;
+use std::collections::HashMap;
 use wasm_bindgen::prelude::*;
 use web_sys::BroadcastChannel;
 
+thread_local! {
+    static BROADCAST_CHANNELS: RefCell<HashMap<String, BroadcastChannel>> = RefCell::new(HashMap::new());
+}
+
 #[wasm_bindgen]
 extern "C" {
+    #[wasm_bindgen(js_name = queueMicrotask)]
+    fn queue_microtask(callback: &js_sys::Function);
+
     /// Objects implementing the interface of [`web_sys::MessagePort`].
     ///
     /// Attempts to coerce [`JsValue`]s into this interface using [`dyn_into`][JsCast::dyn_into]
@@ -10,16 +20,66 @@ extern "C" {
     #[derive(Clone)]
     pub type PortLike;
     #[wasm_bindgen(method, catch, js_name = "postMessage")]
-    pub fn post_message(this: &PortLike, value: &JsValue) -> Result<(), JsValue>;
+    fn post_message_raw(this: &PortLike, value: &JsValue) -> Result<(), JsValue>;
     #[wasm_bindgen(method, catch)]
-    pub fn close(this: &PortLike) -> Result<(), JsValue>;
+    #[wasm_bindgen(js_name = close)]
+    fn close_raw(this: &PortLike) -> Result<(), JsValue>;
+    #[wasm_bindgen(method, getter, js_name = __frb_port_name)]
+    pub(crate) fn channel_name(this: &PortLike) -> Option<String>;
 }
 
 impl PortLike {
     /// Create a [`BroadcastChannel`] with the specified name.
     pub fn broadcast(name: &str) -> Self {
+        if name.starts_with("__frb_broadcast_") {
+            let port = Object::new();
+            Reflect::set(&port, &"__frb_port_name".into(), &name.into()).unwrap_throw();
+            return port.unchecked_into();
+        }
         BroadcastChannel::new(name)
             .expect("Failed to create broadcast channel")
             .unchecked_into()
     }
+
+    pub fn post_message(&self, value: &JsValue) -> Result<(), JsValue> {
+        match self.channel_name() {
+            Some(name) => post_named_message(&name, value),
+            None => self.post_message_raw(value),
+        }
+    }
+
+    pub fn close(&self) -> Result<(), JsValue> {
+        match self.channel_name() {
+            Some(_) => Ok(()),
+            None => self.close_raw(),
+        }
+    }
+}
+
+fn post_named_message(name: &str, value: &JsValue) -> Result<(), JsValue> {
+    let (channel_name, port_name) = name
+        .split_once('/')
+        .ok_or_else(|| JsValue::from_str("Invalid broadcast port name"))?;
+    let channel = BROADCAST_CHANNELS.with(|channels| {
+        let mut channels = channels.borrow_mut();
+        if channels.is_empty() {
+            queue_microtask(Closure::once_into_js(close_broadcast_channels).unchecked_ref());
+        }
+        let channel = match channels.entry(channel_name.to_owned()) {
+            std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(BroadcastChannel::new(channel_name)?)
+            }
+        };
+        Ok::<_, JsValue>(channel.clone())
+    })?;
+    channel.post_message(&Array::of2(&port_name.into(), value))
+}
+
+fn close_broadcast_channels() {
+    BROADCAST_CHANNELS.with(|channels| {
+        for (_, channel) in channels.borrow_mut().drain() {
+            channel.close();
+        }
+    });
 }

--- a/frb_rust/src/platform_types/web.rs
+++ b/frb_rust/src/platform_types/web.rs
@@ -89,9 +89,12 @@ extern "C" {
 
 pub fn message_port_to_handle(port: &MessagePort) -> SendableMessagePortHandle {
     SendableMessagePortHandle(
-        port.dyn_ref::<BroadcastChannel>()
-            .map(|channel| channel.name())
-            .expect("Not a BroadcastChannel"),
+        port.channel_name()
+            .or_else(|| {
+                port.dyn_ref::<BroadcastChannel>()
+                    .map(|channel| channel.name())
+            })
+            .expect("Not a named message port"),
     )
 }
 

--- a/frb_rust/src/stream/closer.rs
+++ b/frb_rust/src/stream/closer.rs
@@ -2,11 +2,17 @@ use crate::codec::BaseCodec;
 use crate::codec::Rust2DartMessageTrait;
 use crate::generalized_isolate::{release_channel_handle, SendableChannelHandle};
 use std::marker::PhantomData;
+#[cfg(target_family = "wasm")]
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 // *NOT* cloneable, since it invokes stream-close when dropped
 pub(crate) struct StreamSinkCloser<Rust2DartCodec: BaseCodec> {
     sendable_channel_handle: SendableChannelHandle,
     _phantom_data: PhantomData<Rust2DartCodec>,
+    #[cfg(target_family = "wasm")]
+    pub(super) next_sequence: AtomicU64,
+    #[cfg(target_family = "wasm")]
+    pub(super) failed: AtomicBool,
 }
 
 impl<Rust2DartCodec: BaseCodec> StreamSinkCloser<Rust2DartCodec> {
@@ -14,14 +20,29 @@ impl<Rust2DartCodec: BaseCodec> StreamSinkCloser<Rust2DartCodec> {
         Self {
             sendable_channel_handle,
             _phantom_data: PhantomData,
+            #[cfg(target_family = "wasm")]
+            next_sequence: AtomicU64::new(0),
+            #[cfg(target_family = "wasm")]
+            failed: AtomicBool::new(false),
         }
     }
 }
 
 impl<Rust2DartCodec: BaseCodec> Drop for StreamSinkCloser<Rust2DartCodec> {
     fn drop(&mut self) {
-        super::stream_sink::sender(&self.sendable_channel_handle)
-            .send_or_warn(Rust2DartCodec::encode_close_stream().into_dart_abi());
+        let message = Rust2DartCodec::encode_close_stream().into_dart_abi();
+        #[cfg(target_family = "wasm")]
+        let message: wasm_bindgen::JsValue = if self.failed.load(Ordering::Relaxed) {
+            js_sys::Array::of1(&"__frb_stream_failed".into()).into()
+        } else {
+            js_sys::Array::of3(
+                &"__frb_stream".into(),
+                &(self.next_sequence.load(Ordering::Relaxed) as f64).into(),
+                &message,
+            )
+            .into()
+        };
+        super::stream_sink::sender(&self.sendable_channel_handle).send_or_warn(message);
         release_channel_handle(&self.sendable_channel_handle);
     }
 }

--- a/frb_rust/src/stream/stream_sink.rs
+++ b/frb_rust/src/stream/stream_sink.rs
@@ -37,7 +37,33 @@ impl<T, Rust2DartCodec: BaseCodec> StreamSinkBase<T, Rust2DartCodec> {
     /// Add data to the stream. Returns false when data could not be sent,
     /// or the stream has been closed.
     pub fn add_raw(&self, value: Rust2DartCodec::Message) -> Result<(), Rust2DartSendError> {
-        sender(&self.sendable_channel_handle).send(value.into_dart_abi())
+        let message = value.into_dart_abi();
+        let sender = sender(&self.sendable_channel_handle);
+        #[cfg(target_family = "wasm")]
+        {
+            use std::sync::atomic::Ordering;
+
+            if self._closer.failed.load(Ordering::Relaxed) {
+                return Err(Rust2DartSendError);
+            }
+            let sequence = self._closer.next_sequence.fetch_add(1, Ordering::Relaxed);
+            let frame =
+                js_sys::Array::of3(&"__frb_stream".into(), &(sequence as f64).into(), &message);
+            let result = sender.send(wasm_bindgen::JsValue::from(frame));
+            if result.is_err()
+                && sender
+                    .send(wasm_bindgen::JsValue::from(js_sys::Array::of2(
+                        &"__frb_stream".into(),
+                        &(sequence as f64).into(),
+                    )))
+                    .is_err()
+            {
+                self._closer.failed.store(true, Ordering::Relaxed);
+            }
+            result
+        }
+        #[cfg(not(target_family = "wasm"))]
+        sender.send(message)
     }
 }
 

--- a/frb_rust/src/web_transfer/transfer.rs
+++ b/frb_rust/src/web_transfer/transfer.rs
@@ -29,7 +29,7 @@ impl<T: Transfer> Transfer for Option<T> {
 impl Transfer for PortLike {
     fn deserialize(value: &JsValue) -> Self {
         if let Some(name) = value.as_string() {
-            BroadcastChannel::new(&name).unwrap().unchecked_into()
+            PortLike::broadcast(&name)
         } else if value.dyn_ref::<web_sys::MessagePort>().is_some() {
             value.unchecked_ref::<Self>().clone()
         } else {
@@ -37,14 +37,18 @@ impl Transfer for PortLike {
         }
     }
     fn serialize(self) -> JsValue {
-        if let Some(channel) = self.dyn_ref::<BroadcastChannel>() {
+        if let Some(name) = self.channel_name() {
+            name.into()
+        } else if let Some(channel) = self.dyn_ref::<BroadcastChannel>() {
             channel.name().into()
         } else {
             self.into()
         }
     }
     fn transferables(&self) -> Vec<JsValue> {
-        if let Some(port) = self.dyn_ref::<web_sys::MessagePort>() {
+        if self.channel_name().is_some() {
+            vec![]
+        } else if let Some(port) = self.dyn_ref::<web_sys::MessagePort>() {
             vec![port.clone().into()]
         } else {
             vec![]

--- a/website/docs/guides/contributing/submodules/dco-codec.md
+++ b/website/docs/guides/contributing/submodules/dco-codec.md
@@ -24,24 +24,28 @@ Rust ->> Rust Worker: port2
 Rust Worker ->> Dart: port2.postMessage
 ```
 
-**BroadcastChannel** replaces `dart:ffi`'s `SendPort` for `StreamSink`s, due to the fact that wasm_bindgen
-keeps the ports in a JS-local scope that cannot be shared with other threads. A broadcast channel
-is created by Dart, then passed to the main Rust thread. Rust then transfers its name to the workers.
-When other workers refer to a `StreamSink` from another worker, e.g. if the sink was put in a static variable,
-a new `BroadcastChannel` will be created from its name.
+**BroadcastChannel** carries named `StreamSink` messages between workers, because wasm_bindgen keeps JavaScript ports in a scope that cannot be shared with other threads.
 
-`BroadcastChannel`s are guaranteed to be unique for each invocation.[^1]
+- Dart creates one persistent broadcast receiver per library and verifies a round trip before starting Rust. Its name includes a cryptographically generated 128-bit nonce.
+- Each sink has a distinct logical name and a local `MessageChannel`. Rust receives a handle containing the shared receiver name and the logical name.
+- Workers open senders for the shared receiver and post `[logicalName, payload]`. Dart routes each payload to its local message port. Worker senders are reused within the current microtask and closed afterward.
+- Closing a sink removes its logical route and closes its local ports without closing the shared receiver.
+- Stream values and close frames share a sequence counter across Rust sink clones.
+- Dart buffers out-of-order frames and delivers only consecutive sequence numbers, so an early close cannot discard preceding values.
+- A rejected payload is followed by an empty frame for its reserved sequence number. If that frame also fails, the final sink drop sends a transport-error frame instead of a normal close.
+- This framing applies only to stream broadcast channels; ordinary message ports retain their original payloads.
 
 ```mermaid
 sequenceDiagram
-Dart ->> Rust: channel
-Rust ->> Rust Worker 1: channel.name
-Rust Worker 1 ->> Dart: channel.postMessage
-Rust ->> Rust Worker 2: channel.name
-Rust Worker 2 ->> Dart: channel.postMessage
+Dart ->> Dart: Verify shared receiver readiness
+Dart ->> Rust: sharedReceiverName/logicalName
+Rust ->> Rust Worker 1: sharedReceiverName/logicalName
+Rust Worker 1 ->> Dart: postMessage([logicalName, frame])
+Dart ->> Dart: Route frame to the sink's local MessagePort
+Rust ->> Rust Worker 2: sharedReceiverName/logicalName
+Rust Worker 2 ->> Dart: postMessage([logicalName, frame])
+Dart ->> Dart: Route frame to the sink's local MessagePort
 ```
 
 It is theoretically possible to have a one-to-one implementation of Isolate using only web primitives,
 `BroadcastChannel`s and `Worker`s, but it remains to be seen how practical such an approach would be.
-
-[^1]: This is currently implemented as a monotonically-increasing index.

--- a/website/docs/guides/cross-platform/thread-pool.md
+++ b/website/docs/guides/cross-platform/thread-pool.md
@@ -14,3 +14,11 @@ FLUTTER_RUST_BRIDGE_HANDLER.thread_pool().execute(transfer!(|| {
 The `transfer!` macro is there in case you need to move data to that thread
 (which needs a bit of trick in WASM, encapsulated inside the macro).
 We may improve the API in the future.
+
+## Web message delivery
+
+- `RustLib.init()` waits until its shared broadcast receiver has received a readiness message before starting Rust.
+- Each named port uses a local `MessageChannel`; worker messages are routed through the established receiver, so creating a stream does not require registering a new cross-worker receiver.
+- Stream values and the final close message carry shared sequence numbers; Dart restores their sending order before decoding them.
+- Initialization fails if readiness is not confirmed within ten seconds; callers can retry initialization after resolving the failure.
+- The receiver is scoped to the Dart library instance and lives for that instance's lifetime. Closing a stream releases its local ports, not the shared receiver.


### PR DESCRIPTION
## Reproduction

- Baseline commit: `05174fdd4fa8b271a49cbf12d9b58308e416bb17`.
- The failure is intermittent. [Run 34006557840](https://github.com/fzyzcjy/flutter_rust_bridge/actions/runs/34006557840) captured a missing first value in the existing static worker stream test at that exact SHA.
- Mechanical steps in a checkout of the baseline with the repository Docker environment prepared:

```bash
.claude/skills/frb-dev-env/frb_dev_env.py docker exec -- bash -lc \
  'timeout 1200 ./frb_internal test-dart-web --package frb_example/pure_dart --wasm'
```

- Observed:

```text
ConcatenateWith static stream sink at 1 test
Expected: [0, 1, 2, 3, 4]
Actual:   [1, 2, 3, 4]
```

- Expected: every worker stream delivers all five values in sending order, followed by close.
- A local minimal reproduction additionally captured successful Rust sends with only value 4 and close reaching Dart's raw message listener. After adding receiver readiness, the new concurrent twin regression exposed `[0, 1, 3, 4, 2]`, requiring the chain's existing ordering protection as well.

## Changes

- Establish one ready broadcast receiver per Dart library before Rust initialization; route named streams through local MessagePorts.
- Move the existing stream sequence protection ahead of the sanitizer chain, preserving raw payload conversion and failure handling.
- Add strict worker regressions in all nine method twin variants across pure_dart and pure_dart_pde, plus initialization and protocol tests.
- Preserve existing assertions, concurrency, skips, CI configuration, sanitizer coverage, and suppressions.
- Keep this PR unmerged while the chain completes its normal CI and final review gates.

## Validation

- Local Docker: the receiver fix passed the Dart runtime on native, JavaScript and WebAssembly, Rust runtime tests, and the full pure_dart/pure_dart_pde suites on native, JavaScript and WebAssembly.
- After restacking, reran native Dart runtime (156 passed), Rust runtime (95 unit tests, 3 integration tests and 1 doc test passed), WebAssembly runtime (132 passed), pure_dart WebAssembly (4,186 passed) and pure_dart_pde WebAssembly (1,989 passed).
- Existing skips remain unchanged; every new concurrent stream regression uses 250 batches of 8 streams and asserts the exact ordered list for each stream.
- Independent correctness, receiver lifecycle, ordering, simplicity, performance and test-weakening reviews completed. Accepted findings led to readiness-state revalidation, a JavaScript-safe random bound, internal API annotations and updated DCO transport documentation.
- The full-chain test/sanitizer review found no unjustified weakening or unresolved context questions. GitHub CI is still required; local results are not presented as a full CI pass.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>